### PR TITLE
fix all custom recipe capabilities being removed

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
@@ -235,9 +235,6 @@ public class GTRecipeComponents {
         KJSRecipeKeyEvent event = new KJSRecipeKeyEvent();
         AddonFinder.getAddons().forEach(addon -> addon.registerRecipeKeys(event));
         VALID_CAPS.putAll(event.getRegisteredKeys());
-        Set<RecipeCapability<?>> addedCaps = event.getRegisteredKeys().keySet();
-        Set<RecipeCapability<?>> registeredCaps = GTRegistries.RECIPE_CAPABILITIES.values();
-        registeredCaps.removeAll(addedCaps);
     }
 
 


### PR DESCRIPTION
This is entirely untested yet, and I have absolutely no idea whether it breaks other things.

It looks like the code I removed isn't being used at any point afterwards, but this may have other implications that need to be tested before it can be merged.