### PR TITLE
More KubeJS utility functions for machines

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.block.IMachineBlock;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.item.MetaMachineItem;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
@@ -23,14 +24,12 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.function.*;
 
 /**
  * @author KilaBash
@@ -59,6 +58,19 @@ public class MachineDefinition implements Supplier<IMachineBlock> {
     private BiFunction<MetaMachine, GTRecipe, GTRecipe> recipeModifier;
     @Getter @Setter
     private boolean alwaysTryModifyRecipe;
+    @NotNull
+    @Getter @Setter
+    private Predicate<IRecipeLogicMachine> beforeWorking = (machine) -> true;
+    @NotNull
+    @Getter @Setter
+    private Predicate<IRecipeLogicMachine> onWorking = (machine) -> true;
+    @NotNull
+    @Getter @Setter
+    private Consumer<IRecipeLogicMachine> onWaiting = (machine) -> {};
+    @NotNull
+    @Getter @Setter
+    private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
+
     @Getter @Setter
     private IRenderer renderer;
     @Setter

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -80,29 +80,29 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
     /**
      * Called in {@link RecipeLogic#setupRecipe(GTRecipe)} ()}
      */
-    default void beforeWorking() {
-
+    default boolean beforeWorking() {
+        return self().getDefinition().getBeforeWorking().test(this);
     }
 
     /**
      * Called per tick in {@link RecipeLogic#handleRecipeWorking()}
      */
-    default void onWorking() {
-
+    default boolean onWorking() {
+        return self().getDefinition().getOnWorking().test(this);
     }
 
     /**
      * Called per tick in {@link RecipeLogic#handleRecipeWorking()}
      */
     default void onWaiting() {
-
+        self().getDefinition().getOnWaiting().accept(this);
     }
 
     /**
      * Called in {@link RecipeLogic#onRecipeFinish()} before outputs are produced
      */
     default void afterWorking() {
-
+        self().getDefinition().getAfterWorking().accept(this);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMaintenanceMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMaintenanceMachine.java
@@ -123,13 +123,15 @@ public interface IMaintenanceMachine extends IMultiPart {
     }
 
     @Override
-    default void afterWorking(IWorkableMultiController controller) {
+    default boolean afterWorking(IWorkableMultiController controller) {
         if (ConfigHolder.INSTANCE.machines.enableMaintenance) {
             calculateMaintenance(this, controller.getRecipeLogic().getProgress());
             if (hasMaintenanceProblems()) {
                 controller.getRecipeLogic().markLastRecipeDirty();
+                return false;
             }
         }
+        return true;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
@@ -63,11 +63,12 @@ public interface IMufflerMachine extends IMultiPart {
     }
 
     @Override
-    default void afterWorking(IWorkableMultiController controller) {
+    default boolean afterWorking(IWorkableMultiController controller) {
         val supplier = controller.self().getDefinition().getRecoveryItems();
         if (supplier != null) {
             recoverItemsTable(supplier.get());
         }
+        return IMultiPart.super.afterWorking(controller);
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
@@ -80,29 +80,29 @@ public interface IMultiPart extends IMachineFeature, IFancyUIMachine {
     /**
      * Called per tick in {@link RecipeLogic#handleRecipeWorking()}
      */
-    default void onWorking(IWorkableMultiController controller) {
-
+    default boolean onWorking(IWorkableMultiController controller) {
+        return true;
     }
 
     /**
      * Called per tick in {@link RecipeLogic#handleRecipeWorking()}
      */
-    default void onWaiting(IWorkableMultiController controller) {
-
+    default boolean onWaiting(IWorkableMultiController controller) {
+        return true;
     }
 
     /**
      * Called in {@link RecipeLogic#onRecipeFinish()} before outputs are produced
      */
-    default void afterWorking(IWorkableMultiController controller) {
-
+    default boolean afterWorking(IWorkableMultiController controller) {
+        return true;
     }
 
     /**
      * Called in {@link RecipeLogic#setupRecipe(GTRecipe)} ()}
      */
-    default void beforeWorking(IWorkableMultiController controller) {
-
+    default boolean beforeWorking(IWorkableMultiController controller) {
+        return true;
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -224,20 +224,27 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
         for (IMultiPart part : getParts()) {
             part.afterWorking(this);
         }
+        IWorkableMultiController.super.afterWorking();
     }
 
     @Override
-    public void beforeWorking() {
+    public boolean beforeWorking() {
         for (IMultiPart part : getParts()) {
-            part.beforeWorking(this);
+            if (!part.beforeWorking(this)) {
+                return false;
+            }
         }
+        return IWorkableMultiController.super.beforeWorking();
     }
 
     @Override
-    public void onWorking() {
+    public boolean onWorking() {
         for (IMultiPart part : getParts()) {
-            part.onWorking(this);
+            if (!part.onWorking(this)) {
+                return false;
+            }
         }
+        return IWorkableMultiController.super.onWorking();
     }
 
     @Override
@@ -245,6 +252,7 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
         for (IMultiPart part : getParts()) {
             part.onWaiting(this);
         }
+        IWorkableMultiController.super.onWaiting();
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
@@ -256,11 +256,13 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine implements
     }
 
     @Override
-    public void onWorking() {
+    public boolean onWorking() {
+        boolean value = super.onWorking();
         if (currentTemperature < getMaxTemperature()) {
             currentTemperature = Math.max(1, currentTemperature);
             updateSteamSubscription();
         }
+        return value;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -1,16 +1,20 @@
 package com.gregtechceu.gtceu.api.machine.trait;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.DummyCraftingContainer;
 import com.lowdragmc.lowdraglib.misc.ItemStackTransfer;
 import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
 import com.lowdragmc.lowdraglib.side.item.ItemTransferHelper;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
+import dev.architectury.hooks.item.ItemStackHooks;
+import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import lombok.Getter;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -73,11 +77,11 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
 
     @Override
     public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, @Nullable String slotName, boolean simulate) {
-        return handleIngredient(io, left, simulate, this.handlerIO, storage);
+        return handleIngredient(io, recipe, left, simulate, this.handlerIO, storage);
     }
 
     @Nullable
-    public static List<Ingredient> handleIngredient(IO io, List<Ingredient> left, boolean simulate, IO handlerIO, ItemStackTransfer storage) {
+    public static List<Ingredient> handleIngredient(IO io, GTRecipe recipe, List<Ingredient> left, boolean simulate, IO handlerIO, ItemStackTransfer storage) {
         if (io != handlerIO) return left;
         var capability = simulate ? storage.copy() : storage;
         Iterator<Ingredient> iterator = left.iterator();
@@ -92,7 +96,19 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                         ItemStack[] ingredientStacks = ingredient.getItems();
                         for (ItemStack ingredientStack : ingredientStacks) {
                             if (ingredientStack.is(itemStack.getItem())) {
-                                ItemStack extracted = capability.extractItem(i, ingredientStack.getCount(), false);
+                                ItemStack extracted = ItemStack.EMPTY;
+                                boolean didRunIngredientAction = false;
+                                if (GTCEu.isKubeJSLoaded()) {
+                                    //noinspection unchecked must be List<?> to be able to load without KJS.
+                                    ItemStack actioned = KJSCallWrapper.applyIngredientAction(capability, i, (List<IngredientAction>) recipe.ingredientActions);
+                                    if (!actioned.isEmpty()) {
+                                        extracted = actioned;
+                                        didRunIngredientAction = true;
+                                    }
+                                }
+                                if (!didRunIngredientAction) {
+                                    extracted = capability.extractItem(i, ingredientStack.getCount(), false);
+                                }
                                 ingredientStack.setCount(ingredientStack.getCount() - extracted.getCount());
                                 if (ingredientStack.isEmpty()) {
                                     iterator.remove();
@@ -114,7 +130,19 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                 ItemStack output = items[0];
                 if (!output.isEmpty()) {
                     for (int i = 0; i < capability.getSlots(); i++) {
-                        ItemStack leftStack = capability.insertItem(i, output.copy(), false);
+                        ItemStack leftStack = ItemStack.EMPTY;
+                        boolean didRunIngredientAction = false;
+                        if (GTCEu.isKubeJSLoaded()) {
+                            //noinspection unchecked must be List<?> to be able to load without KJS.
+                            ItemStack actioned = KJSCallWrapper.applyIngredientAction(capability, i, (List<IngredientAction>) recipe.ingredientActions);
+                            if (!actioned.isEmpty()) {
+                                leftStack = actioned;
+                                didRunIngredientAction = true;
+                            }
+                        }
+                        if (!didRunIngredientAction) {
+                            leftStack = capability.insertItem(i, output.copy(), false);
+                        }
                         output.setCount(leftStack.getCount());
                         if (output.isEmpty()) break;
                     }
@@ -240,6 +268,25 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
     @Override
     public void restoreFromSnapshot(Object snapshot) {
         storage.restoreFromSnapshot(snapshot);
+    }
+
+    public static class KJSCallWrapper {
+        public static ItemStack applyIngredientAction(ItemStackTransfer storage, int index, List<IngredientAction> ingredientActions) {
+            var stack = storage.getStackInSlot(index);
+
+            if (stack.isEmpty()) {
+                return ItemStack.EMPTY;
+            }
+
+            DummyCraftingContainer container = new DummyCraftingContainer(storage);
+            for (var action : ingredientActions) {
+                if (action.checkFilter(index, stack)) {
+                    return action.transform(stack.copy(), index, container);
+                }
+            }
+
+            return ItemStack.EMPTY;
+        }
     }
 
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -206,7 +206,10 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                 result = handleTickRecipe(lastRecipe);
                 if (result.isSuccess()) {
                     setStatus(Status.WORKING);
-                    machine.onWorking();
+                    if (!machine.onWorking()) {
+                        this.interruptRecipe();
+                        return;
+                    }
                     progress++;
                     totalContinuousRunningTime++;
                 } else {
@@ -310,7 +313,9 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
 
     public void setupRecipe(GTRecipe recipe) {
         if (handleFuelRecipe()) {
-            machine.beforeWorking();
+            if (!machine.beforeWorking()) {
+                return;
+            }
             recipe.preWorking(this.machine);
             if (handleRecipeIO(recipe, IO.IN)) {
                 recipeDirty = false;

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
@@ -36,7 +36,7 @@ public class ItemRecipeHandler implements IRecipeHandler<Ingredient> {
 
     @Override
     public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, @Nullable String slotName, boolean simulate) {
-        return handleIngredient(io, left, simulate, this.handlerIO, storage);
+        return handleIngredient(io, recipe, left, simulate, this.handlerIO, storage);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/DummyCraftingContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/DummyCraftingContainer.java
@@ -1,0 +1,80 @@
+package com.gregtechceu.gtceu.api.recipe;
+
+import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.inventory.TransientCraftingContainer;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public class DummyCraftingContainer extends TransientCraftingContainer {
+
+    private final IItemTransfer itemTransfer;
+
+    public DummyCraftingContainer(IItemTransfer itemHandler) {
+        super(null, 0, 0);
+        this.itemTransfer = itemHandler;
+    }
+
+    @Override
+    public int getContainerSize() {
+        return this.itemTransfer.getSlots();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        for (int slot = 0; slot < this.getContainerSize(); slot++) {
+            if (!this.getItem(slot).isEmpty())
+                return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public @NotNull ItemStack getItem(int slot) {
+        return slot >= this.getContainerSize() ? ItemStack.EMPTY : this.itemTransfer.getStackInSlot(slot);
+    }
+
+    @Override
+    public @NotNull ItemStack removeItemNoUpdate(int slot) {
+        return this.itemTransfer.extractItem(slot, Integer.MAX_VALUE, false, false);
+    }
+
+    @Override
+    public @NotNull ItemStack removeItem(int slot, int count) {
+        return this.itemTransfer.extractItem(slot, count, false, true);
+    }
+
+    @Override
+    public void setItem(int slot, @NotNull ItemStack stack) {
+        this.itemTransfer.setStackInSlot(slot, stack);
+    }
+
+    @Override
+    public void clearContent() {
+        for (int i = 0; i < this.itemTransfer.getSlots(); ++i) {
+            this.itemTransfer.setStackInSlot(i, ItemStack.EMPTY);
+        }
+    }
+
+    @Override
+    public void fillStackedContents(@NotNull StackedContents helper) {}
+
+    private static NonNullList<ItemStack> createInventory(IItemTransfer itemHandler) {
+        NonNullList<ItemStack> inv = NonNullList.create();
+
+        for (int slot = 0; slot < itemHandler.getSlots(); slot++) {
+            ItemStack stack = itemHandler.getStackInSlot(slot);
+
+            if (stack.isEmpty())
+                continue;
+
+            ItemStack stackCopy = stack.copy();
+            inv.add(stackCopy);
+        }
+
+        return inv;
+    }
+
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -22,7 +22,6 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.*;
 import java.util.function.Supplier;
@@ -44,13 +43,26 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     public final Map<RecipeCapability<?>, List<Content>> tickInputs;
     public final Map<RecipeCapability<?>, List<Content>> tickOutputs;
     public final List<RecipeCondition> conditions;
+    // for KubeJS. actual type is List<IngredientAction>.
+    // Must be List<?> to not cause crashes without KubeJS.
+    public final List<?> ingredientActions;
     @NotNull
     public CompoundTag data;
     public int duration;
     @Getter
     public boolean isFuel;
 
-    public GTRecipe(GTRecipeType recipeType, ResourceLocation id, Map<RecipeCapability<?>, List<Content>> inputs, Map<RecipeCapability<?>, List<Content>> outputs, Map<RecipeCapability<?>, List<Content>> tickInputs, Map<RecipeCapability<?>, List<Content>> tickOutputs, List<RecipeCondition> conditions, @NotNull CompoundTag data, int duration, boolean isFuel) {
+    public GTRecipe(GTRecipeType recipeType,
+                    ResourceLocation id,
+                    Map<RecipeCapability<?>, List<Content>> inputs,
+                    Map<RecipeCapability<?>, List<Content>> outputs,
+                    Map<RecipeCapability<?>, List<Content>> tickInputs,
+                    Map<RecipeCapability<?>, List<Content>> tickOutputs,
+                    List<RecipeCondition> conditions,
+                    List<?> ingredientActions,
+                    @NotNull CompoundTag data,
+                    int duration,
+                    boolean isFuel) {
         this.recipeType = recipeType;
         this.id = id;
         this.inputs = inputs;
@@ -58,6 +70,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
         this.tickInputs = tickInputs;
         this.tickOutputs = tickOutputs;
         this.conditions = conditions;
+        this.ingredientActions = ingredientActions;
         this.data = data;
         this.duration = duration;
         this.isFuel = isFuel;
@@ -80,7 +93,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     }
 
     public GTRecipe copy() {
-        return new GTRecipe(recipeType, id, copyContents(inputs, null), copyContents(outputs, null), copyContents(tickInputs, null), copyContents(tickOutputs, null), new ArrayList<>(conditions), data, duration, isFuel);
+        return new GTRecipe(recipeType, id, copyContents(inputs, null), copyContents(outputs, null), copyContents(tickInputs, null), copyContents(tickOutputs, null), new ArrayList<>(conditions), new ArrayList<>(ingredientActions), data, duration, isFuel);
     }
 
     public GTRecipe copy(ContentModifier modifier) {
@@ -88,7 +101,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     }
 
     public GTRecipe copy(ContentModifier modifier, boolean modifyDuration) {
-        var copied = new GTRecipe(recipeType, id, copyContents(inputs, modifier), copyContents(outputs, modifier), copyContents(tickInputs, modifier), copyContents(tickOutputs, modifier), new ArrayList<>(conditions), data, duration, isFuel);
+        var copied = new GTRecipe(recipeType, id, copyContents(inputs, modifier), copyContents(outputs, modifier), copyContents(tickInputs, modifier), copyContents(tickOutputs, modifier), new ArrayList<>(conditions), new ArrayList<>(ingredientActions), data, duration, isFuel);
         if (modifyDuration) {
             copied.duration = modifier.apply(this.duration).intValue();
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -3,15 +3,14 @@ package com.gregtechceu.gtceu.api.recipe;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
-import net.minecraft.core.Registry;
+import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.TagParser;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.util.Tuple;
@@ -74,8 +73,12 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                 }
             }
         }
+        List<?> ingredientActions = new ArrayList<>();
+        if (GTCEu.isKubeJSLoaded()) {
+            ingredientActions = KJSCallWrapper.getIngredientActions(json);
+        }
         boolean isFuel = GsonHelper.getAsBoolean(json, "isFuel", false);
-        return new GTRecipe((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(new ResourceLocation(recipeType)), id, inputs, outputs, tickInputs, tickOutputs, conditions, data, duration, isFuel);
+        return new GTRecipe((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(new ResourceLocation(recipeType)), id, inputs, outputs, tickInputs, tickOutputs, conditions, ingredientActions, data, duration, isFuel);
     }
 
     public static Tuple<RecipeCapability<?>, List<Content>> entryReader(FriendlyByteBuf buf) {
@@ -110,29 +113,52 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
     @Override
     @NotNull
     public GTRecipe fromNetwork(@NotNull ResourceLocation id, @NotNull FriendlyByteBuf buf) {
-        String recipeType = buf.readUtf();
+        ResourceLocation recipeType = buf.readResourceLocation();
         int duration = buf.readVarInt();
         Map<RecipeCapability<?>, List<Content>> inputs = tuplesToMap(buf.readCollection(c -> new ArrayList<>(), GTRecipeSerializer::entryReader));
         Map<RecipeCapability<?>, List<Content>> tickInputs = tuplesToMap(buf.readCollection(c -> new ArrayList<>(), GTRecipeSerializer::entryReader));
         Map<RecipeCapability<?>, List<Content>> outputs = tuplesToMap(buf.readCollection(c -> new ArrayList<>(), GTRecipeSerializer::entryReader));
         Map<RecipeCapability<?>, List<Content>> tickOutputs = tuplesToMap(buf.readCollection(c -> new ArrayList<>(), GTRecipeSerializer::entryReader));
         List<RecipeCondition> conditions = buf.readCollection(c -> new ArrayList<>(), GTRecipeSerializer::conditionReader);
+        List<?> ingredientActions = new ArrayList<>();
+        if (GTCEu.isKubeJSLoaded()) {
+            ingredientActions = KJSCallWrapper.getIngredientActions(buf);
+        }
         CompoundTag data = buf.readNbt();
+        if (data == null) {
+            data = new CompoundTag();
+        }
         boolean isFuel = buf.readBoolean();
-        return new GTRecipe((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(new ResourceLocation(recipeType)), id, inputs, outputs, tickInputs, tickOutputs, conditions, data, duration, isFuel);
+        return new GTRecipe((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(recipeType), id, inputs, outputs, tickInputs, tickOutputs, conditions, ingredientActions, data, duration, isFuel);
     }
 
     @Override
     public void toNetwork(FriendlyByteBuf buf, GTRecipe recipe) {
-        buf.writeUtf(recipe.recipeType == null ? "dummy" : recipe.recipeType.toString());
+        buf.writeResourceLocation(recipe.recipeType.registryName);
         buf.writeVarInt(recipe.duration);
         buf.writeCollection(recipe.inputs.entrySet(), GTRecipeSerializer::entryWriter);
         buf.writeCollection(recipe.tickInputs.entrySet(), GTRecipeSerializer::entryWriter);
         buf.writeCollection(recipe.outputs.entrySet(), GTRecipeSerializer::entryWriter);
         buf.writeCollection(recipe.tickOutputs.entrySet(), GTRecipeSerializer::entryWriter);
         buf.writeCollection(recipe.conditions, GTRecipeSerializer::conditionWriter);
+        if (GTCEu.isKubeJSLoaded()) {
+            KJSCallWrapper.writeIngredientActions(recipe.ingredientActions, buf);
+        }
         buf.writeNbt(recipe.data);
         buf.writeBoolean(recipe.isFuel);
     }
 
+    public static class KJSCallWrapper {
+        public static List<?> getIngredientActions(JsonObject json) {
+            return IngredientAction.parseList(json.get("kubejs:actions"));
+        }
+        public static List<?> getIngredientActions(FriendlyByteBuf buf) {
+            return IngredientAction.readList(buf);
+        }
+        public static void writeIngredientActions(List<?> ingredientActions, FriendlyByteBuf buf) {
+            //noinspection unchecked must be List<?> to be able to load without KJS.
+            IngredientAction.writeList(buf, (List<IngredientAction>) ingredientActions);
+
+        }
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -4,22 +4,18 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.lowdragmc.lowdraglib.LDLib;
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
-import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.PoseStack;
-import dev.emi.emi.screen.RecipeScreen;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
 import org.jetbrains.annotations.Nullable;
 
+@AllArgsConstructor
 public class Content {
     @Getter
     public Object content;
@@ -29,14 +25,6 @@ public class Content {
     public String slotName;
     @Nullable
     public String uiName;
-
-    public Content(Object content, float chance, float tierChanceBoost, @Nullable String slotName, @Nullable String uiName) {
-        this.content = content;
-        this.chance = chance;
-        this.tierChanceBoost = tierChanceBoost;
-        this.slotName = slotName;
-        this.uiName = uiName;
-    }
 
     public Content copy(RecipeCapability<?> capability, @Nullable ContentModifier modifier) {
         if (modifier == null || chance == 0) {

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.item.MetaMachineItem;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
@@ -53,6 +54,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.function.TriFunction;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.*;
@@ -113,6 +115,19 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     private BiFunction<MetaMachine, GTRecipe, GTRecipe> recipeModifier = GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.NON_PERFECT_OVERCLOCK);
     @Setter
     private boolean alwaysTryModifyRecipe;
+    @NotNull
+    @Getter @Setter
+    private Predicate<IRecipeLogicMachine> beforeWorking = (machine) -> true;
+    @NotNull
+    @Getter @Setter
+    private Predicate<IRecipeLogicMachine> onWorking = (machine) -> true;
+    @NotNull
+    @Getter @Setter
+    private Consumer<IRecipeLogicMachine> onWaiting = (machine) -> {};
+    @NotNull
+    @Getter @Setter
+    private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
+
     @Setter
     private Supplier<BlockState> appearance;
     @Setter @Nullable
@@ -341,6 +356,11 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         });
         definition.setRecipeModifier(recipeModifier);
         definition.setAlwaysTryModifyRecipe(alwaysTryModifyRecipe);
+        definition.setBeforeWorking(this.beforeWorking);
+        definition.setOnWorking(this.onWorking);
+        definition.setOnWaiting(this.onWaiting);
+        definition.setAfterWorking(this.afterWorking);
+
         if (renderer == null) {
             renderer = () -> new MachineRenderer(new ResourceLocation(registrate.getModid(), "block/machine/" + name));
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.registry.registrate;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
@@ -16,7 +17,6 @@ import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.pattern.BlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
-import com.gregtechceu.gtceu.common.data.GTCompassNodes;
 import com.gregtechceu.gtceu.common.data.GTCompassSections;
 import com.gregtechceu.gtceu.utils.SupplierMemoizer;
 import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
@@ -272,6 +272,26 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     @Override
     public MultiblockMachineBuilder alwaysTryModifyRecipe(boolean alwaysTryModifyRecipe) {
         return (MultiblockMachineBuilder) super.alwaysTryModifyRecipe(alwaysTryModifyRecipe);
+    }
+
+    @Override
+    public MultiblockMachineBuilder beforeWorking(Predicate<IRecipeLogicMachine> beforeWorking) {
+        return (MultiblockMachineBuilder) super.beforeWorking(beforeWorking);
+    }
+
+    @Override
+    public MultiblockMachineBuilder onWorking(Predicate<IRecipeLogicMachine> onWorking) {
+        return (MultiblockMachineBuilder) super.onWorking(onWorking);
+    }
+
+    @Override
+    public MultiblockMachineBuilder onWaiting(Consumer<IRecipeLogicMachine> onWaiting) {
+        return (MultiblockMachineBuilder) super.onWaiting(onWaiting);
+    }
+
+    @Override
+    public MultiblockMachineBuilder afterWorking(Consumer<IRecipeLogicMachine> afterWorking) {
+        return (MultiblockMachineBuilder) super.afterWorking(afterWorking);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
@@ -189,7 +189,9 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine im
 
             // Do RecipeLogic#setupRecipe but without any i/o
             if (handleFuelRecipe()) {
-                machine.beforeWorking();
+                if (!machine.beforeWorking()) {
+                    return;
+                }
                 recipe.preWorking(this.machine);
 
                 // do not consume inputs here, consume them on completion

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeCombustionEngineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeCombustionEngineMachine.java
@@ -122,14 +122,15 @@ public class LargeCombustionEngineMachine extends WorkableElectricMultiblockMach
     }
 
     @Override
-    public void onWorking() {
-        super.onWorking();
+    public boolean onWorking() {
+        boolean value = super.onWorking();
         // check lubricant
         val totalContinuousRunningTime = recipeLogic.getTotalContinuousRunningTime();
         if ((totalContinuousRunningTime == 1 || totalContinuousRunningTime % 72 == 0)) {
             // insufficient lubricant
             if (!getLubricantRecipe().handleRecipeIO(IO.IN, this)) {
                 recipeLogic.interruptRecipe();
+                return false;
             }
         }
         // check boost fluid
@@ -137,6 +138,7 @@ public class LargeCombustionEngineMachine extends WorkableElectricMultiblockMach
             var boosterRecipe = getBoostRecipe();
             this.isOxygenBoosted = boosterRecipe.matchRecipe(this).isSuccess() && boosterRecipe.handleRecipeIO(IO.IN, this);
         }
+        return value;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
@@ -141,7 +141,7 @@ public class RotorHolderPartMachine extends TieredPartMachine implements IMachin
     }
 
     @Override
-    public void onWorking(IWorkableMultiController controller) {
+    public boolean onWorking(IWorkableMultiController controller) {
         if (getRotorSpeed() < getMaxRotorHolderSpeed()) {
             setRotorSpeed(getRotorSpeed() + SPEED_INCREMENT);
             updateRotorSubscription();
@@ -156,6 +156,7 @@ public class RotorHolderPartMachine extends TieredPartMachine implements IMachin
             }
             damageRotor(1 + numMaintenanceProblems);
         }
+        return true;
     }
 
     public int getTierDifference() {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -175,11 +175,13 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IEx
     }
 
     @Override
-    public void onWorking() {
+    public boolean onWorking() {
+        boolean value = super.onWorking();
         if (currentTemperature < getMaxTemperature()) {
             currentTemperature = Math.max(1, currentTemperature);
             updateSteamSubscription();
         }
+        return value;
     }
 
     @Nullable

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/CleanroomLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/CleanroomLogic.java
@@ -71,11 +71,15 @@ public class CleanroomLogic extends RecipeLogic implements IWorkable {
                 }
                 // increase progress
                 if (progress++ < getMaxProgress()) {
-                    machine.onWorking();
+                    if (!machine.onWorking()) {
+                        this.interruptRecipe();
+                    }
                     return;
                 }
                 progress = 0;
-                machine.beforeWorking();
+                if (!machine.beforeWorking()) {
+                    return;
+                }
                 adjustCleanAmount(false);
                 setStatus(Status.WORKING);
             } else {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -756,7 +756,7 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipe buildRawRecipe() {
-        return new GTRecipe(recipeType, id.withPrefix(recipeType.registryName.getPath() + "/"), input, output, tickInput, tickOutput, conditions, data, duration, isFuel);
+        return new GTRecipe(recipeType, id.withPrefix(recipeType.registryName.getPath() + "/"), input, output, tickInput, tickOutput, conditions, List.of(), data, duration, isFuel);
     }
 
     //////////////////////////////////////
@@ -786,9 +786,9 @@ public class GTRecipeBuilder {
      */
     @Accessors(fluent = false)
     public record ResearchRecipeEntry(
-            @NotNull @Getter String researchId,
-            @NotNull @Getter ItemStack researchStack,
-            @NotNull @Getter ItemStack dataStack,
+            @NotNull String researchId,
+            @NotNull ItemStack researchStack,
+            @NotNull ItemStack dataStack,
             @Getter int duration,
             @Getter int EUt,
             @Getter int CWUt) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
@@ -132,7 +132,7 @@ public class MEInputBusPartMachine extends MEBusPartMachine implements IInWorldG
 
         @Override
         public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, @Nullable String slotName, boolean simulate) {
-            return handleIngredient(io, left, simulate, this.handlerIO, new ItemStackTransfer(NonNullList.of(ItemStack.EMPTY, Arrays.stream(inventory).map(item -> item.getStackInSlot(0)).toArray(ItemStack[]::new))) {
+            return handleIngredient(io, recipe, left, simulate, this.handlerIO, new ItemStackTransfer(NonNullList.of(ItemStack.EMPTY, Arrays.stream(inventory).map(item -> item.getStackInSlot(0)).toArray(ItemStack[]::new))) {
                 @NotNull
                 @Override
                 public ItemStack extractItem(int slot, int amount, boolean simulate, boolean notifyChanges) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputBusPartMachine.java
@@ -137,7 +137,7 @@ public class MEOutputBusPartMachine extends MEBusPartMachine {
 
         @Override
         public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, @Nullable String slotName, boolean simulate) {
-            return handleIngredient(io, left, simulate, this.handlerIO, new ItemStackTransfer(16) {
+            return handleIngredient(io, recipe, left, simulate, this.handlerIO, new ItemStackTransfer(16) {
                 @NotNull
                 @Override
                 public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate, boolean notifyChanges) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -8,19 +8,23 @@ import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.item.component.IDataItem;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.CleanroomType;
 import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
+import com.gregtechceu.gtceu.api.recipe.ResearchData;
+import com.gregtechceu.gtceu.api.recipe.ResearchRecipeBuilder;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntCircuitIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.NBTIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
-import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
 import com.gregtechceu.gtceu.common.recipe.*;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.CapabilityMap;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
+import com.gregtechceu.gtceu.utils.ResearchManager;
 import com.lowdragmc.lowdraglib.LDLib;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.fluid.InputFluid;
@@ -42,10 +46,17 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
 import org.apache.commons.lang3.ArrayUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 public interface GTRecipeSchema {
     
@@ -58,8 +69,15 @@ public interface GTRecipeSchema {
         public float chance = 1;
         @Setter
         public float tierChanceBoost = 0;
+        @Setter
+        public boolean isFuel = false;
         @Getter
         private ResourceLocation idWithoutType;
+        @Setter
+        public Consumer<GTRecipeJS> onSave;
+        @Getter
+        private final Collection<GTRecipeBuilder.ResearchRecipeEntry> researchRecipeEntries = new ArrayList<>();
+        private boolean generatingRecipes = true;
 
         @HideFromJS
         @Override
@@ -440,6 +458,10 @@ public interface GTRecipeSchema {
             return addData("eu_to_start", eu);
         }
 
+        public GTRecipeJS researchScan(boolean isScan) {
+            return addData("scan_for_research", isScan);
+        }
+
         public GTRecipeJS durationIsTotalCWU(boolean durationIsTotalCWU) {
             return addData("duration_is_total_cwu", durationIsTotalCWU);
         }
@@ -504,9 +526,96 @@ public interface GTRecipeSchema {
             return rpm(rpm, false);
         }
 
+        private boolean applyResearchProperty(ResearchData.ResearchEntry researchEntry) {
+            if (!ConfigHolder.INSTANCE.machines.enableResearch) return false;
+            if (researchEntry == null) {
+                GTCEu.LOGGER.error("Assembly Line Research Entry cannot be empty.", new IllegalArgumentException());
+                return false;
+            }
+
+            if (!generatingRecipes) {
+                GTCEu.LOGGER.error("Cannot generate recipes when using researchWithoutRecipe()", new IllegalArgumentException());
+                return false;
+            }
+
+            if (getValue(CONDITIONS) == null) setValue(CONDITIONS, new RecipeCondition[0]);
+            ResearchCondition condition = Arrays.stream(this.getValue(CONDITIONS)).filter(ResearchCondition.class::isInstance).findAny().map(ResearchCondition.class::cast).orElse(null);
+            if (condition != null) {
+                condition.data.add(researchEntry);
+            } else {
+                condition = new ResearchCondition();
+                condition.data.add(researchEntry);
+                this.addCondition(condition);
+            }
+            return true;
+        }
+
+        /**
+         * Does not generate a research recipe.
+         *
+         * @param researchId the researchId for the recipe
+         * @return this
+         */
+        public GTRecipeJS researchWithoutRecipe(@NotNull String researchId) {
+            return researchWithoutRecipe(researchId, ResearchManager.getDefaultScannerItem());
+        }
+
+        /**
+         * Does not generate a research recipe.
+         *
+         * @param researchId the researchId for the recipe
+         * @param dataStack the stack to hold the data. Must have the {@link IDataItem} behavior.
+         * @return this
+         */
+        public GTRecipeJS researchWithoutRecipe(@NotNull String researchId, @NotNull ItemStack dataStack) {
+            applyResearchProperty(new ResearchData.ResearchEntry(researchId, dataStack));
+            this.generatingRecipes = false;
+            return this;
+        }
+
+        /**
+         * Generates a research recipe for the Scanner.
+         */
+        public GTRecipeJS scannerResearch(UnaryOperator<ResearchRecipeBuilder.ScannerRecipeBuilder> research) {
+            GTRecipeBuilder.ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.ScannerRecipeBuilder()).build();
+            if (applyResearchProperty(new ResearchData.ResearchEntry(entry.researchId(), entry.dataStack()))) {
+                this.researchRecipeEntries.add(entry);
+            }
+            return this;
+        }
+
+        /**
+         * Generates a research recipe for the Scanner. All values are defaults other than the research stack.
+         *
+         * @param researchStack the stack to use for research
+         * @return this
+         */
+        public GTRecipeJS scannerResearch(@NotNull ItemStack researchStack) {
+            return scannerResearch(b -> b.researchStack(researchStack));
+        }
+
+        /**
+         * Generates a research recipe for the Research Station.
+         */
+        public GTRecipeJS stationResearch(UnaryOperator<ResearchRecipeBuilder.StationRecipeBuilder> research) {
+            GTRecipeBuilder.ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.StationRecipeBuilder()).build();
+            if (applyResearchProperty(new ResearchData.ResearchEntry(entry.researchId(), entry.dataStack()))) {
+                this.researchRecipeEntries.add(entry);
+            }
+            return this;
+        }
+
         /*
          * KubeJS overrides
          */
+
+        @Override
+        public @Nullable Recipe<?> createRecipe() {
+            if (onSave != null) {
+                onSave.accept(this);
+            }
+            return super.createRecipe();
+        }
 
         public InputItem readInputItem(Object from) {
             if (from instanceof SizedIngredient ingr) {


### PR DESCRIPTION
## What
adds:
- callbacks for machine actions (onWorking/onWaiting/beforeWorking/afterWorking)
- KubeJS ingredient action support for transforming item inputs (KubeJS doesn't support fluids so those aren't done here either.).
- the research recipe methods into the KubeJS recipe builder.
- an `onSave` action for KubeJS recipes, for creating "subrecipes" à la Distillation tower -> distillery, or circuit assembler (no fluid) -> circuit assembler (tin or soldering alloy)

## Implementation Details
the actions are stored as a `List<?>` in GTRecipe to remove the generics when KubeJS isn't installed. this is a safety feature so that the mod doesn't crash.

## Outcome
closes #1077 
closes #1029 