### PR TITLE
Avoid O(n) lookup behavior in ChemicalHelper

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
@@ -49,7 +49,7 @@ public class ChemicalHelper {
     /** Used for custom material data for items that do not fall into the normal "prefix, material" pair */
     public static final Map<ItemLike, ItemMaterialInfo> ITEM_MATERIAL_INFO = new ConcurrentHashMap<>();
     /** Mapping of an item to a "prefix, material" pair */
-    public static final Set<Map.Entry<Supplier<? extends ItemLike>, UnificationEntry>> ITEM_UNIFICATION_ENTRY = new HashSet<>();
+    public static final Set<Map.Entry<Supplier<? extends ItemLike>, UnificationEntry>> ITEM_UNIFICATION_ENTRY = ConcurrentHashMap.newKeySet();
     public static final Map<ItemLike, UnificationEntry> ITEM_UNIFICATION_ENTRY_COLLECTED = new ConcurrentHashMap<>();
     /** Mapping of a tag to a "prefix, material" pair */
     public static final Map<TagKey<Item>, UnificationEntry> TAG_UNIFICATION_ENTRY = new Object2ObjectLinkedOpenHashMap<>();
@@ -223,14 +223,22 @@ public class ChemicalHelper {
 
     @Nullable
     public static UnificationEntry getUnificationEntry(ItemLike itemLike) {
-        return ITEM_UNIFICATION_ENTRY_COLLECTED.computeIfAbsent(itemLike, item -> {
-            for (var entry : ITEM_UNIFICATION_ENTRY) {
-                if (entry.getKey().get().asItem() == itemLike.asItem()) {
-                    return entry.getValue();
-                }
-            }
-            return UnificationEntry.EmptyMapMarkerEntry;
-        });
+        // asItem is a bit slow, avoid calling it multiple times
+        var itemKey = itemLike.asItem();
+        var unifyingEntry = ITEM_UNIFICATION_ENTRY_COLLECTED.get(itemKey);
+
+        if(unifyingEntry == null) {
+            // Resolve all the lazy suppliers once, rather than on each request. This avoids O(n) lookup performance
+            // for unification entries.
+            ITEM_UNIFICATION_ENTRY.removeIf(entry -> {
+                ITEM_UNIFICATION_ENTRY_COLLECTED.put(entry.getKey().get().asItem(), entry.getValue());
+                return true;
+            });
+
+            unifyingEntry = ITEM_UNIFICATION_ENTRY_COLLECTED.computeIfAbsent(itemKey, item -> UnificationEntry.EmptyMapMarkerEntry);
+        }
+
+        return unifyingEntry;
     }
 
     public static UnificationEntry getUnificationEntry(TagKey<Item> tag) {


### PR DESCRIPTION
`ChemicalHelper#getUnificationEntry` is a fairly major bottleneck to joining a world quickly/reloading a recipe mod like EMI. Most of the CPU time appeared to be spent inside the lambda passed to `computeIfAbsent`. Upon further investigation, this method has very poor time complexity, as every computation of a map value requires iterating the entire `ITEM_UNIFICATION_ENTRY` set.

I have changed this method to effectively populate the values from `ITEM_UNIFICATION_ENTRY` once, and then clear that set. This resolves the issue and allows the method to have roughly O(1) complexity as one would expect when caching results in a map.

Additionally, the code was restructured for slightly better efficiency (e.g. `asItem` is only called once on the parameter, as it is not very fast).

I would appreciate testing/feedback on whether my optimized approach still handles the `ItemLike`s correctly, as it seems basically anything can get thrown into the map (Block/Item/etc).