### PR TITLE
Improve unification search performance

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
@@ -131,7 +131,7 @@ public class ChemicalHelper {
     @Nullable
     public static MaterialStack getMaterial(ItemLike itemLike) {
         var entry = getUnificationEntry(itemLike);
-        if (entry != null) {
+        if (entry != null && entry != UnificationEntry.EmptyMapMarkerEntry) {
             Material entryMaterial = entry.material;
             if (entryMaterial != null) {
                 return new MaterialStack(entryMaterial, entry.tagPrefix.getMaterialAmount(entryMaterial));
@@ -166,7 +166,7 @@ public class ChemicalHelper {
     public static TagPrefix getPrefix(ItemLike itemLike) {
         if (itemLike == null) return null;
         UnificationEntry entry = getUnificationEntry(itemLike);
-        if (entry != null) return entry.tagPrefix;
+        if (entry != null && entry != UnificationEntry.EmptyMapMarkerEntry) return entry.tagPrefix;
         return null;
     }
 
@@ -229,7 +229,7 @@ public class ChemicalHelper {
                     return entry.getValue();
                 }
             }
-            return null;
+            return UnificationEntry.EmptyMapMarkerEntry;
         });
     }
 
@@ -242,7 +242,7 @@ public class ChemicalHelper {
                     }
                 }
             }
-            return new UnificationEntry.EmptyMapMarkerEntry();
+            return UnificationEntry.EmptyMapMarkerEntry;
         });
     }
 
@@ -252,7 +252,7 @@ public class ChemicalHelper {
         return ITEM_UNIFICATION_ENTRY_COLLECTED.computeIfAbsent(itemLike, item -> {
             Holder<Item> holder = BuiltInRegistries.ITEM.wrapAsHolder(item.asItem());
             return holder.tags().map(ChemicalHelper::getUnificationEntry).filter(Objects::nonNull)
-                    .filter(entry -> !(entry instanceof UnificationEntry.EmptyMapMarkerEntry)).findFirst().orElse(null);
+                    .filter(entry -> !(entry == UnificationEntry.EmptyMapMarkerEntry)).findFirst().orElse(null);
         });
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/UnificationEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/UnificationEntry.java
@@ -45,12 +45,7 @@ public class UnificationEntry {
         return tagPrefix.name + (material != null ? material.toCamelCaseString() : "");
     }
 
-    public static class EmptyMapMarkerEntry extends UnificationEntry {
-
-        public EmptyMapMarkerEntry() {
-            super(null);
-        }
-
+    public static final UnificationEntry EmptyMapMarkerEntry = new UnificationEntry(null) {
         @Override
         public boolean equals(Object o) {
             return this == o;
@@ -65,5 +60,6 @@ public class UnificationEntry {
         public String toString() {
             return "EMPTY UNIFICATION ENTRY";
         }
-    }
+    };
+
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ToolHeadReplaceRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ToolHeadReplaceRecipe.java
@@ -71,7 +71,7 @@ public class ToolHeadReplaceRecipe extends CustomRecipe {
             } else return false;
 
             if (!tool.isElectric()) return false;
-            if (toolHead == null) return false;
+            if (toolHead == null || toolHead == UnificationEntry.EmptyMapMarkerEntry) return false;
             GTToolType[] output = TOOL_HEAD_TO_TOOL_MAP.get(toolHead.tagPrefix);
             return output != null && output[tool.getElectricTier()] != null;
         }
@@ -107,7 +107,7 @@ public class ToolHeadReplaceRecipe extends CustomRecipe {
             } else return ItemStack.EMPTY;
             if (!tool.isElectric()) return ItemStack.EMPTY;
             IElectricItem powerUnit = GTCapabilityHelper.getElectricItem(realTool);
-            if (toolHead == null) return ItemStack.EMPTY;
+            if (toolHead == null || toolHead == UnificationEntry.EmptyMapMarkerEntry) return ItemStack.EMPTY;
             GTToolType[] toolArray = TOOL_HEAD_TO_TOOL_MAP.get(toolHead.tagPrefix);
             ItemStack newTool = GTItems.TOOL_ITEMS.get(toolHead.material, toolArray[tool.getElectricTier()])
                 .get().get(powerUnit.getCharge(), powerUnit.getMaxCharge());

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/RecyclingRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/RecyclingRecipes.java
@@ -109,7 +109,7 @@ public class RecyclingRecipes {
 
         UnificationEntry entry = ChemicalHelper.getUnificationEntry(input.getItem());
         TagKey<Item> inputTag = null;
-        if (entry != null) {
+        if (entry != null && entry != UnificationEntry.EmptyMapMarkerEntry) {
             inputTag = ChemicalHelper.getTag(entry.tagPrefix, entry.material);
         }
 
@@ -134,7 +134,7 @@ public class RecyclingRecipes {
 
         UnificationEntry entry = ChemicalHelper.getUnificationEntry(input.getItem());
         TagKey<Item> inputTag = null;
-        if (entry != null) {
+        if (entry != null && entry != UnificationEntry.EmptyMapMarkerEntry) {
             inputTag = ChemicalHelper.getTag(entry.tagPrefix, entry.material);
         }
 
@@ -217,7 +217,7 @@ public class RecyclingRecipes {
     private static void registerArcRecycling(Consumer<FinishedRecipe> provider, ItemStack input, List<MaterialStack> materials, @Nullable TagPrefix prefix) {
         UnificationEntry entry = ChemicalHelper.getUnificationEntry(input.getItem());
         TagKey<Item> inputTag = null;
-        if (entry != null) {
+        if (entry != null && entry != UnificationEntry.EmptyMapMarkerEntry) {
             inputTag = ChemicalHelper.getTag(entry.tagPrefix, entry.material);
         }
 
@@ -407,7 +407,7 @@ public class RecyclingRecipes {
             if (stack == ItemStack.EMPTY) continue;
             if (stack.getCount() > 64) {
                 UnificationEntry entry = ChemicalHelper.getUnificationEntry(stack.getItem());
-                if (entry != null) { // should always be true
+                if (entry != null && entry != UnificationEntry.EmptyMapMarkerEntry) { // should always be true
                     TagPrefix prefix = entry.tagPrefix;
 
                     // These are the highest forms that a Material can have (for Ingot and Dust, respectively),


### PR DESCRIPTION
## What
This reduces the lag spike reported in #964 

## Implementation Details
Map.computeIfAbsent() always recomputes if the entry value is null. I'm *assuming* that this isn't intended here. 
I've also changed EmptyMapMarkerEntry to a singleton.

## Outcome
Thus far there's a noticeable reduction in time loading search results in the AE2 terminals in my game. I'll keep playing with this change and see what happens.

## Potential Compatibility Issues
I didn't dig too deeply into the recipe generation code and my java's rusty enough that I'm a little nervous that there's some dependency on the null values that wasn't obvious to me. 