### PR TITLE
Now the hoes are working properly 2

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
@@ -79,7 +79,7 @@ public class GTToolType {
             .toolTag(FABRIC, TagUtil.createItemTag("hoes", true))
             .harvestTag(FORGE, TagUtil.createBlockTag("mineable/hoe", true))
             .harvestTag(FABRIC, TagUtil.createBlockTag("mineable/hoe", true))
-            .toolStats(b -> b.cannotAttack().attackSpeed(-1.0F))
+            .toolStats(b -> b.cannotAttack().attackSpeed(-1.0F).behaviors(HoeGroundBehavior.INSTANCE))
             .constructor(GTHoeItem::create)
             .build();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/HoeGroundBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/HoeGroundBehavior.java
@@ -58,8 +58,7 @@ public class HoeGroundBehavior implements IToolBehavior {
 
         Set<BlockPos> blocks;
         // only attempt to till if the center block is tillable
-        Block hitBlock = world.getBlockState(pos).getBlock();
-        if (HoeItem.TILLABLES.containsKey(hitBlock) && HoeItem.TILLABLES.get(hitBlock).getFirst().test(context)) {
+        if (isBlockTillable(stack, world, player, pos, context)) {
             if (aoeDefinition == AoESymmetrical.none()) {
                 blocks = ImmutableSet.of(pos);
             } else {
@@ -82,15 +81,12 @@ public class HoeGroundBehavior implements IToolBehavior {
         boolean tilled = false;
         for (BlockPos blockPos : blocks) {
             BlockState state = world.getBlockState(blockPos);
-            Block block = state.getBlock();
-            if (HoeItem.TILLABLES.containsKey(block)) {
-                tilled |= tillGround(new UseOnContext(player, hand, context.getHitResult().withPosition(blockPos)), state);
-                if (!player.isCreative()) {
-                    ToolHelper.damageItem(context.getItemInHand(), context.getPlayer());
-                }
-                if (stack.isEmpty())
-                    break;
+            tilled |= tillGround(new UseOnContext(player, hand, context.getHitResult().withPosition(blockPos)), state);
+            if (!player.isCreative()) {
+                ToolHelper.damageItem(context.getItemInHand(), context.getPlayer());
             }
+            if (stack.isEmpty())
+                break;
         }
 
         if (tilled) {


### PR DESCRIPTION
## What
Fixed the operation of the hoe in various situations

## Implementation Details
Added a behavior for the hoe, which apparently forgot to add.
Changed how the behavior understands whether the block can be tilled. Previously, methods from vanilla hoe were used, which is not correct, since this restricts the use of hoes only on vanilla land, now the getToolModifiedState method is used and the hoe works with mod blocks. This has been done in all other behaviors, so I just migrated the logic.

## Outcome
Now the hoes are working properly! yay

## Additional Info

Tested on vanilla dirt, grass, also tested with tfc grass, dirt, now all works fine

Fixes https://github.com/GregTechCEu/GregTech-Modern/issues/707