### PR TITLE
fix chainsaw always using durability for tree felling

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -60,8 +60,7 @@ public class TreeFellingHelper {
                 orderedBlocks.subList(durabilityLeft, orderedBlocks.size()).clear();
             }
 
-
-            stack.hurtAndBreak(orderedBlocks.size(), serverPlayer, p -> p.broadcastBreakEvent(EquipmentSlot.MAINHAND));
+            ToolHelper.damageItem(stack, serverPlayer);
 
             breakBlocksPerTick(serverPlayer, orderedBlocks, origin.getBlock());
         }


### PR DESCRIPTION
## What
#960 

## Implementation Details
changed it to use the ToolHelper method instead of directly dealing durability damage.

## Outcome
fixes #960