### PR TITLE
Cache recipe UI size instead of recalculating it on each call

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ui/GTRecipeTypeUI.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ui/GTRecipeTypeUI.java
@@ -77,6 +77,7 @@ public class GTRecipeTypeUI {
     private boolean JEIVisible = true;
 
     private CompoundTag customUICache;
+    private Size jeiSize;
 
     /**
      * @param recipeType the recipemap corresponding to this ui
@@ -120,11 +121,16 @@ public class GTRecipeTypeUI {
 
     public void reloadCustomUI() {
         this.customUICache = null;
+        this.jeiSize = null;
     }
 
     public Size getJEISize() {
-        Size size = createEditableUITemplate(false, false).createDefault().getSize();
-        return new Size(size.width, getPropertyHeightShift() + 5 + size.height);
+        Size size = this.jeiSize;
+        if(size == null) {
+            var originalSize = createEditableUITemplate(false, false).createDefault().getSize();
+            this.jeiSize = size = new Size(originalSize.width, getPropertyHeightShift() + 5 + originalSize.height);
+        }
+        return size;
     }
 
     public record RecipeHolder(DoubleSupplier progressSupplier, IItemTransfer importItems, IItemTransfer exportItems, IFluidTransfer importFluids, IFluidTransfer exportFluids, boolean isSteam, boolean isHighPressure) {};


### PR DESCRIPTION
The `createDefault` call here is very expensive, and from what I can tell the returned template will be the same each time; it's just a new copy made from deserializing the NBT. We can just create the template once, store the computed size, and reuse that size for all recipes of a given type.