### PR TITLE
Add NNC for value of fluid vein to avoid NPE when updating maps from lower versions

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockfluid/FluidVeinWorldEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockfluid/FluidVeinWorldEntry.java
@@ -51,7 +51,7 @@ public class FluidVeinWorldEntry {
         var tag = new CompoundTag();
         tag.putInt("fluidYield", fluidYield);
         tag.putInt("operationsRemaining", operationsRemaining);
-        if (vein != null) {
+        if (vein != null && GTRegistries.BEDROCK_FLUID_DEFINITIONS.getKey(vein) != null) {
             tag.putString("vein", GTRegistries.BEDROCK_FLUID_DEFINITIONS.getKey(vein).toString());
         }
         return tag;


### PR DESCRIPTION
## What
Added an NonNullCheck to FluidVeinWorldEntry.java. We noted that the *key* of fluid vein is checked by now, but the *value* is ignored, causing a crash when entering maps from a lower version of GTCEu, e.g. 1.2.1 (we used this version for the proper work of parallel hatch, which is very important but cannot work properly in 1.2.3, and the problem is hopefully already fixed in 1.2.3.a).
A detailed stack trace of the crash is provided:
[Crash Report](https://pastebin.com/g4YSVKaW)

## Implementation Details
A version converter of former maps' fluid vein data may be developed, instead of this straightforward fix.

## Outcome
The crash is avoided, and former maps can be entered and played.

## Potential Compatibility Issues
This may cause a lose of former maps' fluid vein data.
