### PR TITLE
Fix multiblocks with only 1 energy/dynamo hatch not overclocking

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 @MethodsReturnNonnullByDefault
 public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine implements IFancyUIMachine, IDisplayUIMachine, ITieredMachine, IOverclockMachine {
     // runtime
-    protected IEnergyContainer energyContainer;
+    protected EnergyContainerList energyContainer;
 
     public WorkableElectricMultiblockMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
@@ -148,30 +148,26 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
         if (this.energyContainer == null) {
             this.energyContainer = getEnergyContainer();
         }
-        if (energyContainer instanceof EnergyContainerList) {
-            long voltage;
-            long amperage;
-            if (energyContainer.getInputVoltage() > energyContainer.getOutputVoltage()) {
-                voltage = energyContainer.getInputVoltage();
-                amperage = energyContainer.getInputAmperage();
-            } else {
-                voltage = energyContainer.getOutputVoltage();
-                amperage = energyContainer.getOutputAmperage();
-            }
-
-            if (amperage == 1) {
-                // amperage is 1 when the energy is not exactly on a tier
-
-                // the voltage for recipe search is always on tier, so take the closest lower tier
-                return GTValues.V[GTUtil.getFloorTierByVoltage(voltage)];
-            } else {
-                // amperage != 1 means the voltage is exactly on a tier
-                // ignore amperage, since only the voltage is relevant for recipe search
-                // amps are never > 3 in an EnergyContainerList
-                return voltage;
-            }
+        long voltage;
+        long amperage;
+        if (energyContainer.getInputVoltage() > energyContainer.getOutputVoltage()) {
+            voltage = energyContainer.getInputVoltage();
+            amperage = energyContainer.getInputAmperage();
+        } else {
+            voltage = energyContainer.getOutputVoltage();
+            amperage = energyContainer.getOutputAmperage();
         }
-        return Math.max(energyContainer.getInputVoltage(), energyContainer.getOutputVoltage());
+
+        if (amperage == 1) {
+            // amperage is 1 when the energy is not exactly on a tier
+            // the voltage for recipe search is always on tier, so take the closest lower tier
+            return GTValues.V[GTUtil.getFloorTierByVoltage(voltage)];
+        } else {
+            // amperage != 1 means the voltage is exactly on a tier
+            // ignore amperage, since only the voltage is relevant for recipe search
+            // amps are never > 3 in an EnergyContainerList
+            return voltage;
+        }
     }
 
     //////////////////////////////////////
@@ -186,7 +182,7 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
         return GTUtil.getFloorTierByVoltage(getMaxVoltage());
     }
 
-    public IEnergyContainer getEnergyContainer() {
+    public EnergyContainerList getEnergyContainer() {
         List<IEnergyContainer> containers = new ArrayList<>();
         var capabilities = capabilitiesProxy.get(IO.IN, EURecipeCapability.CAP);
         if (capabilities != null) {
@@ -205,7 +201,7 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
                 }
             }
         }
-        return containers.size() == 1 ? containers.get(0) : new EnergyContainerList(containers);
+        return new EnergyContainerList(containers);
     }
 
     public long getMaxVoltage() {
@@ -216,27 +212,24 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
             // Generators
             long voltage = energyContainer.getOutputVoltage();
             long amperage = energyContainer.getOutputAmperage();
-            if (energyContainer instanceof EnergyContainerList && amperage == 1) {
+            if (amperage == 1) {
                 // Amperage is 1 when the energy is not exactly on a tier.
                 // The voltage for recipe search is always on tier, so take the closest lower tier.
                 // List check is done because single hatches will always be a "clean voltage," no need
                 // for any additional checks.
                 return GTValues.V[GTUtil.getFloorTierByVoltage(voltage)];
+            } else {
+                return voltage;
             }
-            return voltage;
         } else {
             // Machines
-            if (energyContainer instanceof EnergyContainerList energyList) {
-                long highestVoltage = energyList.getHighestInputVoltage();
-                if (energyList.getNumHighestInputContainers() > 1) {
-                    // allow tier + 1 if there are multiple hatches present at the highest tier
-                    int tier = GTUtil.getTierByVoltage(highestVoltage);
-                    return GTValues.V[Math.min(tier + 1, GTValues.MAX)];
-                } else {
-                    return highestVoltage;
-                }
+            long highestVoltage = energyContainer.getHighestInputVoltage();
+            if (energyContainer.getNumHighestInputContainers() > 1) {
+                // allow tier + 1 if there are multiple hatches present at the highest tier
+                int tier = GTUtil.getTierByVoltage(highestVoltage);
+                return GTValues.V[Math.min(tier + 1, GTValues.MAX)];
             } else {
-                return energyContainer.getInputVoltage();
+                return highestVoltage;
             }
         }
     }


### PR DESCRIPTION
## What
After #1009, multiblocks with one multi-amp energy hatch can't skip recipe tiers anymore, which is expected, but they also can't overclock anymore, which is unexpected. Examples:
- EBF with one IV 4A energy hatch or one IV 16A energy hatch still only accepts 8192 EU/t input.
- EBF with one IV 16A energy hatch and one LV enegy hatch correctly overclocks to ZPM: the only difference between IV and ZPM is that one LV energy hatch
- ECE with IV 4A dynamo hatch or IV 16A dynamo hatch will not oxygen-boost.
- There is a picture in Discord https://discord.com/channels/701354865217110096/1086528220356161546/1224371743603425422 that nicely summarizes the weirdness.

## Implementation Details
The issue is that the new `calculateVoltageAmperage` logic in `EnergyContainerList` doesn't get run at all for single-hatch multiblocks. The change is simply to remove the single-hatch special case in `WorkableElectricMultiblockMachine` and always use the logic in `EnergyContainerList`. 

## Outcome
- EBF with one IV 16A energy hatch now accepts 131072 EU/t input and still limits to IV recipe tier.
- ECE with IV 16A dynamo hatch now allows boosting.