### PR TITLE
Changed return type of getDurabilityForDisplay from int to float

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/IDurabilityBar.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/IDurabilityBar.java
@@ -16,8 +16,8 @@ public interface IDurabilityBar extends IItemComponent {
         return Math.round(getDurabilityForDisplay(stack) * 13);
     }
 
-    default int getDurabilityForDisplay(ItemStack stack) {
-        return (stack.getMaxDamage() - stack.getDamageValue()) / stack.getMaxDamage();
+    default float getDurabilityForDisplay(ItemStack stack) {
+        return (float) (stack.getMaxDamage() - stack.getDamageValue()) / stack.getMaxDamage();
     }
 
     default int getMaxDurability(ItemStack stack) {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/IMaterialPartItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/IMaterialPartItem.java
@@ -101,9 +101,9 @@ public interface IMaterialPartItem extends IItemComponent, IDurabilityBar, IAddI
     }
 
     @Override
-    default int getDurabilityForDisplay(ItemStack itemStack) {
+    default float getDurabilityForDisplay(ItemStack itemStack) {
         var maxDurability = getPartMaxDurability(itemStack);
-        return (maxDurability - getPartDamage(itemStack)) / maxDurability;
+        return (float) (maxDurability - getPartDamage(itemStack)) / maxDurability;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/client/util/ToolChargeBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/ToolChargeBarRenderer.java
@@ -87,14 +87,14 @@ public final class ToolChargeBarRenderer {
     }
 
     private static boolean renderDurabilityBar(GuiGraphics graphics, ItemStack stack, IDurabilityBar manager, int xPosition, int yPosition) {
-        int level = manager.getDurabilityForDisplay(stack);
+        float level = manager.getDurabilityForDisplay(stack);
         if (level == 0.0 && !manager.showEmptyBar(stack)) return false;
         if (level == 1.0 && !manager.showFullBar(stack)) return false;
         Pair<Integer, Integer> colors = manager.getDurabilityColorsForDisplay(stack);
         boolean doDepletedColor = manager.doDamagedStateColors(stack);
         int left = colors != null ? colors.getLeft() : colorBarLeftDurability;
         int right = colors != null ? colors.getRight() : colorBarRightDurability;
-        render(graphics, level, xPosition, yPosition, 0, true, left, right, doDepletedColor);
+        render(graphics, manager.getBarWidth(stack), xPosition, yPosition, 0, true, left, right, doDepletedColor);
         return true;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -144,8 +144,8 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
     }
 
     @Override
-    public int getDurabilityForDisplay(ItemStack stack) {
-        return getUsesLeft(stack) / totalUses;
+    public float getDurabilityForDisplay(ItemStack stack) {
+        return (float) getUsesLeft(stack) / totalUses;
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes durability bar for the spray cans and the tools (atleast I think the tools had the bug aswell, only noticed it on spray cans before)

## Implementation Details
`getDurabilityForDisplay()` has always been returning a value from 0.0 .. 1.0 so it seems float was the intentional return type.

## Outcome
Full spray cans no longer show as empty

## Potential Compatibility Issues
Everything that implements IDurabiltiyBar would need to be changed in addons. An alterantive solution could be to not change the data type and instead return the number of durability left. Then the percentage could be calculated in the rendering.