### PR TITLE
Override `BE.setChanged` to significantly reduce neighbor updates

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/MetaMachineBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/MetaMachineBlockEntity.java
@@ -120,6 +120,13 @@ public class MetaMachineBlockEntity extends BlockEntity implements IMachineBlock
         return result == null ? super.getCapability(cap, side) : result;
     }
 
+    @Override
+    public void setChanged() {
+        if (getLevel() != null) {
+            getLevel().blockEntityChanged(getBlockPos());
+        }
+    }
+
     @Nullable
     public static <T> LazyOptional<T> getCapability(MetaMachine machine, @NotNull Capability<T> cap, @Nullable Direction side) {
         if (cap == GTCapability.CAPABILITY_COVERABLE) {

--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -302,6 +302,12 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
         return false;
     }
 
+    @Override
+    public void setChanged() {
+        if (getLevel() != null) {
+            getLevel().blockEntityChanged(getBlockPos());
+        }
+    }
 
     //////////////////////////////////////
     //*******     Interaction    *******//


### PR DESCRIPTION
## What
While using another mod allowing to create custom CC:Tweaked peripheral through KubeJS, I noticed there was something causing interferences, which originates in calls made to `BlockEntity.setChanged` every tick when any change (energy &/or recipe progress) happens to a GTCEu machine/pipe/cable, causing CC:Tweaked to call `refreshPeripheral`, temporarily invalidating the peripheral during the given tick (and so on for a while).

I believe this call is/was made to make sure the BlockEntity data will be saved in the chunk data, but it also makes a call to `level.updateNeighbourForOutputSignal` which calls `BS.onNeighborChange` & `BS.neighborChanged` on up-to the 6 blocks around the GTCEu BlockEntity. I prefer not to copy/paste MC/Forge sourcecode here, but in your IDE you can take a look at what's inside `BlockEntity.setChanged` and also have a look at `Level.updateNeighbourForOutputSignal`.

## Implementation Details
Simply override `BlockEntity.setChanged` to only call `level.blockEntityChanged` and nothing more.

## Outcome
This fixes the issue I described before, and I wouldn't be surprised it could save some TPS as a side-effect.

## Additional Information
I have tested some functionalities to make sure my changes didn't break anything:
- redstone covers still work
- auto item transfers between machines
- cable connections (placing a cable next to a connected side, placing a machine/buffer next to a connected side, toggling connexion with wire cutter)
- same for pipes

## Potential Compatibility Issues
None that I'm aware of.
If at some point in the future we would witness any bug related to this change, I think the proper way to resolve them would be to trigger neighbor updates when/where necessary rather than relying on something that is doing it every tick.
