### PR TITLE
Fix when autoBuild, reducing inventory even when block placement fails.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
@@ -312,12 +312,7 @@ public class BlockPattern {
         Direction frontFacing = controller.self().getFrontFacing();
         blocks.forEach((pos, block) -> { // adjust facing
             if (!(block instanceof IMultiController)) {
-                if (block instanceof BlockState) {
-                    resetFacing(pos, (BlockState) block, frontFacing, (p, f) -> {
-                        Object object = blocks.get(p.relative(f));
-                        return object == null || (object instanceof BlockState && ((BlockState) object).getBlock() == Blocks.AIR);
-                    }, state -> world.setBlock(pos, state, 3));
-                } else if (block instanceof MetaMachine machine) {
+                if (block instanceof MetaMachine machine) {
                     resetFacing(pos, machine.getBlockState(), frontFacing, (p, f) -> {
                         Object object = blocks.get(p.relative(f));
                         if (object == null || (object instanceof BlockState blockState && blockState.isAir())) {

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
@@ -272,11 +273,12 @@ public class BlockPattern {
 
                             // check inventory
                             ItemStack found = null;
+                            ItemStack originalItemStack = null;
                             if (!player.isCreative()) {
                                 for (ItemStack itemStack : player.getInventory().items) {
                                     if (candidates.stream().anyMatch(candidate -> ItemStack.isSameItemSameTags(candidate, itemStack)) && !itemStack.isEmpty() && itemStack.getItem() instanceof BlockItem) {
                                         found = itemStack.copy();
-                                        itemStack.setCount(itemStack.getCount() - 1);
+                                        originalItemStack = itemStack;
                                         break;
                                     }
                                 }
@@ -292,7 +294,10 @@ public class BlockPattern {
                             if (found == null) continue;
                             BlockItem itemBlock = (BlockItem) found.getItem();
                             BlockPlaceContext context = new BlockPlaceContext(world, player, InteractionHand.MAIN_HAND, found, BlockHitResult.miss(player.getEyePosition(0), Direction.UP, pos));
-                            itemBlock.place(context);
+                            InteractionResult interactionResult = itemBlock.place(context);
+                            if(originalItemStack != null && interactionResult != InteractionResult.FAIL) {
+                                originalItemStack.setCount(originalItemStack.getCount() - 1);
+                            }
                             if (world.getBlockEntity(pos) instanceof IMachineBlockEntity machineBlockEntity) {
                                 blocks.put(pos, machineBlockEntity.getMetaMachine());
                             } else {

--- a/src/main/resources/assets/gtceu/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceu/lang/zh_cn.json
@@ -1316,7 +1316,7 @@
     "block.gtceu.zpm_chemical_reactor":"§c精英化学反应釜 III§r",
     "block.gtceu.zpm_circuit_assembler":"§c精英电路组装机 III§r",
     "block.gtceu.zpm_compressor":"§c精英压缩机 III§r",
-    "block.gtceu.zpm_cutter":"§精英切割机 III§r",
+    "block.gtceu.zpm_cutter":"§c精英切割机 III§r",
     "block.gtceu.zpm_diode":"§cZPM§r二极管",
     "block.gtceu.zpm_distillery":"§c精英蒸馏室 III§r",
     "block.gtceu.zpm_electric_furnace":"§c精英电炉 III§r",


### PR DESCRIPTION
## What
1. Fix a bug in cn.lang.
2. Fix when autoBuild, reducing inventory even when block placement fails.
For example, the player stands on a certain coordinate, causing the placement to fail, but still consuming blocks.
3. Change: When autoBuild do not adjust facing of the blocks already placed.
An undiscussed change.
But I hope not to change the orientation of the block that has been placed, because this block may be an energy input hatch on the edge, but I have set up the power input for it with the cable, (or this block is I/O bus), but the auto adjust facing changes it.

## Implementation Details
Reduce inventory when the blocks are successfully placed.

## Outcome
Fix bugs, and one changes