### PR TITLE
Remove "equality jank" in MapFluidTagIngredient to fix recipes randomly not working when server restarts

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/MapFluidTagIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/MapFluidTagIngredient.java
@@ -22,10 +22,6 @@ public class MapFluidTagIngredient extends AbstractMapIngredient {
         if (super.equals(obj)) {
             return tag == ((MapFluidTagIngredient) obj).tag;
         }
-        // equality jank
-        if (obj instanceof MapFluidIngredient ingredient) {
-            return ingredient.fluid.is(tag);
-        }
         return false;
     }
 


### PR DESCRIPTION
## What
If a recipe type has two recipes that share the same input fluid, but one specified using tag and the other not, then the recipe using tag will sometimes not work.

This was discovered in the https://github.com/ThePansmith/Monifactory modpack: every time the server restarts or reloads, there is a chance that assembly lines stop working until the next restart or reload.

After some debugging, it was found out that whenever it stops working, the recipe lookup tree was built into a structure where the two soldering alloy ingredient variants
`MapFluidTagIngredient{tag=forge:soldering_alloy}` and `MapFluidIngredient{{fluid=gtceu:soldering_alloy} {tag=null}` ended up being the branching keys of the same node.

Because of the "equality jank", we always go down the `MapFluidIngredient` branch even when a `MapFluidTagIngredient` key is used to query. Therefore, none of the recipes in the `MapFluidTagIngredient` branch would work.

## Implementation Details
The "equality jank" is removed. It probably was needed at some point in the past, but removing it doesn't seem to break anything after testing many recipes on a variety of machines.

## Outcome
Assembly lines now work consistently on the modpack.
