### PR TITLE
added a energy use config option for the prospector's scanner tool

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2005,6 +2005,7 @@
   "config.gtceu.option.enableWorldAccelerators": "enableWorldAccelerators",
   "config.gtceu.option.energy": "energy",
   "config.gtceu.option.energyUsageMultiplier": "energyUsageMultiplier",
+  "config.gtceu.option.prospectorEnergyUseMultiplier": "prospectorEnergyUsageMultiplier",
   "config.gtceu.option.euToPlatformRatio": "euToPlatformRatio",
   "config.gtceu.option.flintAndSteelRequireSteel": "flintAndSteelRequireSteel",
   "config.gtceu.option.gameplay": "gameplay",

--- a/src/main/java/com/gregtechceu/gtceu/common/item/ProspectorScannerBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ProspectorScannerBehavior.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.gui.widget.ProspectingMapWidget;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
 import com.gregtechceu.gtceu.api.item.component.IInteractionItem;
 import com.gregtechceu.gtceu.api.item.component.IItemUIFactory;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.lowdragmc.lowdraglib.gui.factory.HeldItemUIFactory;
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
@@ -67,7 +68,10 @@ public class ProspectorScannerBehavior implements IItemUIFactory, IInteractionIt
     public boolean drainEnergy(@NotNull ItemStack stack, boolean simulate) {
         IElectricItem electricItem = GTCapabilityHelper.getElectricItem(stack);
         if (electricItem == null) return false;
-        return electricItem.discharge(cost, Integer.MAX_VALUE, true, false, simulate) >= cost;
+
+        int amount = Math.round(cost * (ConfigHolder.INSTANCE.machines.prospectorEnergyUseMultiplier / 100F));
+
+        return electricItem.discharge(amount, Integer.MAX_VALUE, true, false, simulate) >= amount;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -246,6 +246,10 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Energy use multiplier for electric items.", "Default: 100" })
         public int energyUsageMultiplier = 100;
+
+        @Configurable
+        @Configurable.Comment({ "Energu use multiplier for prospectors.", "Default: 100"})
+        public int prospectorEnergyUseMultiplier = 100;
         @Configurable
         @Configurable.Comment({"Whether machines or boilers damage the terrain when they explode.",
                 "Note machines and boilers always explode when overloaded with power or met with special conditions, regardless of this config.", "Default: true"})

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -248,7 +248,7 @@ public class ConfigHolder {
         public int energyUsageMultiplier = 100;
 
         @Configurable
-        @Configurable.Comment({ "Energu use multiplier for prospectors.", "Default: 100"})
+        @Configurable.Comment({ "Energy use multiplier for prospectors.", "Default: 100"})
         public int prospectorEnergyUseMultiplier = 100;
         @Configurable
         @Configurable.Comment({"Whether machines or boilers damage the terrain when they explode.",


### PR DESCRIPTION
I wanted to be able to set the energy use of the scanners in the configs, so I added it.

As far as I'm aware, this should not change anything else, as I touched very little, and it only took 10 minutes to figure out what to do and implement this change.

