### PR TITLE
Allow the spray can to paint a chain of blocks at once

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -193,7 +193,7 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
         var player = context.getPlayer();
         var level = context.getLevel();
         var facing = context.getClickedFace();
-        var pos = context.getClickedPos();
+        var pos = context.getClickedPos().mutable();
         var stack = context.getItemInHand();
         var block = level.getBlockState(pos).getBlock();
 
@@ -215,14 +215,7 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
                     break;
                 }
 
-                switch (getPaintDirection(player)) {
-                    case UP -> pos = pos.offset(0, 1, 0);
-                    case DOWN -> pos = pos.offset(0, -1, 0);
-                    case NORTH -> pos = pos.offset(0, 0, -1);
-                    case SOUTH -> pos = pos.offset(0, 0, 1);
-                    case WEST -> pos = pos.offset(-1, 0, 0);
-                    case EAST -> pos = pos.offset(1, 0, 0);
-                }
+                pos.move(getPaintDirection(player));
             }
 
             GTSoundEntries.SPRAY_CAN_TOOL.play(level, null, player.position(), 1.0f, 1.0f);

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -329,6 +329,10 @@ public class ConfigHolder {
         @Configurable.Comment({ "Random chance for electric tools to take actual damage", "Default: 10%" })
         @Configurable.Range(min = 0, max = 100)
         public int rngDamageElectricTools = 10;
+        @Configurable
+        @Configurable.Comment({ "Amount of blocks that can be spray painted at once", "Default: 16" })
+        @Configurable.Range(min = 1, max = 512)
+        public int sprayCanChainLength = 16;
     }
 
     public static class ClientConfigs {


### PR DESCRIPTION
## What
Allows the spray can to spray paint a chain of blocks, which makes setting up stuff like lasers easier.

## Implementation Details
Just takes the looking direction and moves block by block, coloring them, until the block changes. `getPaintDirection` is based off of `player.kjs$getFacing()`.
## Outcome
When sneaking while spray painting a chain of blocks will now be colored, though once a different block is reached the coloring will stop.

## Additional Information
The max length of the chain can be configured in the tool config.
