### PR TITLE
Large distillery fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GCyMMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GCyMMachines.java
@@ -560,9 +560,9 @@ public class GCyMMachines {
     public final static MultiblockMachineDefinition LARGE_DISTILLERY = REGISTRATE.multiblock("large_distillery", WorkableElectricMultiblockMachine::new)
             .langValue("Large Fractionating Distillery")
             .tooltips(Component.translatable("gtceu.multiblock.parallelizable.tooltip"))
-            .tooltips(Component.translatable("gtceu.machine.available_recipe_map_2.tooltip", Component.translatable("gtceu.distillery"), Component.translatable("gtceu.distillation_tower")))
+            .tooltips(Component.translatable("gtceu.machine.available_recipe_map_2.tooltip", Component.translatable("gtceu.distillation_tower"), Component.translatable("gtceu.distillery")))
             .rotationState(RotationState.NON_Y_AXIS)
-            .recipeTypes(DISTILLERY_RECIPES, DISTILLATION_RECIPES)
+            .recipeTypes(DISTILLATION_RECIPES, DISTILLERY_RECIPES)
             .recipeModifier(GTRecipeModifiers.PARALLEL_HATCH.apply(OverclockingLogic.PERFECT_OVERCLOCK, GTRecipeModifiers.ELECTRIC_OVERCLOCK))
             .appearanceBlock(CASING_WATERTIGHT)
             .pattern(definition -> {
@@ -580,7 +580,7 @@ public class GCyMMachines {
                                 .or(abilities(EXPORT_ITEMS))
                                 .or(autoAbilities(true, false, true)))
                         .where('X', casingPredicate
-                                .or(abilities(EXPORT_FLUIDS).setMinLayerLimited(1).setMaxLayerLimited(1)))
+                                .or(abilities(EXPORT_FLUIDS_1X).setMinLayerLimited(1).setMaxLayerLimited(1)))
                         .where('Z', casingPredicate)
                         .where('P', blocks(CASING_STEEL_PIPE.get()))
                         .where('C', abilities(MUFFLER))
@@ -588,6 +588,7 @@ public class GCyMMachines {
                         .where('#', any())
                         .build();
             })
+            .partSorter(Comparator.comparingInt(a -> a.self().getPos().getY()))
             .workableCasingRenderer(GTCEu.id("block/casings/gcym/watertight_casing"),
                     GTCEu.id("block/multiblock/gcym/large_distillery"), false)
             .compassSections(GTCompassSections.TIER[IV])


### PR DESCRIPTION
Ordered outputs on large distillery to match distillation tower
Changed default mode to distillation tower instead of distillery
Prevent the multiblock from forming with non-1x output hatches
