### PR TITLE
Fix parallel machine only processes one item at a time

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ParallelLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ParallelLogic.java
@@ -53,7 +53,7 @@ public class ParallelLogic {
 
         // tick inputs.
         for (RecipeCapability<?> cap : recipe.tickInputs.keySet()) {
-            if (cap.doMatchInRecipe()) {
+            if (cap != EURecipeCapability.CAP && cap.doMatchInRecipe()) {
                 // Find the maximum number of recipes that can be performed from the contents of the input inventories
                 multipliers.add(cap.getMaxParallelRatio(holder, recipe, parallelAmount));
             }


### PR DESCRIPTION
## What
I found that steam smelter only smelts one item at a time.

## Implementation Details
Exclude `EURecipeCapability` from iterating `tickInputs`.

## Outcome
Fix parallel machine only processes one item at a time.

## Additional Information
No matter how many recipes are processing in parallel, the power (EU/t) should be the same, right?
[Discord](https://discord.com/channels/701354865217110096/1243256595459084359)

## Potential Compatibility Issues
I am not sure if there is other `tickInputs` might cause the similar bug. I only excluded energy and at least steam smelter works fine now.