### PR TITLE
fix(EURecipeCapability): fix getMaxParallelRatio method

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.capability.recipe;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
@@ -58,7 +59,9 @@ public class EURecipeCapability extends RecipeCapability<Long> {
     @Override
     public int getMaxParallelRatio(IRecipeCapabilityHolder holder, GTRecipe recipe, int parallelAmount) {
         long maxVoltage = Long.MAX_VALUE;
-        if (holder instanceof IOverclockMachine overclockMachine) {
+        if (holder instanceof WorkableElectricMultiblockMachine multiblockMachine) {
+            maxVoltage = GTValues.V[multiblockMachine.getTier()];
+        } else if (holder instanceof IOverclockMachine overclockMachine) {
             maxVoltage = overclockMachine.getOverclockVoltage();
         } else if (holder instanceof ITieredMachine tieredMachine) {
             maxVoltage = GTValues.V[tieredMachine.getTier()];


### PR DESCRIPTION
## What
when is WorkableElectricMultiblockMachine, error use getOverclockVoltage to calc MaxParallel