### PR TITLE
Add setMaterialSecondaryARGB

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -319,8 +319,12 @@ public class Material implements Comparable<Material> {
         return getProperty(PropertyKey.TOOL).getHarvestLevel();
     }
 
-    public void setMaterialRGB(int materialRGB) {
+    public void setMaterialARGB(int materialRGB) {
         materialInfo.colors.set(0, materialRGB);
+    }
+
+    public void setMaterialSecondaryARGB(int materialRGB) {
+        materialInfo.colors.set(1, materialRGB);
     }
 
     public int getLayerARGB(int layerIndex) {


### PR DESCRIPTION
This is added as a counterpart to `setMaterialRGB` (which I have renamed to `setMaterialARGB` to be consistent with other methods). I'm adding `setMaterialSecondaryARGB` because currently to set material secondary colors in kubejs you need to do:
`GTMaterials.Diamond.getMaterialInfo().setColors([0xff0000, 0xff0000, -1, -1, -1, -1, -1, -1, -1, -1])`
Whereas with this change its as easy as the primary color:
`GTMaterials.Diamond.setMaterialSecondaryARGB(0xff0000)`