### PR TITLE
Move RotorEfficiency to it's own Parameter in .rotorStats()

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -1007,8 +1007,8 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        public Builder rotorStats(float speed, float efficiency, float damage, int durability) {
-            properties.setProperty(PropertyKey.ROTOR, new RotorProperty(speed, efficiency, damage, durability));
+        public Builder rotorStats(float power, float efficiency, float damage, int durability) {
+            properties.setProperty(PropertyKey.ROTOR, new RotorProperty(power, efficiency, damage, durability));
             return this;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -1007,8 +1007,8 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        public Builder rotorStats(float speed, float damage, int durability) {
-            properties.setProperty(PropertyKey.ROTOR, new RotorProperty(speed, damage, durability));
+        public Builder rotorStats(float speed, float efficiency, float damage, int durability) {
+            properties.setProperty(PropertyKey.ROTOR, new RotorProperty(speed, efficiency, damage, durability));
             return this;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -1007,7 +1007,7 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        public Builder rotorStats(float power, float efficiency, float damage, int durability) {
+        public Builder rotorStats(int power, int efficiency, float damage, int durability) {
             properties.setProperty(PropertyKey.ROTOR, new RotorProperty(power, efficiency, damage, durability));
             return this;
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
 import org.jetbrains.annotations.NotNull;
+import org.openjdk.nashorn.internal.objects.annotations.Getter;
 
 public class RotorProperty implements IMaterialProperty<RotorProperty> {
 
@@ -37,7 +38,7 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
         this.damage = damage;
         this.durability = durability;
     }
-
+    @Getter
     public float getSpeed() {
         return speed;
     }
@@ -46,6 +47,7 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
         if (speed <= 0) throw new IllegalArgumentException("Rotor Speed must be greater than zero!");
         this.speed = speed;
     }
+    @Getter
     public float getEfficiency() {
         return efficiency;
     }
@@ -53,6 +55,7 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
         if (efficiency <= 0) throw new IllegalArgumentException("Rotor Efficiency must be greater than zero!");
         this.efficiency = efficiency;
     }
+    @Getter
     public float getDamage() {
         return damage;
     }
@@ -61,7 +64,7 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
         if (damage <= 0) throw new IllegalArgumentException("Rotor Attack Damage must be greater than zero!");
         this.damage = damage;
     }
-
+    @Getter
     public int getDurability() {
         return durability;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
@@ -1,22 +1,24 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
-import org.openjdk.nashorn.internal.objects.annotations.Getter;
 
 public class RotorProperty implements IMaterialProperty<RotorProperty> {
 
     /**
-     * Speed of rotors made from this Material.
+     * Power of rotors made from this Material.
      * <p>
      * Default:
      */
-    private float speed;
+    @Getter
+    private float power;
 
     /**
      * Attack damage of rotors made from this Material
      * <p>
      * Default:
      */
+    @Getter
     private float damage;
 
     /**
@@ -24,49 +26,36 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
      * <p>
      * Default:
      */
+    @Getter
     private int durability;
     /**
      * Efficiency of rotors made from this Material
      * <p>
      * Default:
      */
+    @Getter
     private float efficiency;
 
-    public RotorProperty(float speed, float efficiency, float damage, int durability) {
-        this.speed = speed;
+    public RotorProperty(float power, float efficiency, float damage, int durability) {
+        this.power = power;
         this.efficiency = efficiency;
         this.damage = damage;
         this.durability = durability;
     }
-    @Getter
-    public float getSpeed() {
-        return speed;
+
+    public void setPower(float power) {
+        if (power <= 0) throw new IllegalArgumentException("Rotor Power must be greater than zero!");
+        this.power = power;
     }
 
-    public void setSpeed(float speed) {
-        if (speed <= 0) throw new IllegalArgumentException("Rotor Speed must be greater than zero!");
-        this.speed = speed;
-    }
-    @Getter
-    public float getEfficiency() {
-        return efficiency;
-    }
     public void setEfficiency(float efficiency) {
         if (efficiency <= 0) throw new IllegalArgumentException("Rotor Efficiency must be greater than zero!");
         this.efficiency = efficiency;
-    }
-    @Getter
-    public float getDamage() {
-        return damage;
     }
 
     public void setDamage(float damage) {
         if (damage <= 0) throw new IllegalArgumentException("Rotor Attack Damage must be greater than zero!");
         this.damage = damage;
-    }
-    @Getter
-    public int getDurability() {
-        return durability;
     }
 
     public void setDurability(int durability) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
@@ -24,9 +24,16 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
      * Default:
      */
     private int durability;
+    /**
+     * Efficiency of rotors made from this Material
+     * <p>
+     * Default:
+     */
+    private float efficiency;
 
-    public RotorProperty(float speed, float damage, int durability) {
+    public RotorProperty(float speed, float efficiency, float damage, int durability) {
         this.speed = speed;
+        this.efficiency = efficiency;
         this.damage = damage;
         this.durability = durability;
     }
@@ -39,7 +46,13 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
         if (speed <= 0) throw new IllegalArgumentException("Rotor Speed must be greater than zero!");
         this.speed = speed;
     }
-
+    public float getEfficiency() {
+        return efficiency;
+    }
+    public void setEfficiency(float efficiency) {
+        if (efficiency <= 0) throw new IllegalArgumentException("Rotor Efficiency must be greater than zero!");
+        this.efficiency = efficiency;
+    }
     public float getDamage() {
         return damage;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
@@ -11,7 +11,7 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
      * Default:
      */
     @Getter
-    private float power;
+    private int power;
 
     /**
      * Attack damage of rotors made from this Material
@@ -34,26 +34,26 @@ public class RotorProperty implements IMaterialProperty<RotorProperty> {
      * Default:
      */
     @Getter
-    private float efficiency;
+    private int efficiency;
 
-    public RotorProperty(float power, float efficiency, float damage, int durability) {
+    public RotorProperty(int power, int efficiency, float damage, int durability) {
         this.power = power;
         this.efficiency = efficiency;
         this.damage = damage;
         this.durability = durability;
     }
 
-    public void setPower(float power) {
+    public void setPower(int power) {
         if (power <= 0) throw new IllegalArgumentException("Rotor Power must be greater than zero!");
         this.power = power;
     }
 
-    public void setEfficiency(float efficiency) {
+    public void setEfficiency(int efficiency) {
         if (efficiency <= 0) throw new IllegalArgumentException("Rotor Efficiency must be greater than zero!");
         this.efficiency = efficiency;
     }
 
-    public void setDamage(float damage) {
+    public void setDamage(int damage) {
         if (damage <= 0) throw new IllegalArgumentException("Rotor Attack Damage must be greater than zero!");
         this.damage = damage;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -35,7 +35,7 @@ public class ElementMaterials {
                 .element(GTElements.Al)
                 .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
                         .enchantability(14).build())
-                .rotorStats(10.0f, 140, 2.0f, 128)
+                .rotorStats(100.0f, 140, 2.0f, 128)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
                 .blastTemp(1700, GasTier.LOW)
@@ -169,7 +169,7 @@ public class ElementMaterials {
                 .color(0xf3e0ea).secondaryColor(0x441f2e).iconSet(SHINY)
                 .appendFlags(EXT_METAL, GENERATE_ROTOR)
                 .element(GTElements.Cr)
-                .rotorStats(12.0f, 155,3.0f, 512)
+                .rotorStats(130.0f, 155,3.0f, 512)
                 .fluidPipeProperties(2180, 35, true, true, false, false)
                 .blastTemp(1700, GasTier.LOW)
                 .buildAndRegister();
@@ -361,7 +361,7 @@ public class ElementMaterials {
                 .color(0xfdfce9).secondaryColor(0x3d011b).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.Ir)
-                .rotorStats(7.0f, 115,3.0f, 2560)
+                .rotorStats(130.0f, 115,3.0f, 2560)
                 .fluidPipeProperties(3398, 250, true, false, true, false)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1100)
                 .buildAndRegister();
@@ -376,7 +376,7 @@ public class ElementMaterials {
                 .element(GTElements.Fe)
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 256, 2)
                         .enchantability(14).addTypes(GTToolType.MORTAR).build())
-                .rotorStats(7.0f, 115,2.5f, 256)
+                .rotorStats(115.0f, 115,2.5f, 256)
                 .cableProperties(GTValues.V[2], 2, 3)
                 .buildAndRegister();
 
@@ -450,7 +450,7 @@ public class ElementMaterials {
                 .color(0xEEEEEE).secondaryColor(0xCDE1B9)
                 .appendFlags(STD_METAL, GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .element(GTElements.Mn)
-                .rotorStats(7.0f, 115,2.0f, 512)
+                .rotorStats(100.0f, 115,2.0f, 512)
                 .buildAndRegister();
 
         Meitnerium = new Material.Builder(GTCEu.id("meitnerium"))
@@ -471,7 +471,7 @@ public class ElementMaterials {
                 .color(0xc1c1ce).secondaryColor(0x404068).iconSet(SHINY)
                 .element(GTElements.Mo)
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW)
-                .rotorStats(7.0f, 115,2.0f, 512)
+                .rotorStats(100.0f, 115,2.0f, 512)
                 .buildAndRegister();
 
         Moscovium = new Material.Builder(GTCEu.id("moscovium"))
@@ -484,7 +484,7 @@ public class ElementMaterials {
                 .color(0x9a8b94).secondaryColor(0x2c2c2c).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nd)
-                .rotorStats(7.0f, 115,2.0f, 512)
+                .rotorStats(100.0f, 115,2.0f, 512)
                 .blastTemp(1297, GasTier.MID)
                 .buildAndRegister();
 
@@ -546,7 +546,7 @@ public class ElementMaterials {
                 .color(0xf9f9f9).secondaryColor(0x307fc2).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_FOIL)
                 .element(GTElements.Os)
-                .rotorStats(16.0f, 185,4.0f, 1280)
+                .rotorStats(160.0f, 185,4.0f, 1280)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .itemPipeProperties(256, 8.0f)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
@@ -811,7 +811,7 @@ public class ElementMaterials {
                 .element(GTElements.Ti)
                 .toolStats(ToolProperty.Builder.of(8.0F, 6.0F, 1536, 3)
                         .enchantability(14).build())
-                .rotorStats(7.0f, 115,3.0f, 1600)
+                .rotorStats(130.0f, 115,3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
                 .blastTemp(1941, GasTier.MID, GTValues.VA[GTValues.HV], 1500)
                 .buildAndRegister();
@@ -829,7 +829,7 @@ public class ElementMaterials {
                 .color(0x3b3a32).secondaryColor(0x2a2800).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.W)
-                .rotorStats(7.0f, 115,3.0f, 2560)
+                .rotorStats(130.0f, 115,3.0f, 2560)
                 .cableProperties(GTValues.V[5], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
                 .blastTemp(3600, GasTier.MID, GTValues.VA[GTValues.EV], 1800)
@@ -896,7 +896,7 @@ public class ElementMaterials {
                 .color(0x323232, false).secondaryColor(0x1e251b).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nq)
-                .rotorStats(6.0f, 105,4.0f, 1280)
+                .rotorStats(160.0f, 105,4.0f, 1280)
                 .cableProperties(GTValues.V[7], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.IV], 600)
@@ -928,7 +928,7 @@ public class ElementMaterials {
                 .element(GTElements.Nt)
                 .toolStats(ToolProperty.Builder.of(180.0F, 100.0F, 65535, 6)
                         .attackSpeed(0.5F).enchantability(33).magnetic().unbreakable().build())
-                .rotorStats(24.0f, 250.0f, 12.0f, 655360)
+                .rotorStats(400.0f, 250.0f, 12.0f, 655360)
                 .fluidPipeProperties(100_000, 5000, true, true, true, true)
                 .buildAndRegister();
 
@@ -939,7 +939,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .element(GTElements.Tr)
                 .cableProperties(GTValues.V[8], 1, 8)
-                .rotorStats(20.0f,220.0f, 6.0f, 10240)
+                .rotorStats(220.0f,220.0f, 6.0f, 10240)
                 .buildAndRegister();
 
         Duranium = new Material.Builder(GTCEu.id("duranium"))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -35,7 +35,7 @@ public class ElementMaterials {
                 .element(GTElements.Al)
                 .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
                         .enchantability(14).build())
-                .rotorStats(10.0f, 140,2.0f, 128)
+                .rotorStats(10.0f, 140, 2.0f, 128)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
                 .blastTemp(1700, GasTier.LOW)
@@ -928,7 +928,7 @@ public class ElementMaterials {
                 .element(GTElements.Nt)
                 .toolStats(ToolProperty.Builder.of(180.0F, 100.0F, 65535, 6)
                         .attackSpeed(0.5F).enchantability(33).magnetic().unbreakable().build())
-                .rotorStats(24.0f, 250.0f,12.0f, 655360)
+                .rotorStats(24.0f, 250.0f, 12.0f, 655360)
                 .fluidPipeProperties(100_000, 5000, true, true, true, true)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -35,7 +35,7 @@ public class ElementMaterials {
                 .element(GTElements.Al)
                 .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
                         .enchantability(14).build())
-                .rotorStats(10.0f, 2.0f, 128)
+                .rotorStats(10.0f, 140,2.0f, 128)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
                 .blastTemp(1700, GasTier.LOW)
@@ -169,7 +169,7 @@ public class ElementMaterials {
                 .color(0xf3e0ea).secondaryColor(0x441f2e).iconSet(SHINY)
                 .appendFlags(EXT_METAL, GENERATE_ROTOR)
                 .element(GTElements.Cr)
-                .rotorStats(12.0f, 3.0f, 512)
+                .rotorStats(12.0f, 155,3.0f, 512)
                 .fluidPipeProperties(2180, 35, true, true, false, false)
                 .blastTemp(1700, GasTier.LOW)
                 .buildAndRegister();
@@ -361,7 +361,7 @@ public class ElementMaterials {
                 .color(0xfdfce9).secondaryColor(0x3d011b).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.Ir)
-                .rotorStats(7.0f, 3.0f, 2560)
+                .rotorStats(7.0f, 115,3.0f, 2560)
                 .fluidPipeProperties(3398, 250, true, false, true, false)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1100)
                 .buildAndRegister();
@@ -376,7 +376,7 @@ public class ElementMaterials {
                 .element(GTElements.Fe)
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 256, 2)
                         .enchantability(14).addTypes(GTToolType.MORTAR).build())
-                .rotorStats(7.0f, 2.5f, 256)
+                .rotorStats(7.0f, 115,2.5f, 256)
                 .cableProperties(GTValues.V[2], 2, 3)
                 .buildAndRegister();
 
@@ -450,7 +450,7 @@ public class ElementMaterials {
                 .color(0xEEEEEE).secondaryColor(0xCDE1B9)
                 .appendFlags(STD_METAL, GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .element(GTElements.Mn)
-                .rotorStats(7.0f, 2.0f, 512)
+                .rotorStats(7.0f, 115,2.0f, 512)
                 .buildAndRegister();
 
         Meitnerium = new Material.Builder(GTCEu.id("meitnerium"))
@@ -471,7 +471,7 @@ public class ElementMaterials {
                 .color(0xc1c1ce).secondaryColor(0x404068).iconSet(SHINY)
                 .element(GTElements.Mo)
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW)
-                .rotorStats(7.0f, 2.0f, 512)
+                .rotorStats(7.0f, 115,2.0f, 512)
                 .buildAndRegister();
 
         Moscovium = new Material.Builder(GTCEu.id("moscovium"))
@@ -484,7 +484,7 @@ public class ElementMaterials {
                 .color(0x9a8b94).secondaryColor(0x2c2c2c).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nd)
-                .rotorStats(7.0f, 2.0f, 512)
+                .rotorStats(7.0f, 115,2.0f, 512)
                 .blastTemp(1297, GasTier.MID)
                 .buildAndRegister();
 
@@ -546,7 +546,7 @@ public class ElementMaterials {
                 .color(0xf9f9f9).secondaryColor(0x307fc2).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_FOIL)
                 .element(GTElements.Os)
-                .rotorStats(16.0f, 4.0f, 1280)
+                .rotorStats(16.0f, 185,4.0f, 1280)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .itemPipeProperties(256, 8.0f)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
@@ -811,7 +811,7 @@ public class ElementMaterials {
                 .element(GTElements.Ti)
                 .toolStats(ToolProperty.Builder.of(8.0F, 6.0F, 1536, 3)
                         .enchantability(14).build())
-                .rotorStats(7.0f, 3.0f, 1600)
+                .rotorStats(7.0f, 115,3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
                 .blastTemp(1941, GasTier.MID, GTValues.VA[GTValues.HV], 1500)
                 .buildAndRegister();
@@ -829,7 +829,7 @@ public class ElementMaterials {
                 .color(0x3b3a32).secondaryColor(0x2a2800).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.W)
-                .rotorStats(7.0f, 3.0f, 2560)
+                .rotorStats(7.0f, 115,3.0f, 2560)
                 .cableProperties(GTValues.V[5], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
                 .blastTemp(3600, GasTier.MID, GTValues.VA[GTValues.EV], 1800)
@@ -896,7 +896,7 @@ public class ElementMaterials {
                 .color(0x323232, false).secondaryColor(0x1e251b).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nq)
-                .rotorStats(6.0f, 4.0f, 1280)
+                .rotorStats(6.0f, 105,4.0f, 1280)
                 .cableProperties(GTValues.V[7], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.IV], 600)
@@ -928,7 +928,7 @@ public class ElementMaterials {
                 .element(GTElements.Nt)
                 .toolStats(ToolProperty.Builder.of(180.0F, 100.0F, 65535, 6)
                         .attackSpeed(0.5F).enchantability(33).magnetic().unbreakable().build())
-                .rotorStats(24.0f, 12.0f, 655360)
+                .rotorStats(24.0f, 250.0f,12.0f, 655360)
                 .fluidPipeProperties(100_000, 5000, true, true, true, true)
                 .buildAndRegister();
 
@@ -939,7 +939,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .element(GTElements.Tr)
                 .cableProperties(GTValues.V[8], 1, 8)
-                .rotorStats(20.0f, 6.0f, 10240)
+                .rotorStats(20.0f,220.0f, 6.0f, 10240)
                 .buildAndRegister();
 
         Duranium = new Material.Builder(GTCEu.id("duranium"))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -35,7 +35,7 @@ public class ElementMaterials {
                 .element(GTElements.Al)
                 .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
                         .enchantability(14).build())
-                .rotorStats(100.0f, 140, 2.0f, 128)
+                .rotorStats(100, 140, 2.0f, 128)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
                 .blastTemp(1700, GasTier.LOW)
@@ -169,7 +169,7 @@ public class ElementMaterials {
                 .color(0xf3e0ea).secondaryColor(0x441f2e).iconSet(SHINY)
                 .appendFlags(EXT_METAL, GENERATE_ROTOR)
                 .element(GTElements.Cr)
-                .rotorStats(130.0f, 155,3.0f, 512)
+                .rotorStats(130, 155, 3.0f, 512)
                 .fluidPipeProperties(2180, 35, true, true, false, false)
                 .blastTemp(1700, GasTier.LOW)
                 .buildAndRegister();
@@ -361,7 +361,7 @@ public class ElementMaterials {
                 .color(0xfdfce9).secondaryColor(0x3d011b).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.Ir)
-                .rotorStats(130.0f, 115,3.0f, 2560)
+                .rotorStats(130, 115, 3.0f, 2560)
                 .fluidPipeProperties(3398, 250, true, false, true, false)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1100)
                 .buildAndRegister();
@@ -376,7 +376,7 @@ public class ElementMaterials {
                 .element(GTElements.Fe)
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 256, 2)
                         .enchantability(14).addTypes(GTToolType.MORTAR).build())
-                .rotorStats(115.0f, 115,2.5f, 256)
+                .rotorStats(115, 115, 2.5f, 256)
                 .cableProperties(GTValues.V[2], 2, 3)
                 .buildAndRegister();
 
@@ -450,7 +450,7 @@ public class ElementMaterials {
                 .color(0xEEEEEE).secondaryColor(0xCDE1B9)
                 .appendFlags(STD_METAL, GENERATE_FOIL, GENERATE_BOLT_SCREW)
                 .element(GTElements.Mn)
-                .rotorStats(100.0f, 115,2.0f, 512)
+                .rotorStats(100, 115, 2.0f, 512)
                 .buildAndRegister();
 
         Meitnerium = new Material.Builder(GTCEu.id("meitnerium"))
@@ -471,7 +471,7 @@ public class ElementMaterials {
                 .color(0xc1c1ce).secondaryColor(0x404068).iconSet(SHINY)
                 .element(GTElements.Mo)
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW)
-                .rotorStats(100.0f, 115,2.0f, 512)
+                .rotorStats(100, 115, 2.0f, 512)
                 .buildAndRegister();
 
         Moscovium = new Material.Builder(GTCEu.id("moscovium"))
@@ -484,7 +484,7 @@ public class ElementMaterials {
                 .color(0x9a8b94).secondaryColor(0x2c2c2c).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nd)
-                .rotorStats(100.0f, 115,2.0f, 512)
+                .rotorStats(100, 115,2.0f, 512)
                 .blastTemp(1297, GasTier.MID)
                 .buildAndRegister();
 
@@ -546,7 +546,7 @@ public class ElementMaterials {
                 .color(0xf9f9f9).secondaryColor(0x307fc2).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_FOIL)
                 .element(GTElements.Os)
-                .rotorStats(160.0f, 185,4.0f, 1280)
+                .rotorStats(160, 185, 4.0f, 1280)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .itemPipeProperties(256, 8.0f)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
@@ -811,7 +811,7 @@ public class ElementMaterials {
                 .element(GTElements.Ti)
                 .toolStats(ToolProperty.Builder.of(8.0F, 6.0F, 1536, 3)
                         .enchantability(14).build())
-                .rotorStats(130.0f, 115,3.0f, 1600)
+                .rotorStats(130, 115, 3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
                 .blastTemp(1941, GasTier.MID, GTValues.VA[GTValues.HV], 1500)
                 .buildAndRegister();
@@ -829,7 +829,7 @@ public class ElementMaterials {
                 .color(0x3b3a32).secondaryColor(0x2a2800).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.W)
-                .rotorStats(130.0f, 115,3.0f, 2560)
+                .rotorStats(130, 115, 3.0f, 2560)
                 .cableProperties(GTValues.V[5], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
                 .blastTemp(3600, GasTier.MID, GTValues.VA[GTValues.EV], 1800)
@@ -896,7 +896,7 @@ public class ElementMaterials {
                 .color(0x323232, false).secondaryColor(0x1e251b).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nq)
-                .rotorStats(160.0f, 105,4.0f, 1280)
+                .rotorStats(160, 105, 4.0f, 1280)
                 .cableProperties(GTValues.V[7], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.IV], 600)
@@ -928,7 +928,7 @@ public class ElementMaterials {
                 .element(GTElements.Nt)
                 .toolStats(ToolProperty.Builder.of(180.0F, 100.0F, 65535, 6)
                         .attackSpeed(0.5F).enchantability(33).magnetic().unbreakable().build())
-                .rotorStats(400.0f, 250.0f, 12.0f, 655360)
+                .rotorStats(400, 250, 12.0f, 655360)
                 .fluidPipeProperties(100_000, 5000, true, true, true, true)
                 .buildAndRegister();
 
@@ -939,7 +939,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .element(GTElements.Tr)
                 .cableProperties(GTValues.V[8], 1, 8)
-                .rotorStats(220.0f,220.0f, 6.0f, 10240)
+                .rotorStats(220,220, 6.0f, 10240)
                 .buildAndRegister();
 
         Duranium = new Material.Builder(GTCEu.id("duranium"))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
@@ -89,7 +89,7 @@ public class FirstDegreeMaterials {
                 .color(0xffe36e).secondaryColor(0x935828).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE)
                 .components(Zinc, 1, Copper, 3)
-                .rotorStats(8.0f, 120.0f,3.0f, 152)
+                .rotorStats(130.0f, 120.0f,3.0f, 152)
                 .itemPipeProperties(2048, 1)
                 .buildAndRegister();
 
@@ -101,7 +101,7 @@ public class FirstDegreeMaterials {
                 .components(Tin, 1, Copper, 3)
                 .toolStats(ToolProperty.Builder.of(3.0F, 2.0F, 192, 2)
                         .enchantability(18).addTypes(GTToolType.MORTAR).build())
-                .rotorStats(6.0f, 105.0f,2.5f, 192)
+                .rotorStats(115.0f, 105.0f,2.5f, 192)
                 .fluidPipeProperties(1696, 20, true)
                 .buildAndRegister();
 
@@ -294,7 +294,7 @@ public class FirstDegreeMaterials {
                         .enchantability(18)
                         .enchantment(Enchantments.BANE_OF_ARTHROPODS, 3)
                         .enchantment(Enchantments.BLOCK_EFFICIENCY, 1).build())
-                .rotorStats(7.0f, 115.0f,3.0f, 512)
+                .rotorStats(130.0f, 115.0f,3.0f, 512)
                 .buildAndRegister();
 
         Kanthal = new Material.Builder(GTCEu.id("kanthal"))
@@ -320,7 +320,7 @@ public class FirstDegreeMaterials {
                 .color(0xadc5e8).secondaryColor(0x522a77).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL)
                 .components(Magnesium, 1, Aluminium, 2)
-                .rotorStats(6.0f, 105.0f,2.0f, 256)
+                .rotorStats(100.0f, 105.0f,2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .buildAndRegister();
 
@@ -402,7 +402,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(3.0F, 8.0F, 768, 2)
                         .attackSpeed(0.3F).enchantability(33)
                         .enchantment(Enchantments.SMITE, 3).build())
-                .rotorStats(13.0f, 160.0f,2.0f, 196)
+                .rotorStats(100.0f, 160.0f,2.0f, 196)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1700, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -416,7 +416,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(12.0F, 2.0F, 768, 2)
                         .enchantability(33)
                         .enchantment(Enchantments.BLOCK_FORTUNE, 2).build())
-                .rotorStats(14.0f, 170.0f,2.0f, 152)
+                .rotorStats(100.0f, 170.0f,2.0f, 152)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1600, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -427,7 +427,7 @@ public class FirstDegreeMaterials {
                 .color(0x8b7c70).secondaryColor(0x4b3d32).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_GEAR)
                 .components(Gold, 1, Silver, 1, Copper, 3)
-                .rotorStats(12.0f, 155.0f,2.0f, 256)
+                .rotorStats(100.0f, 155.0f,2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(2000, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -438,7 +438,7 @@ public class FirstDegreeMaterials {
                 .color(0xffd26f).secondaryColor(0x895f3d).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
-                .rotorStats(8.0f, 120.0f,3.0f, 256)
+                .rotorStats(130.0f, 120.0f,3.0f, 256)
                 .blastTemp(1100, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
 
@@ -587,7 +587,7 @@ public class FirstDegreeMaterials {
                 .components(Iron, 6, Chromium, 1, Manganese, 1, Nickel, 1)
                 .toolStats(ToolProperty.Builder.of(7.0F, 5.0F, 1024, 3)
                         .enchantability(14).build())
-                .rotorStats(7.0f, 115.0f,4.0f, 480)
+                .rotorStats(160.0f, 115.0f,4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
                 .blastTemp(1700, GasTier.LOW, GTValues.VA[HV], 1100)
                 .buildAndRegister();
@@ -602,7 +602,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(5.0F, 3.0F, 512, 3)
                         .addTypes(GTToolType.MORTAR)
                         .enchantability(14).build())
-                .rotorStats(6.0f, 105.0f,3.0f, 512)
+                .rotorStats(130.0f, 105.0f,3.0f, 512)
                 .fluidPipeProperties(1855, 50, true)
                 .cableProperties(GTValues.V[EV], 2, 2)
                 .blastTemp(1000, null, GTValues.VA[MV], 800) // no gas tier for steel
@@ -653,7 +653,7 @@ public class FirstDegreeMaterials {
                 .components(Cobalt, 5, Chromium, 2, Nickel, 1, Molybdenum, 1)
                 .toolStats(ToolProperty.Builder.of(10.0F, 7.0F, 2048, 4)
                         .attackSpeed(0.1F).enchantability(21).build())
-                .rotorStats(9.0f, 130.0f,4.0f, 2048)
+                .rotorStats(160.0f, 130.0f,4.0f, 2048)
                 .itemPipeProperties(128, 16)
                 .blastTemp(2700, GasTier.MID, GTValues.VA[HV], 1300)
                 .buildAndRegister();
@@ -691,7 +691,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 384, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(6.0f, 105.0f, 3.5f, 384)
+                .rotorStats(145.0f, 105.0f, 3.5f, 384)
                 .buildAndRegister();
         Iron.getProperty(PropertyKey.INGOT).setSmeltingInto(WroughtIron);
         Iron.getProperty(PropertyKey.INGOT).setArcSmeltingInto(WroughtIron);
@@ -768,7 +768,7 @@ public class FirstDegreeMaterials {
                 .color(0xe5dcef).secondaryColor(0x241a44).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Iridium, 3, Osmium, 1)
-                .rotorStats(9.0f, 130,3.0f, 3152)
+                .rotorStats(130.0f, 130,3.0f, 3152)
                 .itemPipeProperties(64, 32)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 900)
                 .buildAndRegister();
@@ -1067,7 +1067,7 @@ public class FirstDegreeMaterials {
                 .components(Tungsten, 1, Carbon, 1)
                 .toolStats(ToolProperty.Builder.of(60.0F, 2.0F, 1024, 4)
                         .enchantability(21).build())
-                .rotorStats(12.0f, 155.0f,4.0f, 1280)
+                .rotorStats(160.0f, 155.0f,4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
                 .blastTemp(3058, GasTier.MID, GTValues.VA[HV], 1500)
                 .buildAndRegister();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
@@ -89,7 +89,7 @@ public class FirstDegreeMaterials {
                 .color(0xffe36e).secondaryColor(0x935828).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE)
                 .components(Zinc, 1, Copper, 3)
-                .rotorStats(130.0f, 120.0f,3.0f, 152)
+                .rotorStats(130, 120, 3.0f, 152)
                 .itemPipeProperties(2048, 1)
                 .buildAndRegister();
 
@@ -101,7 +101,7 @@ public class FirstDegreeMaterials {
                 .components(Tin, 1, Copper, 3)
                 .toolStats(ToolProperty.Builder.of(3.0F, 2.0F, 192, 2)
                         .enchantability(18).addTypes(GTToolType.MORTAR).build())
-                .rotorStats(115.0f, 105.0f,2.5f, 192)
+                .rotorStats(115, 105, 2.5f, 192)
                 .fluidPipeProperties(1696, 20, true)
                 .buildAndRegister();
 
@@ -294,7 +294,7 @@ public class FirstDegreeMaterials {
                         .enchantability(18)
                         .enchantment(Enchantments.BANE_OF_ARTHROPODS, 3)
                         .enchantment(Enchantments.BLOCK_EFFICIENCY, 1).build())
-                .rotorStats(130.0f, 115.0f,3.0f, 512)
+                .rotorStats(130, 115, 3.0f, 512)
                 .buildAndRegister();
 
         Kanthal = new Material.Builder(GTCEu.id("kanthal"))
@@ -320,7 +320,7 @@ public class FirstDegreeMaterials {
                 .color(0xadc5e8).secondaryColor(0x522a77).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL)
                 .components(Magnesium, 1, Aluminium, 2)
-                .rotorStats(100.0f, 105.0f,2.0f, 256)
+                .rotorStats(100, 105, 2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .buildAndRegister();
 
@@ -402,7 +402,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(3.0F, 8.0F, 768, 2)
                         .attackSpeed(0.3F).enchantability(33)
                         .enchantment(Enchantments.SMITE, 3).build())
-                .rotorStats(100.0f, 160.0f,2.0f, 196)
+                .rotorStats(100, 160, 2.0f, 196)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1700, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -416,7 +416,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(12.0F, 2.0F, 768, 2)
                         .enchantability(33)
                         .enchantment(Enchantments.BLOCK_FORTUNE, 2).build())
-                .rotorStats(100.0f, 170.0f,2.0f, 152)
+                .rotorStats(100, 170, 2.0f, 152)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1600, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -427,7 +427,7 @@ public class FirstDegreeMaterials {
                 .color(0x8b7c70).secondaryColor(0x4b3d32).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_GEAR)
                 .components(Gold, 1, Silver, 1, Copper, 3)
-                .rotorStats(100.0f, 155.0f,2.0f, 256)
+                .rotorStats(100, 155, 2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(2000, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -438,7 +438,7 @@ public class FirstDegreeMaterials {
                 .color(0xffd26f).secondaryColor(0x895f3d).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
-                .rotorStats(130.0f, 120.0f,3.0f, 256)
+                .rotorStats(130, 120, 3.0f, 256)
                 .blastTemp(1100, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
 
@@ -587,7 +587,7 @@ public class FirstDegreeMaterials {
                 .components(Iron, 6, Chromium, 1, Manganese, 1, Nickel, 1)
                 .toolStats(ToolProperty.Builder.of(7.0F, 5.0F, 1024, 3)
                         .enchantability(14).build())
-                .rotorStats(160.0f, 115.0f,4.0f, 480)
+                .rotorStats(160, 115, 4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
                 .blastTemp(1700, GasTier.LOW, GTValues.VA[HV], 1100)
                 .buildAndRegister();
@@ -602,7 +602,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(5.0F, 3.0F, 512, 3)
                         .addTypes(GTToolType.MORTAR)
                         .enchantability(14).build())
-                .rotorStats(130.0f, 105.0f,3.0f, 512)
+                .rotorStats(130, 105, 3.0f, 512)
                 .fluidPipeProperties(1855, 50, true)
                 .cableProperties(GTValues.V[EV], 2, 2)
                 .blastTemp(1000, null, GTValues.VA[MV], 800) // no gas tier for steel
@@ -653,7 +653,7 @@ public class FirstDegreeMaterials {
                 .components(Cobalt, 5, Chromium, 2, Nickel, 1, Molybdenum, 1)
                 .toolStats(ToolProperty.Builder.of(10.0F, 7.0F, 2048, 4)
                         .attackSpeed(0.1F).enchantability(21).build())
-                .rotorStats(160.0f, 130.0f,4.0f, 2048)
+                .rotorStats(160, 130, 4.0f, 2048)
                 .itemPipeProperties(128, 16)
                 .blastTemp(2700, GasTier.MID, GTValues.VA[HV], 1300)
                 .buildAndRegister();
@@ -691,7 +691,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 384, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(145.0f, 105.0f, 3.5f, 384)
+                .rotorStats(145, 105, 3.5f, 384)
                 .buildAndRegister();
         Iron.getProperty(PropertyKey.INGOT).setSmeltingInto(WroughtIron);
         Iron.getProperty(PropertyKey.INGOT).setArcSmeltingInto(WroughtIron);
@@ -768,7 +768,7 @@ public class FirstDegreeMaterials {
                 .color(0xe5dcef).secondaryColor(0x241a44).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Iridium, 3, Osmium, 1)
-                .rotorStats(130.0f, 130,3.0f, 3152)
+                .rotorStats(130, 130, 3.0f, 3152)
                 .itemPipeProperties(64, 32)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 900)
                 .buildAndRegister();
@@ -1067,7 +1067,7 @@ public class FirstDegreeMaterials {
                 .components(Tungsten, 1, Carbon, 1)
                 .toolStats(ToolProperty.Builder.of(60.0F, 2.0F, 1024, 4)
                         .enchantability(21).build())
-                .rotorStats(160.0f, 155.0f,4.0f, 1280)
+                .rotorStats(160, 155, 4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
                 .blastTemp(3058, GasTier.MID, GTValues.VA[HV], 1500)
                 .buildAndRegister();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
@@ -89,7 +89,7 @@ public class FirstDegreeMaterials {
                 .color(0xffe36e).secondaryColor(0x935828).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE)
                 .components(Zinc, 1, Copper, 3)
-                .rotorStats(8.0f, 3.0f, 152)
+                .rotorStats(8.0f, 120.0f,3.0f, 152)
                 .itemPipeProperties(2048, 1)
                 .buildAndRegister();
 
@@ -101,7 +101,7 @@ public class FirstDegreeMaterials {
                 .components(Tin, 1, Copper, 3)
                 .toolStats(ToolProperty.Builder.of(3.0F, 2.0F, 192, 2)
                         .enchantability(18).addTypes(GTToolType.MORTAR).build())
-                .rotorStats(6.0f, 2.5f, 192)
+                .rotorStats(6.0f, 105.0f,2.5f, 192)
                 .fluidPipeProperties(1696, 20, true)
                 .buildAndRegister();
 
@@ -294,7 +294,7 @@ public class FirstDegreeMaterials {
                         .enchantability(18)
                         .enchantment(Enchantments.BANE_OF_ARTHROPODS, 3)
                         .enchantment(Enchantments.BLOCK_EFFICIENCY, 1).build())
-                .rotorStats(7.0f, 3.0f, 512)
+                .rotorStats(7.0f, 115.0f,3.0f, 512)
                 .buildAndRegister();
 
         Kanthal = new Material.Builder(GTCEu.id("kanthal"))
@@ -320,7 +320,7 @@ public class FirstDegreeMaterials {
                 .color(0xadc5e8).secondaryColor(0x522a77).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL)
                 .components(Magnesium, 1, Aluminium, 2)
-                .rotorStats(6.0f, 2.0f, 256)
+                .rotorStats(6.0f, 105.0f,2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .buildAndRegister();
 
@@ -402,7 +402,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(3.0F, 8.0F, 768, 2)
                         .attackSpeed(0.3F).enchantability(33)
                         .enchantment(Enchantments.SMITE, 3).build())
-                .rotorStats(13.0f, 2.0f, 196)
+                .rotorStats(13.0f, 160.0f,2.0f, 196)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1700, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -416,7 +416,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(12.0F, 2.0F, 768, 2)
                         .enchantability(33)
                         .enchantment(Enchantments.BLOCK_FORTUNE, 2).build())
-                .rotorStats(14.0f, 2.0f, 152)
+                .rotorStats(14.0f, 170.0f,2.0f, 152)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1600, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -427,7 +427,7 @@ public class FirstDegreeMaterials {
                 .color(0x8b7c70).secondaryColor(0x4b3d32).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_GEAR)
                 .components(Gold, 1, Silver, 1, Copper, 3)
-                .rotorStats(12.0f, 2.0f, 256)
+                .rotorStats(12.0f, 155.0f,2.0f, 256)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(2000, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
@@ -438,7 +438,7 @@ public class FirstDegreeMaterials {
                 .color(0xffd26f).secondaryColor(0x895f3d).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
-                .rotorStats(8.0f, 3.0f, 256)
+                .rotorStats(8.0f, 120.0f,3.0f, 256)
                 .blastTemp(1100, GasTier.LOW, GTValues.VA[MV], 1000)
                 .buildAndRegister();
 
@@ -587,7 +587,7 @@ public class FirstDegreeMaterials {
                 .components(Iron, 6, Chromium, 1, Manganese, 1, Nickel, 1)
                 .toolStats(ToolProperty.Builder.of(7.0F, 5.0F, 1024, 3)
                         .enchantability(14).build())
-                .rotorStats(7.0f, 4.0f, 480)
+                .rotorStats(7.0f, 115.0f,4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
                 .blastTemp(1700, GasTier.LOW, GTValues.VA[HV], 1100)
                 .buildAndRegister();
@@ -602,7 +602,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(5.0F, 3.0F, 512, 3)
                         .addTypes(GTToolType.MORTAR)
                         .enchantability(14).build())
-                .rotorStats(6.0f, 3.0f, 512)
+                .rotorStats(6.0f, 105.0f,3.0f, 512)
                 .fluidPipeProperties(1855, 50, true)
                 .cableProperties(GTValues.V[EV], 2, 2)
                 .blastTemp(1000, null, GTValues.VA[MV], 800) // no gas tier for steel
@@ -653,7 +653,7 @@ public class FirstDegreeMaterials {
                 .components(Cobalt, 5, Chromium, 2, Nickel, 1, Molybdenum, 1)
                 .toolStats(ToolProperty.Builder.of(10.0F, 7.0F, 2048, 4)
                         .attackSpeed(0.1F).enchantability(21).build())
-                .rotorStats(9.0f, 4.0f, 2048)
+                .rotorStats(9.0f, 130.0f,4.0f, 2048)
                 .itemPipeProperties(128, 16)
                 .blastTemp(2700, GasTier.MID, GTValues.VA[HV], 1300)
                 .buildAndRegister();
@@ -691,7 +691,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 384, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(6.0f, 3.5f, 384)
+                .rotorStats(6.0f, 105,3.5f, 384)
                 .buildAndRegister();
         Iron.getProperty(PropertyKey.INGOT).setSmeltingInto(WroughtIron);
         Iron.getProperty(PropertyKey.INGOT).setArcSmeltingInto(WroughtIron);
@@ -768,7 +768,7 @@ public class FirstDegreeMaterials {
                 .color(0xe5dcef).secondaryColor(0x241a44).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .components(Iridium, 3, Osmium, 1)
-                .rotorStats(9.0f, 3.0f, 3152)
+                .rotorStats(9.0f, 130,3.0f, 3152)
                 .itemPipeProperties(64, 32)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 900)
                 .buildAndRegister();
@@ -1067,7 +1067,7 @@ public class FirstDegreeMaterials {
                 .components(Tungsten, 1, Carbon, 1)
                 .toolStats(ToolProperty.Builder.of(60.0F, 2.0F, 1024, 4)
                         .enchantability(21).build())
-                .rotorStats(12.0f, 4.0f, 1280)
+                .rotorStats(12.0f, 155.0f,4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
                 .blastTemp(3058, GasTier.MID, GTValues.VA[HV], 1500)
                 .buildAndRegister();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
@@ -691,7 +691,7 @@ public class FirstDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 384, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(6.0f, 105,3.5f, 384)
+                .rotorStats(6.0f, 105.0f, 3.5f, 384)
                 .buildAndRegister();
         Iron.getProperty(PropertyKey.INGOT).setSmeltingInto(WroughtIron);
         Iron.getProperty(PropertyKey.INGOT).setArcSmeltingInto(WroughtIron);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
@@ -88,7 +88,7 @@ public class HigherDegreeMaterials {
                 .color(0x9cbabe).secondaryColor(0x032550).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(TungstenSteel, 5, Chromium, 1, Molybdenum, 2, Vanadium, 1)
-                .rotorStats(10.0f, 5.5f, 4000)
+                .rotorStats(10.0f, 140.0f,5.5f, 4000)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .blastTemp(4200, GasTier.MID, GTValues.VA[GTValues.EV], 1300)
                 .buildAndRegister();
@@ -116,7 +116,7 @@ public class HigherDegreeMaterials {
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
                 .toolStats(ToolProperty.Builder.of(5.0F, 10.0F, 3072, 4)
                         .attackSpeed(0.3F).enchantability(33).build())
-                .rotorStats(10.0f, 8.0f, 5120)
+                .rotorStats(10.0f, 140.0f,8.0f, 5120)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1400)
                 .buildAndRegister();
 
@@ -125,7 +125,7 @@ public class HigherDegreeMaterials {
                 .color(0xae9abe).secondaryColor(0x66000e).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
-                .rotorStats(15.0f, 7.0f, 3000)
+                .rotorStats(15.0f, 180.0f,7.0f, 3000)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1500)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
@@ -88,7 +88,7 @@ public class HigherDegreeMaterials {
                 .color(0x9cbabe).secondaryColor(0x032550).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(TungstenSteel, 5, Chromium, 1, Molybdenum, 2, Vanadium, 1)
-                .rotorStats(10.0f, 140.0f,5.5f, 4000)
+                .rotorStats(205.0f, 140.0f,5.5f, 4000)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .blastTemp(4200, GasTier.MID, GTValues.VA[GTValues.EV], 1300)
                 .buildAndRegister();
@@ -116,7 +116,7 @@ public class HigherDegreeMaterials {
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
                 .toolStats(ToolProperty.Builder.of(5.0F, 10.0F, 3072, 4)
                         .attackSpeed(0.3F).enchantability(33).build())
-                .rotorStats(10.0f, 140.0f,8.0f, 5120)
+                .rotorStats(280.0f, 140.0f,8.0f, 5120)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1400)
                 .buildAndRegister();
 
@@ -125,7 +125,7 @@ public class HigherDegreeMaterials {
                 .color(0xae9abe).secondaryColor(0x66000e).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
-                .rotorStats(15.0f, 180.0f,7.0f, 3000)
+                .rotorStats(250.0f, 180.0f,7.0f, 3000)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1500)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
@@ -88,7 +88,7 @@ public class HigherDegreeMaterials {
                 .color(0x9cbabe).secondaryColor(0x032550).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_FOIL, GENERATE_GEAR)
                 .components(TungstenSteel, 5, Chromium, 1, Molybdenum, 2, Vanadium, 1)
-                .rotorStats(205.0f, 140.0f,5.5f, 4000)
+                .rotorStats(205, 140, 5.5f, 4000)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .blastTemp(4200, GasTier.MID, GTValues.VA[GTValues.EV], 1300)
                 .buildAndRegister();
@@ -116,7 +116,7 @@ public class HigherDegreeMaterials {
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
                 .toolStats(ToolProperty.Builder.of(5.0F, 10.0F, 3072, 4)
                         .attackSpeed(0.3F).enchantability(33).build())
-                .rotorStats(280.0f, 140.0f,8.0f, 5120)
+                .rotorStats(280, 140, 8.0f, 5120)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1400)
                 .buildAndRegister();
 
@@ -125,7 +125,7 @@ public class HigherDegreeMaterials {
                 .color(0xae9abe).secondaryColor(0x66000e).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_ROUND, GENERATE_FOIL, GENERATE_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
-                .rotorStats(250.0f, 180.0f,7.0f, 3000)
+                .rotorStats(250, 180, 7.0f, 3000)
                 .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1500)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -124,7 +124,7 @@ public class SecondDegreeMaterials {
                 .components(Steel, 1, Tungsten, 1)
                 .toolStats(ToolProperty.Builder.of(9.0F, 7.0F, 2048, 4)
                         .enchantability(14).build())
-                .rotorStats(8.0f, 4.0f, 2560)
+                .rotorStats(8.0f, 120.0f,4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
                 .cableProperties(GTValues.V[5], 3, 2)
                 .blastTemp(3000, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
@@ -139,7 +139,7 @@ public class SecondDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.5F, 2.0F, 1024, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(8.0f, 2.0f, 256)
+                .rotorStats(8.0f, 120.0f,2.0f, 256)
                 .itemPipeProperties(2048, 1)
                 .buildAndRegister();
 
@@ -286,7 +286,7 @@ public class SecondDegreeMaterials {
                 .components(Vanadium, 1, Chromium, 1, Steel, 7)
                 .toolStats(ToolProperty.Builder.of(3.0F, 3.0F, 1536, 3)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(7.0f, 3.0f, 1920)
+                .rotorStats(7.0f, 115.0f,3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
                 .blastTemp(1453, GasTier.LOW)
                 .buildAndRegister();
@@ -322,7 +322,7 @@ public class SecondDegreeMaterials {
                 .components(Naquadah, 2, Osmiridium, 1, Trinium, 1)
                 .toolStats(ToolProperty.Builder.of(40.0F, 12.0F, 3072, 5)
                         .attackSpeed(0.3F).enchantability(33).magnetic().build())
-                .rotorStats(8.0f, 5.0f, 5120)
+                .rotorStats(8.0f, 120.0f,5.0f, 5120)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
                 .buildAndRegister();
@@ -466,7 +466,7 @@ public class SecondDegreeMaterials {
                 .color(0xd1d1d1).secondaryColor(0x000000).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE, GENERATE_SMALL_GEAR)
                 .components(Palladium, 3, Rhodium, 1)
-                .rotorStats(12.0f, 3.0f, 1024)
+                .rotorStats(12.0f, 155.0f,3.0f, 1024)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1200)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -124,7 +124,7 @@ public class SecondDegreeMaterials {
                 .components(Steel, 1, Tungsten, 1)
                 .toolStats(ToolProperty.Builder.of(9.0F, 7.0F, 2048, 4)
                         .enchantability(14).build())
-                .rotorStats(160.0f, 120.0f,4.0f, 2560)
+                .rotorStats(160, 120, 4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
                 .cableProperties(GTValues.V[5], 3, 2)
                 .blastTemp(3000, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
@@ -139,7 +139,7 @@ public class SecondDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.5F, 2.0F, 1024, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(100.0f, 120.0f,2.0f, 256)
+                .rotorStats(100, 120, 2.0f, 256)
                 .itemPipeProperties(2048, 1)
                 .buildAndRegister();
 
@@ -286,7 +286,7 @@ public class SecondDegreeMaterials {
                 .components(Vanadium, 1, Chromium, 1, Steel, 7)
                 .toolStats(ToolProperty.Builder.of(3.0F, 3.0F, 1536, 3)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(130.0f, 115.0f,3.0f, 1920)
+                .rotorStats(130, 115, 3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
                 .blastTemp(1453, GasTier.LOW)
                 .buildAndRegister();
@@ -322,7 +322,7 @@ public class SecondDegreeMaterials {
                 .components(Naquadah, 2, Osmiridium, 1, Trinium, 1)
                 .toolStats(ToolProperty.Builder.of(40.0F, 12.0F, 3072, 5)
                         .attackSpeed(0.3F).enchantability(33).magnetic().build())
-                .rotorStats(190.0f, 120.0f,5.0f, 5120)
+                .rotorStats(190, 120, 5.0f, 5120)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
                 .buildAndRegister();
@@ -466,7 +466,7 @@ public class SecondDegreeMaterials {
                 .color(0xd1d1d1).secondaryColor(0x000000).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE, GENERATE_SMALL_GEAR)
                 .components(Palladium, 3, Rhodium, 1)
-                .rotorStats(130.0f, 155.0f,3.0f, 1024)
+                .rotorStats(130, 155, 3.0f, 1024)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1200)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -124,7 +124,7 @@ public class SecondDegreeMaterials {
                 .components(Steel, 1, Tungsten, 1)
                 .toolStats(ToolProperty.Builder.of(9.0F, 7.0F, 2048, 4)
                         .enchantability(14).build())
-                .rotorStats(8.0f, 120.0f,4.0f, 2560)
+                .rotorStats(160.0f, 120.0f,4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
                 .cableProperties(GTValues.V[5], 3, 2)
                 .blastTemp(3000, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
@@ -139,7 +139,7 @@ public class SecondDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(2.5F, 2.0F, 1024, 2)
                         .addTypes(GTToolType.MORTAR)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(8.0f, 120.0f,2.0f, 256)
+                .rotorStats(100.0f, 120.0f,2.0f, 256)
                 .itemPipeProperties(2048, 1)
                 .buildAndRegister();
 
@@ -286,7 +286,7 @@ public class SecondDegreeMaterials {
                 .components(Vanadium, 1, Chromium, 1, Steel, 7)
                 .toolStats(ToolProperty.Builder.of(3.0F, 3.0F, 1536, 3)
                         .attackSpeed(-0.2F).enchantability(5).build())
-                .rotorStats(7.0f, 115.0f,3.0f, 1920)
+                .rotorStats(130.0f, 115.0f,3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
                 .blastTemp(1453, GasTier.LOW)
                 .buildAndRegister();
@@ -322,7 +322,7 @@ public class SecondDegreeMaterials {
                 .components(Naquadah, 2, Osmiridium, 1, Trinium, 1)
                 .toolStats(ToolProperty.Builder.of(40.0F, 12.0F, 3072, 5)
                         .attackSpeed(0.3F).enchantability(33).magnetic().build())
-                .rotorStats(8.0f, 120.0f,5.0f, 5120)
+                .rotorStats(190.0f, 120.0f,5.0f, 5120)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
                 .buildAndRegister();
@@ -466,7 +466,7 @@ public class SecondDegreeMaterials {
                 .color(0xd1d1d1).secondaryColor(0x000000).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE, GENERATE_SMALL_GEAR)
                 .components(Palladium, 3, Rhodium, 1)
-                .rotorStats(12.0f, 155.0f,3.0f, 1024)
+                .rotorStats(130.0f, 155.0f,3.0f, 1024)
                 .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1200)
                 .buildAndRegister();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
@@ -38,16 +38,23 @@ public class TurbineRotorBehaviour implements IMaterialPartItem, ISubItemHandler
         });
     }
 
-    @Override
-    public int getPartMaxDurability(ItemStack itemStack) {
-        var property = getPartMaterial(itemStack).getProperty(PropertyKey.ROTOR);
-        return property == null ? -1 : 800 * (int) Math.pow(property.getDurability(), 0.65);
+    public int getRotorPower(ItemStack stack) {
+        var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
+        return property == null ? -1 : (int) property.getPower();
     }
 
     public int getRotorEfficiency(ItemStack stack) {
         var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
         return property == null ? -1 : ((int) property.getEfficiency());
     }
+
+    @Override
+    public int getPartMaxDurability(ItemStack itemStack) {
+        var property = getPartMaterial(itemStack).getProperty(PropertyKey.ROTOR);
+        return property == null ? -1 : 800 * (int) Math.pow(property.getDurability(), 0.65);
+    }
+
+    //TODO : getDamage() and Hurt Player
 
     public int getRotorDurabilityPercent(ItemStack itemStack) {
         return 100 - 100 * getPartDamage(itemStack) / getPartMaxDurability(itemStack);
@@ -63,10 +70,7 @@ public class TurbineRotorBehaviour implements IMaterialPartItem, ISubItemHandler
         }
     }
 
-    public int getRotorPower(ItemStack stack) {
-        var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
-        return property == null ? -1 : (int) (40 + property.getDamage() * 30);
-    }
+
 
     @Override
     public void appendHoverText(ItemStack stack, @org.jetbrains.annotations.Nullable Level level, List<Component> tooltipComponents, TooltipFlag isAdvanced) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
@@ -46,7 +46,7 @@ public class TurbineRotorBehaviour implements IMaterialPartItem, ISubItemHandler
 
     public int getRotorEfficiency(ItemStack stack) {
         var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
-        return property == null ? -1 : ((int) ((property.getEfficiency())));
+        return property == null ? -1 : ((int) property.getEfficiency());
     }
 
     public int getRotorDurabilityPercent(ItemStack itemStack) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
@@ -46,7 +46,7 @@ public class TurbineRotorBehaviour implements IMaterialPartItem, ISubItemHandler
 
     public int getRotorEfficiency(ItemStack stack) {
         var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
-        return property == null ? -1 : ((int) ((60 + property.getSpeed() * 8)) / 5 * 5);
+        return property == null ? -1 : ((int) ((property.getEfficiency())));
     }
 
     public int getRotorDurabilityPercent(ItemStack itemStack) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
@@ -40,12 +40,12 @@ public class TurbineRotorBehaviour implements IMaterialPartItem, ISubItemHandler
 
     public int getRotorPower(ItemStack stack) {
         var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
-        return property == null ? -1 : (int) property.getPower();
+        return property == null ? -1 : property.getPower();
     }
 
     public int getRotorEfficiency(ItemStack stack) {
         var property = getPartMaterial(stack).getProperty(PropertyKey.ROTOR);
-        return property == null ? -1 : ((int) property.getEfficiency());
+        return property == null ? -1 : property.getEfficiency();
     }
 
     @Override


### PR DESCRIPTION
## What
I noticed the only parameters for .rotorStats() were Damage (unimplemented) Speed (Power Prod %) and Durability (Rotor Item Dura) - This PR makes the parameter more flexible for addon devs. As well as opens the floor for a more intimate Turbine Rotor Stat balance in the future

## Implementation Details
Adds getEfficiency() to RotorProperty.java, which is then fed into the getRotorEfficiency() function in TurbineRotorBehavior.java

## Additional Information
addon Devs will need to provide an additional float value in their rotorStats() builders inside of their material classes

## Potential Compatibility Issues
None So far, all rotors have their same efficiency value prior to the expansion of the arguments.
