### PR TITLE
Fix AE2 compatibilty configurations are not registered correctly.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -179,11 +179,13 @@ public class ConfigHolder {
 
         public static class AE2CompatConfig {
 
+            @Configurable
             @Configurable.Comment({ "The interval between ME Hatch/Bus interact ME network.",
                     "It may cause lag if the interval is too small.", "Default: 2 sec" })
             @Configurable.Range(min = 1, max = 80)
             public int updateIntervals = 40;
 
+            @Configurable
             @Configurable.Comment({ "The energy consumption of ME Hatch/Bus.", "Default: 1.0AE/t" })
             @Configurable.DecimalRange(min = 0.0, max = 10.0)
             public double meHatchEnergyUsage = 1.0;


### PR DESCRIPTION
## What
In issue #1305

Some configurations are missing `@Configurable` annotation, which causes them not being registered correctly, and this is partly fixed in #1336, except for the AE2 compatibility configs.

## Implementation Details
Add `@Configurable` before the configurations

## Outcome
Fixes: #1305 (again)