### PR TITLE
fix worldgen deadlock

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/DikeVeinGenerator.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/DikeVeinGenerator.java
@@ -66,8 +66,8 @@ public class DikeVeinGenerator extends VeinGenerator {
     public boolean generate(WorldGenLevel level, RandomSource random, GTOreDefinition entry, BlockPos origin) {
         WorldgenRandom worldgenRandom = new WorldgenRandom(new LegacyRandomSource(level.getSeed()));
         NormalNoise normalNoise = NormalNoise.create(worldgenRandom, -2, 4.0D);
+
         ChunkPos chunkPos = new ChunkPos(origin);
-        BulkSectionAccess access = new BulkSectionAccess(level);
 
         float density = entry.getDensity();
         int size = entry.getClusterSize();
@@ -81,29 +81,30 @@ public class DikeVeinGenerator extends VeinGenerator {
 
         int blocksPlaced = 0;
 
-        for (int dY = yBottom; dY <= yTop; dY++) {
-            for (int dX = -size; dX <= size; dX++) {
-                for (int dZ = -size; dZ <= size; dZ++) {
-                    float dist = (dX * dX) + (dZ * dZ);
-                    if (dist > size * 2) {
-                        continue;
-                    }
-                    BlockPos pos = new BlockPos(basePos.getX() + dX, dY, basePos.getZ() + dZ);
-                    if (!level.ensureCanWrite(pos))
-                        continue;
-                    LevelChunkSection section = access.getSection(pos);
-                    if (section == null)
-                        continue;
-                    if (normalNoise.getValue(dX, dY, dZ) >= 0.5 && random.nextFloat() <= density) {
-                        if (placeBlock(access, section, random, pos, entry)) {
-                            ++blocksPlaced;
+        try (BulkSectionAccess access = new BulkSectionAccess(level)) {
+            for (int dY = yBottom; dY <= yTop; dY++) {
+                for (int dX = -size; dX <= size; dX++) {
+                    for (int dZ = -size; dZ <= size; dZ++) {
+                        float dist = (dX * dX) + (dZ * dZ);
+                        if (dist > size * 2) {
+                            continue;
+                        }
+                        BlockPos pos = new BlockPos(basePos.getX() + dX, dY, basePos.getZ() + dZ);
+                        if (!level.ensureCanWrite(pos))
+                            continue;
+                        LevelChunkSection section = access.getSection(pos);
+                        if (section == null)
+                            continue;
+                        if (normalNoise.getValue(dX, dY, dZ) >= 0.5 && random.nextFloat() <= density) {
+                            if (placeBlock(access, section, random, pos, entry)) {
+                                ++blocksPlaced;
+                            }
                         }
                     }
                 }
             }
         }
 
-        access.close();
         return blocksPlaced > 0;
     }
 

--- a/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/GeodeVeinGenerator.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/GeodeVeinGenerator.java
@@ -16,8 +16,8 @@ import lombok.experimental.Accessors;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.core.SectionPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.ExtraCodecs;
@@ -119,7 +119,6 @@ public class GeodeVeinGenerator extends VeinGenerator {
 
     @Override
     public boolean generate(WorldGenLevel level, RandomSource random, GTOreDefinition entry, BlockPos origin) {
-        BulkSectionAccess access = new BulkSectionAccess(level);
 
         BlockState blockState;
         int offset;
@@ -139,110 +138,114 @@ public class GeodeVeinGenerator extends VeinGenerator {
         double crackSize = 1.0 / Math.sqrt(geodeCrackSettings.baseCrackSize + random.nextDouble() / 2.0 + (distributionSample > 3 ? wallDistance : 0.0));
         boolean doCrack = (double)random.nextFloat() < geodeCrackSettings.generateCrackChance;
         int invalidBlocksCount = 0;
-        for (offset2 = 0; offset2 < distributionSample; ++offset2) {
-            offset = this.outerWallDistance.sample(random);
-            BlockPos origin2 = origin.offset(offset, this.outerWallDistance.sample(random), this.outerWallDistance.sample(random));
-            blockState = access.getBlockState(origin2);
-            if ((blockState.isAir() || blockState.is(BlockTags.GEODE_INVALID_BLOCKS)) && ++invalidBlocksCount > this.invalidBlocksThreshold) {
-                return false;
-            }
-            points.add(Pair.of(origin2, this.pointOffset.sample(random)));
-        }
-        if (doCrack) {
-            offset2 = random.nextInt(4);
-            offset = distributionSample * 2 + 1;
-            if (offset2 == 0) {
-                list2.add(origin.offset(offset, 7, 0));
-                list2.add(origin.offset(offset, 5, 0));
-                list2.add(origin.offset(offset, 1, 0));
-            } else if (offset2 == 1) {
-                list2.add(origin.offset(0, 7, offset));
-                list2.add(origin.offset(0, 5, offset));
-                list2.add(origin.offset(0, 1, offset));
-            } else if (offset2 == 2) {
-                list2.add(origin.offset(offset, 7, offset));
-                list2.add(origin.offset(offset, 5, offset));
-                list2.add(origin.offset(offset, 1, offset));
-            } else {
-                list2.add(origin.offset(0, 7, 0));
-                list2.add(origin.offset(0, 5, 0));
-                list2.add(origin.offset(0, 1, 0));
-            }
-        }
-        ArrayList<BlockPos> positions = Lists.newArrayList();
-        Predicate<BlockState> placementPredicate = GeodeFeature.isReplaceable(this.geodeBlockSettings.cannotReplace);
-        for (BlockPos pos : BlockPos.betweenClosed(origin.offset(minOffset, minOffset, minOffset), origin.offset(maxOffset, maxOffset, maxOffset))) {
-            double noiseValue = normalNoise.getValue(pos.getX(), pos.getY(), pos.getZ()) * this.noiseMultiplier;
-            double s = 0.0;
-            double t = 0.0;
-            for (var pair : points) {
-                s += Mth.fastInvSqrt(pos.distSqr(pair.getFirst()) + (double) pair.getSecond()) + noiseValue;
-            }
-            for (BlockPos origin4 : list2) {
-                t += Mth.fastInvSqrt(pos.distSqr(origin4) + (double)geodeCrackSettings.crackPointOffset) + noiseValue;
-            }
-            if (s < outerSize) continue;
-            if (!level.ensureCanWrite(pos))
-                continue;
-            LevelChunkSection section = access.getSection(pos);
-            if (section == null)
-                continue;
-            if (doCrack && t >= crackSize && s < fillingSize) {
-                this.safeSetBlock(access, section, pos, Blocks.AIR.defaultBlockState(), placementPredicate);
-                for (Direction direction : DIRECTIONS) {
-                    BlockPos origin5 = pos.relative(direction);
-                    FluidState fluidState = level.getFluidState(origin5);
-                    if (fluidState.isEmpty()) continue;
-                    level.scheduleTick(origin5, fluidState.getType(), 0);
+
+        try (BulkSectionAccess access = new BulkSectionAccess(level)) {
+            for (offset2 = 0; offset2 < distributionSample; ++offset2) {
+                offset = this.outerWallDistance.sample(random);
+                BlockPos origin2 = origin.offset(offset, this.outerWallDistance.sample(random), this.outerWallDistance.sample(random));
+                blockState = access.getBlockState(origin2);
+                if ((blockState.isAir() || blockState.is(BlockTags.GEODE_INVALID_BLOCKS)) && ++invalidBlocksCount > this.invalidBlocksThreshold) {
+                    return false;
                 }
-                continue;
+                points.add(Pair.of(origin2, this.pointOffset.sample(random)));
             }
-            if (s >= fillingSize) {
-                this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.fillingProvider, geodeBlockSettings, random, pos), placementPredicate);
-                continue;
-            }
-            if (s >= innerSize) {
-                boolean useAltLayer = (double)random.nextFloat() < this.useAlternateLayer0Chance;
-                if (useAltLayer) {
-                    this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.alternateInnerLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
+            if (doCrack) {
+                offset2 = random.nextInt(4);
+                offset = distributionSample * 2 + 1;
+                if (offset2 == 0) {
+                    list2.add(origin.offset(offset, 7, 0));
+                    list2.add(origin.offset(offset, 5, 0));
+                    list2.add(origin.offset(offset, 1, 0));
+                } else if (offset2 == 1) {
+                    list2.add(origin.offset(0, 7, offset));
+                    list2.add(origin.offset(0, 5, offset));
+                    list2.add(origin.offset(0, 1, offset));
+                } else if (offset2 == 2) {
+                    list2.add(origin.offset(offset, 7, offset));
+                    list2.add(origin.offset(offset, 5, offset));
+                    list2.add(origin.offset(offset, 1, offset));
                 } else {
-                    this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.innerLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
+                    list2.add(origin.offset(0, 7, 0));
+                    list2.add(origin.offset(0, 5, 0));
+                    list2.add(origin.offset(0, 1, 0));
                 }
-                if (this.placementsRequireLayer0Alternate && !useAltLayer || !((double)random.nextFloat() < this.usePotentialPlacementsChance)) continue;
-                positions.add(pos.immutable());
-                continue;
             }
-            if (s >= middleSize) {
-                this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.middleLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
-                continue;
-            }
-            if (!(s >= outerSize)) continue;
-            this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.outerLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
-        }
-        List<BlockState> innerPlacements = geodeBlockSettings.innerPlacements;
-        block5: for (BlockPos origin2 : positions) {
-            blockState = Util.getRandom(innerPlacements, random);
-            for (Direction direction2 : DIRECTIONS) {
-                if (blockState.hasProperty(BlockStateProperties.FACING)) {
-                    blockState = blockState.setValue(BlockStateProperties.FACING, direction2);
+            ArrayList<BlockPos> positions = Lists.newArrayList();
+            Predicate<BlockState> placementPredicate = GeodeFeature.isReplaceable(this.geodeBlockSettings.cannotReplace);
+            for (BlockPos pos : BlockPos.betweenClosed(origin.offset(minOffset, minOffset, minOffset), origin.offset(maxOffset, maxOffset, maxOffset))) {
+                double noiseValue = normalNoise.getValue(pos.getX(), pos.getY(), pos.getZ()) * this.noiseMultiplier;
+                double s = 0.0;
+                double t = 0.0;
+                for (var pair : points) {
+                    s += Mth.fastInvSqrt(pos.distSqr(pair.getFirst()) + (double) pair.getSecond()) + noiseValue;
                 }
-                BlockPos origin6 = origin2.relative(direction2);
-                BlockState blockState2 = access.getBlockState(origin6);
-                if (blockState.hasProperty(BlockStateProperties.WATERLOGGED)) {
-                    blockState = blockState.setValue(BlockStateProperties.WATERLOGGED, blockState2.getFluidState().isSource());
+                for (BlockPos origin4 : list2) {
+                    t += Mth.fastInvSqrt(pos.distSqr(origin4) + (double) geodeCrackSettings.crackPointOffset) + noiseValue;
                 }
-                if (!BuddingAmethystBlock.canClusterGrowAtState(blockState2)) continue;
-                if (!level.ensureCanWrite(origin6))
+                if (s < outerSize) continue;
+                if (!level.ensureCanWrite(pos))
                     continue;
-                LevelChunkSection section = access.getSection(origin6);
+                LevelChunkSection section = access.getSection(pos);
                 if (section == null)
                     continue;
-                this.safeSetBlock(access, section, origin6, blockState, placementPredicate);
-                continue block5;
+                if (doCrack && t >= crackSize && s < fillingSize) {
+                    this.safeSetBlock(access, section, pos, Blocks.AIR.defaultBlockState(), placementPredicate);
+                    for (Direction direction : DIRECTIONS) {
+                        BlockPos origin5 = pos.relative(direction);
+                        FluidState fluidState = level.getFluidState(origin5);
+                        if (fluidState.isEmpty()) continue;
+                        level.scheduleTick(origin5, fluidState.getType(), 0);
+                    }
+                    continue;
+                }
+                if (s >= fillingSize) {
+                    this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.fillingProvider, geodeBlockSettings, random, pos), placementPredicate);
+                    continue;
+                }
+                if (s >= innerSize) {
+                    boolean useAltLayer = (double) random.nextFloat() < this.useAlternateLayer0Chance;
+                    if (useAltLayer) {
+                        this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.alternateInnerLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
+                    } else {
+                        this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.innerLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
+                    }
+                    if (this.placementsRequireLayer0Alternate && !useAltLayer || !((double) random.nextFloat() < this.usePotentialPlacementsChance))
+                        continue;
+                    positions.add(pos.immutable());
+                    continue;
+                }
+                if (s >= middleSize) {
+                    this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.middleLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
+                    continue;
+                }
+                if (!(s >= outerSize)) continue;
+                this.safeSetBlock(access, section, pos, getStateFromEither(geodeBlockSettings.outerLayerProvider, geodeBlockSettings, random, pos), placementPredicate);
+            }
+            List<BlockState> innerPlacements = geodeBlockSettings.innerPlacements;
+            block5:
+            for (BlockPos origin2 : positions) {
+                blockState = Util.getRandom(innerPlacements, random);
+                for (Direction direction2 : DIRECTIONS) {
+                    if (blockState.hasProperty(BlockStateProperties.FACING)) {
+                        blockState = blockState.setValue(BlockStateProperties.FACING, direction2);
+                    }
+                    BlockPos origin6 = origin2.relative(direction2);
+                    BlockState blockState2 = access.getBlockState(origin6);
+                    if (blockState.hasProperty(BlockStateProperties.WATERLOGGED)) {
+                        blockState = blockState.setValue(BlockStateProperties.WATERLOGGED, blockState2.getFluidState().isSource());
+                    }
+                    if (!BuddingAmethystBlock.canClusterGrowAtState(blockState2)) continue;
+                    if (!level.ensureCanWrite(origin6))
+                        continue;
+                    LevelChunkSection section = access.getSection(origin6);
+                    if (section == null)
+                        continue;
+                    this.safeSetBlock(access, section, origin6, blockState, placementPredicate);
+                    continue block5;
+                }
             }
         }
 
-        access.close();
         return true;
     }
 

--- a/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/LayeredVeinGenerator.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/LayeredVeinGenerator.java
@@ -3,8 +3,8 @@ package com.gregtechceu.gtceu.api.data.worldgen.generator;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.worldgen.GTLayerPattern;
-import com.gregtechceu.gtceu.api.data.worldgen.GTOreFeature;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
+import com.gregtechceu.gtceu.api.data.worldgen.GTOreFeature;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -86,13 +86,12 @@ public class LayeredVeinGenerator extends VeinGenerator {
         List<Float> layerDiameterOffsets = new ArrayList<>();
 
         BlockPos.MutableBlockPos posCursor = new BlockPos.MutableBlockPos();
-        BulkSectionAccess access = new BulkSectionAccess(level);
+
         int layerCoordinate = random.nextInt(4);
         int slantyCoordinate = random.nextInt(3);
         float slope = random.nextFloat() * .75f;
 
-        try {
-
+        try (BulkSectionAccess access = new BulkSectionAccess(level)) {
             for (int xC = 0; xC < width; xC++) {
                 float dx = xC * 2f / width - 1;
                 if (dx * dx > 1)
@@ -169,22 +168,11 @@ public class LayeredVeinGenerator extends VeinGenerator {
                                 placedAmount.increment();
                             });
                         }
-
                     }
                 }
             }
-
-        } catch (Throwable throwable1) {
-            try {
-                access.close();
-            } catch (Throwable throwable) {
-                throwable1.addSuppressed(throwable);
-            }
-
-            throw throwable1;
         }
 
-        access.close();
         return placedAmount.getValue() > 0;
     }
 

--- a/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/StandardVeinGenerator.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/StandardVeinGenerator.java
@@ -187,9 +187,7 @@ public class StandardVeinGenerator extends VeinGenerator {
             }
         }
 
-        BulkSectionAccess access = new BulkSectionAccess(level);
-
-        try {
+        try (BulkSectionAccess access = new BulkSectionAccess(level)) {
             for(int j4 = 0; j4 < size; ++j4) {
                 double d9 = shape[j4 * 4 + 3];
                 if (!(d9 < 0.0D)) {
@@ -258,17 +256,8 @@ public class StandardVeinGenerator extends VeinGenerator {
                     }
                 }
             }
-        } catch (Throwable throwable1) {
-            try {
-                access.close();
-            } catch (Throwable throwable) {
-                throwable1.addSuppressed(throwable);
-            }
-
-            throw throwable1;
         }
 
-        access.close();
         return placedAmount.getValue() > 0;
     }
 }

--- a/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/VeinedVeinGenerator.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/VeinedVeinGenerator.java
@@ -27,7 +27,8 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.BulkSectionAccess;
 import net.minecraft.world.level.chunk.LevelChunkSection;
-import net.minecraft.world.level.levelgen.*;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.blending.Blender;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -113,7 +114,6 @@ public class VeinedVeinGenerator extends VeinGenerator {
         List<? extends Map.Entry<Integer, VeinBlockDefinition>> commonEntries = oreBlocks.stream().map(b -> Map.entry(b.weight, b)).toList();
         List<? extends Map.Entry<Integer, VeinBlockDefinition>> rareEntries = rareBlocks == null ? null : rareBlocks.stream().map(b -> Map.entry(b.weight, b)).toList(); // never accessed if rareBlocks is null
 
-        BulkSectionAccess access = new BulkSectionAccess(level);
         RandomState randomState = level.getLevel().getChunkSource().randomState();
         Blender blender;
         if (level instanceof WorldGenRegion region) {
@@ -133,92 +133,93 @@ public class VeinedVeinGenerator extends VeinGenerator {
         int randOffsetY = random.nextInt(16);
         int randOffsetZ = random.nextInt(16);
 
-        for (int x = origin.getX() - size; x < origin.getX() + size; ++x) {
-            for (int y = origin.getY() - size; y < origin.getY() + size; ++y) {
-                for (int z = origin.getZ() - size; z < origin.getZ() + size; ++z) {
-                    final int finalX = x;
-                    final int finalY = y;
-                    final int finalZ = z;
-                    DensityFunction.FunctionContext functionContext = new DensityFunction.FunctionContext() {
-                        @Override
-                        public int blockX() {
-                            return finalX + randOffsetX;
-                        }
 
-                        @Override
-                        public int blockY() {
-                            return finalY + randOffsetY;
-                        }
-
-                        @Override
-                        public int blockZ() {
-                            return finalZ + randOffsetZ;
-                        }
-
-                        @Override
-                        public Blender getBlender() {
-                            return finalizedBlender;
-                        }
-                    };
-
-                    double toggleNoise = veinToggle.compute(functionContext);
-                    int blockY = origin.getY();
-                    double absToggleNoise = Math.abs(toggleNoise);
-                    int minY = blockY - this.minYLevel;
-                    int maxY = this.maxYLevel - blockY;
-                    if (minY < 0 || maxY < 0) {
-                        continue;
-                    }
-                    int lowY = Math.min(maxY, minY);
-                    double edgeRoundoff = Mth.clampedMap(lowY, 0.0, edgeRoundoffBegin, -maxEdgeRoundoff, 0.0);
-                    if (absToggleNoise + edgeRoundoff < veininessThreshold) {
-                        continue;
-                    }
-                    if (random.nextFloat() > entry.getDensity()) {
-                        continue;
-                    }
-                    if (veinRidged.compute(functionContext) >= 0.0) {
-                        continue;
-                    }
-                    double chance = Mth.clampedMap(absToggleNoise, veininessThreshold, maxRichnessThreshold, minRichness, maxRichness);
-
-                    BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(finalX, finalY, finalZ);
-                    LevelChunkSection section = access.getSection(pos);
-                    if (section == null)
-                        continue;
-                    int sectionX = SectionPos.sectionRelative(pos.getX());
-                    int sectionY = SectionPos.sectionRelative(pos.getY());
-                    int sectionZ = SectionPos.sectionRelative(pos.getZ());
-                    if (!level.ensureCanWrite(pos))
-                        continue;
-                    BlockState current = section.getBlockState(sectionX, sectionY, sectionZ);
-                    boolean placed = false;
-                    if (random.nextFloat() <= entry.getDensity()) {
-                        if (random.nextFloat() < chance) {
-                            if (rareBlocks != null && !rareBlocks.isEmpty() && random.nextFloat() < rareBlockChance) {
-                                placed = placeOre(rareBlocks.get(GTUtil.getRandomItem(random, rareEntries, rareEntries.size())).block, current, access, section, random, pos, entry);
-                            } else {
-                                placed = placeOre(oreBlocks.get(GTUtil.getRandomItem(random, commonEntries, commonEntries.size())).block, current, access, section, random, pos, entry);
+        try (BulkSectionAccess access = new BulkSectionAccess(level)) {
+            for (int x = origin.getX() - size; x < origin.getX() + size; ++x) {
+                for (int y = origin.getY() - size; y < origin.getY() + size; ++y) {
+                    for (int z = origin.getZ() - size; z < origin.getZ() + size; ++z) {
+                        final int finalX = x;
+                        final int finalY = y;
+                        final int finalZ = z;
+                        DensityFunction.FunctionContext functionContext = new DensityFunction.FunctionContext() {
+                            @Override
+                            public int blockX() {
+                                return finalX + randOffsetX;
                             }
-                        } else {
-                            if (fillerBlock == null || fillerBlock.isAir())
-                                continue;
-                            if (!GTOreFeature.canPlaceOre(current, level::getBlockState, random, entry, pos))
-                                continue;
-                            section.setBlockState(sectionX, sectionY, sectionZ, fillerBlock, false);
-                            if (level.getBlockState(pos) != current) placed = true;
-                        }
-                    }
 
-                    if (placed)  {
-                        ++placedCount;
+                            @Override
+                            public int blockY() {
+                                return finalY + randOffsetY;
+                            }
+
+                            @Override
+                            public int blockZ() {
+                                return finalZ + randOffsetZ;
+                            }
+
+                            @Override
+                            public Blender getBlender() {
+                                return finalizedBlender;
+                            }
+                        };
+
+                        double toggleNoise = veinToggle.compute(functionContext);
+                        int blockY = origin.getY();
+                        double absToggleNoise = Math.abs(toggleNoise);
+                        int minY = blockY - this.minYLevel;
+                        int maxY = this.maxYLevel - blockY;
+                        if (minY < 0 || maxY < 0) {
+                            continue;
+                        }
+                        int lowY = Math.min(maxY, minY);
+                        double edgeRoundoff = Mth.clampedMap(lowY, 0.0, edgeRoundoffBegin, -maxEdgeRoundoff, 0.0);
+                        if (absToggleNoise + edgeRoundoff < veininessThreshold) {
+                            continue;
+                        }
+                        if (random.nextFloat() > entry.getDensity()) {
+                            continue;
+                        }
+                        if (veinRidged.compute(functionContext) >= 0.0) {
+                            continue;
+                        }
+                        double chance = Mth.clampedMap(absToggleNoise, veininessThreshold, maxRichnessThreshold, minRichness, maxRichness);
+
+                        BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos(finalX, finalY, finalZ);
+                        LevelChunkSection section = access.getSection(pos);
+                        if (section == null)
+                            continue;
+                        int sectionX = SectionPos.sectionRelative(pos.getX());
+                        int sectionY = SectionPos.sectionRelative(pos.getY());
+                        int sectionZ = SectionPos.sectionRelative(pos.getZ());
+                        if (!level.ensureCanWrite(pos))
+                            continue;
+                        BlockState current = section.getBlockState(sectionX, sectionY, sectionZ);
+                        boolean placed = false;
+                        if (random.nextFloat() <= entry.getDensity()) {
+                            if (random.nextFloat() < chance) {
+                                if (rareBlocks != null && !rareBlocks.isEmpty() && random.nextFloat() < rareBlockChance) {
+                                    placed = placeOre(rareBlocks.get(GTUtil.getRandomItem(random, rareEntries, rareEntries.size())).block, current, access, section, random, pos, entry);
+                                } else {
+                                    placed = placeOre(oreBlocks.get(GTUtil.getRandomItem(random, commonEntries, commonEntries.size())).block, current, access, section, random, pos, entry);
+                                }
+                            } else {
+                                if (fillerBlock == null || fillerBlock.isAir())
+                                    continue;
+                                if (!GTOreFeature.canPlaceOre(current, level::getBlockState, random, entry, pos))
+                                    continue;
+                                section.setBlockState(sectionX, sectionY, sectionZ, fillerBlock, false);
+                                if (level.getBlockState(pos) != current) placed = true;
+                            }
+                        }
+
+                        if (placed) {
+                            ++placedCount;
+                        }
                     }
                 }
             }
-
         }
 
-        access.close();
         return placedCount > 0;
     }
 


### PR DESCRIPTION
Fixes a deadlock with worldgen threads, where `BulkSectionAccess` would sometimes not be closed. This was solved using try-with-resources statements to leverage it implementing `AutoCloseable`.

Needs further verification if this actually resolves the error in all scenarios.