### PR TITLE
fix: always apply OC logic even if amount of OCs is 0.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -93,9 +93,7 @@ public class RecipeHelper {
         int numberOfOCs = maximumTier - recipeTier;
         if (recipeTier == GTValues.ULV) numberOfOCs--; // no ULV overclocking
 
-        // cannot overclock, so return the starting values
-        if (numberOfOCs <= 0) return LongIntMutablePair.of(EUt, recipe.duration);
-
+        // Always overclock even if numberOfOCs is <=0 as without it, some logic for coil bonuses ETC won't apply.
         return logic.getLogic().runOverclockingLogic(recipe, EUt, maxOverclockVoltage, recipe.duration, numberOfOCs);
     }
 


### PR DESCRIPTION
… oven penalties apply.

## What
#952 

## Implementation Details
removed `amountOfOCs <= 0` check to always apply OC logic because it can have other effects as well.

## Outcome
fixes #952 