### PR TITLE
Fix RecipeManagerMixin not discovering proxy recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
@@ -54,8 +54,7 @@ public abstract class RecipeManagerMixin {
                         .forEach(gtRecipe -> gtRecipeType.getLookup().addRecipe(gtRecipe));
                 } else if (!proxyRecipes.isEmpty()) {
                     proxyRecipes.values().stream()
-                        .filter(GTRecipe.class::isInstance)
-                        .map(GTRecipe.class::cast)
+                        .flatMap(List::stream)
                         .forEach(gtRecipe -> gtRecipeType.getLookup().addRecipe(gtRecipe));
                 }
             }


### PR DESCRIPTION
## What
RecipeManagerMixin had a wonky cast that was causing proxy recipes to not be correctly added to recipe lookups.

## Outcome
Fixes any bugs with vanilla/other mods' recipes not working correctly.
Closes: #921 
Closes: #916 