### PR TITLE
Fixes PA voltage stack overflow on load

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/ProcessingArrayMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/ProcessingArrayMachine.java
@@ -191,11 +191,6 @@ public class ProcessingArrayMachine extends TieredWorkableElectricMultiblockMach
         return getOverclockTier();
     }
 
-    @Override
-    public long getMaxVoltage() {
-        return getOverclockVoltage();
-    }
-
     @Nullable
     public static GTRecipe recipeModifier(MetaMachine machine, @Nonnull GTRecipe recipe) {
         if (machine instanceof ProcessingArrayMachine processingArray && processingArray.machineStorage.storage.getStackInSlot(0).getCount() > 0) {


### PR DESCRIPTION
## What
A build from latest dev is causing a stack overflow on load, I think this is probably a result of the recent overclocking fixes.

```
java.lang.StackOverflowError: Ticking block entity
	at com.lowdragmc.lowdraglib.misc.ItemStackTransfer.getStackInSlot(ItemStackTransfer.java:69) ~[ldlib-forge-1.20.1-1.0.24.a.jar%231102!/:?] {re:classloading}
	at com.gregtechceu.gtceu.common.machine.multiblock.electric.ProcessingArrayMachine.getMachineDefinition(ProcessingArrayMachine.java:116) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.common.machine.multiblock.electric.ProcessingArrayMachine.getOverclockTier(ProcessingArrayMachine.java:179) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.api.machine.multiblock.TieredWorkableElectricMultiblockMachine.getOverclockVoltage(TieredWorkableElectricMultiblockMachine.java:60) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.common.machine.multiblock.electric.ProcessingArrayMachine.getMaxVoltage(ProcessingArrayMachine.java:196) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.common.machine.multiblock.electric.ProcessingArrayMachine.getOverclockTier(ProcessingArrayMachine.java:181) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.api.machine.multiblock.TieredWorkableElectricMultiblockMachine.getOverclockVoltage(TieredWorkableElectricMultiblockMachine.java:60) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.common.machine.multiblock.electric.ProcessingArrayMachine.getMaxVoltage(ProcessingArrayMachine.java:196) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.common.machine.multiblock.electric.ProcessingArrayMachine.getOverclockTier(ProcessingArrayMachine.java:181) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
	at com.gregtechceu.gtceu.api.machine.multiblock.TieredWorkableElectricMultiblockMachine.getOverclockVoltage(TieredWorkableElectricMultiblockMachine.java:60) ~[gtceu-1.20.1-1.1.4.jar%23755!/:?] {re:classloading}
...
```

## Implementation Details
Removed overload for getMaxVoltage(). 

## Outcome
I'm no longer getting the overflow, but I'm not 100% sure what the intended behavior for the PA is here. A quick test seemed right to me and since it's deprecated I'm not too worried about non game-breaking changes or I'd check in discord.

