### PR TITLE
fix turbines energy gen off by factor of turbine efficiency

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -96,7 +96,7 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
                     turbineMachine.excessVoltage += (int) (maxParallel * EUt * holderEfficiency - turbineMaxVoltage);
                     var parallelResult = GTRecipeModifiers.fastParallel(turbineMachine, recipe, Math.max(1, maxParallel), false);
                     recipe = parallelResult.getA() == recipe ? recipe.copy() : parallelResult.getA();
-                    long eut = turbineMachine.boostProduction(EUt * parallelResult.getB());
+                    long eut = turbineMachine.boostProduction((long) (EUt * holderEfficiency * parallelResult.getB()));
                     recipe.tickOutputs.put(EURecipeCapability.CAP, List.of(new Content(eut, 1.0f, 0.0f, null, null)));
                     return recipe;
                 }


### PR DESCRIPTION
this fix increases the EU/t output of turbines to the value given by [turbineMaxVoltage](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/common/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java#L88) at max speed and keeps the turbine efficiency effect of reducing fuel usage
closes #363 