### PR TITLE
Fix wrench interaction to not care about durability (#1155)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java
@@ -287,8 +287,6 @@ public class SimpleTieredMachine extends WorkableTieredMachine implements IAutoO
     @Override
     protected InteractionResult onWrenchClick(Player playerIn, InteractionHand hand, Direction gridSide, BlockHitResult hitResult) {
         if (!playerIn.isShiftKeyDown() && !isRemote()) {
-            var tool = playerIn.getItemInHand(hand);
-            if (tool.getDamageValue() >= tool.getMaxDamage()) return InteractionResult.PASS;
             if (hasFrontFacing() && gridSide == getFrontFacing()) return InteractionResult.PASS;
 
             // important not to use getters here, which have different logic


### PR DESCRIPTION
## What
Makes wrench interactions not check durability, so they properly support items without durability and items with 0 durability.

## Outcome
Fixes: #1155