### PR TITLE
Allow addons to filter GT recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipes.java
@@ -13,9 +13,12 @@ import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.ComposterBlock;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class GTRecipes {
+    private static final List<ResourceLocation> RECIPE_FILTERS = new ArrayList<>();
 
     /*
      * Called on resource reload in-game.
@@ -26,7 +29,13 @@ public class GTRecipes {
      * This should also be used for recipes that need
      * to respond to a config option in ConfigHolder.
      */
-    public static void recipeAddition(Consumer<FinishedRecipe> consumer) {
+    public static void recipeAddition(Consumer<FinishedRecipe> originalConsumer) {
+        Consumer<FinishedRecipe> consumer = recipe -> {
+            if (!RECIPE_FILTERS.contains(recipe.getId())) {
+                originalConsumer.accept(recipe);
+            }
+        };
+
         ComposterRecipes.addComposterRecipes(ComposterBlock.COMPOSTABLES::put);
         ResearchManager.registerScannerLogic();
 
@@ -86,6 +95,7 @@ public class GTRecipes {
     public static void recipeRemoval(Consumer<ResourceLocation> consumer) {
         RecipeRemoval.init(consumer);
 
-        AddonFinder.getAddons().forEach(addon -> addon.removeRecipes(consumer));
+        RECIPE_FILTERS.clear();
+        AddonFinder.getAddons().forEach(addon -> addon.removeRecipes(consumer.andThen(RECIPE_FILTERS::add)));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipes.java
@@ -9,16 +9,16 @@ import com.gregtechceu.gtceu.data.recipe.generated.*;
 import com.gregtechceu.gtceu.data.recipe.misc.*;
 import com.gregtechceu.gtceu.data.recipe.serialized.chemistry.ChemistryRecipes;
 import com.gregtechceu.gtceu.utils.ResearchManager;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.ComposterBlock;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class GTRecipes {
-    private static final List<ResourceLocation> RECIPE_FILTERS = new ArrayList<>();
+    private static final Set<ResourceLocation> RECIPE_FILTERS = new ObjectOpenHashSet<>();
 
     /*
      * Called on resource reload in-game.


### PR DESCRIPTION
## What
`IGTAddon.removeRecipes()` adds to the filter section in the pack metadata. However, this only applies to packs that load below GT's dynamic pack. This, unfortunately, does not include the GT pack itself, making removing GT recipes impossible without mixins.

## Implementation Details
This adds all the recipe filters to an ArrayList - there might be a better way to do this, but I figured the memory cost of a list is less than the performance cost of rerunning the (potentially expensive) recipe removal logic. I thought about adding a specific method to `IGTAddon` for this, but decided against fragmenting the recipe filtering logic - though this might also be another solution to this problem.