### PR TITLE
Use getEnergyStored for HPCA hasNotEnoughEnergy logic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -207,7 +207,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine implements IO
             energyToConsume += maintenance.getNumMaintenanceProblems() * energyToConsume / 10;
         }
 
-        if (this.hasNotEnoughEnergy && energyContainer.getInputPerSec() > 19L * energyToConsume) {
+        if (this.hasNotEnoughEnergy && energyContainer.getEnergyStored() > 19L * energyToConsume) {
             this.hasNotEnoughEnergy = false;
         }
 


### PR DESCRIPTION
## What
- Changes the logic that flips the `hasNotEnoughEnergy` boolean field to work when the energy is available but hasn't been input recently
- Placing down an energy hatch and giving it power will fill its buffer. If you do that first and build the rest of an HPCA around it after the buffer is full, then you can run into an issue where the HPCA has power but does not consume it and does not provide CWU.
- Prevents the HPCA from entering a state where it doesn't provide CWU despite having ample power available

## Implementation Details
Just makes line 210 look similar to line 214 in `com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java`

## Outcome
Allows the HPCA to turn on when formed even if you build it around a full energy hatch

## Additional Information
An example of the HPCA formed but unable to provide CWU because the energy hatch was full before it was formed
![image](https://github.com/GregTechCEu/GregTech-Modern/assets/26778483/5889b883-db72-432d-8d5b-667c832ada40)
