### PR TITLE
fix machines not connecting to already placed cables

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -127,6 +127,13 @@ public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
         }
     }
 
+    @Override
+    public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston) {
+        super.onPlace(state, level, pos, oldState, movedByPiston);
+        //needed to trigger block updates so machines connect to open cables properly.
+        level.updateNeighbourForOutputSignal(pos, this);
+    }
+
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/MetaMachineItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/MetaMachineItem.java
@@ -1,12 +1,20 @@
 package com.gregtechceu.gtceu.api.item;
 
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
+import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
+import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.lowdragmc.lowdraglib.client.renderer.IItemRendererProvider;
 import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -25,13 +33,36 @@ public class MetaMachineItem extends BlockItem implements IItemRendererProvider 
     }
 
     public MachineDefinition getDefinition() {
-        return ((IMachineBlock)getBlock()).getDefinition();
+        return ((IMachineBlock) getBlock()).getDefinition();
     }
 
     @Nullable
     @Override
     public IRenderer getRenderer(ItemStack stack) {
-        return ((IMachineBlock)getBlock()).getDefinition().getRenderer();
+        return ((IMachineBlock) getBlock()).getDefinition().getRenderer();
     }
 
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected boolean placeBlock(BlockPlaceContext context, BlockState state) {
+        Level level = context.getLevel();
+        BlockPos pos = context.getClickedPos();
+        Direction side = context.getClickedFace();
+
+        boolean superVal = super.placeBlock(context, state);
+
+        if (!level.isClientSide) {
+            BlockPos possiblePipe = pos.offset(side.getOpposite().getNormal());
+            Block block = level.getBlockState(possiblePipe).getBlock();
+            if (block instanceof PipeBlock<?, ?, ?>) {
+                IPipeNode pipeTile = ((PipeBlock<?, ?, ?>) block).getPipeTile(level, possiblePipe);
+                if (pipeTile != null && ((PipeBlock<?, ?, ?>) block).canPipeConnectToBlock(pipeTile, side.getOpposite(),
+                    level.getBlockEntity(pos))) {
+                    pipeTile.setConnection(side, true, false);
+                }
+            }
+        }
+        return superVal;
+    }
 }
+


### PR DESCRIPTION
## What
This PR fixes machines not connecting to already placed blocks, either an already "open" cable or clicking the machine item on a cable.

## Implementation Details
Ported missing implementation from 1.12 GTCEu:
 emit block update on machine placement so the enet is reset

## Outcome
Machines now connect to cables like you expect.

## Additional Information
None

## Potential Compatibility Issues
None expected, as it was ported as closely as possible.