### PR TITLE
Decrease minimum casings for large engraving laser

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/common/data/GCyMMachines.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/common/data/GCyMMachines.java
@@ -346,7 +346,7 @@ public class GCyMMachines {
                     .aisle("XXSXX","XXGXX","XXGXX","XXXXX")
                     .where('S', controller(blocks(definition.get())))
                     .where('C', blocks(CASING_TUNGSTENSTEEL_PIPE.get()))
-                    .where('X', blocks(CASING_LASER_SAFE_ENGRAVING.get()).setMinGlobalLimited(50)
+                    .where('X', blocks(CASING_LASER_SAFE_ENGRAVING.get()).setMinGlobalLimited(45)
                             .or(Predicates.autoAbilities(definition.getRecipeTypes()))
                             .or(Predicates.autoAbilities(true, false, true)))
                     .where('G', blocks(CASING_TEMPERED_GLASS.get()))


### PR DESCRIPTION
allow for having one bus per lens color + parallel hatch (up to 16 input buses +parallel hatch)