### PR TITLE
Fix strange behavior when setting auto output sides

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
@@ -183,13 +183,13 @@ public class SimpleTieredMachine extends WorkableTieredMachine implements IAutoO
     }
 
     @Override
-    public void setOutputFacingFluids(Direction outputFacing) {
+    public void setOutputFacingFluids(@Nullable Direction outputFacing) {
         this.outputFacingFluids = outputFacing;
         updateAutoOutputSubscription();
     }
 
     @Override
-    public void setOutputFacingItems(Direction outputFacing) {
+    public void setOutputFacingItems(@Nullable Direction outputFacing) {
         this.outputFacingItems = outputFacing;
         updateAutoOutputSubscription();
     }
@@ -259,31 +259,27 @@ public class SimpleTieredMachine extends WorkableTieredMachine implements IAutoO
             var tool = playerIn.getItemInHand(hand);
             if (tool.getDamageValue() >= tool.getMaxDamage()) return InteractionResult.PASS;
             if (hasFrontFacing() && gridSide == getFrontFacing()) return InteractionResult.PASS;
-            var itemFacing = outputFacingItems;
-            var fluidFacing = outputFacingFluids;
-            if (itemFacing == null && fluidFacing == null) {
+
+            // important not to use getters here, which have different logic
+            Direction itemFacing = this.outputFacingItems;
+            Direction fluidFacing = this.outputFacingFluids;
+
+            if (gridSide != itemFacing) {
+                // if it is a new side, move it
                 setOutputFacingItems(gridSide);
-                setOutputFacingFluids(gridSide);
-                return InteractionResult.CONSUME;
-            }
-            if (itemFacing == null && gridSide != fluidFacing) {
-                setOutputFacingItems(gridSide);
-                return InteractionResult.CONSUME;
-            }
-            if (fluidFacing == null && gridSide != itemFacing) {
-                setOutputFacingFluids(gridSide);
-                return InteractionResult.CONSUME;
-            }
-            if (itemFacing == gridSide) {
+            } else {
+                // remove the output facing when wrenching the current one to disable it
                 setOutputFacingItems(null);
-                return InteractionResult.CONSUME;
             }
-            if (fluidFacing == gridSide) {
+
+            if (gridSide != fluidFacing) {
+                // if it is a new side, move it
+                setOutputFacingFluids(gridSide);
+            } else {
+                // remove the output facing when wrenching the current one to disable it
                 setOutputFacingFluids(null);
-                return InteractionResult.CONSUME;
             }
-            setOutputFacingItems(gridSide);
-            setOutputFacingFluids(gridSide);
+
             return InteractionResult.CONSUME;
         }
 

--- a/common/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IAutoOutputFluid.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IAutoOutputFluid.java
@@ -23,6 +23,5 @@ public interface IAutoOutputFluid {
     @Nullable
     Direction getOutputFacingFluids();
 
-
-    void setOutputFacingFluids(Direction outputFacing);
+    void setOutputFacingFluids(@Nullable Direction outputFacing);
 }

--- a/common/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IAutoOutputItem.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IAutoOutputItem.java
@@ -21,6 +21,6 @@ public interface IAutoOutputItem {
     @Nullable
     Direction getOutputFacingItems();
 
-    void setOutputFacingItems(Direction outputFacing);
+    void setOutputFacingItems(@Nullable Direction outputFacing);
 
 }

--- a/common/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -1,15 +1,15 @@
 package com.gregtechceu.gtceu.common.machine.storage;
 
-import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
-import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.TickableSubscription;
-import com.gregtechceu.gtceu.api.machine.TieredMachine;
 import com.gregtechceu.gtceu.api.capability.IControllable;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.UITemplate;
 import com.gregtechceu.gtceu.api.gui.widget.ToggleButtonWidget;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
+import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.TickableSubscription;
+import com.gregtechceu.gtceu.api.machine.TieredMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputItem;
 import com.gregtechceu.gtceu.api.machine.feature.IDropSaveMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IUIMachine;
@@ -207,7 +207,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     }
 
     @Override
-    public void setOutputFacingItems(Direction outputFacing) {
+    public void setOutputFacingItems(@Nullable Direction outputFacing) {
         this.outputFacingItems = outputFacing;
         updateAutoOutputSubscription();
     }
@@ -294,17 +294,13 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
             var tool = playerIn.getItemInHand(hand);
             if (tool.getDamageValue() >= tool.getMaxDamage()) return InteractionResult.PASS;
             if (hasFrontFacing() && gridSide == getFrontFacing()) return InteractionResult.PASS;
-            var itemFacing = getOutputFacingItems();
-            if (itemFacing == null) {
+            if (gridSide != getOutputFacingItems()) {
                 setOutputFacingItems(gridSide);
-                return InteractionResult.CONSUME;
-            }
-            if (itemFacing == gridSide) {
+            } else {
                 setOutputFacingItems(null);
-                return InteractionResult.CONSUME;
             }
-            setOutputFacingItems(gridSide);
             return InteractionResult.CONSUME;
+
         }
 
         return super.onWrenchClick(playerIn, hand, gridSide, hitResult);

--- a/common/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -157,7 +157,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     }
 
     @Override
-    public void setOutputFacingFluids(Direction outputFacing) {
+    public void setOutputFacingFluids(@Nullable Direction outputFacing) {
         this.outputFacingFluids = outputFacing;
         updateAutoOutputSubscription();
     }
@@ -252,16 +252,11 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
             var tool = playerIn.getItemInHand(hand);
             if (tool.getDamageValue() >= tool.getMaxDamage()) return InteractionResult.PASS;
             if (hasFrontFacing() && gridSide == getFrontFacing()) return InteractionResult.PASS;
-            var fluidFacing = getOutputFacingFluids();
-            if (fluidFacing == null) {
+            if (gridSide != getOutputFacingFluids()) {
                 setOutputFacingFluids(gridSide);
-                return InteractionResult.CONSUME;
-            }
-            if (fluidFacing == gridSide) {
+            } else {
                 setOutputFacingFluids(null);
-                return InteractionResult.CONSUME;
             }
-            setOutputFacingFluids(gridSide);
             return InteractionResult.CONSUME;
         }
 


### PR DESCRIPTION
Fixes some weird behavior that could happen when setting the auto output side.

Currently, clicking an output face will disable it, but one had to click that disabled face twice to put the output back. This fixes this behavior, and simplifies the logic overall.
