### PR TITLE
add filtering to output hatches

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
         def vineFlowerVersion = "1.+"
         def macheteVersion = "1.+"
         def configurationVersion = "2.2.0"
-        def ldLibVersion = "1.0.25.d"
+        def ldLibVersion = "1.0.25.e"
         def mixinextrasVersion = "0.2.0"
         def shimmerVersion = "0.2.2"
         

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/BlockStateRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/BlockStateRecipeCapability.java
@@ -8,7 +8,7 @@ public class BlockStateRecipeCapability extends RecipeCapability<BlockState> {
     public final static BlockStateRecipeCapability CAP = new BlockStateRecipeCapability();
 
     protected BlockStateRecipeCapability() {
-        super("block_state", 0xFFABABAB, SerializerBlockState.INSTANCE);
+        super("block_state", 0xFFABABAB, false, SerializerBlockState.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/BlockStateRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/BlockStateRecipeCapability.java
@@ -8,7 +8,7 @@ public class BlockStateRecipeCapability extends RecipeCapability<BlockState> {
     public final static BlockStateRecipeCapability CAP = new BlockStateRecipeCapability();
 
     protected BlockStateRecipeCapability() {
-        super("block_state", 0xFFABABAB, false, SerializerBlockState.INSTANCE);
+        super("block_state", 0xFFABABAB, false, 5, SerializerBlockState.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/CWURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/CWURecipeCapability.java
@@ -21,7 +21,7 @@ public class CWURecipeCapability extends RecipeCapability<Integer> {
     public final static CWURecipeCapability CAP = new CWURecipeCapability();
 
     protected CWURecipeCapability() {
-        super("cwu", 0xFFEEEE00, false, SerializerInteger.INSTANCE);
+        super("cwu", 0xFFEEEE00, false, 3, SerializerInteger.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/CWURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/CWURecipeCapability.java
@@ -21,7 +21,7 @@ public class CWURecipeCapability extends RecipeCapability<Integer> {
     public final static CWURecipeCapability CAP = new CWURecipeCapability();
 
     protected CWURecipeCapability() {
-        super("cwu", 0xFFEEEE00, SerializerInteger.INSTANCE);
+        super("cwu", 0xFFEEEE00, false, SerializerInteger.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
@@ -16,7 +16,7 @@ public class EURecipeCapability extends RecipeCapability<Long> {
     public final static EURecipeCapability CAP = new EURecipeCapability();
 
     protected EURecipeCapability() {
-        super("eu", 0xFFFFFF00, false, SerializerLong.INSTANCE);
+        super("eu", 0xFFFFFF00, false, 2, SerializerLong.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
@@ -16,7 +16,7 @@ public class EURecipeCapability extends RecipeCapability<Long> {
     public final static EURecipeCapability CAP = new EURecipeCapability();
 
     protected EURecipeCapability() {
-        super("eu", 0xFFFFFF00, SerializerLong.INSTANCE);
+        super("eu", 0xFFFFFF00, false, SerializerLong.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -45,7 +45,7 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
     public final static FluidRecipeCapability CAP = new FluidRecipeCapability();
 
     protected FluidRecipeCapability() {
-        super("fluid", 0xFF3C70EE, true, SerializerFluidIngredient.INSTANCE);
+        super("fluid", 0xFF3C70EE, true, 1, SerializerFluidIngredient.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IFilteredHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IFilteredHandler.java
@@ -1,0 +1,27 @@
+package com.gregtechceu.gtceu.api.capability.recipe;
+
+import java.util.Comparator;
+import java.util.function.Predicate;
+
+public interface IFilteredHandler<K> extends Predicate<K> {
+    Comparator<IFilteredHandler<?>> PRIORITY_COMPARATOR = Comparator.comparingInt(IFilteredHandler::getPriority);
+    int NO_PRIORITY = Integer.MIN_VALUE;
+
+    /**
+     * Test an ingredient for filtering & priority.
+     * @param ingredient the ingredient
+     * @return {@code true} if the input argument matches the predicate,
+     * otherwise {@code false}
+     */
+    @Override
+    default boolean test(K ingredient) {
+        return true;
+    }
+
+    /**
+     * The priority of this recipe handler.
+     */
+    default int getPriority() {
+        return NO_PRIORITY;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
@@ -4,6 +4,8 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -12,7 +14,19 @@ import java.util.Set;
  * @date 2023/2/20
  * @implNote IRecipeHandler
  */
-public interface IRecipeHandler<K> {
+public interface IRecipeHandler<K> extends IFilteredHandler<K> {
+    /**
+     * Comparator for entries that can be used in insertion logic
+     */
+    Comparator<IRecipeHandler<?>> ENTRY_COMPARATOR = (o1, o2) -> {
+        // #1: non-empty storage first
+        boolean empty1 = o1.getTotalContentAmount() <= 0;
+        boolean empty2 = o2.getTotalContentAmount() <= 0;
+        if (empty1 != empty2) return empty1 ? 1 : -1;
+
+        // #2: filter priority
+        return IFilteredHandler.PRIORITY_COMPARATOR.compare(o1, o2);
+    };
 
     /**
      * matching or handling the given recipe.

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
@@ -6,7 +6,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author KilaBash
@@ -45,6 +44,8 @@ public interface IRecipeHandler<K> {
     }
 
     List<Object> getContents();
+
+    double getTotalContentAmount();
 
     /**
      * Whether the content of same capability  can only be handled distinct.

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -56,7 +56,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
     public final static ItemRecipeCapability CAP = new ItemRecipeCapability();
 
     protected ItemRecipeCapability() {
-        super("item", 0xFFD96106, true, SerializerIngredient.INSTANCE);
+        super("item", 0xFFD96106, true, 0, SerializerIngredient.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -3,23 +3,48 @@ package com.gregtechceu.gtceu.api.capability.recipe;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.api.recipe.ResearchData;
+import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.content.SerializerIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntCircuitIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.api.recipe.lookup.*;
-import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.api.recipe.ui.GTRecipeTypeUI;
+import com.gregtechceu.gtceu.common.recipe.ResearchCondition;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.IngredientAccessor;
+import com.gregtechceu.gtceu.core.mixins.IntersectionIngredientAccessor;
 import com.gregtechceu.gtceu.core.mixins.TagValueAccessor;
+import com.gregtechceu.gtceu.integration.GTRecipeWidget;
 import com.gregtechceu.gtceu.utils.IngredientEquality;
+import com.gregtechceu.gtceu.utils.ResearchManager;
+import com.lowdragmc.lowdraglib.gui.widget.SlotWidget;
+import com.lowdragmc.lowdraglib.gui.widget.Widget;
+import com.lowdragmc.lowdraglib.jei.IngredientIO;
+import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
+import com.lowdragmc.lowdraglib.utils.CycleItemStackHandler;
+import com.lowdragmc.lowdraglib.utils.TagOrCycleItemStackTransfer;
+import com.mojang.datafixers.util.Either;
+import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.IntersectionIngredient;
 import net.minecraftforge.common.crafting.StrictNBTIngredient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * @author KilaBash
@@ -31,7 +56,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
     public final static ItemRecipeCapability CAP = new ItemRecipeCapability();
 
     protected ItemRecipeCapability() {
-        super("item", 0xFFD96106, SerializerIngredient.INSTANCE);
+        super("item", 0xFFD96106, true, SerializerIngredient.INSTANCE);
     }
 
     @Override
@@ -153,4 +178,218 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
         return true;
     }
 
+    @Override
+    public @NotNull List<Object> createXEIContainerContents(List<Content> contents, GTRecipe recipe) {
+        var outputStacks = contents.stream().map(content -> content.content)
+            .map(this::of)
+            .map(ItemRecipeCapability::mapItem)
+            .collect(Collectors.toList());
+
+        List<Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>>> scannerPossibilities = null;
+        if (recipe.recipeType.isScanner()) {
+            scannerPossibilities = new ArrayList<>();
+            // Scanner Output replacing, used for cycling research outputs
+            Pair<GTRecipeType, String> researchData = null;
+            for (Content stack : recipe.getOutputContents(ItemRecipeCapability.CAP)) {
+                researchData = ResearchManager.readResearchId(ItemRecipeCapability.CAP.of(stack.content).getItems()[0]);
+                if (researchData != null) break;
+            }
+            if (researchData != null) {
+                Collection<GTRecipe> possibleRecipes = researchData.getFirst().getDataStickEntry(researchData.getSecond());
+                if (possibleRecipes != null) {
+                    for (GTRecipe r : possibleRecipes) {
+                        ItemStack researchItem = ItemRecipeCapability.CAP.of(r.getOutputContents(ItemRecipeCapability.CAP).get(0).content).getItems()[0];
+                        researchItem = researchItem.copy();
+                        researchItem.setCount(1);
+                        boolean didMatch = false;
+                        for (Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>> stacks : scannerPossibilities) {
+                            for (ItemStack stack : stacks.map(
+                                tag -> tag
+                                    .stream()
+                                    .flatMap(key -> BuiltInRegistries.ITEM.getTag(key.getFirst()).stream())
+                                    .flatMap(holders -> holders.stream().map(holder -> new ItemStack(holder.get())))
+                                    .collect(Collectors.toList()),
+                                Function.identity())) {
+                                if (ItemStack.isSameItem(stack, researchItem)) {
+                                    didMatch = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!didMatch) scannerPossibilities.add(Either.right(List.of(researchItem)));
+                    }
+                }
+                scannerPossibilities.add(outputStacks.get(0));
+            }
+        }
+
+        if (scannerPossibilities != null && !scannerPossibilities.isEmpty()) {
+            outputStacks = scannerPossibilities;
+        }
+        while (outputStacks.size() < recipe.recipeType.getMaxOutputs(ItemRecipeCapability.CAP)) outputStacks.add(null);
+
+        return new ArrayList<>(outputStacks);
+    }
+
+    public Object createXEIContainer(List<?> contents) {
+        // cast is safe if you don't pass the wrong thing.
+        //noinspection unchecked
+        return new TagOrCycleItemStackTransfer((List<Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>>>) contents);
+    }
+
+    @NotNull
+    @Override
+    public Widget createWidget() {
+        SlotWidget slot = new SlotWidget();
+        slot.initTemplate();
+        return slot;
+    }
+
+    @NotNull
+    @Override
+    public Class<? extends Widget> getWidgetClass() {
+        return SlotWidget.class;
+    }
+
+    @Override
+    public void applyWidgetInfo(@NotNull Widget widget,
+                                int index,
+                                boolean isXEI,
+                                IO io,
+                                GTRecipeTypeUI.@UnknownNullability("null when storage == null") RecipeHolder recipeHolder,
+                                @NotNull GTRecipeType recipeType,
+                                @UnknownNullability("null when content == null") GTRecipe recipe,
+                                @Nullable Content content,
+                                @Nullable Object storage) {
+        if (widget instanceof SlotWidget slot) {
+            if (storage instanceof IItemTransfer items) {
+                if (index >= 0 && index < items.getSlots()) {
+                    slot.setHandlerSlot(items, index);
+                    slot.setIngredientIO(io == IO.IN ? IngredientIO.INPUT : IngredientIO.OUTPUT);
+                    slot.setCanTakeItems(!isXEI);
+                    slot.setCanPutItems(false);
+
+                    // 1 over container size.
+                    // If in a recipe viewer and a research slot can be added, add it.
+                    if (isXEI && recipeType.isHasResearchSlot() && index == items.getSlots()) {
+                        if (ConfigHolder.INSTANCE.machines.enableResearch) {
+                            ResearchCondition condition = recipeHolder.conditions().stream().filter(ResearchCondition.class::isInstance).findAny().map(ResearchCondition.class::cast).orElse(null);
+                            if (condition == null) {
+                                return;
+                            }
+                            List<ItemStack> dataItems = new ArrayList<>();
+                            for (ResearchData.ResearchEntry entry : condition.data) {
+                                ItemStack dataStick = entry.getDataItem().copy();
+                                ResearchManager.writeResearchToNBT(dataStick.getOrCreateTag(), entry.getResearchId(), recipeType);
+                                dataItems.add(dataStick);
+                            }
+                            CycleItemStackHandler handler = new CycleItemStackHandler(List.of(dataItems));
+                            slot.setHandlerSlot(handler, 0);
+                            slot.setIngredientIO(IngredientIO.INPUT);
+                            slot.setCanTakeItems(false);
+                            slot.setCanPutItems(false);
+                        }
+                    }
+                }
+            }
+            if (content != null) {
+                slot.setXEIChance(content.chance);
+                slot.setOnAddedTooltips((w, tooltips) -> {
+                    GTRecipeWidget.setConsumedChance(content, tooltips);
+                    if (index >= recipe.getOutputContents(this).size()) {
+                        tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
+                    }
+                });
+            }
+        }
+    }
+
+    // Maps ingredients to Either <(Tag with count), ItemStack>s
+    @SuppressWarnings("deprecation")
+    private static Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>> mapItem(Ingredient ingredient) {
+        if (ingredient instanceof SizedIngredient sizedIngredient) {
+            final int amount = sizedIngredient.getAmount();
+            if (sizedIngredient.getInner() instanceof IntersectionIngredient intersection) {
+                List<Ingredient> children = ((IntersectionIngredientAccessor)intersection).getChildren();
+                if (children.isEmpty()) {
+                    return Either.right(null);
+                }
+                var childEither = mapItem(children.get(0));
+                return Either.right(childEither.map(tags -> {
+                    List<ItemStack> tagItems = tags.stream()
+                        .map(pair -> Pair.of(BuiltInRegistries.ITEM.getTag(pair.getFirst()).stream(), pair.getSecond()))
+                        .flatMap(pair -> pair.getFirst().flatMap(tag -> tag.stream().map(holder -> new ItemStack(holder.value(), pair.getSecond()))))
+                        .collect(Collectors.toList());
+                    ListIterator<ItemStack> iterator = tagItems.listIterator();
+                    while (iterator.hasNext()) {
+                        var item = iterator.next();
+                        for (int i = 1; i < children.size(); ++i) {
+                            if (!children.get(i).test(item)) {
+                                iterator.remove();
+                                break;
+                            }
+                        }
+                        iterator.set(item.copyWithCount(amount));
+                    }
+                    return tagItems;
+                }, items -> {
+                    items = new ArrayList<>(items);
+                    ListIterator<ItemStack> iterator = items.listIterator();
+                    while (iterator.hasNext()) {
+                        var item = iterator.next();
+                        for (int i = 1; i < children.size(); ++i) {
+                            if (!children.get(i).test(item)) {
+                                iterator.remove();
+                                break;
+                            }
+                        }
+                        iterator.set(item.copyWithCount(amount));
+                    }
+                    return items;
+                }));
+            } else if (((IngredientAccessor)sizedIngredient.getInner()).getValues().length > 0 && ((IngredientAccessor)sizedIngredient.getInner()).getValues()[0] instanceof Ingredient.TagValue tagValue) {
+                return Either.left(List.of(Pair.of(((TagValueAccessor)tagValue).getTag(), amount)));
+            }
+        } else if (ingredient instanceof IntersectionIngredient intersection) {
+            // Map intersection ingredients to the items inside, as recipe viewers don't support them.
+            List<Ingredient> children = ((IntersectionIngredientAccessor)intersection).getChildren();
+            if (children.isEmpty()) {
+                return Either.right(null);
+            }
+            var childEither = mapItem(children.get(0));
+            return Either.right(childEither.map(tags -> {
+                List<ItemStack> tagItems = tags.stream()
+                    .map(pair -> Pair.of(BuiltInRegistries.ITEM.getTag(pair.getFirst()).stream(), pair.getSecond()))
+                    .flatMap(pair -> pair.getFirst().flatMap(tag -> tag.stream().map(holder -> new ItemStack(holder.value(), pair.getSecond()))))
+                    .collect(Collectors.toList());
+                ListIterator<ItemStack> iterator = tagItems.listIterator();
+                while (iterator.hasNext()) {
+                    var item = iterator.next();
+                    for (int i = 1; i < children.size(); ++i) {
+                        if (!children.get(i).test(item)) {
+                            iterator.remove();
+                            break;
+                        }
+                    }
+                }
+                return tagItems;
+            }, items -> {
+                items = new ArrayList<>(items);
+                ListIterator<ItemStack> iterator = items.listIterator();
+                while (iterator.hasNext()) {
+                    var item = iterator.next();
+                    for (int i = 1; i < children.size(); ++i) {
+                        if (!children.get(i).test(item)) {
+                            iterator.remove();
+                            break;
+                        }
+                    }
+                }
+                return items;
+            }));
+        } else if (((IngredientAccessor)ingredient).getValues().length > 0 && ((IngredientAccessor)ingredient).getValues()[0] instanceof Ingredient.TagValue tagValue) {
+            return Either.left(List.of(Pair.of(((TagValueAccessor)tagValue).getTag(), 1)));
+        }
+        return Either.right(Arrays.stream(ingredient.getItems()).toList());
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
@@ -1,14 +1,21 @@
 package com.gregtechceu.gtceu.api.capability.recipe;
 
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.content.IContentSerializer;
 import com.gregtechceu.gtceu.api.recipe.lookup.AbstractMapIngredient;
+import com.gregtechceu.gtceu.api.recipe.ui.GTRecipeTypeUI;
+import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 import io.netty.buffer.Unpooled;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,10 +30,12 @@ public abstract class RecipeCapability<T> {
     public final String name;
     public final int color;
     public final IContentSerializer<T> serializer;
+    public final boolean doRenderSlot;
 
-    protected RecipeCapability(String name, int color, IContentSerializer<T> serializer) {
+    protected RecipeCapability(String name, int color, boolean doRenderSlot, IContentSerializer<T> serializer) {
         this.name = name;
         this.color = color;
+        this.doRenderSlot = doRenderSlot;
         this.serializer = serializer;
     }
 
@@ -93,7 +102,7 @@ public abstract class RecipeCapability<T> {
     }
 
     /**
-     * Does the recipe test if this capability is workable? if not, you should test validity somewhere later.
+     * Does the recipe test if this capability is workable? if not, you should test validity somewhere else.
      */
     public boolean doMatchInRecipe() {
         return true;
@@ -104,6 +113,38 @@ public abstract class RecipeCapability<T> {
     }
 
     public void addXEIInfo(WidgetGroup group, int xOffset, List<Content> contents, boolean perTick, boolean isInput, MutableInt yOffset) {
+
+    }
+
+    @NotNull
+    public List<Object> createXEIContainerContents(List<Content> contents, GTRecipe recipe) {
+        return new ArrayList<>();
+    }
+
+    @Nullable
+    public Object createXEIContainer(List<?> contents) {
+        return null;
+    }
+
+    @UnknownNullability("null when getWidgetClass() == null")
+    public Widget createWidget() {
+        return null;
+    }
+
+    @Nullable
+    public Class<? extends Widget> getWidgetClass() {
+        return null;
+    }
+
+    public void applyWidgetInfo(@NotNull Widget widget,
+                                int index,
+                                boolean isXEI,
+                                IO io,
+                                GTRecipeTypeUI.@UnknownNullability("null when storage == null") RecipeHolder recipeHolder,
+                                @NotNull GTRecipeType recipeType,
+                                @UnknownNullability("null when content == null") GTRecipe recipe,
+                                @Nullable Content content,
+                                @Nullable Object storage) {
 
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
@@ -17,25 +17,25 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * Used to detect whether a machine has a certain capability.
  */
 public abstract class RecipeCapability<T> {
+    public static final Comparator<RecipeCapability<?>> COMPARATOR = Comparator.comparingInt(o -> o.sortIndex);
 
     public final String name;
     public final int color;
-    public final IContentSerializer<T> serializer;
     public final boolean doRenderSlot;
+    public final int sortIndex;
+    public final IContentSerializer<T> serializer;
 
-    protected RecipeCapability(String name, int color, boolean doRenderSlot, IContentSerializer<T> serializer) {
+    protected RecipeCapability(String name, int color, boolean doRenderSlot, int sortIndex, IContentSerializer<T> serializer) {
         this.name = name;
         this.color = color;
         this.doRenderSlot = doRenderSlot;
+        this.sortIndex = sortIndex;
         this.serializer = serializer;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/StressRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/StressRecipeCapability.java
@@ -17,7 +17,7 @@ public class StressRecipeCapability extends RecipeCapability<Float> {
     public final static StressRecipeCapability CAP = new StressRecipeCapability();
 
     protected StressRecipeCapability() {
-        super("su", 0xFF77A400, SerializerFloat.INSTANCE);
+        super("su", 0xFF77A400, false, SerializerFloat.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/StressRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/StressRecipeCapability.java
@@ -17,7 +17,7 @@ public class StressRecipeCapability extends RecipeCapability<Float> {
     public final static StressRecipeCapability CAP = new StressRecipeCapability();
 
     protected StressRecipeCapability() {
-        super("su", 0xFF77A400, false, SerializerFloat.INSTANCE);
+        super("su", 0xFF77A400, false, 4, SerializerFloat.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleGeneratorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleGeneratorMachine.java
@@ -1,10 +1,8 @@
 package com.gregtechceu.gtceu.api.machine;
 
+import com.google.common.collect.Tables;
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
-import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
-import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
-import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
@@ -26,7 +24,8 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.Collections;
-import java.util.List;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.function.BiFunction;
 
 /**
@@ -101,6 +100,7 @@ public class SimpleGeneratorMachine extends WorkableTieredMachine implements IFa
     //***********     GUI    ***********//
     //////////////////////////////////////
 
+    @SuppressWarnings("UnstableApiUsage")
     public static BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> EDITABLE_UI_CREATOR = Util.memoize((path, recipeType)-> new EditableMachineUI("generator", path, () -> {
         WidgetGroup template = recipeType.getRecipeUI().createEditableUITemplate(false, false).createDefault();
         WidgetGroup group = new WidgetGroup(0, 0, template.getSize().width + 4 + 8, template.getSize().height + 8);
@@ -112,15 +112,18 @@ public class SimpleGeneratorMachine extends WorkableTieredMachine implements IFa
         return group;
     }, (template, machine) -> {
         if (machine instanceof SimpleGeneratorMachine generatorMachine) {
+            var storages = Tables.newCustomTable(new EnumMap<>(IO.class), LinkedHashMap<RecipeCapability<?>, Object>::new);
+            storages.put(IO.IN, ItemRecipeCapability.CAP, generatorMachine.importItems.storage);
+            storages.put(IO.OUT, ItemRecipeCapability.CAP, generatorMachine.exportItems.storage);
+            storages.put(IO.IN, FluidRecipeCapability.CAP, generatorMachine.importFluids);
+            storages.put(IO.OUT, FluidRecipeCapability.CAP, generatorMachine.exportFluids);
+
             generatorMachine.getRecipeType().getRecipeUI().createEditableUITemplate(false, false).setupUI(template,
                     new GTRecipeTypeUI.RecipeHolder(generatorMachine.recipeLogic::getProgressPercent,
-                            generatorMachine.importItems.storage,
-                            generatorMachine.exportItems.storage,
-                            generatorMachine.importFluids,
-                            generatorMachine.exportFluids,
-                            new CompoundTag(),
-                            Collections.emptyList(),
-                            false, false));
+                        storages,
+                        new CompoundTag(),
+                        Collections.emptyList(),
+                        false, false));
             createEnergyBar().setupUI(template, generatorMachine);
         }
     }));

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
@@ -1,8 +1,9 @@
 package com.gregtechceu.gtceu.api.machine;
 
+import com.google.common.collect.Tables;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
-import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.gui.editor.EditableUI;
@@ -52,9 +53,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiFunction;
 
 /**
@@ -354,6 +353,7 @@ public class SimpleTieredMachine extends WorkableTieredMachine implements IAutoO
         configuratorPanel.attachConfigurators(new CircuitFancyConfigurator(circuitInventory.storage));
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     public static BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> EDITABLE_UI_CREATOR = Util.memoize((path, recipeType) -> new EditableMachineUI("simple", path, () -> {
         WidgetGroup template = recipeType.getRecipeUI().createEditableUITemplate(false, false).createDefault();
         SlotWidget batterySlot = createBatterySlot().createDefault();
@@ -373,15 +373,20 @@ public class SimpleTieredMachine extends WorkableTieredMachine implements IAutoO
         return group;
     }, (template, machine) -> {
         if (machine instanceof SimpleTieredMachine tieredMachine) {
+            var storages = Tables.newCustomTable(new EnumMap<>(IO.class), LinkedHashMap<RecipeCapability<?>, Object>::new);
+            storages.put(IO.IN, ItemRecipeCapability.CAP, tieredMachine.importItems.storage);
+            storages.put(IO.OUT, ItemRecipeCapability.CAP, tieredMachine.exportItems.storage);
+            storages.put(IO.IN, FluidRecipeCapability.CAP, tieredMachine.importFluids);
+            storages.put(IO.OUT, FluidRecipeCapability.CAP, tieredMachine.exportFluids);
+            storages.put(IO.IN, CWURecipeCapability.CAP, tieredMachine.importComputation);
+            storages.put(IO.OUT, CWURecipeCapability.CAP, tieredMachine.exportComputation);
+
             tieredMachine.getRecipeType().getRecipeUI().createEditableUITemplate(false, false).setupUI(template,
                     new GTRecipeTypeUI.RecipeHolder(tieredMachine.recipeLogic::getProgressPercent,
-                            tieredMachine.importItems.storage,
-                            tieredMachine.exportItems.storage,
-                            tieredMachine.importFluids,
-                            tieredMachine.exportFluids,
-                            new CompoundTag(),
-                            Collections.emptyList(),
-                            false, false));
+                        storages,
+                        new CompoundTag(),
+                        Collections.emptyList(),
+                        false, false));
             createBatterySlot().setupUI(template, tieredMachine);
 //            createCircuitConfigurator().setupUI(template, tieredMachine);
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -72,7 +72,7 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
         this.recipeTypes = getDefinition().getRecipeTypes();
         this.activeRecipeType = 0;
         this.tankScalingFunction = tankScalingFunction;
-        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), HashMap::new);
+        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), IdentityHashMap::new);
         this.traitSubscriptions = new ArrayList<>();
         this.recipeLogic = createRecipeLogic(args);
         this.importItems = createImportItemHandler(args);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -65,7 +65,7 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
         this.recipeTypes = getDefinition().getRecipeTypes();
         this.activeRecipeType = 0;
         this.recipeLogic = createRecipeLogic(args);
-        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), HashMap::new);
+        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), IdentityHashMap::new);
         this.traitSubscriptions = new ArrayList<>();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.machine.steam;
 
+import com.google.common.collect.Tables;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
@@ -21,7 +22,6 @@ import com.gregtechceu.gtceu.common.recipe.VentCondition;
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.side.fluid.FluidHelper;
-import com.lowdragmc.lowdraglib.side.fluid.IFluidTransfer;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.lowdragmc.lowdraglib.utils.Position;
@@ -34,11 +34,8 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.jetbrains.annotations.NotNull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -157,7 +154,16 @@ public class SimpleSteamMachine extends SteamWorkableMachine implements IExhaust
 
     @Override
     public ModularUI createUI(Player entityPlayer) {
-        var group = getRecipeType().getRecipeUI().createUITemplate(recipeLogic::getProgressPercent, importItems.storage, exportItems.storage, IFluidTransfer.EMPTY, IFluidTransfer.EMPTY, new CompoundTag(), Collections.emptyList(), true, isHighPressure);
+        var storages = Tables.newCustomTable(new EnumMap<>(IO.class), LinkedHashMap<RecipeCapability<?>, Object>::new);
+        storages.put(IO.IN, ItemRecipeCapability.CAP, importItems.storage);
+        storages.put(IO.OUT, ItemRecipeCapability.CAP, exportItems.storage);
+
+        var group = getRecipeType().getRecipeUI().createUITemplate(recipeLogic::getProgressPercent,
+            storages,
+            new CompoundTag(),
+            Collections.emptyList(),
+            true,
+            isHighPressure);
         Position pos = new Position((Math.max(group.getSize().width + 4 + 8, 176) - 4 - group.getSize().width) / 2 + 4, 32);
         group.setSelfPosition(pos);
         return new ModularUI(176, 166, this, entityPlayer)

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
@@ -82,7 +82,7 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine implements
     public SteamBoilerMachine(IMachineBlockEntity holder, boolean isHighPressure, Object... args) {
         super(holder, isHighPressure, args);
         this.waterTank = createWaterTank(args);
-        this.waterTank.setFilter(fluid -> Fluids.WATER == fluid.getFluid());
+        this.waterTank.setFilter(fluid -> fluid.getFluid().is(GTMaterials.Water.getFluidTag()));
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamEnergyRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamEnergyRecipeHandler.java
@@ -61,6 +61,19 @@ public class SteamEnergyRecipeHandler implements IRecipeHandler<Long> {
     }
 
     @Override
+    public double getTotalContentAmount() {
+        List<FluidStack> tankContents = new ArrayList<>();
+        for (int i = 0; i < steamTank.getTanks(); ++i) {
+            FluidStack stack = steamTank.getFluidInTank(i);
+            if (!stack.isEmpty()) {
+                tankContents.add(stack);
+            }
+        }
+        long sum = tankContents.stream().map(FluidStack::getAmount).reduce(0L, Long::sum);
+        return (long) Math.ceil(sum * conversionRate);
+    }
+
+    @Override
     public RecipeCapability<Long> getCapability() {
         return EURecipeCapability.CAP;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamWorkableMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamWorkableMachine.java
@@ -66,7 +66,7 @@ public abstract class SteamWorkableMachine extends SteamMachine implements IReci
         this.recipeTypes = getDefinition().getRecipeTypes();
         this.activeRecipeType = 0;
         this.recipeLogic = createRecipeLogic(args);
-        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), HashMap::new);
+        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), IdentityHashMap::new);
         this.traitSubscriptions = new ArrayList<>();
         this.outputFacing = hasFrontFacing() ? getFrontFacing().getOpposite() : Direction.UP;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/ItemHandlerProxyRecipeTrait.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/ItemHandlerProxyRecipeTrait.java
@@ -55,6 +55,15 @@ public class ItemHandlerProxyRecipeTrait extends NotifiableRecipeHandlerTrait<In
     }
 
     @Override
+    public double getTotalContentAmount() {
+        long amount = 0;
+        for (NotifiableRecipeHandlerTrait<Ingredient> handler : handlers) {
+            amount += handler.getTotalContentAmount();
+        }
+        return amount;
+    }
+
+    @Override
     public RecipeCapability<Ingredient> getCapability() {
         return ItemRecipeCapability.CAP;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
@@ -213,6 +213,11 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
     }
 
     @Override
+    public double getTotalContentAmount() {
+        return lastOutputCwu;
+    }
+
+    @Override
     public RecipeCapability<Integer> getCapability() {
         return CWURecipeCapability.CAP;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
@@ -290,6 +290,11 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Long
     }
 
     @Override
+    public double getTotalContentAmount() {
+        return energyStored;
+    }
+
+    @Override
     public RecipeCapability<Long> getCapability() {
         return EURecipeCapability.CAP;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -6,18 +6,17 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
-import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.lowdragmc.lowdraglib.misc.FluidStorage;
+import com.lowdragmc.lowdraglib.side.fluid.FluidHelper;
 import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 import com.lowdragmc.lowdraglib.side.fluid.FluidTransferHelper;
 import com.lowdragmc.lowdraglib.side.fluid.IFluidTransfer;
+import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.core.Direction;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,11 +35,19 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
     public final IO handlerIO;
     @Getter
     public final IO capabilityIO;
-    @Persisted @Getter
+    @Persisted
+    @Getter
     private final FluidStorage[] storages;
     @Setter
     protected boolean allowSameFluids; // Can different tanks be filled with the same fluid. It should be determined while creating tanks.
     private Boolean isEmpty;
+
+    @Persisted @DescSynced
+    @Getter
+    private boolean locked = false;
+    @Persisted @DescSynced
+    @Getter
+    protected FluidStorage lockedFluid = new FluidStorage(FluidHelper.getBucket());
 
     public NotifiableFluidTank(MetaMachine machine, int slots, long capacity, IO io, IO capabilityIO) {
         super(machine);
@@ -147,6 +154,32 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         return left.isEmpty() ? null : left;
     }
 
+    @Override
+    public boolean test(FluidIngredient ingredient) {
+        return !this.locked || ingredient.test(this.lockedFluid.getFluid());
+    }
+
+    @Override
+    public int getPriority() {
+        return !locked || lockedFluid.getFluid().isEmpty() ? super.getPriority() : Integer.MAX_VALUE - getTanks();
+    }
+
+    public void setLocked(boolean locked) {
+        if (this.locked == locked) return;
+        this.locked = locked;
+        FluidStack fluidStack = getStorages()[0].getFluid();
+        if (locked && !fluidStack.isEmpty()) {
+            this.lockedFluid.setFluid(fluidStack.copy());
+            this.lockedFluid.getFluid().setAmount(1);
+            onContentsChanged();
+            setFilter(stack -> stack.isFluidEqual(this.lockedFluid.getFluid()));
+            return;
+        }
+        this.lockedFluid.setFluid(FluidStack.empty());
+        setFilter(stack -> true);
+        onContentsChanged();
+    }
+
     public NotifiableFluidTank setFilter(Predicate<FluidStack> filter) {
         for (FluidStorage storage : getStorages()) {
             storage.setValidator(filter);
@@ -178,6 +211,18 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
             }
         }
         return Arrays.asList(ingredients.toArray());
+    }
+
+    @Override
+    public double getTotalContentAmount() {
+        long amount = 0;
+        for (int i = 0; i < getTanks(); ++i) {
+            FluidStack stack = getFluidInTank(i);
+            if (!stack.isEmpty()) {
+                amount += stack.getAmount();
+            }
+        }
+        return amount;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -13,7 +13,6 @@ import com.lowdragmc.lowdraglib.side.item.ItemTransferHelper;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
-import dev.architectury.hooks.item.ItemStackHooks;
 import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import lombok.Getter;
 import net.minecraft.core.Direction;
@@ -177,6 +176,18 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
             }
         }
         return Arrays.asList(stacks.toArray());
+    }
+
+    @Override
+    public double getTotalContentAmount() {
+        long amount = 0;
+        for (int i = 0; i < getSlots(); ++i) {
+            ItemStack stack = getStackInSlot(i);
+            if (!stack.isEmpty()) {
+                amount += stack.getCount();
+            }
+        }
+        return amount;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/IgnoreEnergyRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/IgnoreEnergyRecipeHandler.java
@@ -21,6 +21,11 @@ public class IgnoreEnergyRecipeHandler implements IRecipeHandler<Long> {
     }
 
     @Override
+    public double getTotalContentAmount() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
     public RecipeCapability<Long> getCapability() {
         return EURecipeCapability.CAP;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
@@ -5,7 +5,6 @@ import com.gregtechceu.gtceu.api.capability.recipe.IRecipeHandler;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.lowdragmc.lowdraglib.misc.ItemStackTransfer;
 import lombok.Getter;
 import net.minecraft.world.item.ItemStack;
@@ -14,7 +13,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import static com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler.handleIngredient;
@@ -49,6 +47,18 @@ public class ItemRecipeHandler implements IRecipeHandler<Ingredient> {
             }
         }
         return Arrays.asList(ingredients.toArray());
+    }
+
+    @Override
+    public double getTotalContentAmount() {
+        long amount = 0;
+        for (int i = 0; i < storage.getSlots(); ++i) {
+            ItemStack stack = storage.getStackInSlot(i);
+            if (!stack.isEmpty()) {
+                amount += stack.getCount();
+            }
+        }
+        return amount;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -296,7 +296,10 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
         if (!capabilityProxies.contains(capIO, capability))
             return new Tuple<>(content, contentSlot);
 
-        var handlers = capabilityProxies.get(capIO, capability);
+        //noinspection DataFlowIssue checked above.
+        var handlers = new ArrayList<>(capabilityProxies.get(capIO, capability));
+        handlers.sort(IRecipeHandler.ENTRY_COMPARATOR);
+
         // handle distinct first
         for (IRecipeHandler<?> handler : handlers) {
             if (!handler.isDistinct()) continue;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -138,7 +138,8 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
     }
 
     public GTRecipeType setSlotOverlay(boolean isOutput, boolean isFluid, IGuiTexture slotOverlay) {
-        return this.setSlotOverlay(isOutput, isFluid, false, slotOverlay).setSlotOverlay(isOutput, isFluid, true, slotOverlay);
+        this.recipeUI.setSlotOverlay(isOutput, isFluid, slotOverlay);
+        return this;
     }
 
     public GTRecipeType setSlotOverlay(boolean isOutput, boolean isFluid, boolean isLast, IGuiTexture slotOverlay) {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -34,7 +34,6 @@ import net.minecraft.world.level.ItemLike;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -52,8 +51,8 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
 
     public final ResourceLocation registryName;
     public final String group;
-    public final Object2IntMap<RecipeCapability<?>> maxInputs = new Object2IntOpenHashMap<>();
-    public final Object2IntMap<RecipeCapability<?>> maxOutputs = new Object2IntOpenHashMap<>();
+    public final TreeMap<RecipeCapability<?>, Integer> maxInputs = new TreeMap<>(RecipeCapability.COMPARATOR);
+    public final TreeMap<RecipeCapability<?>, Integer> maxOutputs = new TreeMap<>(RecipeCapability.COMPARATOR);
     @Setter
     private GTRecipeBuilder recipeBuilder;
     @Getter

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ui/GTRecipeTypeUI.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ui/GTRecipeTypeUI.java
@@ -48,7 +48,7 @@ import java.io.DataInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.BiConsumer;
 import java.util.function.DoubleSupplier;
 
@@ -259,11 +259,11 @@ public class GTRecipeTypeUI {
     protected WidgetGroup addInventorySlotGroup(boolean isOutputs, boolean isSteam, boolean isHighPressure) {
         int maxCount = 0;
         int totalR = 0;
-        Map<RecipeCapability<?>, Integer> map = new Object2IntLinkedOpenHashMap<>();
+        TreeMap<RecipeCapability<?>, Integer> map = new TreeMap<>(RecipeCapability.COMPARATOR);
         if (isOutputs) {
-            for (var value : recipeType.maxOutputs.object2IntEntrySet()) {
+            for (var value : recipeType.maxOutputs.entrySet()) {
                 if (value.getKey().doRenderSlot) {
-                    int val = value.getIntValue();
+                    int val = value.getValue();
                     if (val > maxCount) {
                         maxCount = Math.min(val, 3);
                     }
@@ -272,9 +272,9 @@ public class GTRecipeTypeUI {
                 }
             }
         } else {
-            for (var value : recipeType.maxInputs.object2IntEntrySet()) {
+            for (var value : recipeType.maxInputs.entrySet()) {
                 if (value.getKey().doRenderSlot) {
-                    int val = value.getIntValue();
+                    int val = value.getValue();
                     if (val > maxCount) {
                         maxCount = Math.min(val, 3);
                     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ui/GTRecipeTypeUI.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ui/GTRecipeTypeUI.java
@@ -1,8 +1,10 @@
 package com.gregtechceu.gtceu.api.recipe.ui;
 
+import com.google.common.collect.Table;
 import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.SteamTexture;
 import com.gregtechceu.gtceu.api.gui.WidgetUtils;
@@ -11,14 +13,9 @@ import com.gregtechceu.gtceu.api.gui.widget.DualProgressWidget;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
-import com.gregtechceu.gtceu.api.recipe.ResearchData;
-import com.gregtechceu.gtceu.common.recipe.ResearchCondition;
-import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.integration.emi.recipe.GTRecipeTypeEmiCategory;
 import com.gregtechceu.gtceu.integration.jei.recipe.GTRecipeTypeCategory;
 import com.gregtechceu.gtceu.integration.rei.recipe.GTRecipeTypeDisplayCategory;
-import com.gregtechceu.gtceu.utils.ResearchManager;
-import com.gregtechceu.gtceu.utils.OverlayingFluidStorage;
 import com.lowdragmc.lowdraglib.LDLib;
 import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.gui.editor.configurator.IConfigurableWidget;
@@ -28,18 +25,13 @@ import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ProgressTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
 import com.lowdragmc.lowdraglib.gui.widget.*;
-import com.lowdragmc.lowdraglib.jei.IngredientIO;
 import com.lowdragmc.lowdraglib.jei.JEIPlugin;
-import com.lowdragmc.lowdraglib.side.fluid.IFluidTransfer;
-import com.lowdragmc.lowdraglib.side.item.IItemTransfer;
-import com.lowdragmc.lowdraglib.utils.CycleItemStackHandler;
 import com.lowdragmc.lowdraglib.utils.Position;
 import com.lowdragmc.lowdraglib.utils.Size;
-import com.lowdragmc.lowdraglib.utils.TagOrCycleFluidTransfer;
 import dev.emi.emi.api.EmiApi;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectArrayMap;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import me.shedaniel.rei.api.client.view.ViewSearchBuilder;
@@ -47,22 +39,20 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.DataInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.DoubleSupplier;
 
+@SuppressWarnings("UnusedReturnValue")
 public class GTRecipeTypeUI {
 
     @Getter
@@ -93,7 +83,6 @@ public class GTRecipeTypeUI {
     private Size jeiSize;
     @Getter
     private int originalWidth;
-    private final Map<String, Collection<GTRecipe>> researchEntries = new Object2ObjectOpenHashMap<>();
 
     /**
      * @param recipeType the recipemap corresponding to this ui
@@ -116,7 +105,7 @@ public class GTRecipeTypeUI {
                 try {
                     var resource = resourceManager.getResourceOrThrow(new ResourceLocation(recipeType.registryName.getNamespace(), "ui/recipe_type/%s.rtui".formatted(recipeType.registryName.getPath())));
                     try (InputStream inputStream = resource.open()){
-                        try (DataInputStream dataInputStream = new DataInputStream(inputStream);){
+                        try (DataInputStream dataInputStream = new DataInputStream(inputStream)) {
                             this.customUICache = NbtIo.read(dataInputStream, NbtAccounter.UNLIMITED);
                         }
                     }
@@ -150,21 +139,34 @@ public class GTRecipeTypeUI {
         return size;
     }
 
-    public record RecipeHolder(DoubleSupplier progressSupplier, IItemTransfer importItems, IItemTransfer exportItems, IFluidTransfer importFluids, IFluidTransfer exportFluids, CompoundTag data, List<RecipeCondition> conditions, boolean isSteam, boolean isHighPressure) {}
+    public record RecipeHolder(DoubleSupplier progressSupplier,
+                               Table<IO, RecipeCapability<?>, Object> storages,
+                               CompoundTag data,
+                               List<RecipeCondition> conditions,
+                               boolean isSteam,
+                               boolean isHighPressure) {}
 
     /**
      * Auto layout UI template for recipes.
      * @param progressSupplier progress. To create a JEI / REI UI, use the para {@link ProgressWidget#JEIProgress}.
      */
-    public WidgetGroup createUITemplate(DoubleSupplier progressSupplier, IItemTransfer importItems, IItemTransfer exportItems, IFluidTransfer importFluids, IFluidTransfer exportFluids, CompoundTag data, List<RecipeCondition> conditions, boolean isSteam, boolean isHighPressure) {
+    public WidgetGroup createUITemplate(DoubleSupplier progressSupplier,
+                                        Table<IO, RecipeCapability<?>, Object> storages,
+                                        CompoundTag data,
+                                        List<RecipeCondition> conditions,
+                                        boolean isSteam,
+                                        boolean isHighPressure) {
         var template = createEditableUITemplate(isSteam, isHighPressure);
         var group = template.createDefault();
-        template.setupUI(group, new RecipeHolder(progressSupplier, importItems, exportItems, importFluids, exportFluids, data, conditions, isSteam, isHighPressure));
+        template.setupUI(group, new RecipeHolder(progressSupplier, storages, data, conditions, isSteam, isHighPressure));
         return group;
     }
 
-    public WidgetGroup createUITemplate(DoubleSupplier progressSupplier, IItemTransfer importItems, IItemTransfer exportItems, IFluidTransfer importFluids, IFluidTransfer exportFluids, CompoundTag data, List<RecipeCondition> conditions) {
-        return createUITemplate(progressSupplier, importItems, exportItems, importFluids, exportFluids, data, conditions, false, false);
+    public WidgetGroup createUITemplate(DoubleSupplier progressSupplier,
+                                        Table<IO, RecipeCapability<?>, Object> storages,
+                                        CompoundTag data,
+                                        List<RecipeCondition> conditions) {
+        return createUITemplate(progressSupplier, storages, data, conditions, false, false);
     }
 
     /**
@@ -234,108 +236,71 @@ public class GTRecipeTypeUI {
                     }).setHoverTooltips("gtceu.recipe_type.show_recipes"));
                 }
             }
-            // bind item in
-            WidgetUtils.widgetByIdForEach(template, "^%s_[0-9]+$".formatted(ItemRecipeCapability.CAP.slotName(IO.IN)), SlotWidget.class, slot -> {
-                var index = WidgetUtils.widgetIdIndex(slot);
-                if (index >= 0 && index < recipeHolder.importItems.getSlots()) {
-                    slot.setHandlerSlot(recipeHolder.importItems, index);
-                    slot.setIngredientIO(IngredientIO.INPUT);
-                    slot.setCanTakeItems(!isJEI);
-                    slot.setCanPutItems(!isJEI);
-                }
-                // 1 over container size.
-                // If in a recipe viewer and a research slot can be added, add it.
-                if (isJEI && recipeType.isHasResearchSlot() && index == recipeHolder.importItems.getSlots()) {
-                    if (ConfigHolder.INSTANCE.machines.enableResearch) {
-                        ResearchCondition condition = recipeHolder.conditions.stream().filter(ResearchCondition.class::isInstance).findAny().map(ResearchCondition.class::cast).orElse(null);
-                        if (condition == null) {
-                            return;
-                        }
-                        List<ItemStack> dataItems = new ArrayList<>();
-                        for (ResearchData.ResearchEntry entry : condition.data) {
-                            ItemStack dataStick = entry.getDataItem().copy();
-                            ResearchManager.writeResearchToNBT(dataStick.getOrCreateTag(), entry.getResearchId(), this.recipeType);
-                            dataItems.add(dataStick);
-                        }
-                        CycleItemStackHandler handler = new CycleItemStackHandler(List.of(dataItems));
-                        slot.setHandlerSlot(handler, 0);
-                        slot.setIngredientIO(IngredientIO.INPUT);
-                        slot.setCanTakeItems(false);
-                        slot.setCanPutItems(false);
-                    }
 
-                }
-            });
-            // bind item out
-            WidgetUtils.widgetByIdForEach(template, "^%s_[0-9]+$".formatted(ItemRecipeCapability.CAP.slotName(IO.OUT)), SlotWidget.class, slot -> {
-                var index = WidgetUtils.widgetIdIndex(slot);
-                if (index >= 0 && index < recipeHolder.exportItems.getSlots()) {
-                    slot.setHandlerSlot(recipeHolder.exportItems, index);
-                    slot.setIngredientIO(IngredientIO.OUTPUT);
-                    slot.setCanTakeItems(!isJEI);
-                    slot.setCanPutItems(false);
-                }
-            });
-            // bind fluid in
-            WidgetUtils.widgetByIdForEach(template, "^%s_[0-9]+$".formatted(FluidRecipeCapability.CAP.slotName(IO.IN)), TankWidget.class, tank -> {
-                var index = WidgetUtils.widgetIdIndex(tank);
-                if (index >= 0 && index < recipeHolder.importFluids.getTanks()) {
-                    if (recipeHolder.importFluids instanceof TagOrCycleFluidTransfer fluidTransfer) {
-                        tank.setFluidTank(fluidTransfer, index);
-                    } else {
-                        tank.setFluidTank(new OverlayingFluidStorage(recipeHolder.importFluids, index));
+            // Bind I/O
+            for (var capabilityEntry : recipeHolder.storages.rowMap().entrySet()) {
+                IO io = capabilityEntry.getKey();
+                for (var storagesEntry : capabilityEntry.getValue().entrySet()) {
+                    RecipeCapability<?> cap = storagesEntry.getKey();
+                    Object storage = storagesEntry.getValue();
+                    // bind overlays
+                    Class<? extends Widget> widgetClass = cap.getWidgetClass();
+                    if (widgetClass != null) {
+                        WidgetUtils.widgetByIdForEach(template, "^%s_[0-9]+$".formatted(cap.slotName(io)), widgetClass, widget -> {
+                            var index = WidgetUtils.widgetIdIndex(widget);
+                            cap.applyWidgetInfo(widget, index, isJEI, io, recipeHolder, recipeType, null, null, storage);
+                        });
                     }
-                    tank.setIngredientIO(IngredientIO.INPUT);
-                    tank.setAllowClickFilled(!isJEI);
-                    tank.setAllowClickDrained(!isJEI);
                 }
-            });
-            // bind fluid out
-            WidgetUtils.widgetByIdForEach(template, "^%s_[0-9]+$".formatted(FluidRecipeCapability.CAP.slotName(IO.OUT)), TankWidget.class, tank -> {
-                var index = WidgetUtils.widgetIdIndex(tank);
-                if (index >= 0 && index < recipeHolder.exportFluids.getTanks()) {
-                    if (recipeHolder.exportFluids instanceof TagOrCycleFluidTransfer fluidTransfer) {
-                        tank.setFluidTank(fluidTransfer, index);
-                    } else {
-                        tank.setFluidTank(new OverlayingFluidStorage(recipeHolder.exportFluids, index));
-                    }
-                    tank.setIngredientIO(IngredientIO.OUTPUT);
-                    tank.setAllowClickFilled(!isJEI);
-                    tank.setAllowClickDrained(false);
-                }
-            });
+            }
         });
     }
 
     protected WidgetGroup addInventorySlotGroup(boolean isOutputs, boolean isSteam, boolean isHighPressure) {
-        var itemCount = isOutputs ? recipeType.getMaxOutputs(ItemRecipeCapability.CAP) : recipeType.getMaxInputs(ItemRecipeCapability.CAP);
-        var fluidCount = isOutputs ? recipeType.getMaxOutputs(FluidRecipeCapability.CAP) : recipeType.getMaxInputs(FluidRecipeCapability.CAP);
-        var itemR = (itemCount + 2) / 3;
-        var fluidR = (fluidCount + 2) / 3;
-        var itemC = Math.min(itemCount, 3);
-        var fluidC = Math.min(fluidCount, 3);
-        WidgetGroup group = new WidgetGroup(0, 0, Math.max(itemC, fluidC) * 18 + 8, (itemR + fluidR) * 18 + 8);
-        int index = 0;
-        for (int slotIndex = 0; slotIndex < itemCount; slotIndex++) {
-            var slot = new SlotWidget();
-            slot.initTemplate();
-            slot.setSelfPosition(new Position((index % 3) * 18 + 4, (index / 3) * 18 + 4));
-            slot.setBackground(getOverlaysForSlot(isOutputs, false, slotIndex == itemCount - 1, isSteam, isHighPressure));
-            slot.setId(ItemRecipeCapability.CAP.slotName(isOutputs ? IO.OUT : IO.IN, slotIndex));
-            group.addWidget(slot);
-            index++;
+        int maxCount = 0;
+        int totalR = 0;
+        Map<RecipeCapability<?>, Integer> map = new Object2IntLinkedOpenHashMap<>();
+        if (isOutputs) {
+            for (var value : recipeType.maxOutputs.object2IntEntrySet()) {
+                if (value.getKey().doRenderSlot) {
+                    int val = value.getIntValue();
+                    if (val > maxCount) {
+                        maxCount = Math.min(val, 3);
+                    }
+                    totalR += (val + 2) / 3;
+                    map.put(value.getKey(), val);
+                }
+            }
+        } else {
+            for (var value : recipeType.maxInputs.object2IntEntrySet()) {
+                if (value.getKey().doRenderSlot) {
+                    int val = value.getIntValue();
+                    if (val > maxCount) {
+                        maxCount = Math.min(val, 3);
+                    }
+                    totalR += (val + 2) / 3;
+                    map.put(value.getKey(), val);
+                }
+            }
         }
-        // move to new row
-        index += (3 - (index % 3)) % 3;
-        for (int i = 0; i < fluidCount; i++) {
-            var tank = new TankWidget();
-            tank.initTemplate();
-            tank.setFillDirection(ProgressTexture.FillDirection.ALWAYS_FULL);
-            tank.setSelfPosition(new Position((index % 3) * 18 + 4, (index / 3) * 18 + 4));
-            tank.setBackground(getOverlaysForSlot(isOutputs, true, i == fluidCount - 1, isSteam, isHighPressure));
-            tank.setId(FluidRecipeCapability.CAP.slotName(isOutputs ? IO.OUT : IO.IN, i));
-            group.addWidget(tank);
-            index++;
+        WidgetGroup group = new WidgetGroup(0, 0, maxCount * 18 + 8, totalR * 18 + 8);
+        int index = 0;
+        for (var entry : map.entrySet()) {
+            RecipeCapability<?> cap = entry.getKey();
+            if (cap.getWidgetClass() == null) {
+                continue;
+            }
+            int capCount = entry.getValue();
+            for (int slotIndex = 0; slotIndex < capCount; slotIndex++) {
+                var slot = cap.createWidget();
+                slot.setSelfPosition(new Position((index % 3) * 18 + 4, (index / 3) * 18 + 4));
+                slot.setBackground(getOverlaysForSlot(isOutputs, cap, slotIndex == capCount - 1, isSteam, isHighPressure));
+                slot.setId(cap.slotName(isOutputs ? IO.OUT : IO.IN, slotIndex));
+                group.addWidget(slot);
+                index++;
+            }
+            // move to new row
+            index += (3 - (index % 3)) % 3;
         }
         return group;
     }
@@ -343,12 +308,12 @@ public class GTRecipeTypeUI {
     /**
      * Add a slot to this ui
      */
-    protected void addSlot(WidgetGroup group, int x, int y, int slotIndex, int count, boolean isFluid, boolean isOutputs, boolean isSteam, boolean isHighPressure) {
-        if (!isFluid) {
+    protected void addSlot(WidgetGroup group, int x, int y, int slotIndex, int count, RecipeCapability<?> capability, boolean isOutputs, boolean isSteam, boolean isHighPressure) {
+        if (capability != FluidRecipeCapability.CAP) {
             var slot = new SlotWidget();
             slot.initTemplate();
             slot.setSelfPosition(new Position(x, y));
-            slot.setBackground(getOverlaysForSlot(isOutputs, false, slotIndex == count - 1, isSteam, isHighPressure));
+            slot.setBackground(getOverlaysForSlot(isOutputs, capability, slotIndex == count - 1, isSteam, isHighPressure));
             slot.setId(ItemRecipeCapability.CAP.slotName(isOutputs ? IO.OUT : IO.IN, slotIndex));
             group.addWidget(slot);
         } else {
@@ -356,7 +321,7 @@ public class GTRecipeTypeUI {
             tank.initTemplate();
             tank.setFillDirection(ProgressTexture.FillDirection.ALWAYS_FULL);
             tank.setSelfPosition(new Position(x, y));
-            tank.setBackground(getOverlaysForSlot(isOutputs, true, slotIndex == count - 1, isSteam, isHighPressure));
+            tank.setBackground(getOverlaysForSlot(isOutputs, capability, slotIndex == count - 1, isSteam, isHighPressure));
             tank.setId(FluidRecipeCapability.CAP.slotName(isOutputs ? IO.OUT : IO.IN, slotIndex));
             group.addWidget(tank);
         }
@@ -388,9 +353,9 @@ public class GTRecipeTypeUI {
     }
 
 
-    protected IGuiTexture getOverlaysForSlot(boolean isOutput, boolean isFluid, boolean isLast, boolean isSteam, boolean isHighPressure) {
-        IGuiTexture base = isFluid ? GuiTextures.FLUID_SLOT : (isSteam ? GuiTextures.SLOT_STEAM.get(isHighPressure) : GuiTextures.SLOT);
-        byte overlayKey = (byte) ((isOutput ? 2 : 0) + (isFluid ? 1 : 0) + (isLast ? 4 : 0));
+    protected IGuiTexture getOverlaysForSlot(boolean isOutput, RecipeCapability<?> capability, boolean isLast, boolean isSteam, boolean isHighPressure) {
+        IGuiTexture base = capability == FluidRecipeCapability.CAP ? GuiTextures.FLUID_SLOT : (isSteam ? GuiTextures.SLOT_STEAM.get(isHighPressure) : GuiTextures.SLOT);
+        byte overlayKey = (byte) ((isOutput ? 2 : 0) + (capability == FluidRecipeCapability.CAP ? 1 : 0) + (isLast ? 4 : 0));
         if (slotOverlays.containsKey(overlayKey)) {
             return new GuiTextureGroup(base, slotOverlays.get(overlayKey));
         }

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
@@ -65,7 +65,7 @@ public class QuantumTankRenderer extends TieredHullMachineRenderer {
     @OnlyIn(Dist.CLIENT)
     public void render(BlockEntity blockEntity, float partialTicks, PoseStack poseStack, MultiBufferSource buffer, int combinedLight, int combinedOverlay) {
         if (blockEntity instanceof IMachineBlockEntity machineBlockEntity && machineBlockEntity.getMetaMachine() instanceof QuantumTankMachine machine) {
-            renderTank(poseStack, buffer, machine.getFrontFacing(), machine.getStored(), machine.getLockedFluid().getFluid());
+            renderTank(poseStack, buffer, machine.getFrontFacing(), machine.getStored(), machine.getCache().getLockedFluid().getFluid());
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java
@@ -156,16 +156,16 @@ public class FluidHatchPartMachine extends TieredIOPartMachine {
         if (this.io == IO.OUT) {
             tankWidget = new PhantomFluidWidget(this.tank.getLockedFluid(), 67, 41, 18, 18)
                 .setIFluidStackUpdater(f -> {
-                    if (this.tank.getStorages()[0].getFluidAmount() != 0) {
+                    if (this.tank.getFluidInTank(0).getAmount() != 0) {
                         return;
                     }
                     if (f.isEmpty()) {
                         this.tank.setLocked(false);
-                        this.tank.getLockedFluid().setFluid(FluidStack.empty());
                     } else {
                         this.tank.setLocked(true);
-                        this.tank.getLockedFluid().setFluid(f.copy());
-                        this.tank.getLockedFluid().getFluid().setAmount(1);
+                        FluidStack newFluid = f.copy();
+                        newFluid.setAmount(1);
+                        this.tank.getLockedFluid().setFluid(newFluid);
                     }
                 }).setShowAmount(true).setDrawHoverTips(false);
 
@@ -192,8 +192,8 @@ public class FluidHatchPartMachine extends TieredIOPartMachine {
 
     private Component getFluidNameText(TankWidget tankWidget) {
         Component translation;
-        if (tankWidget.getFluidTank() == null && !tankWidget.getFluidTank().getFluidInTank(tankWidget.getTank()).isEmpty()) {
-            translation = tankWidget.getFluidTank().getFluidInTank(tankWidget.getTank()).getDisplayName();
+        if (!tank.getFluidInTank(tankWidget.getTank()).isEmpty()) {
+            translation = tank.getFluidInTank(tankWidget.getTank()).getDisplayName();
         } else {
             translation = this.tank.getLockedFluid().getFluid().getDisplayName();
         }
@@ -202,8 +202,8 @@ public class FluidHatchPartMachine extends TieredIOPartMachine {
 
     private String getFluidAmountText(TankWidget tankWidget) {
         String fluidAmount = "";
-        if (tankWidget.getFluidTank() != null && !tankWidget.getFluidTank().getFluidInTank(tankWidget.getTank()).isEmpty()) {
-            fluidAmount = getFormattedFluidAmount(tankWidget.getFluidTank().getFluidInTank(tankWidget.getTank()));
+        if (!tank.getFluidInTank(tankWidget.getTank()).isEmpty()) {
+            fluidAmount = getFormattedFluidAmount(tank.getFluidInTank(tankWidget.getTank()));
         } else {
             // Display Zero to show information about the locked fluid
             if (!this.tank.getLockedFluid().getFluid().isEmpty()) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/PumpHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/PumpHatchPartMachine.java
@@ -27,7 +27,7 @@ public class PumpHatchPartMachine extends FluidHatchPartMachine {
 
     @Override
     protected NotifiableFluidTank createTank(long initialCapacity, int slots, Object... args) {
-        return super.createTank(initialCapacity, slots).setFilter(fluidStack -> fluidStack.getFluid() == GTMaterials.Water.getFluid());
+        return super.createTank(initialCapacity, slots).setFilter(fluidStack -> fluidStack.getFluid().is(GTMaterials.Water.getFluidTag()));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -75,15 +75,12 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     protected FluidStack stored = FluidStack.empty();
     @Persisted @Getter @Setter
     private boolean isVoiding;
-    @Persisted @DescSynced @Getter
-    protected final FluidStorage lockedFluid;
 
     public QuantumTankMachine(IMachineBlockEntity holder, int tier, long maxStoredFluids, Object... args) {
         super(holder, tier);
         this.outputFacingFluids = getFrontFacing().getOpposite();
         this.maxStoredFluids = maxStoredFluids;
         this.cache = createCacheFluidHandler(args);
-        this.lockedFluid = new FluidStorage(FluidHelper.getBucket());
     }
 
     //////////////////////////////////////
@@ -120,7 +117,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
 
                 return filled;
             }
-        }.setFilter(fluidStack -> !isLocked() || lockedFluid.getFluid().isFluidEqual(fluidStack));
+        };
     }
 
     @Override
@@ -293,16 +290,18 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     }
 
     public boolean isLocked() {
-        return !lockedFluid.getFluid().isEmpty();
+        return cache.isLocked();
     }
 
     protected void setLocked(boolean locked) {
         if (!stored.isEmpty() && locked) {
             var copied = stored.copy();
-            copied.setAmount(lockedFluid.getCapacity());
-            lockedFluid.setFluid(copied);
+            copied.setAmount(cache.getLockedFluid().getCapacity());
+            cache.getLockedFluid().setFluid(copied);
+            cache.setLocked(true);
         } else if (!locked) {
-            lockedFluid.setFluid(FluidStack.empty());
+            cache.getLockedFluid().setFluid(FluidStack.empty());
+            cache.setLocked(false);
         }
     }
 
@@ -318,7 +317,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
                 ).setTextColor(-1).setDropShadow(true))
                 .addWidget(new TankWidget(cache.getStorages()[0], 68, 23, true, true)
                         .setBackground(GuiTextures.FLUID_SLOT))
-                .addWidget(new PhantomFluidWidget(lockedFluid, 68, 41, 18, 18)
+                .addWidget(new PhantomFluidWidget(cache.getLockedFluid(), 68, 41, 18, 18)
                         .setShowAmount(false)
                         .setBackground(ColorPattern.T_GRAY.rectTexture()))
                 .addWidget(new ToggleButtonWidget(4, 41, 18, 18,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -65,6 +65,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     protected boolean allowInputFromOutputSideFluids;
     @Getter
     private final long maxStoredFluids;
+    @Getter
     @Persisted @DropSaved
     protected final NotifiableFluidTank cache;
     @Nullable

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/NotifiableStressTrait.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/NotifiableStressTrait.java
@@ -84,6 +84,11 @@ public class NotifiableStressTrait extends NotifiableRecipeHandlerTrait<Float> i
     }
 
     @Override
+    public double getTotalContentAmount() {
+        return available;
+    }
+
+    @Override
     public void preWorking(IRecipeCapabilityHolder holder, IO io, GTRecipe recipe) {
         if (machine instanceof IKineticMachine kineticMachine) {
             var kineticDefinition = kineticMachine.getKineticDefinition();

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -132,7 +132,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         this.isDone = false;
         this.pickaxeTool = GTItems.TOOL_ITEMS.get(GTMaterials.Neutronium, GTToolType.PICKAXE).get().get();
         this.pickaxeTool.enchant(Enchantments.BLOCK_FORTUNE, fortune);
-        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), HashMap::new);
+        this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), IdentityHashMap::new);
         this.inputItemHandler = new ItemRecipeHandler(IO.IN, machine.getRecipeType().getMaxInputs(ItemRecipeCapability.CAP));
         this.outputItemHandler = new ItemRecipeHandler(IO.OUT, machine.getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP));
         this.inputEnergyHandler = new IgnoreEnergyRecipeHandler();

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/OreDataLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/OreDataLoader.java
@@ -43,7 +43,10 @@ public class OreDataLoader extends SimpleJsonResourceReloadListener {
 
     @Override
     protected void apply(Map<ResourceLocation, JsonElement> resourceList, ResourceManager resourceManager, ProfilerFiller profiler) {
-        GTRegistries.ORE_VEINS.unfreeze();
+        // Check condition in cause of reload failing which makes the registry not freeze.
+        if (GTRegistries.ORE_VEINS.isFrozen()) {
+            GTRegistries.ORE_VEINS.unfreeze();
+        }
         GTRegistries.ORE_VEINS.registry().clear();
 
         GTOres.init();
@@ -76,7 +79,9 @@ public class OreDataLoader extends SimpleJsonResourceReloadListener {
         buildVeinGenerator();
 
         GTOres.updateLargestVeinSize();
-        GTRegistries.ORE_VEINS.freeze();
+        if (!GTRegistries.ORE_VEINS.isFrozen()) {
+            GTRegistries.ORE_VEINS.freeze();
+        }
     }
 
     public static void buildVeinGenerator() {

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -1,53 +1,42 @@
 package com.gregtechceu.gtceu.integration;
 
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.CWURecipeCapability;
-import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
-import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.WidgetUtils;
 import com.gregtechceu.gtceu.api.gui.widget.PredicatedButtonWidget;
-import com.gregtechceu.gtceu.api.recipe.*;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
+import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
+import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
-import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
-import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
-import com.gregtechceu.gtceu.core.mixins.IngredientAccessor;
-import com.gregtechceu.gtceu.core.mixins.IntersectionIngredientAccessor;
-import com.gregtechceu.gtceu.core.mixins.TagValueAccessor;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
-import com.gregtechceu.gtceu.utils.ResearchManager;
 import com.lowdragmc.lowdraglib.LDLib;
 import com.lowdragmc.lowdraglib.gui.compass.CompassManager;
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
 import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
-import com.lowdragmc.lowdraglib.gui.widget.*;
-import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
-import com.lowdragmc.lowdraglib.utils.TagOrCycleFluidTransfer;
-import com.lowdragmc.lowdraglib.utils.TagOrCycleItemStackTransfer;
-import com.mojang.datafixers.util.Either;
-import com.mojang.datafixers.util.Pair;
+import com.lowdragmc.lowdraglib.gui.widget.ButtonWidget;
+import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
+import com.lowdragmc.lowdraglib.gui.widget.ProgressWidget;
+import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 import it.unimi.dsi.fastutil.longs.LongIntPair;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import lombok.Getter;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
-import net.minecraft.world.level.material.Fluid;
-import net.minecraftforge.common.crafting.IntersectionIngredient;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.gregtechceu.gtceu.api.GTValues.*;
 
@@ -85,156 +74,17 @@ public class GTRecipeWidget extends WidgetGroup {
         return 0;
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     private void setRecipeWidget() {
         setClientSideWidget();
-        List<Content> inputStackContents = new ArrayList<>();
-        inputStackContents.addAll(recipe.getInputContents(ItemRecipeCapability.CAP));
-        inputStackContents.addAll(recipe.getTickInputContents(ItemRecipeCapability.CAP));
-        List<Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>>> inputStacks = inputStackContents.stream().map(content -> content.content)
-            .map(ItemRecipeCapability.CAP::of)
-            .map(GTRecipeWidget::mapItem)
-            .collect(Collectors.toList());
-        while (inputStacks.size() < recipe.recipeType.getMaxInputs(ItemRecipeCapability.CAP)) inputStacks.add(null);
 
-        List<Content> outputStackContents = new ArrayList<>();
-        outputStackContents.addAll(recipe.getOutputContents(ItemRecipeCapability.CAP));
-        outputStackContents.addAll(recipe.getTickOutputContents(ItemRecipeCapability.CAP));
-        List<Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>>> outputStacks = outputStackContents.stream().map(content -> content.content)
-            .map(ItemRecipeCapability.CAP::of)
-            .map(GTRecipeWidget::mapItem)
-            .collect(Collectors.toList());
-        while (outputStacks.size() < recipe.recipeType.getMaxOutputs(ItemRecipeCapability.CAP)) outputStacks.add(null);
+        var storages = Tables.newCustomTable(new EnumMap<>(IO.class), LinkedHashMap<RecipeCapability<?>, Object>::new);
+        var contents = Tables.newCustomTable(new EnumMap<>(IO.class), LinkedHashMap<RecipeCapability<?>, List<Content>>::new);
+        collectStorage(storages, contents, recipe);
 
+        WidgetGroup group = recipe.recipeType.getRecipeUI().createUITemplate(ProgressWidget.JEIProgress, storages, recipe.data.copy(), recipe.conditions);
+        addSlots(contents, group, recipe);
 
-        List<Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>>> scannerPossibilities = null;
-        if (recipe.recipeType.isScanner()) {
-            scannerPossibilities = new ArrayList<>();
-            // Scanner Output replacing, used for cycling research outputs
-            Pair<GTRecipeType, String> researchData = null;
-            for (Content stack : recipe.getOutputContents(ItemRecipeCapability.CAP)) {
-                researchData = ResearchManager.readResearchId(ItemRecipeCapability.CAP.of(stack.content).getItems()[0]);
-                if (researchData != null) break;
-            }
-            if (researchData != null) {
-                Collection<GTRecipe> possibleRecipes = researchData.getFirst().getDataStickEntry(researchData.getSecond());
-                if (possibleRecipes != null) {
-                    for (GTRecipe r : possibleRecipes) {
-                        ItemStack researchItem = ItemRecipeCapability.CAP.of(r.getOutputContents(ItemRecipeCapability.CAP).get(0).content).getItems()[0];
-                        researchItem = researchItem.copy();
-                        researchItem.setCount(1);
-                        boolean didMatch = false;
-                        for (Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>> stacks : scannerPossibilities) {
-                            for (ItemStack stack : stacks.map(
-                                tag -> tag
-                                    .stream()
-                                    .flatMap(key -> BuiltInRegistries.ITEM.getTag(key.getFirst()).stream())
-                                    .flatMap(holders -> holders.stream().map(holder -> new ItemStack(holder.get())))
-                                    .collect(Collectors.toList()),
-                                Function.identity())) {
-                                if (ItemStack.isSameItem(stack, researchItem)) {
-                                    didMatch = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (!didMatch) scannerPossibilities.add(Either.right(List.of(researchItem)));
-                    }
-                }
-                scannerPossibilities.add(outputStacks.get(0));
-            }
-        }
-
-        if (scannerPossibilities != null && !scannerPossibilities.isEmpty()) {
-            outputStacks = scannerPossibilities;
-        }
-        while (outputStacks.size() < recipe.recipeType.getMaxOutputs(ItemRecipeCapability.CAP)) outputStacks.add(null);
-
-        List<Content> inputFluidContents = new ArrayList<>();
-        inputFluidContents.addAll(recipe.getInputContents(FluidRecipeCapability.CAP));
-        inputFluidContents.addAll(recipe.getTickInputContents(FluidRecipeCapability.CAP));
-        List<Either<List<Pair<TagKey<Fluid>, Long>>, List<FluidStack>>> inputFluids = inputFluidContents.stream().map(content -> content.content)
-            .map(FluidRecipeCapability.CAP::of)
-            .map(GTRecipeWidget::mapFluid)
-            .collect(Collectors.toList());
-        while (inputFluids.size() < recipe.recipeType.getMaxInputs(FluidRecipeCapability.CAP)) inputFluids.add(null);
-
-        List<Content> outputFluidContents = new ArrayList<>();
-        outputFluidContents.addAll(recipe.getOutputContents(FluidRecipeCapability.CAP));
-        outputFluidContents.addAll(recipe.getTickOutputContents(FluidRecipeCapability.CAP));
-        List<Either<List<Pair<TagKey<Fluid>, Long>>, List<FluidStack>>> outputFluids = outputFluidContents.stream().map(content -> content.content)
-            .map(FluidRecipeCapability.CAP::of)
-            .map(GTRecipeWidget::mapFluid)
-            .collect(Collectors.toList());
-        while (outputFluids.size() < recipe.recipeType.getMaxOutputs(FluidRecipeCapability.CAP)) outputFluids.add(null);
-
-        WidgetGroup group = recipe.recipeType.getRecipeUI().createUITemplate(ProgressWidget.JEIProgress,
-            new TagOrCycleItemStackTransfer(inputStacks),
-            new TagOrCycleItemStackTransfer(outputStacks),
-            new TagOrCycleFluidTransfer(inputFluids),
-            new TagOrCycleFluidTransfer(outputFluids),
-            recipe.data.copy(),
-            recipe.conditions
-        );
-        // bind item in overlay
-        WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(ItemRecipeCapability.CAP.slotName(IO.IN)), SlotWidget.class, slot -> {
-            var index = WidgetUtils.widgetIdIndex(slot);
-            if (index >= 0 && index < inputStackContents.size()) {
-                var content = inputStackContents.get(index);
-                slot.setXEIChance(content.chance);
-                slot.setOverlay(content.createOverlay(index >= recipe.getInputContents(ItemRecipeCapability.CAP).size()));
-                slot.setOnAddedTooltips((w, tooltips) -> {
-                    setConsumedChance(content, tooltips);
-                    if (index >= recipe.getInputContents(ItemRecipeCapability.CAP).size()) {
-                        tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
-                    }
-                });
-            }
-        });
-        // bind item out overlay
-        WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(ItemRecipeCapability.CAP.slotName(IO.OUT)), SlotWidget.class, slot -> {
-            var index = WidgetUtils.widgetIdIndex(slot);
-            if (index >= 0 && index < outputStackContents.size()) {
-                var content = outputStackContents.get(index);
-                slot.setXEIChance(content.chance);
-                slot.setOverlay(content.createOverlay(index >= recipe.getOutputContents(ItemRecipeCapability.CAP).size()));
-                slot.setOnAddedTooltips((w, tooltips) -> {
-                    setConsumedChance(content, tooltips);
-                    if (index >= recipe.getOutputContents(ItemRecipeCapability.CAP).size()) {
-                        tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
-                    }
-                });
-            }
-        });
-        // bind fluid in overlay
-        WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(FluidRecipeCapability.CAP.slotName(IO.IN)), TankWidget.class, tank -> {
-            var index = WidgetUtils.widgetIdIndex(tank);
-            if (index >= 0 && index < inputFluidContents.size()) {
-                var content = inputFluidContents.get(index);
-                tank.setXEIChance(content.chance);
-                tank.setOverlay(content.createOverlay(index >= recipe.getInputContents(FluidRecipeCapability.CAP).size()));
-                tank.setOnAddedTooltips((w, tooltips) -> {
-                    setConsumedChance(content, tooltips);
-                    if (index >= recipe.getInputContents(FluidRecipeCapability.CAP).size()) {
-                        tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
-                    }
-                });
-            }
-        });
-        // bind fluid out overlay
-        WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(FluidRecipeCapability.CAP.slotName(IO.OUT)), TankWidget.class, tank -> {
-            var index = WidgetUtils.widgetIdIndex(tank);
-            if (index >= 0 && index < outputFluidContents.size()) {
-                var content = outputFluidContents.get(index);
-                tank.setXEIChance(content.chance);
-                tank.setOverlay(content.createOverlay(index >= recipe.getOutputContents(FluidRecipeCapability.CAP).size()));
-                tank.setOnAddedTooltips((w, tooltips) -> {
-                    setConsumedChance(content, tooltips);
-                    if (index >= recipe.getOutputContents(FluidRecipeCapability.CAP).size()) {
-                        tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
-                    }
-                });
-            }
-        });
         var size = group.getSize();
         addWidget(group);
         var EUt = RecipeHelper.getInputEUt(recipe);
@@ -395,7 +245,7 @@ public class GTRecipeWidget extends WidgetGroup {
         updateScreen();
     }
 
-    private void setConsumedChance(Content content, List<Component> tooltips) {
+    public static void setConsumedChance(Content content, List<Component> tooltips) {
         var chance = content.chance;
         if (chance < 1) {
             tooltips.add(chance == 0 ?
@@ -419,113 +269,70 @@ public class GTRecipeWidget extends WidgetGroup {
         setTier(getMinTier());
     }
 
-    // Maps ingredients to Either <(Tag with count), ItemStack>s
-    @SuppressWarnings("deprecation")
-    private static Either<List<Pair<TagKey<Item>, Integer>>, List<ItemStack>> mapItem(Ingredient ingredient) {
-        if (ingredient instanceof SizedIngredient sizedIngredient) {
-            final int amount = sizedIngredient.getAmount();
-             if (sizedIngredient.getInner() instanceof IntersectionIngredient intersection) {
-                List<Ingredient> children = ((IntersectionIngredientAccessor)intersection).getChildren();
-                if (children.isEmpty()) {
-                    return Either.right(null);
-                }
-                var childEither = mapItem(children.get(0));
-                return Either.right(childEither.map(tags -> {
-                    List<ItemStack> tagItems = tags.stream()
-                        .map(pair -> Pair.of(BuiltInRegistries.ITEM.getTag(pair.getFirst()).stream(), pair.getSecond()))
-                        .flatMap(pair -> pair.getFirst().flatMap(tag -> tag.stream().map(holder -> new ItemStack(holder.value(), pair.getSecond()))))
-                        .collect(Collectors.toList());
-                    ListIterator<ItemStack> iterator = tagItems.listIterator();
-                    while (iterator.hasNext()) {
-                        var item = iterator.next();
-                        for (int i = 1; i < children.size(); ++i) {
-                            if (!children.get(i).test(item)) {
-                                iterator.remove();
-                                break;
-                            }
-                        }
-                        iterator.set(item.copyWithCount(amount));
-                    }
-                    return tagItems;
-                }, items -> {
-                    items = new ArrayList<>(items);
-                    ListIterator<ItemStack> iterator = items.listIterator();
-                    while (iterator.hasNext()) {
-                        var item = iterator.next();
-                        for (int i = 1; i < children.size(); ++i) {
-                            if (!children.get(i).test(item)) {
-                                iterator.remove();
-                                break;
-                            }
-                        }
-                        iterator.set(item.copyWithCount(amount));
-                    }
-                    return items;
-                }));
-            } else if (((IngredientAccessor)sizedIngredient.getInner()).getValues().length > 0 && ((IngredientAccessor)sizedIngredient.getInner()).getValues()[0] instanceof Ingredient.TagValue tagValue) {
-                return Either.left(List.of(Pair.of(((TagValueAccessor)tagValue).getTag(), amount)));
-            }
-        } else if (ingredient instanceof IntersectionIngredient intersection) {
-            // Map intersection ingredients to the items inside, as recipe viewers don't support them.
-            List<Ingredient> children = ((IntersectionIngredientAccessor)intersection).getChildren();
-            if (children.isEmpty()) {
-                return Either.right(null);
-            }
-            var childEither = mapItem(children.get(0));
-            return Either.right(childEither.map(tags -> {
-                List<ItemStack> tagItems = tags.stream()
-                    .map(pair -> Pair.of(BuiltInRegistries.ITEM.getTag(pair.getFirst()).stream(), pair.getSecond()))
-                    .flatMap(pair -> pair.getFirst().flatMap(tag -> tag.stream().map(holder -> new ItemStack(holder.value(), pair.getSecond()))))
-                    .collect(Collectors.toList());
-                ListIterator<ItemStack> iterator = tagItems.listIterator();
-                while (iterator.hasNext()) {
-                    var item = iterator.next();
-                    for (int i = 1; i < children.size(); ++i) {
-                        if (!children.get(i).test(item)) {
-                            iterator.remove();
-                            break;
-                        }
-                    }
-                }
-                return tagItems;
-            }, items -> {
-                items = new ArrayList<>(items);
-                ListIterator<ItemStack> iterator = items.listIterator();
-                while (iterator.hasNext()) {
-                    var item = iterator.next();
-                    for (int i = 1; i < children.size(); ++i) {
-                        if (!children.get(i).test(item)) {
-                            iterator.remove();
-                            break;
-                        }
-                    }
-                }
-                return items;
-            }));
-        } else if (((IngredientAccessor)ingredient).getValues().length > 0 && ((IngredientAccessor)ingredient).getValues()[0] instanceof Ingredient.TagValue tagValue) {
-            return Either.left(List.of(Pair.of(((TagValueAccessor)tagValue).getTag(), 1)));
+    public void collectStorage(Table<IO, RecipeCapability<?>, Object> extraTable, Table<IO, RecipeCapability<?>, List<Content>> extraContents, GTRecipe recipe) {
+        Map<RecipeCapability<?>, List<Object>> inputCapabilities = new Object2ObjectLinkedOpenHashMap<>();
+        for (var entry : recipe.inputs.entrySet()) {
+            RecipeCapability<?> cap = entry.getKey();
+            List<Content> contents = entry.getValue();
+
+            extraContents.put(IO.IN, cap, contents);
+            inputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe));
         }
-        return Either.right(Arrays.stream(ingredient.getItems()).toList());
+        for (var entry : recipe.tickInputs.entrySet()) {
+            RecipeCapability<?> cap = entry.getKey();
+            List<Content> contents = entry.getValue();
+
+            extraContents.put(IO.IN, cap, contents);
+            inputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe));
+        }
+        for (var entry : inputCapabilities.entrySet()) {
+            while (entry.getValue().size() < recipe.recipeType.getMaxInputs(entry.getKey())) entry.getValue().add(null);
+            var container = entry.getKey().createXEIContainer(entry.getValue());
+            if (container != null) {
+                extraTable.put(IO.IN, entry.getKey(), container);
+            }
+        }
+
+        Map<RecipeCapability<?>, List<Object>> outputCapabilities = new Object2ObjectLinkedOpenHashMap<>();
+        for (var entry : recipe.outputs.entrySet()) {
+            RecipeCapability<?> cap = entry.getKey();
+            List<Content> contents = entry.getValue();
+
+            extraContents.put(IO.OUT, cap, contents);
+            outputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe));
+        }
+        for (var entry : recipe.tickOutputs.entrySet()) {
+            RecipeCapability<?> cap = entry.getKey();
+            List<Content> contents = entry.getValue();
+
+            extraContents.put(IO.OUT, cap, contents);
+            outputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe));
+        }
+        for (var entry : outputCapabilities.entrySet()) {
+            while (entry.getValue().size() < recipe.recipeType.getMaxOutputs(entry.getKey())) entry.getValue().add(null);
+            var container = entry.getKey().createXEIContainer(entry.getValue());
+            if (container != null) {
+                extraTable.put(IO.OUT, entry.getKey(), container);
+            }
+        }
     }
 
-    // Maps fluids to Either <(tag with count), ItemStack>s
-    private static Either<List<Pair<TagKey<Fluid>, Long>>, List<FluidStack>> mapFluid(FluidIngredient ingredient) {
-        long amount = ingredient.getAmount();
-        CompoundTag tag = ingredient.getNbt();
-
-        List<Pair<TagKey<Fluid>, Long>> tags = new ArrayList<>();
-        List<FluidStack> fluids = new ArrayList<>();
-        for (FluidIngredient.Value value : ingredient.values) {
-            if (value instanceof FluidIngredient.TagValue tagValue) {
-                tags.add(Pair.of(tagValue.getTag(), amount));
-            } else {
-                fluids.addAll(value.getFluids().stream().map(fluid -> FluidStack.create(fluid, amount, tag)).toList());
+    public void addSlots(Table<IO, RecipeCapability<?>, List<Content>> contentTable, WidgetGroup group, GTRecipe recipe) {
+        for (var capabilityEntry : contentTable.rowMap().entrySet()) {
+            IO io = capabilityEntry.getKey();
+            for (var contentsEntry : capabilityEntry.getValue().entrySet()) {
+                RecipeCapability<?> cap = contentsEntry.getKey();
+                List<Content> contents = contentsEntry.getValue();
+                // bind fluid out overlay
+                WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(cap.slotName(io)), cap.getWidgetClass(), widget -> {
+                    var index = WidgetUtils.widgetIdIndex(widget);
+                    if (index >= 0 && index < contents.size()) {
+                        var content = contents.get(index);
+                        cap.applyWidgetInfo(widget, index, true, io, null, recipe.getType(), recipe, content, null);
+                        widget.setOverlay(content.createOverlay(index >= recipe.getOutputContents(cap).size()));
+                    }
+                });
             }
-        }
-        if (!tags.isEmpty()) {
-            return Either.left(tags);
-        }else {
-            return Either.right(fluids);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -322,6 +322,7 @@ public class GTRecipeWidget extends WidgetGroup {
             IO io = capabilityEntry.getKey();
             for (var contentsEntry : capabilityEntry.getValue().entrySet()) {
                 RecipeCapability<?> cap = contentsEntry.getKey();
+                int nonTickInputCount = (io == IO.IN ? recipe.getInputContents(cap) : recipe.getOutputContents(cap)).size();
                 List<Content> contents = contentsEntry.getValue();
                 // bind fluid out overlay
                 WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(cap.slotName(io)), cap.getWidgetClass(), widget -> {
@@ -329,7 +330,7 @@ public class GTRecipeWidget extends WidgetGroup {
                     if (index >= 0 && index < contents.size()) {
                         var content = contents.get(index);
                         cap.applyWidgetInfo(widget, index, true, io, null, recipe.getType(), recipe, content, null);
-                        widget.setOverlay(content.createOverlay(index >= recipe.getOutputContents(cap).size()));
+                        widget.setOverlay(content.createOverlay(index >= nonTickInputCount));
                     }
                 });
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -322,7 +322,7 @@ public class GTRecipeWidget extends WidgetGroup {
             IO io = capabilityEntry.getKey();
             for (var contentsEntry : capabilityEntry.getValue().entrySet()) {
                 RecipeCapability<?> cap = contentsEntry.getKey();
-                int nonTickInputCount = (io == IO.IN ? recipe.getInputContents(cap) : recipe.getOutputContents(cap)).size();
+                int nonTickCount = (io == IO.IN ? recipe.getInputContents(cap) : recipe.getOutputContents(cap)).size();
                 List<Content> contents = contentsEntry.getValue();
                 // bind fluid out overlay
                 WidgetUtils.widgetByIdForEach(group, "^%s_[0-9]+$".formatted(cap.slotName(io)), cap.getWidgetClass(), widget -> {
@@ -330,7 +330,7 @@ public class GTRecipeWidget extends WidgetGroup {
                     if (index >= 0 && index < contents.size()) {
                         var content = contents.get(index);
                         cap.applyWidgetInfo(widget, index, true, io, null, recipe.getType(), recipe, content, null);
-                        widget.setOverlay(content.createOverlay(index >= nonTickInputCount));
+                        widget.setOverlay(content.createOverlay(index >= nonTickCount));
                     }
                 });
             }


### PR DESCRIPTION
## What
adds a fluid filter slot to single-output fluid hatches, as well as API for others.

## Implementation Details
adds the ability to filter any i/o, and the ability to make any recipe capability have slots like items and fluids do (advanced feature).
optimizes capabilitiesProxy fields to use identity hash maps for efficiency.


## Outcome
fusion reactor no longer places the output in a random hatch every time.

## Additional Information

## Potential Compatibility Issues
addons that for some reason mixin into these part of GT will break.