### PR TITLE
Make defensive copies of GTRecipe.conditions list

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -79,7 +79,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     }
 
     public GTRecipe copy() {
-        return new GTRecipe(recipeType, id, copyContents(inputs, null), copyContents(outputs, null), copyContents(tickInputs, null), copyContents(tickOutputs, null), conditions, data, duration, isFuel);
+        return new GTRecipe(recipeType, id, copyContents(inputs, null), copyContents(outputs, null), copyContents(tickInputs, null), copyContents(tickOutputs, null), new ArrayList<>(conditions), data, duration, isFuel);
     }
 
     public GTRecipe copy(ContentModifier modifier) {
@@ -87,7 +87,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     }
 
     public GTRecipe copy(ContentModifier modifier, boolean modifyDuration) {
-        var copied = new GTRecipe(recipeType, id, copyContents(inputs, modifier), copyContents(outputs, modifier), copyContents(tickInputs, modifier), copyContents(tickOutputs, modifier), conditions, data, duration, isFuel);
+        var copied = new GTRecipe(recipeType, id, copyContents(inputs, modifier), copyContents(outputs, modifier), copyContents(tickInputs, modifier), copyContents(tickOutputs, modifier), new ArrayList<>(conditions), data, duration, isFuel);
         if (modifyDuration) {
             copied.duration = modifier.apply(this.duration).intValue();
         }


### PR DESCRIPTION
## What
This PR fixes the `GTRecipe.copy` methods to make copies of the `conditions` lists. Originally, the `Map` fields are all copied over, but the list was neglected.

## Implementation Details
Changes two `copy` methods to pass `new ArrayList<>(conditions)` instead of `conditions`.

## Outcome
This fixes a bug with Steam machines adding the VentCondition to all recipes, adding useless `instanceof IExhaustVentMachine` checks to regular machine logic.
More importantly, it attempts to fix the following ConcurrentModificationException (I couldn't reproduce it, but there have been instances where it has occurred)
```
Caused by: java.util.ConcasurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013) ~[?:?]
	at java.util.ArrayList$Itr.next(ArrayList.java:967) ~[?:?]
	at com.gregtechceu.gtceu.api.recipe.GTRecipe.checkConditions(GTRecipe.java:380) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at com.gregtechceu.gtceu.api.machine.trait.RecipeLogic.onRecipeFinish(RecipeLogic.java:465) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at com.gregtechceu.gtceu.api.machine.trait.RecipeLogic.serverTick(RecipeLogic.java:160) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at com.gregtechceu.gtceu.api.machine.TickableSubscription.run(TickableSubscription.java:23) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at com.gregtechceu.gtceu.api.machine.MetaMachine.executeTick(MetaMachine.java:274) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at com.gregtechceu.gtceu.api.machine.MetaMachine.serverTick(MetaMachine.java:246) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at com.gregtechceu.gtceu.api.block.IMachineBlock.lambda$getTicker$0(IMachineBlock.java:56) ~[gtceu-1.20.1-1.1.3.b-build_498.jar%23196!/:?]
	at net.minecraft.world.level.chunk.LevelChunk$BoundTickingBlockEntity.m_142224_(LevelChunk.java:689) ~[server-1.20.1-20230612.114412-srg.jar%23227!/:?]
	at net.minecraft.world.level.chunk.LevelChunk$RebindableTickingBlockEntityWrapper.m_142224_(LevelChunk.java:782) ~[server-1.20.1-20230612.114412-srg.jar%23227!/:?]
	at net.minecraft.world.level.Level.m_46463_(Level.java:468) ~[server-1.20.1-20230612.114412-srg.jar%23227!/:?]
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:351) ~[server-1.20.1-20230612.114412-srg.jar%23227!/:?]
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893) ~[server-1.20.1-20230612.114412-srg.jar%23227!/:?]
	... 5 more
```
Although I could not reproduce this crash, the only list modification of the `conditions` field happens in the SimpleSteamMachine class, whose `recipeModifier` method makes steam machine copies of recipes and adds the vent condition to them:
```java
@Nullable
public static GTRecipe recipeModifier(MetaMachine machine, @Nonnull GTRecipe recipe) {
    // ...
    var modified = recipe.copy();
    modified.conditions.add(VentCondition.INSTANCE);
    // ...
}
```
The problem here, which potentially causes a concurrent modification exception, is that the `conditions` field of the new copy of the recipe is the same one used in the original recipe, which may be being iterated through in the Server Thread. When `asyncRecipeSearching` is set to true in the config, the modification of the `conditions` list happens in a Worker Thread, which can modify the list while it is still being iterated in the Server Thread, thus triggering the ConcurrentModificationException.