### PR TITLE
Fix logic errors in createMultiblock

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/CustomMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/CustomMultiblockBuilder.java
@@ -81,7 +81,7 @@ public class CustomMultiblockBuilder extends MultiblockMachineBuilder {
     public static MachineBuilder<MultiblockMachineDefinition> createMultiblock(String name, Object... args) {
         CustomMultiblockBuilder[] builders;
         int start = 0;
-        while (start < args.length && (!(args[start] instanceof Number) || !(args[start] instanceof Number[]) || !(args[start] instanceof int[]))) {
+        while (start < args.length && (!(args[start] instanceof Number || args[start] instanceof Number[] || args[start] instanceof int[]))) {
             ++start;
         }
         Object[] tierObjects = MachineFunctionPresets.copyArgs(args, start);


### PR DESCRIPTION
## What

There is a logic problem when finding the start of tierObjects, the condition is always true even if the `args[start]` is Number or Number[], so the `tiers.length > 0` will not be satisfied.