### PR TITLE
Fix AveragingPerTickCounter.checkValueState

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/AveragingPerTickCounter.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/AveragingPerTickCounter.java
@@ -38,16 +38,12 @@ public class AveragingPerTickCounter {
                 Arrays.fill(values, defaultValue);
                 currentIndex = 0;
             } else {
-                currentIndex += dif;
-                if (currentIndex > values.length - 1)
-                    currentIndex -= values.length;
-                int index;
-                for (int i = 0, n = values.length; i < dif; i++) {
-                    index = i + currentIndex;
-                    if (index >= n)
-                        index -= n;
-                    values[index] = defaultValue;
+                for (int i = currentIndex + 1; i <= currentIndex + dif; i++) {
+                    values[i % values.length] = defaultValue;
                 }
+                currentIndex += dif;
+                if (currentIndex >= values.length)
+                    currentIndex = currentIndex % values.length;
             }
             this.lastUpdatedWorldTime = currentWorldTime;
             dirty = true;


### PR DESCRIPTION
## What
I noticed there was inconsistencies when a current is emitted during a single tick. I fixed AveragingPerTickCounter.checkValueState accordingly
cf. Discord feedback issue called "Average voltage can miss sparse single/double tick energy transfers"

## Implementation Details
Currentindex was updated before the for, but it needed to be updated only after.

Explanation: let's take an example where currentIndex=6 and dif=4, and the array is [4,2,4,2,4,2,4,2,4,2,4,2,4,2,4,2,4,2,4,2]

when the method is called, currentIndex always represents the last written index (either through increment or last time inside the for)

so it's only right we write zeros starting from the next index (`for (int i = currentIndex + 1`), until we reach currentIndex+dif (`i <= currentIndex + dif`), including the moment we reach it (since we started `+1`, we need to also reset index+dif, because it happened exactly 20 ticks ago, and if we are called by increment, we really need to zero it down)

the array then becomes: 
```
[4,2,4,2,4,2,4,0,0,0,0,2,4,2,4,2,4,2,4,2]
                     ^ new currentIndex
```
and that's when we need to update currentIndex to its new value (currentIndex + dif), the latest we reset inside the for loop


## Outcome
The issue was resolved (cf. second video on Discord), and no new issue is to deplore when I let a continuous current flow during more than a second.

## Additional Information
cf. videos on Discord
**edit 14 hours later:** my base has been running flawlessly on my server since then, there was no crash nor errors logged so far.

## Potential Compatibility Issues
None