### PR TITLE
Tweak mortar bonemeal recipe to be more in line with 1.12.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -277,7 +277,7 @@ public class VanillaStandardRecipes {
         VanillaRecipeHelper.addShapelessRecipe(provider, "brick_to_dust", ChemicalHelper.get(dustSmall, Brick), 'm', Items.BRICK);
         VanillaRecipeHelper.addShapelessRecipe(provider, "wheat_to_dust", ChemicalHelper.get(dust, Wheat), 'm', Items.WHEAT);
         VanillaRecipeHelper.addShapelessRecipe(provider, "gravel_to_flint", new ItemStack(Items.FLINT), 'm', Blocks.GRAVEL);
-        VanillaRecipeHelper.addShapelessRecipe(provider, "bone_to_bone_meal", new ItemStack(Items.BONE_MEAL, 4), 'm', Items.BONE);
+        VanillaRecipeHelper.addShapelessRecipe(provider, "bone_to_bone_meal", new ItemStack(Items.BONE_MEAL), 'm', Items.BONE);
         VanillaRecipeHelper.addShapelessRecipe(provider, "blaze_rod_to_powder", new ItemStack(Items.BLAZE_POWDER, 3), 'm', Items.BLAZE_ROD);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_cocoa")

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -277,7 +277,7 @@ public class VanillaStandardRecipes {
         VanillaRecipeHelper.addShapelessRecipe(provider, "brick_to_dust", ChemicalHelper.get(dustSmall, Brick), 'm', Items.BRICK);
         VanillaRecipeHelper.addShapelessRecipe(provider, "wheat_to_dust", ChemicalHelper.get(dust, Wheat), 'm', Items.WHEAT);
         VanillaRecipeHelper.addShapelessRecipe(provider, "gravel_to_flint", new ItemStack(Items.FLINT), 'm', Blocks.GRAVEL);
-        VanillaRecipeHelper.addShapelessRecipe(provider, "bone_to_bone_meal", new ItemStack(Items.BONE_MEAL), 'm', Items.BONE);
+        VanillaRecipeHelper.addShapelessRecipe(provider, "bone_to_bone_meal", new ItemStack(Items.BONE_MEAL, 4), 'm', Items.BONE);
         VanillaRecipeHelper.addShapelessRecipe(provider, "blaze_rod_to_powder", new ItemStack(Items.BLAZE_POWDER, 3), 'm', Items.BLAZE_ROD);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_cocoa")


### PR DESCRIPTION
## What
Changes the recipe for using a mortar to make bonemeal to be 4 bonemeal instead of 1, which was less than vanilla's 3 without a tool. Fixes #1300.

## Outcome
Crushing a bone with a mortar now gives 4 bonemeal instead of 1.