### PR TITLE
Fix steam miner machine not draining steam.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamMinerMachine.java
@@ -214,7 +214,7 @@ public class SteamMinerMachine extends SteamWorkableMachine implements IMiner, I
         long resultSteam = steamTank.getFluidInTank(0).getAmount() - energyPerTick;
         if (!this.isVentingBlocked() && resultSteam >= 0L && resultSteam <= steamTank.getTankCapacity(0)) {
             if (!simulate)
-                steamTank.drain(energyPerTick, false);
+                steamTank.drainInternal(energyPerTick, false);
             return true;
         }
         return false;


### PR DESCRIPTION
## What
This fixes a bug where the steam miner machine was not draining any steam despite actively mining. This issue can first be seen reported here: https://discord.com/channels/701354865217110096/1239192799321129093/1239192799321129093

## Implementation Details
Simply swaps the `drain` call in SteamMinerMachine.java on the `steamTank` variable to instead be `drainInternal`, as the actual logistics of draining the tank do not involve any form of IO (the old call would always fail as it assumed IO was being performed, which it was not).

## Outcome
Steam miners should now consume 16L per tick as mentioned in the tooltip.

## Additional Information
Shoutout to Mike for helping my stupid ass figure this out since the IO stuff was a bit confusing at first.

## Potential Compatibility Issues
This change should only directly affect steam miners and therefore probably people who like them, but other than that should not have any residual effects.