### PR TITLE
fix crafting table recipes are being considered processing recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
@@ -32,7 +32,7 @@ public class Ae2PatternTerminalHandler<T extends PatternEncodingTermMenu> implem
     }
     @Override
     public boolean supportsRecipe(EmiRecipe recipe) {
-        return true;
+        return recipe instanceof GTEmiRecipe;
     }
     @Override
     public boolean canCraft(EmiRecipe recipe, EmiCraftContext<T> context) {


### PR DESCRIPTION
## What
fix crafting table recipes are being considered processing recipe

## Implementation Details
I changed it wrongly before

## Outcome
fix it
