### PR TITLE
buff the large miner's fortune to be at least 3x guaranteed.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
@@ -79,7 +79,7 @@ public class LargeMinerLogic extends MinerLogic {
     }
 
     private int getDropCountMultiplier() {
-        return 3;
+        return 5;
     }
 
     public void setChunkMode(boolean isChunkMode) {
@@ -114,7 +114,7 @@ public class LargeMinerLogic extends MinerLogic {
                 if (getDropCountMultiplier() > 0) {
                     ItemStack fortunePick = pickaxeTool.copy();
                     fortunePick.enchant(Enchantments.BLOCK_FORTUNE, getDropCountMultiplier());
-                    outputStack = ApplyBonusCount.addUniformBonusCount(Enchantments.BLOCK_FORTUNE).build().apply(outputStack,
+                    outputStack = ApplyBonusCount.addOreBonusCount(Enchantments.BLOCK_FORTUNE).build().apply(outputStack,
                             new LootContext.Builder(builder.withParameter(LootContextParams.TOOL, fortunePick).create(LootContextParamSets.BLOCK)).create(null));
                 }
             }


### PR DESCRIPTION
## What
#902 

## Implementation Details
changed the large miner's fortune level from 3 to 5 in order to guarantee 3x drops compared to macerators.

## Outcome
fixes #902 