### PR TITLE
Large boiler fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -1885,7 +1885,7 @@ public class GTMachines {
                 .langValue("Large %s Boiler".formatted(FormattingUtil.toEnglishName(name)))
                 .rotationState(RotationState.NON_Y_AXIS)
                 .recipeType(GTRecipeTypes.LARGE_BOILER_RECIPES)
-                .recipeModifier(LargeBoilerMachine::recipeModifier)
+                .recipeModifier(LargeBoilerMachine::recipeModifier, true)
                 .appearanceBlock(casing)
                 .partAppearance((controller, part, side) -> controller.self().getPos().below().getY() == part.self().getPos().getY() ? fireBox.get().defaultBlockState() : casing.get().defaultBlockState())
                 .pattern(definition -> FactoryBlockPattern.start()


### PR DESCRIPTION
Makes large boilers factor throttle into the display of steam generated and updates fuel consumption when throttle is changed instead of when it changes fuels.

Some of this is just guesswork, especially the timing part so please make sure I'm not breaking something horribly.