### PR TITLE
Add Ores Blocks in Collapsible Entry for REI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
@@ -1,10 +1,11 @@
 package com.gregtechceu.gtceu.integration.rei;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.integration.rei.multipage.MultiblockInfoDisplayCategory;
@@ -12,7 +13,6 @@ import com.gregtechceu.gtceu.integration.rei.oreprocessing.GTOreProcessingDispla
 import com.gregtechceu.gtceu.integration.rei.orevein.GTBedrockFluidDisplayCategory;
 import com.gregtechceu.gtceu.integration.rei.orevein.GTOreVeinDisplayCategory;
 import com.gregtechceu.gtceu.integration.rei.recipe.GTRecipeTypeDisplayCategory;
-import com.tterrag.registrate.util.entry.ItemProviderEntry;
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
@@ -22,9 +22,11 @@ import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.ItemLike;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static me.shedaniel.rei.plugin.common.BuiltinPlugin.SMELTING;
 
@@ -80,6 +82,38 @@ public class GTREIPlugin implements REIClientPlugin {
             registry.group(GTCEu.id("tool/" + toolType.name), Component.translatable("gtceu.tool.class." + toolType.name), EntryIngredients.ofItemTag(toolType.itemTags.get(0)));
             // EntryIngredients.ofItemStacks(GTItems.TOOL_ITEMS.column(toolType).values().stream().filter(Objects::nonNull).map(ItemProviderEntry::get).map(IGTTool::get).collect(Collectors.toSet()))
         }
+
+        for (var cell : GTBlocks.MATERIAL_BLOCKS.columnMap().entrySet()) {
+            var value = cell.getValue();
+            if (value.size() <= 1) continue;
+
+            var material = cell.getKey();
+            List<ItemLike> items = new ArrayList<>();
+            for (var t : value.entrySet()) {
+                var name = t.getKey().name;
+                if (Objects.equals(name, TagPrefix.frameGt.name) ||
+                    Objects.equals(name, TagPrefix.block.name) ||
+                    Objects.equals(name, TagPrefix.rawOreBlock.name))
+                    continue;
+
+                items.add(t.getValue());
+            }
+
+            var name = material.getName();
+            var label = ToUpperAllWords(name.replace("_", " "));
+            registry.group(GTCEu.id("ore/" + name), Component.translatable("tagprefix.stone", label), EntryIngredients.ofItems(items));
+        }
     }
 
+    private static String ToUpperAllWords(String text) {
+        StringBuilder result = new StringBuilder();
+        result.append(text.substring(0, 1).toUpperCase());
+        for (int i = 1; i < text.length(); i++) {
+            if (" ".equals(text.substring(i-1, i)))
+                result.append(text.substring(i, i + 1).toUpperCase());
+            else
+                result.append(text.charAt(i));
+        }
+        return result.toString();
+    }
 }


### PR DESCRIPTION
## What
[Collapse ore blocks into REI categories similar to tools.](https://github.com/GregTechCEu/GregTech-Modern/issues/125#issuecomment-1613879905)

## Implementation Details
I found the MATERIAL_BLOCKS field in GTBlocks and went through each of the materials and ore blocks associated with this material.
After finding ore blocks of the same material, I added them to the list and registered them as an ore group.

## Outcome
Added ores from the mod to REI "CollapsibleEntries".

## Additional Information
![2024-02-28_08 58 59](https://github.com/GregTechCEu/GregTech-Modern/assets/22248940/b9d3a4cb-0f1a-4a79-aec0-b8d7a6a6e91d)