### PR TITLE
Added Overworld Dimension Requirement to All "overworld" Fluid veins

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
@@ -31,7 +31,6 @@ public class GTBedrockFluids {
     //////////////////////////////////////
     //********     OVERWORLD    ********//
     //////////////////////////////////////
-    //Added overworld Dimension requirements to overworld veins to prevent modded dim generation
     public static BedrockFluidDefinition HEAVY_OIL = BedrockFluidDefinition.builder(GTCEu.id("heavy_oil_deposit"))
             .fluid(GTMaterials.OilHeavy::getFluid)
             .weight(15)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
@@ -31,6 +31,7 @@ public class GTBedrockFluids {
     //////////////////////////////////////
     //********     OVERWORLD    ********//
     //////////////////////////////////////
+    //Added overworld Dimension requirements to overworld veins to prevent modded dim generation
     public static BedrockFluidDefinition HEAVY_OIL = BedrockFluidDefinition.builder(GTCEu.id("heavy_oil_deposit"))
             .fluid(GTMaterials.OilHeavy::getFluid)
             .weight(15)
@@ -40,6 +41,7 @@ public class GTBedrockFluids {
             .depletedYield(20)
             .biomes(5, BiomeTags.IS_OCEAN)
             .biomes(10, CustomTags.IS_SANDY)
+            .dimensions(overworld())
             .register();
 
     public static BedrockFluidDefinition LIGHT_OIL = BedrockFluidDefinition.builder(GTCEu.id("light_oil_deposit"))
@@ -49,6 +51,7 @@ public class GTBedrockFluids {
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(25)
+            .dimensions(overworld())
             .register();
 
     public static BedrockFluidDefinition NATURAL_GAS = BedrockFluidDefinition.builder(GTCEu.id("natural_gas_deposit"))
@@ -58,6 +61,7 @@ public class GTBedrockFluids {
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(20)
+            .dimensions(overworld())
             .register();
 
     public static BedrockFluidDefinition OIL = BedrockFluidDefinition.builder(GTCEu.id("oil_deposit"))
@@ -69,6 +73,7 @@ public class GTBedrockFluids {
             .depletedYield(25)
             .biomes(5, BiomeTags.IS_OCEAN)
             .biomes(5, CustomTags.IS_SANDY)
+            .dimensions(overworld())
             .register();
 
     public static BedrockFluidDefinition RAW_OIL = BedrockFluidDefinition.builder(GTCEu.id("raw_oil_deposit"))
@@ -78,6 +83,7 @@ public class GTBedrockFluids {
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(25)
+            .dimensions(overworld())
             .register();
 
     public static BedrockFluidDefinition SALT_WATER = BedrockFluidDefinition.builder(GTCEu.id("salt_water_deposit"))
@@ -87,6 +93,7 @@ public class GTBedrockFluids {
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(15)
+            .dimensions(overworld())
             .biomes(200, Biomes.DEEP_OCEAN, Biomes.DEEP_COLD_OCEAN, Biomes.DEEP_FROZEN_OCEAN)
             .biomes(150, BiomeTags.IS_OCEAN)
             .register();
@@ -120,5 +127,8 @@ public class GTBedrockFluids {
 
     public static Set<ResourceKey<Level>> nether() {
         return Set.of(Level.NETHER);
+    }
+    public static Set<ResourceKey<Level>> overworld() {
+        return Set.of(Level.OVERWORLD);
     }
 }


### PR DESCRIPTION
## What
This PR Fixes the issue regarding bedrock fluid veins that are meant to generate in the overworld generating in "ANY" dimension

## Implementation Details
All this does is set the required dimension for all overworld veins to the overworld

## Outcome
All Bedrock Veins under the "Overworld" Section now no longer generate in modded dimensions, etc
