### PR TITLE
Fix that kinetic stress output will never not stop

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
@@ -95,7 +95,9 @@ public interface IMultiPart extends IMachineFeature, IFancyUIMachine {
     /**
      * Called in {@link WorkableMultiblockMachine#setWorkingEnabled(boolean)}
      */
-    default boolean onPaused(IWorkableMultiController controller) { return true; }
+    default boolean onPaused(IWorkableMultiController controller) {
+        return true;
+    }
 
     /**
      * Called in {@link RecipeLogic#onRecipeFinish()} before outputs are produced

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.machine.feature.multiblock;
 import com.gregtechceu.gtceu.api.gui.fancy.TooltipsPanel;
 import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IMachineFeature;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.IRecipeHandlerTrait;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -90,6 +91,11 @@ public interface IMultiPart extends IMachineFeature, IFancyUIMachine {
     default boolean onWaiting(IWorkableMultiController controller) {
         return true;
     }
+
+    /**
+     * Called in {@link WorkableMultiblockMachine#setWorkingEnabled(boolean)}
+     */
+    default boolean onPaused(IWorkableMultiController controller) { return true; }
 
     /**
      * Called in {@link RecipeLogic#onRecipeFinish()} before outputs are produced

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -255,6 +255,16 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
         IWorkableMultiController.super.onWaiting();
     }
 
+    @Override
+    public void setWorkingEnabled(boolean isWorkingAllowed) {
+        if (!isWorkingAllowed) {
+            for (IMultiPart part : getParts()) {
+                part.onPaused(this);
+            }
+        }
+        IWorkableMultiController.super.setWorkingEnabled(isWorkingAllowed);
+    }
+
     @NotNull
     public GTRecipeType getRecipeType() {
         return recipeTypes[activeRecipeType];


### PR DESCRIPTION
Fix #1109 
The `preWorking` and `postWorking` is not called when the machine paused or destroyed.