### PR TITLE
add fluid stored tooltip to all fluid cells

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/ThermalFluidStats.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/ThermalFluidStats.java
@@ -4,17 +4,25 @@ import com.gregtechceu.gtceu.api.item.component.forge.IComponentCapability;
 import com.gregtechceu.gtceu.api.misc.forge.SimpleThermalFluidHandlerItemStack;
 import com.gregtechceu.gtceu.api.misc.forge.ThermalFluidHandlerItemStack;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import net.minecraft.network.chat.Component;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
+import com.lowdragmc.lowdraglib.side.fluid.FluidTransferHelper;
+import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * @author KilaBash
  * @date 2023/2/22
  * @implNote ThermalFluidStats
  */
-public class ThermalFluidStats implements IItemComponent, IComponentCapability {
+public class ThermalFluidStats implements IItemComponent, IComponentCapability, IAddInformation {
     public final int capacity;
     public final int maxFluidTemperature;
     public final boolean gasProof;
@@ -48,5 +56,13 @@ public class ThermalFluidStats implements IItemComponent, IComponentCapability {
             }));
         }
         return LazyOptional.empty();
+    }
+
+    @Override
+    public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltipComponents, TooltipFlag isAdvanced) {
+        if (stack.hasTag()) {
+            FluidStack tank = FluidTransferHelper.getFluidContained(stack);
+            tooltipComponents.add(Component.translatable("gtceu.universal.tooltip.fluid_stored", tank.getDisplayName(), tank.getAmount()));
+        }
     }
 }


### PR DESCRIPTION
This adds the fluid hover tooltip to fluid cells.  It shows even when `this.allowPartialFill` is false, that's an easy change if that's not desirable. This could probably show capacity as well.

Not too sure about sidedness and if this is going to go client only, reviewer should check to make sure this is not an issue.

![fluid-hover-stats-2](https://github.com/GregTechCEu/GregTech-Modern/assets/218132/ab0de8b7-dcef-4d31-8d09-3cbddf2f6a93)

![fluid-hover-stats](https://github.com/GregTechCEu/GregTech-Modern/assets/218132/8a5dfdc3-b499-4ad6-9de8-2a4609ab5a42)
