### PR TITLE
Remove unnecessary naming restriction.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -1260,9 +1260,6 @@ public class Material implements Comparable<Material> {
         private Element element;
 
         private MaterialInfo(ResourceLocation resourceLocation) {
-            String name = resourceLocation.getPath();
-            if (!FormattingUtil.toLowerCaseUnderscore(FormattingUtil.lowerUnderscoreToUpperCamel(name)).equals(name))
-                throw new IllegalStateException("Cannot add materials with names like 'materialnumber'! Use 'material_number' instead.");
             this.resourceLocation = resourceLocation;
         }
 


### PR DESCRIPTION
## What
Removes an unnecessary naming restriction put in place in 1.12 MC due to a lack of a consistent naming convention. Modern naming conventions make this case redundant and removing it allows for names such as 2_4_4_something as shown in the following message chain:

https://discord.com/channels/701354865217110096/1089296351906504835/1241830505725562951

## Implementation Details
Alternate is not doing it. Shouldn't make a practical difference, since people that fall out of line with convention are unlikely to follow it either way.

## Outcome
- Removed material naming restriction

## Additional Information
This was tested using the KubeJS plugin and creating a material with the name 2_4_4_something both before and after the patch. Before the patch, it would cause a failure. After, it is an accepted material name.

## Potential Compatibility Issues
Considering this only removes a restriction, this is unlikely to impact anyone as all passing cases would still be passing.