### PR TITLE
Fix mud recipe, use circuit 1 to distinguish it from fertilizer recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -1044,8 +1044,9 @@ public class VanillaStandardRecipes {
 
         MIXER_RECIPES.recipeBuilder("mud")
                 .inputItems(new ItemStack(Blocks.DIRT))
+                .circuitMeta(1)
                 .inputFluids(Water.getFluid(L))
-                .outputItems(new ItemStack(Blocks.COARSE_DIRT, 2))
+                .outputItems(new ItemStack(Blocks.MUD, 1))
                 .duration(100).EUt(4).save(provider);
     }
 


### PR DESCRIPTION
## What
Fixes mud mixer recipe, adds circuit to prevent confusion with fertilizer

## Implementation Details
Self-explanatory from the code

## Outcome
- Ability to make mud with the mixer
- Stability of the fertilizer recipe

## Additional Information
cf Discord feedback channel "Mixer: fertilizer recipe conflicting with coarse dirt"

## Potential Compatibility Issues
None
