### PR TITLE
fix surface rock lang file #1050

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/block/SurfaceRockBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/SurfaceRockBlock.java
@@ -138,7 +138,7 @@ public class SurfaceRockBlock extends Block {
 
     @Override
     public String getDescriptionId() {
-        return super.getDescriptionId();
+        return "block.surface_rock";
     }
 
     @Override


### PR DESCRIPTION
## What
#1050 bug fix

## Implementation Details
Jade use getDescriptionId() method to check is a block has a lang file, so I override this method to make it works.

## Outcome
fixed jade doesn't show ore indicator correctly

## Additional Information
![image](https://github.com/GregTechCEu/GregTech-Modern/assets/58774024/518e6026-618f-456d-b521-f77600dacb8c)
