### PR TITLE
fix: PA multi can form again (remove MACHINE_HATCH PartAbility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,6 @@
 # ChangeLog
 
-Version: 1.1.3.a
-
-### ADDITIONS:
-- added Creative Chest, Creative Tank
-- added a title bar and new multiblock part selector to machine UIs
-- added world accelerators
+Version: 1.1.3.b
 
 ### FIXES:
-- fixed crashes related to KubeJS recipe loading
-- fixed ore block maceration not working
-- fixed high tier tools (duranium, neutronium) not working
-- fixed electric furnace / multismelter recipes not working
-- fixed transformers always having 1A storage
-
-### CHANGES:
-- replaced Tungstensteel coils with RTM-Alloy coils 
-- updated Russian and Chinese translations
+- fixed processing array being unable to form

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx6G
 # Mod Info
 mod_id = gtceu
 mod_name = GregTech
-mod_version = 1.1.3.a
+mod_version = 1.1.3.b
 mod_description = GregTech CE Unofficial, ported from 1.12.2
 mod_license = LGPL-3.0 license
 mod_url = https://github.com/GregTechCEu/GregTech-Modern/

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/PartAbility.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/PartAbility.java
@@ -44,7 +44,6 @@ public class PartAbility {
     public static final PartAbility STEAM_EXPORT_ITEMS = new PartAbility("steam_export_items");
     public static final PartAbility MAINTENANCE = new PartAbility("maintenance");
     public static final PartAbility MUFFLER = new PartAbility("muffler");
-    public static final PartAbility MACHINE_HATCH = new PartAbility("machine_hatch");
     public static final PartAbility TANK_VALVE = new PartAbility("tank_valve");
     public static final PartAbility PASSTHROUGH_HATCH = new PartAbility("passthrough_hatch");
     public static final PartAbility PARALLEL_HATCH = new PartAbility("parallel_hatch");

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -1607,7 +1607,6 @@ public class GTMachines {
                                     .or(Predicates.abilities(PartAbility.IMPORT_FLUIDS).setPreviewCount(1))
                                     .or(Predicates.abilities(PartAbility.EXPORT_FLUIDS).setPreviewCount(1))
                                     .or(Predicates.abilities(PartAbility.INPUT_ENERGY).setMinGlobalLimited(1).setMaxGlobalLimited(4).setPreviewCount(1))
-                                    .or(Predicates.abilities(PartAbility.MACHINE_HATCH).setExactLimit(1))
                                     .or(Predicates.autoAbilities(true, false, false)))
                             .where('C', blocks(CLEANROOM_GLASS.get()))
                             .where('#', Predicates.air())


### PR DESCRIPTION
## What
Fixes processing arrays not being able to form due to a `PartAbility` that was left from a previously rollbacked changed.