### PR TITLE
A Rewrite of `ThermalFluidHandlerItemStack` for Better Compability With Fabric Transfer API

### DIFF
--- a/fabric/src/main/java/com/gregtechceu/gtceu/api/item/component/fabric/ThermalFluidStatsImpl.java
+++ b/fabric/src/main/java/com/gregtechceu/gtceu/api/item/component/fabric/ThermalFluidStatsImpl.java
@@ -6,9 +6,10 @@ import com.gregtechceu.gtceu.api.misc.fabric.FluidCellStorage;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 
 /**
- @author KilaBash
- @date 2023/3/19
- @implNote ThermalFluidStatsImpl */
+ * @author KilaBash
+ * @date 2023/3/19
+ * @implNote ThermalFluidStatsImpl
+ */
 public class ThermalFluidStatsImpl extends ThermalFluidStats {
 
     protected ThermalFluidStatsImpl(int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof, boolean allowPartialFill) {

--- a/fabric/src/main/java/com/gregtechceu/gtceu/api/item/component/fabric/ThermalFluidStatsImpl.java
+++ b/fabric/src/main/java/com/gregtechceu/gtceu/api/item/component/fabric/ThermalFluidStatsImpl.java
@@ -2,16 +2,15 @@ package com.gregtechceu.gtceu.api.item.component.fabric;
 
 import com.gregtechceu.gtceu.api.item.ComponentItem;
 import com.gregtechceu.gtceu.api.item.component.ThermalFluidStats;
-import com.gregtechceu.gtceu.api.misc.fabric.SimpleThermalFluidHandlerItemStack;
-import com.gregtechceu.gtceu.api.misc.fabric.ThermalFluidHandlerItemStack;
+import com.gregtechceu.gtceu.api.misc.fabric.FluidCellStorage;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 
 /**
- * @author KilaBash
- * @date 2023/3/19
- * @implNote ThermalFluidStatsImpl
- */
-public class ThermalFluidStatsImpl extends ThermalFluidStats{
+ @author KilaBash
+ @date 2023/3/19
+ @implNote ThermalFluidStatsImpl */
+public class ThermalFluidStatsImpl extends ThermalFluidStats {
+
     protected ThermalFluidStatsImpl(int capacity, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof, boolean allowPartialFill) {
         super(capacity, maxFluidTemperature, gasProof, acidProof, cryoProof, plasmaProof, allowPartialFill);
     }
@@ -22,11 +21,7 @@ public class ThermalFluidStatsImpl extends ThermalFluidStats{
 
     @Override
     public void onAttached(ComponentItem item) {
-        FluidStorage.ITEM.registerForItems((itemStack, context) -> {
-            if (allowPartialFill) {
-                return new ThermalFluidHandlerItemStack(context, capacity, maxFluidTemperature, gasProof, acidProof, cryoProof, plasmaProof);
-            }
-            return new SimpleThermalFluidHandlerItemStack(context, item.asItem().getDefaultInstance(), capacity, maxFluidTemperature, gasProof, acidProof, cryoProof, plasmaProof);
-        }, item);
+        FluidStorage.ITEM.registerForItems((itemStack, context) -> new FluidCellStorage(context, capacity, allowPartialFill, maxFluidTemperature, gasProof, acidProof, cryoProof, plasmaProof), item);
     }
+
 }

--- a/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/FluidCellStorage.java
+++ b/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/FluidCellStorage.java
@@ -1,19 +1,3 @@
-/*
- * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.gregtechceu.gtceu.api.misc.fabric;
 
 import com.gregtechceu.gtceu.api.capability.IThermalFluidHandlerItemStack;
@@ -31,9 +15,9 @@ import net.minecraft.nbt.CompoundTag;
 import org.jetbrains.annotations.ApiStatus;
 
 /**
- @author Phoupraw
- @date  2023/8/9
- @see ThermalFluidStatsImpl#onAttached
+ * @author Phoupraw
+ * @date 2023/8/9
+ * @see ThermalFluidStatsImpl#onAttached
  */
 public class FluidCellStorage extends SingleVariantItemStorage<FluidVariant> {
 
@@ -97,8 +81,8 @@ public class FluidCellStorage extends SingleVariantItemStorage<FluidVariant> {
     }
 
     /**
-     @see FilteringStorage#canInsert
-     @see IThermalFluidHandlerItemStack#canFillFluidType
+     * @see FilteringStorage#canInsert
+     * @see IThermalFluidHandlerItemStack#canFillFluidType
      */
     @ApiStatus.Internal
     public boolean canInsert(FluidVariant resource) {
@@ -108,7 +92,7 @@ public class FluidCellStorage extends SingleVariantItemStorage<FluidVariant> {
     }
 
     /**
-     @see FilteringStorage#canExtract
+     * @see FilteringStorage#canExtract
      */
     @ApiStatus.Internal
     public boolean canExtract(FluidVariant resource) {

--- a/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/FluidCellStorage.java
+++ b/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/FluidCellStorage.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gregtechceu.gtceu.api.misc.fabric;
+
+import com.gregtechceu.gtceu.api.capability.IThermalFluidHandlerItemStack;
+import com.gregtechceu.gtceu.api.item.component.fabric.ThermalFluidStatsImpl;
+import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
+import com.lowdragmc.lowdraglib.side.fluid.fabric.FluidHelperImpl;
+import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariantAttributes;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.FilteringStorage;
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantItemStorage;
+import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
+import net.minecraft.nbt.CompoundTag;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ @author Phoupraw
+ @date  2023/8/9
+ @see ThermalFluidStatsImpl#onAttached
+ */
+public class FluidCellStorage extends SingleVariantItemStorage<FluidVariant> {
+
+    private final long capacity;
+    private final boolean allowPartialFill;
+    private final int maxFluidTemperature;
+    private final boolean gasProof;
+    private final boolean acidProof;
+    private final boolean cryoProof;
+    private final boolean plasmaProof;
+
+    public FluidCellStorage(ContainerItemContext context, long capacity, boolean allowPartialFill, int maxFluidTemperature, boolean gasProof, boolean acidProof, boolean cryoProof, boolean plasmaProof) {
+        super(context);
+        this.capacity = capacity;
+        this.allowPartialFill = allowPartialFill;
+        this.maxFluidTemperature = maxFluidTemperature;
+        this.gasProof = gasProof;
+        this.acidProof = acidProof;
+        this.cryoProof = cryoProof;
+        this.plasmaProof = plasmaProof;
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public FluidVariant getBlankResource() {
+        return FluidVariant.blank();
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public FluidVariant getResource(ItemVariant currentVariant) {
+        return FluidHelperImpl.toFluidVariant(getFluidStack(currentVariant));
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public long getAmount(ItemVariant currentVariant) {
+        return getFluidStack(currentVariant).getAmount();
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public long getCapacity(FluidVariant variant) {
+        return capacity;
+    }
+
+    @Override
+    @ApiStatus.Internal
+    public ItemVariant getUpdatedVariant(ItemVariant currentVariant, FluidVariant newResource, long newAmount) {
+        CompoundTag newNbt = currentVariant.copyOrCreateNbt();
+        if (newResource.isBlank() || newAmount == 0) {
+            newNbt.remove(FluidHandlerItemStack.FLUID_NBT_KEY);
+            if (newNbt.isEmpty()) {
+                newNbt = null;
+            }
+        } else {
+            CompoundTag nbtFluid = FluidStack.create(newResource.getFluid(), newAmount, newResource.getNbt()).saveToTag(new CompoundTag());
+            newNbt.put(FluidHandlerItemStack.FLUID_NBT_KEY, nbtFluid);
+        }
+        return ItemVariant.of(currentVariant.getItem(), newNbt);
+    }
+
+    /**
+     @see FilteringStorage#canInsert
+     @see IThermalFluidHandlerItemStack#canFillFluidType
+     */
+    @ApiStatus.Internal
+    public boolean canInsert(FluidVariant resource) {
+        int temperature = FluidVariantAttributes.getTemperature(resource);
+        return temperature <= getMaxFluidTemperature() && !(temperature < 120 && !isCryoProof()) && (!FluidVariantAttributes.isLighterThanAir(resource) || isGasProof());
+        //TODO acid, plasma
+    }
+
+    /**
+     @see FilteringStorage#canExtract
+     */
+    @ApiStatus.Internal
+    public boolean canExtract(FluidVariant resource) {
+        return true;
+    }
+
+    @Override
+    public long insert(FluidVariant insertedResource, long maxAmount, TransactionContext transaction) {
+        if (!canInsert(insertedResource)) return 0;
+        if (!isAllowPartialFill()) {
+            maxAmount = maxAmount < getCapacity(insertedResource) ? 0 : getCapacity(insertedResource);
+        }
+        return super.insert(insertedResource, maxAmount, transaction);
+    }
+
+    @Override
+    public long extract(FluidVariant extractedResource, long maxAmount, TransactionContext transaction) {
+        if (!canExtract(extractedResource)) return 0;
+        if (!isAllowPartialFill()) {
+            maxAmount = maxAmount < getAmount() ? 0 : getAmount();
+        }
+        return super.extract(extractedResource, maxAmount, transaction);
+    }
+
+    public FluidStack getFluidStack(ItemVariant currentVariant) {
+        CompoundTag root = currentVariant.getNbt();
+        if (root == null) return FluidStack.empty();
+        return FluidStack.loadFromTag(root.getCompound(FluidHandlerItemStack.FLUID_NBT_KEY));
+    }
+
+    public boolean isAllowPartialFill() {
+        return allowPartialFill;
+    }
+
+    public int getMaxFluidTemperature() {
+        return maxFluidTemperature;
+    }
+
+    public boolean isGasProof() {
+        return gasProof;
+    }
+
+    public boolean isAcidProof() {
+        return acidProof;
+    }
+
+    public boolean isCryoProof() {
+        return cryoProof;
+    }
+
+    public boolean isPlasmaProof() {
+        return plasmaProof;
+    }
+
+}

--- a/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/SimpleThermalFluidHandlerItemStack.java
+++ b/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/SimpleThermalFluidHandlerItemStack.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.ItemStack;
  * @date 2023/2/22
  * @implNote FluidHandlerHelperImpl
  */
+@Deprecated
 public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStack.SwapEmpty implements IThermalFluidHandlerItemStack {
     public final int maxFluidTemperature;
     private final boolean gasProof;

--- a/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/ThermalFluidHandlerItemStack.java
+++ b/fabric/src/main/java/com/gregtechceu/gtceu/api/misc/fabric/ThermalFluidHandlerItemStack.java
@@ -5,7 +5,7 @@ import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import org.jetbrains.annotations.NotNull;
-
+@Deprecated
 public class ThermalFluidHandlerItemStack extends FluidHandlerItemStack implements IThermalFluidHandlerItemStack {
 
     private final int maxFluidTemperature;


### PR DESCRIPTION
Compared to `FluidHandlerItemStack`, this rewrite is based on `SingleVariantItemStorage`, which greatly reduces boilerplate, and gets along better with `Transaction`.