### PR TITLE
Fixed tools taking damage in creative.

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/api/item/GTToolItem.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/item/GTToolItem.java
@@ -75,7 +75,10 @@ public class GTToolItem extends DiggerItem implements IItemRendererProvider, IIt
             var result = toolable.onToolClick(getToolType(), itemStack, context);
             if (result == InteractionResult.CONSUME && context.getPlayer() instanceof ServerPlayer serverPlayer) {
                 ToolHelper.playToolSound(toolType, serverPlayer);
-                ToolHelper.damageItem(itemStack, context.getLevel().getRandom(), serverPlayer);
+
+                if (!serverPlayer.isCreative()) {
+                    ToolHelper.damageItem(itemStack, context.getLevel().getRandom(), serverPlayer);
+                }
             }
             return result;
         }


### PR DESCRIPTION
Tools take damage when you use them in Creative Mode on Blocks. Fixed it, so that it does not take any damage in Creative.