### PR TITLE
Fix buttons appearing before checking predicate

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PredicatedButtonWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PredicatedButtonWidget.java
@@ -3,8 +3,6 @@ package com.gregtechceu.gtceu.api.gui.widget;
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.util.ClickData;
 import com.lowdragmc.lowdraglib.gui.widget.ButtonWidget;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -17,17 +15,22 @@ import java.util.function.Consumer;
  * @date 2023/2/24
  * @implNote DisplayButtonWidget
  */
-@Accessors(chain = true)
 public class PredicatedButtonWidget extends ButtonWidget {
-    @Setter
-    private BooleanSupplier predicate;
+    private final BooleanSupplier predicate;
 
-    public PredicatedButtonWidget(int xPosition, int yPosition, int width, int height, IGuiTexture buttonTexture, Consumer<ClickData> onPressed) {
+    public PredicatedButtonWidget(int xPosition, int yPosition, int width, int height, IGuiTexture buttonTexture, Consumer<ClickData> onPressed, BooleanSupplier predicate, boolean defaultVisibility) {
         super(xPosition, yPosition, width, height, buttonTexture, onPressed);
+        this.predicate = predicate;
+        setVisible(defaultVisibility);
     }
 
-    public PredicatedButtonWidget(int xPosition, int yPosition, int width, int height, Consumer<ClickData> onPressed) {
+    public PredicatedButtonWidget(int xPosition, int yPosition, int width, int height, IGuiTexture buttonTexture, Consumer<ClickData> onPressed, BooleanSupplier predicate) {
+        this(xPosition, yPosition, width, height, buttonTexture, onPressed, predicate, false);
+    }
+
+    public PredicatedButtonWidget(int xPosition, int yPosition, int width, int height, Consumer<ClickData> onPressed, BooleanSupplier predicate) {
         super(xPosition, yPosition, width, height, onPressed);
+        this.predicate = predicate;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/directional/handlers/CoverableConfigHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/directional/handlers/CoverableConfigHandler.java
@@ -76,8 +76,8 @@ public class CoverableConfigHandler implements IDirectionalConfigHandler {
         group.addWidget(slotWidget = new SlotWidget(transfer, 0, 19, 0)
             .setChangeListener(this::coverItemChanged)
             .setBackgroundTexture(new GuiTextureGroup(GuiTextures.SLOT, GuiTextures.IO_CONFIG_COVER_SLOT_OVERLAY)));
-        group.addWidget(new PredicatedButtonWidget(0, 0, 18, 18, CONFIG_BTN_TEXTURE, this::toggleConfigTab)
-            .setPredicate(() -> side != null && coverBehavior != null && machine.getCoverAtSide(side) instanceof IUICover));
+        group.addWidget(new PredicatedButtonWidget(0, 0, 18, 18, CONFIG_BTN_TEXTURE, this::toggleConfigTab,
+            () -> side != null && coverBehavior != null && machine.getCoverAtSide(side) instanceof IUICover));
 
         checkCoverBehaviour();
 

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/fancyconfigurator/OverclockFancyConfigurator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/fancyconfigurator/OverclockFancyConfigurator.java
@@ -86,13 +86,13 @@ public class OverclockFancyConfigurator implements IFancyConfigurator {
                     if (!cd.isRemote) {
                         overclockMachine.setOverclockTier(currentTier - 1);
                     }
-                }).setPredicate(() -> currentTier > overclockMachine.getMinOverclockTier()));
+                }, () -> currentTier > overclockMachine.getMinOverclockTier()));
                 addWidget(new ImageWidget(20, 5, 120 - 5 - 10 - 5 - 20, 20, () -> new GuiTextureGroup(GuiTextures.DISPLAY_FRAME, new TextTexture(GTValues.VNF[currentTier]))));
                 addWidget(new PredicatedButtonWidget(120 -5 - 10, 5, 10, 20, new GuiTextureGroup(GuiTextures.BUTTON, Icons.RIGHT.copy().scale(0.7f)), cd -> {
                     if (!cd.isRemote) {
                         overclockMachine.setOverclockTier(currentTier + 1);
                     }
-                }).setPredicate(() -> currentTier < overclockMachine.getMaxOverclockTier()));
+                }, () -> currentTier < overclockMachine.getMaxOverclockTier()));
             }
 
             @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -222,6 +222,6 @@ public class GTRecipeWidget extends WidgetGroup {
         // add recipe id getter
         addWidget(new PredicatedButtonWidget(getSize().width + 3,3, 15, 15, new GuiTextureGroup(GuiTextures.BUTTON, new TextTexture("ID")), cd -> {
             Minecraft.getInstance().keyboardHandler.setClipboard(recipe.id.toString());
-        }).setPredicate(() -> CompassManager.INSTANCE.devMode).setHoverTooltips("click to copy: " + recipe.id));
+        }, () -> CompassManager.INSTANCE.devMode).setHoverTooltips("click to copy: " + recipe.id));
     }
 }


### PR DESCRIPTION
## What
Before, predicated buttons appeared before the network sent over the predicate - this meant buttons could appear when they shouldn't. Also adds a constructor parameter for buttons that should appear by default, just in case.

## Outcome
Fixes: #992

## Potential Compatibility Issues
Changes the `@Setter` field to a constructor parameter - AFAIK there's no reason to have the predicate modifiable and it makes creating a predicated button more intuitive.