### PR TITLE
Add shell.nix for easily reproducible nix environments.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+with import <nixpkgs> {};
+let
+    libs = [ 
+        pkgs.glfw 
+        pkgs.libGL
+        pkgs.libpulseaudio
+    ];
+
+    existingLDPath = builtins.getEnv "LD_LIBRARY_PATH";
+
+    LDPath = if builtins.stringLength existingLDPath == 0 then
+        "${lib.makeLibraryPath libs}"
+    else
+        "${lib.makeLibraryPath libs}:${existingLDPath}"
+    ;
+in 
+    mkShell {
+        buildInputs = libs;
+        LD_LIBRARY_PATH = LDPath;
+    }


### PR DESCRIPTION
## What
Adds a `shell.nix` file to the root of the project so that NixOS users (or Nix users in general) have an easy way to reproduce the environment by grabbing needed libraries using `nix-shell`. 

For a quick reasoning as to why: NixOS doesn't populate the OS with dev dependencies by default, meaning using shells and dev environs this way is the more canonical method to set up a dev environment with development dependencies. This shouldn't affect anything, just makes life easier for NixOS/Nix users to develop without having to go through hell and back to figure it all out.