### PR TITLE
add ore vein sync packets (needs testing)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
@@ -2,10 +2,13 @@ package com.gregtechceu.gtceu.client.forge;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.client.TooltipHelper;
 import com.gregtechceu.gtceu.client.TooltipsHandler;
 import com.gregtechceu.gtceu.client.renderer.BlockHighLightRenderer;
 import com.gregtechceu.gtceu.client.renderer.MultiblockInWorldPreviewRenderer;
+import com.gregtechceu.gtceu.common.data.GTBedrockFluids;
+import com.gregtechceu.gtceu.common.data.GTOres;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -51,6 +54,33 @@ public class ForgeClientEventListener {
             TooltipHelper.onClientTick();
             MultiblockInWorldPreviewRenderer.onClientTick();
             GTValues.CLIENT_TIME++;
+        }
+    }
+
+    @SubscribeEvent
+    public static void onClientLoggedOut(ClientPlayerNetworkEvent.LoggingOut event) {
+        if (GTRegistries.ORE_VEINS.isFrozen()) {
+            GTRegistries.ORE_VEINS.unfreeze();
+        }
+        GTOres.init();
+        if (!GTRegistries.ORE_VEINS.isFrozen()) {
+            GTRegistries.ORE_VEINS.freeze();
+        }
+
+        if (GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_FLUID_DEFINITIONS.unfreeze();
+        }
+        GTBedrockFluids.init();
+        if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_FLUID_DEFINITIONS.freeze();
+        }
+
+        if (GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_ORE_DEFINITIONS.unfreeze();
+        }
+        GTOres.toReRegisterBedrock.forEach(GTRegistries.BEDROCK_ORE_DEFINITIONS::registerOrOverride);
+        if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_ORE_DEFINITIONS.freeze();
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -37,7 +37,6 @@ import com.gregtechceu.gtceu.data.pack.GTDynamicDataPack;
 import com.gregtechceu.gtceu.data.pack.GTDynamicResourcePack;
 import com.gregtechceu.gtceu.data.pack.GTPackSource;
 import com.gregtechceu.gtceu.forge.AlloyBlastPropertyAddition;
-import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuStartupEvents;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 import com.gregtechceu.gtceu.integration.kjs.events.MaterialModificationEventJS;
@@ -125,7 +124,6 @@ public class CommonProxy {
         GTFoods.init();
         GTItems.init();
         AddonFinder.getAddons().forEach(IGTAddon::initializeAddon);
-        GTOreVeinWidget.init();
 
         // fabric exclusive, squeeze this in here to register before stuff is used
         GTRegistration.REGISTRATE.registerRegistrate();

--- a/src/main/java/com/gregtechceu/gtceu/common/network/GTNetwork.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/GTNetwork.java
@@ -2,6 +2,9 @@ package com.gregtechceu.gtceu.common.network;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.common.network.packets.CPacketKeysPressed;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncBedrockOreVeins;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncFluidVeins;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncOreVeins;
 
 import com.lowdragmc.lowdraglib.networking.INetworking;
 import com.lowdragmc.lowdraglib.networking.forge.LDLNetworkingImpl;
@@ -12,5 +15,8 @@ public class GTNetwork {
 
     public static void init() {
         NETWORK.registerC2S(CPacketKeysPressed.class);
+        NETWORK.registerC2S(SPacketSyncOreVeins.class);
+        NETWORK.registerC2S(SPacketSyncFluidVeins.class);
+        NETWORK.registerC2S(SPacketSyncBedrockOreVeins.class);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncBedrockOreVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncBedrockOreVeins.java
@@ -1,0 +1,71 @@
+package com.gregtechceu.gtceu.common.network.packets;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
+
+import com.lowdragmc.lowdraglib.Platform;
+import com.lowdragmc.lowdraglib.networking.IHandlerContext;
+import com.lowdragmc.lowdraglib.networking.IPacket;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceLocation;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public class SPacketSyncBedrockOreVeins implements IPacket {
+
+    private final Map<ResourceLocation, BedrockOreDefinition> veins;
+
+    public SPacketSyncBedrockOreVeins() {
+        this.veins = new HashMap<>();
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
+        int size = veins.size();
+        buf.writeVarInt(size);
+        for (var entry : veins.entrySet()) {
+            buf.writeResourceLocation(entry.getKey());
+            CompoundTag tag = (CompoundTag) BedrockOreDefinition.FULL_CODEC.encodeStart(ops, entry.getValue())
+                    .getOrThrow(false, GTCEu.LOGGER::error);
+            buf.writeNbt(tag);
+        }
+    }
+
+    @Override
+    public void decode(FriendlyByteBuf buf) {
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
+        Stream.generate(() -> {
+            ResourceLocation id = buf.readResourceLocation();
+            CompoundTag tag = buf.readAnySizeNbt();
+            BedrockOreDefinition def = BedrockOreDefinition.FULL_CODEC.parse(ops, tag).getOrThrow(false,
+                    GTCEu.LOGGER::error);
+            return Map.entry(id, def);
+        }).limit(buf.readVarInt()).forEach(entry -> veins.put(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
+    public void execute(IHandlerContext handler) {
+        if (GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_ORE_DEFINITIONS.unfreeze();
+        }
+        GTRegistries.BEDROCK_ORE_DEFINITIONS.registry().clear();
+        for (var entry : veins.entrySet()) {
+            GTRegistries.BEDROCK_ORE_DEFINITIONS.registerOrOverride(entry.getKey(), entry.getValue());
+        }
+        if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_ORE_DEFINITIONS.freeze();
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncFluidVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncFluidVeins.java
@@ -1,0 +1,71 @@
+package com.gregtechceu.gtceu.common.network.packets;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
+
+import com.lowdragmc.lowdraglib.Platform;
+import com.lowdragmc.lowdraglib.networking.IHandlerContext;
+import com.lowdragmc.lowdraglib.networking.IPacket;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceLocation;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public class SPacketSyncFluidVeins implements IPacket {
+
+    private final Map<ResourceLocation, BedrockFluidDefinition> veins;
+
+    public SPacketSyncFluidVeins() {
+        this.veins = new HashMap<>();
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
+        int size = veins.size();
+        buf.writeVarInt(size);
+        for (var entry : veins.entrySet()) {
+            buf.writeResourceLocation(entry.getKey());
+            CompoundTag tag = (CompoundTag) BedrockFluidDefinition.FULL_CODEC.encodeStart(ops, entry.getValue())
+                    .getOrThrow(false, GTCEu.LOGGER::error);
+            buf.writeNbt(tag);
+        }
+    }
+
+    @Override
+    public void decode(FriendlyByteBuf buf) {
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
+        Stream.generate(() -> {
+            ResourceLocation id = buf.readResourceLocation();
+            CompoundTag tag = buf.readAnySizeNbt();
+            BedrockFluidDefinition def = BedrockFluidDefinition.FULL_CODEC.parse(ops, tag).getOrThrow(false,
+                    GTCEu.LOGGER::error);
+            return Map.entry(id, def);
+        }).limit(buf.readVarInt()).forEach(entry -> veins.put(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
+    public void execute(IHandlerContext handler) {
+        if (GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_FLUID_DEFINITIONS.unfreeze();
+        }
+        GTRegistries.BEDROCK_FLUID_DEFINITIONS.registry().clear();
+        for (var entry : veins.entrySet()) {
+            GTRegistries.BEDROCK_FLUID_DEFINITIONS.registerOrOverride(entry.getKey(), entry.getValue());
+        }
+        if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
+            GTRegistries.BEDROCK_FLUID_DEFINITIONS.freeze();
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncOreVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncOreVeins.java
@@ -1,0 +1,70 @@
+package com.gregtechceu.gtceu.common.network.packets;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
+
+import com.lowdragmc.lowdraglib.Platform;
+import com.lowdragmc.lowdraglib.networking.IHandlerContext;
+import com.lowdragmc.lowdraglib.networking.IPacket;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.RegistryOps;
+import net.minecraft.resources.ResourceLocation;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public class SPacketSyncOreVeins implements IPacket {
+
+    private final Map<ResourceLocation, GTOreDefinition> veins;
+
+    public SPacketSyncOreVeins() {
+        this.veins = new HashMap<>();
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
+        int size = veins.size();
+        buf.writeVarInt(size);
+        for (var entry : veins.entrySet()) {
+            buf.writeResourceLocation(entry.getKey());
+            CompoundTag tag = (CompoundTag) GTOreDefinition.FULL_CODEC.encodeStart(ops, entry.getValue())
+                    .getOrThrow(false, GTCEu.LOGGER::error);
+            buf.writeNbt(tag);
+        }
+    }
+
+    @Override
+    public void decode(FriendlyByteBuf buf) {
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
+        Stream.generate(() -> {
+            ResourceLocation id = buf.readResourceLocation();
+            CompoundTag tag = buf.readAnySizeNbt();
+            GTOreDefinition def = GTOreDefinition.FULL_CODEC.parse(ops, tag).getOrThrow(false, GTCEu.LOGGER::error);
+            return Map.entry(id, def);
+        }).limit(buf.readVarInt()).forEach(entry -> veins.put(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
+    public void execute(IHandlerContext handler) {
+        if (GTRegistries.ORE_VEINS.isFrozen()) {
+            GTRegistries.ORE_VEINS.unfreeze();
+        }
+        GTRegistries.ORE_VEINS.registry().clear();
+        for (var entry : veins.entrySet()) {
+            GTRegistries.ORE_VEINS.registerOrOverride(entry.getKey(), entry.getValue());
+        }
+        if (!GTRegistries.ORE_VEINS.isFrozen()) {
+            GTRegistries.ORE_VEINS.freeze();
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
@@ -7,6 +7,8 @@ import com.gregtechceu.gtceu.api.addon.IGTAddon;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTOres;
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncFluidVeins;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuServerEvents;
 import com.gregtechceu.gtceu.integration.kjs.events.GTBedrockOreVeinEventJS;
 
@@ -79,6 +81,8 @@ public class BedrockOreLoader extends SimpleJsonResourceReloadListener {
         if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
             GTRegistries.BEDROCK_ORE_DEFINITIONS.freeze();
         }
+
+        GTNetwork.NETWORK.sendToAll(new SPacketSyncFluidVeins(GTRegistries.BEDROCK_FLUID_DEFINITIONS.registry()));
     }
 
     public static BedrockOreDefinition fromJson(ResourceLocation id, JsonObject json, RegistryOps<JsonElement> ops) {

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/FluidVeinLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/FluidVeinLoader.java
@@ -7,6 +7,8 @@ import com.gregtechceu.gtceu.api.addon.IGTAddon;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTBedrockFluids;
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncBedrockOreVeins;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuServerEvents;
 import com.gregtechceu.gtceu.integration.kjs.events.GTFluidVeinEventJS;
 
@@ -76,6 +78,8 @@ public class FluidVeinLoader extends SimpleJsonResourceReloadListener {
         if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
             GTRegistries.BEDROCK_FLUID_DEFINITIONS.freeze();
         }
+
+        GTNetwork.NETWORK.sendToAll(new SPacketSyncBedrockOreVeins(GTRegistries.BEDROCK_ORE_DEFINITIONS.registry()));
     }
 
     public static BedrockFluidDefinition fromJson(ResourceLocation id, JsonObject json, RegistryOps<JsonElement> ops) {

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/OreDataLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/OreDataLoader.java
@@ -8,6 +8,8 @@ import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.veins.NoopVeinGenerator;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTOres;
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncOreVeins;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuServerEvents;
 import com.gregtechceu.gtceu.integration.kjs.events.GTOreVeinEventJS;
 
@@ -87,6 +89,8 @@ public class OreDataLoader extends SimpleJsonResourceReloadListener {
         if (!GTRegistries.ORE_VEINS.isFrozen()) {
             GTRegistries.ORE_VEINS.freeze();
         }
+
+        GTNetwork.NETWORK.sendToAll(new SPacketSyncOreVeins(GTRegistries.ORE_VEINS.registry()));
     }
 
     public static void buildVeinGenerator() {

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -16,10 +16,15 @@ import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.capability.HazardEffectTracker;
 import com.gregtechceu.gtceu.common.commands.ServerCommands;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncBedrockOreVeins;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncFluidVeins;
+import com.gregtechceu.gtceu.common.network.packets.SPacketSyncOreVeins;
 import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.FluidVeinLoader;
 import com.gregtechceu.gtceu.data.loader.OreDataLoader;
@@ -45,6 +50,7 @@ import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -186,6 +192,17 @@ public class ForgeCommonEventListener {
     public static void worldUnload(LevelEvent.Unload event) {
         if (event.getLevel() instanceof ServerLevel serverLevel) {
             TaskHandler.onWorldUnLoad(serverLevel);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerJoinServer(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            GTNetwork.NETWORK.sendToPlayer(new SPacketSyncOreVeins(GTRegistries.ORE_VEINS.registry()), serverPlayer);
+            GTNetwork.NETWORK.sendToPlayer(new SPacketSyncFluidVeins(GTRegistries.BEDROCK_FLUID_DEFINITIONS.registry()),
+                    serverPlayer);
+            GTNetwork.NETWORK.sendToPlayer(
+                    new SPacketSyncBedrockOreVeins(GTRegistries.BEDROCK_ORE_DEFINITIONS.registry()), serverPlayer);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTOreVeinWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTOreVeinWidget.java
@@ -1,15 +1,10 @@
 package com.gregtechceu.gtceu.integration;
 
-import com.gregtechceu.gtceu.api.addon.AddonFinder;
-import com.gregtechceu.gtceu.api.addon.IGTAddon;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
-import com.gregtechceu.gtceu.common.data.GTBedrockFluids;
-import com.gregtechceu.gtceu.common.data.GTOres;
-import com.gregtechceu.gtceu.data.loader.OreDataLoader;
 
 import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
 import com.lowdragmc.lowdraglib.gui.widget.*;
@@ -158,21 +153,5 @@ public class GTOreVeinWidget extends WidgetGroup {
     public String getFluidName(BedrockFluidDefinition fluid) {
         ResourceLocation id = GTRegistries.BEDROCK_FLUID_DEFINITIONS.getKey(fluid);
         return id.getPath();
-    }
-
-    public static void init() {
-        if (GTRegistries.ORE_VEINS.values().isEmpty()) {
-            GTRegistries.ORE_VEINS.unfreeze();
-            GTOres.init();
-            AddonFinder.getAddons().forEach(IGTAddon::registerOreVeins);
-            OreDataLoader.buildVeinGenerator();
-            GTRegistries.ORE_VEINS.freeze();
-        }
-        if (GTRegistries.BEDROCK_FLUID_DEFINITIONS.values().isEmpty()) {
-            GTRegistries.BEDROCK_FLUID_DEFINITIONS.unfreeze();
-            GTBedrockFluids.init();
-            AddonFinder.getAddons().forEach(IGTAddon::registerFluidVeins);
-            GTRegistries.BEDROCK_FLUID_DEFINITIONS.freeze();
-        }
     }
 }


### PR DESCRIPTION
## What
makes ore veins be synchronized to the client on servers.

## Implementation Details
3 new packets, one for each vein type. synced on login and reload.
the veins are then cleared from the registry on disconnect.

## Outcome
fixes the ore vein info JEI tab not having custom KubeJS ores in it.