### PR TITLE
Prevent setting output facing to the front facing

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -295,7 +295,7 @@ public class MetaMachine implements IManaged, IToolable, ITickSubscription, IApp
 
     protected InteractionResult onWrenchClick(Player playerIn, InteractionHand hand, Direction gridSide, BlockHitResult hitResult) {
         if (playerIn.isCrouching()) {
-            if (gridSide == getFrontFacing() || !isFacingValid(gridSide) || !hasFrontFacing()) {
+            if (gridSide == getFrontFacing() || !isFacingValid(gridSide)) {
                 return InteractionResult.FAIL;
             }
             if (!isRemote()) {
@@ -367,7 +367,7 @@ public class MetaMachine implements IManaged, IToolable, ITickSubscription, IApp
     public ResourceTexture sideTips(Player player, GTToolType toolType, Direction side) {
         if (toolType == GTToolType.WRENCH) {
             if (player.isCrouching()) {
-                if (hasFrontFacing() && side != this.getFrontFacing() && isFacingValid(side)) {
+                if (isFacingValid(side)) {
                     return GuiTextures.TOOL_FRONT_FACING_ROTATION;
                 }
             }
@@ -418,6 +418,7 @@ public class MetaMachine implements IManaged, IToolable, ITickSubscription, IApp
     }
 
     public boolean isFacingValid(Direction facing) {
+        if (hasFrontFacing() && facing == getFrontFacing()) return false;
         var blockState = getBlockState();
         if (blockState.getBlock() instanceof MetaMachineBlock metaMachineBlock) {
             return metaMachineBlock.rotationState.test(facing);

--- a/common/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
@@ -16,7 +16,10 @@ import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
 import com.gregtechceu.gtceu.data.lang.LangHandler;
 import com.gregtechceu.gtlib.gui.modular.ModularUI;
 import com.gregtechceu.gtlib.gui.texture.*;
-import com.gregtechceu.gtlib.gui.widget.*;
+import com.gregtechceu.gtlib.gui.widget.CycleButtonWidget;
+import com.gregtechceu.gtlib.gui.widget.ImageWidget;
+import com.gregtechceu.gtlib.gui.widget.LabelWidget;
+import com.gregtechceu.gtlib.gui.widget.SlotWidget;
 import com.gregtechceu.gtlib.misc.ItemStackTransfer;
 import com.gregtechceu.gtlib.side.fluid.FluidTransferHelper;
 import com.gregtechceu.gtlib.side.item.ItemTransferHelper;
@@ -239,6 +242,13 @@ public class SimpleTieredMachine extends WorkableTieredMachine implements IAutoO
         updateAutoOutputSubscription();
     }
 
+    @Override
+    public boolean isFacingValid(Direction facing) {
+        if (facing == getOutputFacingItems() || facing == getOutputFacingFluids()) {
+            return false;
+        }
+        return super.isFacingValid(facing);
+    }
 
     //////////////////////////////////////
     //*******     Interaction    *******//


### PR DESCRIPTION
Prevents the exploit where one could rotate the front facing away, set the output facing to the original front facing, and then rotate the front back to the original position. This would previously be a valid/possible state where the front and output facing would be on the same side.