### PR TITLE
fix: findBestFreeChannel finds the actual best free channel

### DIFF
--- a/common/src/main/java/com/gregtechceu/gtceu/common/pipelike/fluidpipe/FluidPipeNet.java
+++ b/common/src/main/java/com/gregtechceu/gtceu/common/pipelike/fluidpipe/FluidPipeNet.java
@@ -163,8 +163,8 @@ public class FluidPipeNet extends PipeNet<FluidPipeData> {
 
         long leastUsedAmount = Long.MAX_VALUE;
         int bestChannel = -1;
-
-        for (int channel = 0; channel < channelFluids.length; channel++) {
+        var nodeData = getNodeAt(BlockPos.of(pos)).data;
+        for (int channel = 0; channel < nodeData.properties.getChannels(); channel++) {
             if (channelFluids[channel] != null)
                 continue;
 


### PR DESCRIPTION
Fixes #600

In FluidPipeBlockEntityImpl on both forge and fabric, checkPathAvailable isn't getting the right channel when calling net.useChannel, because in FluidPipeNet, findBestFreeChannel searches for the channel with the least throughput over all possible channels from 0 to MAX_PIPE_CHANNELS instead of the channels actually available in the pipe.

So, if there's only 1 channel and that channel had steam in it from a different boiler, then the channel with the least throughput is channel 1 instead of channel 0.