### PR TITLE
fix crash when loading recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/FluidPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/FluidPipeBlockEntity.java
@@ -108,10 +108,12 @@ public class FluidPipeBlockEntity extends PipeBlockEntity<FluidPipeType, FluidPi
     @Override
     public <T> LazyOptional<T> getCapability(Capability<T> capability, @Nullable Direction facing) {
         if (capability == ForgeCapabilities.FLUID_HANDLER) {
-            PipeTankList tankList = getTankList(facing);
-            if (tankList == null)
-                return LazyOptional.empty();
-            return ForgeCapabilities.FLUID_HANDLER.orEmpty(capability, LazyOptional.of(() -> FluidTransferHelperImpl.toFluidHandler(tankList)));
+            if (facing != null && isConnected(facing)) {
+                PipeTankList tankList = getTankList(facing);
+                if (tankList == null)
+                    return LazyOptional.empty();
+                return ForgeCapabilities.FLUID_HANDLER.orEmpty(capability, LazyOptional.of(() -> FluidTransferHelperImpl.toFluidHandler(tankList)));
+            }
         } else if (capability == GTCapability.CAPABILITY_COVERABLE) {
             return GTCapability.CAPABILITY_COVERABLE.orEmpty(capability, LazyOptional.of(this::getCoverContainer));
         } else if (capability == GTCapability.CAPABILITY_TOOLABLE) {

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/ItemPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/ItemPipeBlockEntity.java
@@ -72,9 +72,11 @@ public class ItemPipeBlockEntity extends PipeBlockEntity<ItemPipeType, ItemPipeP
             if (world.isClientSide())
                 return LazyOptional.empty();
 
-            ensureHandlersInitialized();
-            checkNetwork();
-            return ForgeCapabilities.ITEM_HANDLER.orEmpty(cap, LazyOptional.of(() -> ItemTransferHelperImpl.toItemHandler(getHandler(side, true))));
+            if (side != null && isConnected(side)) {
+                ensureHandlersInitialized();
+                checkNetwork();
+                return ForgeCapabilities.ITEM_HANDLER.orEmpty(cap, LazyOptional.of(() -> ItemTransferHelperImpl.toItemHandler(getHandler(side, true))));
+            }
         } else if (cap == GTCapability.CAPABILITY_COVERABLE) {
             return GTCapability.CAPABILITY_COVERABLE.orEmpty(cap, LazyOptional.of(this::getCoverContainer));
         } else if (cap == GTCapability.CAPABILITY_TOOLABLE) {

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
@@ -36,14 +36,18 @@ public abstract class RecipeManagerMixin {
                     var type = entry.getKey();
                     var recipes = entry.getValue();
                     recipes.clear();
-                    for (var recipe : this.recipes.get(type).entrySet()) {
-                        recipes.add(gtRecipeType.toGTrecipe(recipe.getKey(), recipe.getValue()));
+                    if (this.recipes.containsKey(type)) {
+                        for (var recipe : this.recipes.get(type).entrySet()) {
+                            recipes.add(gtRecipeType.toGTrecipe(recipe.getKey(), recipe.getValue()));
+                        }
                     }
                 }
 
-                for (Map.Entry<ResourceLocation, Recipe<?>> recipe : this.recipes.get(gtRecipeType).entrySet()) {
-                    if (recipe.getValue() instanceof GTRecipe gtRecipe) {
-                        gtRecipeType.getLookup().addRecipe(gtRecipe);
+                if (this.recipes.containsKey(gtRecipeType)) {
+                    for (Map.Entry<ResourceLocation, Recipe<?>> recipe : this.recipes.get(gtRecipeType).entrySet()) {
+                        if (recipe.getValue() instanceof GTRecipe gtRecipe) {
+                            gtRecipeType.getLookup().addRecipe(gtRecipe);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -344,13 +344,11 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
     @Override
     public void injectRuntimeRecipes(RecipesEventJS event, RecipeManager manager, Map<ResourceLocation, Recipe<?>> recipesByName) {
-
-
         // (jankily) parse all GT recipes for extra ones to add, modify
         RecipesEventJS.runInParallel((() -> event.addedRecipes.forEach(recipe -> {
             if (recipe instanceof GTRecipeSchema.GTRecipeJS gtRecipe) {
                 // get the recipe ID without the leading type path
-                GTRecipeBuilder builder = ((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(gtRecipe.type.id)).recipeBuilder(new ResourceLocation(gtRecipe.id.getNamespace(), gtRecipe.id.getPath().split(Pattern.quote(gtRecipe.type.id.getPath()) + "/")[1]));
+                GTRecipeBuilder builder = ((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(gtRecipe.type.id)).recipeBuilder(gtRecipe.idWithoutType());
 
                 if (gtRecipe.getValue(GTRecipeSchema.DURATION) != null) {
                     builder.duration = gtRecipe.getValue(GTRecipeSchema.DURATION).intValue();

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -31,6 +31,7 @@ import dev.latvian.mods.kubejs.recipe.component.BooleanComponent;
 import dev.latvian.mods.kubejs.recipe.component.TimeComponent;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
 import dev.latvian.mods.rhino.util.HideFromJS;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import net.minecraft.nbt.CompoundTag;
@@ -56,11 +57,14 @@ public interface GTRecipeSchema {
         public float chance = 1;
         @Setter
         public float tierChanceBoost = 0;
+        @Getter
+        private ResourceLocation idWithoutType;
 
         @HideFromJS
         @Override
         public GTRecipeJS id(ResourceLocation _id) {
-            this.id = new ResourceLocation(_id.getNamespace().equals("minecraft") ? this.type.id.getNamespace() : _id.getNamespace(), "%s/%s".formatted(this.type.id.getPath(), _id.getPath()));
+            this.idWithoutType = new ResourceLocation(_id.getNamespace().equals("minecraft") ? this.type.id.getNamespace() : _id.getNamespace(), _id.getPath());
+            this.id = new ResourceLocation(idWithoutType.getNamespace(), "%s/%s".formatted(this.type.id.getPath(), idWithoutType.getPath()));
             return this;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/IngredientEquality.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/IngredientEquality.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.core.mixins.IngredientAccessor;
 import com.gregtechceu.gtceu.core.mixins.StrictNBTIngredientAccessor;
 import com.gregtechceu.gtceu.core.mixins.TagValueAccessor;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.StrictNBTIngredient;
 
@@ -45,8 +46,12 @@ public class IngredientEquality {
                     if (!(value2 instanceof Ingredient.ItemValue)) {
                         return false;
                     }
-                    if (!value1.getItems().containsAll(value2.getItems())) {
-                        return false;
+                    for (ItemStack item1 : value1.getItems()) {
+                        for (ItemStack item2 : value2.getItems()) {
+                            if (!ItemStack.isSameItemSameTags(item1, item2)) {
+                                return false;
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What
fixes a crash when loading the recipe lookup tree.

## Implementation Details
added a null check to the mixin that adds recipes to the lookup table.

## Outcome
no crash

## Additional Information
None

## Potential Compatibility Issues
None