### PR TITLE
restore sio2 ebf recipe to what it was in 1.12

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -747,8 +747,8 @@ public class MachineRecipeLoader {
                 .outputFluids(SulfurDioxide.getFluid(2000))
                 .save(provider);
 
-        BLAST_RECIPES.recipeBuilder("blast_silicon_dioxide").duration(240).EUt(VA[MV]).blastFurnaceTemp(1200)
-                .inputItems(dust, SiliconDioxide)
+        BLAST_RECIPES.recipeBuilder("blast_silicon_dioxide").duration(240).EUt(VA[MV]).blastFurnaceTemp(2273)
+                .inputItems(dust, SiliconDioxide, 3)
                 .inputItems(dust, Carbon, 2)
                 .outputItems(ingotHot, Silicon)
                 .outputItems(dustTiny, Ash)


### PR DESCRIPTION
Silicon used to be gated on Kanthal coils.

The new SiO2 recipe seems suspiciously different, it used to be 3x SiO2 to create 1 silicon ingot (and 3x SiO2 for 1 silicon dust in the electrolyzer).:

![2024-01-19_13 29 28](https://github.com/GregTechCEu/GregTech-Modern/assets/218132/88f7c26d-e44a-4240-96e3-590bd17bba50)

Assuming this was an oversight/mistake, this should restore the old recipe.