### PR TITLE
Switch Certus Quartz material amount to 4 to be on par with AE2's own Certus recipes

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -895,6 +895,7 @@ public class TagPrefix {
             // Blocks (4 materials)
             Map.entry(new UnificationEntry(TagPrefix.block, GTMaterials.Amethyst), GTValues.M * 4),
             Map.entry(new UnificationEntry(TagPrefix.block, GTMaterials.Brick), GTValues.M * 4),
+            Map.entry(new UnificationEntry(TagPrefix.block, GTMaterials.CertusQuartz), GTValues.M * 4),
             Map.entry(new UnificationEntry(TagPrefix.block, GTMaterials.Clay), GTValues.M * 4),
             Map.entry(new UnificationEntry(TagPrefix.block, GTMaterials.Glowstone), GTValues.M * 4),
             Map.entry(new UnificationEntry(TagPrefix.block, GTMaterials.NetherQuartz), GTValues.M * 4),


### PR DESCRIPTION
As AE2's own Certus Quartz blocks now use 4 crystals to craft instead of 9, this should provide some parity again.