### PR TITLE
Reduce memory usage of GTDynamicDataPack

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 public class GTDynamicDataPack implements PackResources {
 
     protected static final ObjectSet<String> SERVER_DOMAINS = new ObjectOpenHashSet<>();
-    protected static final Map<ResourceLocation, JsonObject> DATA = new HashMap<>();
+    protected static final Map<ResourceLocation, byte[]> DATA = new HashMap<>();
 
     private final String name;
 
@@ -70,13 +70,13 @@ public class GTDynamicDataPack implements PackResources {
         if (DATA.containsKey(recipeId)) {
             GTCEu.LOGGER.error("duplicated recipe: {}", recipeId);
         }
-        DATA.put(getRecipeLocation(recipeId), recipeJson);
+        DATA.put(getRecipeLocation(recipeId), recipeJson.toString().getBytes(StandardCharsets.UTF_8));
         if (recipe.serializeAdvancement() != null) {
             JsonObject advancement = recipe.serializeAdvancement();
             if (ConfigHolder.INSTANCE.dev.dumpRecipes) {
                 writeJson(recipe.getAdvancementId(), "advancements", parent, advancement);
             }
-            DATA.put(getAdvancementLocation(Objects.requireNonNull(recipe.getAdvancementId())), advancement);
+            DATA.put(getAdvancementLocation(Objects.requireNonNull(recipe.getAdvancementId())), advancement.toString().getBytes(StandardCharsets.UTF_8));
         }
     }
 
@@ -108,7 +108,7 @@ public class GTDynamicDataPack implements PackResources {
     public static void addAdvancement(ResourceLocation loc, JsonObject obj) {
         ResourceLocation l = getAdvancementLocation(loc);
         synchronized (DATA) {
-            DATA.put(l, obj);
+            DATA.put(l, obj.toString().getBytes(StandardCharsets.UTF_8));
         }
     }
 
@@ -121,8 +121,9 @@ public class GTDynamicDataPack implements PackResources {
     @Override
     public IoSupplier<InputStream> getResource(PackType type, ResourceLocation location) {
         if (type == PackType.SERVER_DATA) {
-            if (DATA.containsKey(location))
-                return () -> new ByteArrayInputStream(DATA.get(location).toString().getBytes(StandardCharsets.UTF_8));
+            var byteArray = DATA.get(location);
+            if (byteArray != null)
+                return () -> new ByteArrayInputStream(byteArray);
             else return null;
         } else {
             return null;


### PR DESCRIPTION
Storing a `JsonObject` in memory for each datapack file is quite inefficient (as the inner JSON primitive objects take up a lot of space). This data can be stored more compactly by converting it to a `byte[]` array at load time and storing that in the map instead. `GTDynamicResourcePack` does something similar.

This change reduced retained memory size of the class from 127MB -> 30MB when testing with Monifactory. Eliminating the memory usage entirely would probably require caching this datapack on disk as a ZIP and regenerating it if the mod list/registry changes.

I also took the opportunity to *slightly* microoptimize `getResource` by refactoring it to only read from the hash map once and capture the byte array in the lambda, rather than location.