### PR TITLE
Adjust recipe copy to not modify amount of non consumed items

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -34,7 +34,7 @@ public class Content {
     }
 
     public Content copy(RecipeCapability<?> capability, @Nullable ContentModifier modifier) {
-        if (modifier == null) {
+        if (modifier == null || chance == 0) {
             return new Content(capability.copyContent(content), chance, tierChanceBoost, slotName, uiName);
         } else {
             return new Content(capability.copyContent(content, modifier), chance, tierChanceBoost, slotName, uiName);


### PR DESCRIPTION
This change makes it so recipes using non consumed items like a programmed circuit can run in parallel with the parallel hatch.

Non consumed items have [chance set to 0](https://github.com/GregTechCEu/GregTech-Modern/blob/1.19.2/common/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java#L301), so we can exclude them from adjustment in the recipe content copying function.

I chose this spot to make the change because it seemed like the simplest place to make it. I followed [this recipeModifier](https://github.com/GregTechCEu/GregTech-Modern/blob/1.19.2/common/src/main/java/com/gregtechceu/gtceu/common/data/GCyMMachines.java#L62) which leads to the adjusted recipe copy [here](https://github.com/GregTechCEu/GregTech-Modern/blob/1.19.2/common/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java#L97) which calls the Content copy [here](https://github.com/GregTechCEu/GregTech-Modern/blob/1.19.2/common/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java#L67)

Hopefully that all makes sense! I did test this quickly on 1.20.1 with the Bender multiblock where it was correctly taking 256 ingots and turning them into 256 plates at once on program 1