### PR TITLE
Fix log to plank recipes issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -179,11 +179,13 @@ public class ConfigHolder {
 
         public static class AE2CompatConfig {
 
+            @Configurable
             @Configurable.Comment({ "The interval between ME Hatch/Bus interact ME network.",
                     "It may cause lag if the interval is too small.", "Default: 2 sec" })
             @Configurable.Range(min = 1, max = 80)
             public int updateIntervals = 40;
 
+            @Configurable
             @Configurable.Comment({ "The energy consumption of ME Hatch/Bus.", "Default: 1.0AE/t" })
             @Configurable.DecimalRange(min = 0.0, max = 10.0)
             public double meHatchEnergyUsage = 1.0;

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -179,13 +179,11 @@ public class ConfigHolder {
 
         public static class AE2CompatConfig {
 
-            @Configurable
             @Configurable.Comment({ "The interval between ME Hatch/Bus interact ME network.",
                     "It may cause lag if the interval is too small.", "Default: 2 sec" })
             @Configurable.Range(min = 1, max = 80)
             public int updateIntervals = 40;
 
-            @Configurable
             @Configurable.Comment({ "The energy consumption of ME Hatch/Bus.", "Default: 1.0AE/t" })
             @Configurable.DecimalRange(min = 0.0, max = 10.0)
             public double meHatchEnergyUsage = 1.0;

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/WoodTypeEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/WoodTypeEntry.java
@@ -3,8 +3,11 @@ package com.gregtechceu.gtceu.data.recipe;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.data.tag.TagUtil;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.common.Tags;
@@ -22,6 +25,8 @@ public final class WoodTypeEntry {
     public final String modid;
     @NotNull
     public final String woodName;
+    @NotNull
+    public final TagKey<Item> logTag;
     @Nullable
     public final Item log;
     @Nullable
@@ -87,11 +92,12 @@ public final class WoodTypeEntry {
     public final boolean addFenceGatesUnificationInfo;
     public final boolean addStairsUnificationInfo;
     public final boolean addBoatsUnificationInfo;
+    public final boolean generateLogToPlankRecipe;
 
     /**
      * @see WoodTypeEntry.Builder
      */
-    private WoodTypeEntry(@NotNull String modid, @NotNull String woodName,
+    private WoodTypeEntry(@NotNull String modid, @NotNull String woodName, @NotNull TagKey<Item> logTag,
                           @Nullable Item log, @Nullable Item strippedLog,
                           @Nullable Item wood, @Nullable Item strippedWood,
                           boolean removeCharcoalRecipe, boolean addCharcoalRecipe,
@@ -110,9 +116,10 @@ public final class WoodTypeEntry {
                           boolean addPlanksUnificationInfo, boolean addDoorsUnificationInfo,
                           boolean addSlabsUnificationInfo, boolean addFencesUnificationInfo,
                           boolean addFenceGatesUnificationInfo, boolean addStairsUnificationInfo,
-                          boolean addBoatsUnificationInfo) {
+                          boolean addBoatsUnificationInfo, boolean generateLogToPlankRecipe) {
         this.modid = modid;
         this.woodName = woodName;
+        this.logTag = logTag;
         this.log = log;
         this.strippedLog = strippedLog;
         this.wood = wood;
@@ -153,6 +160,7 @@ public final class WoodTypeEntry {
         this.addFenceGatesUnificationInfo = addFenceGatesUnificationInfo;
         this.addStairsUnificationInfo = addStairsUnificationInfo;
         this.addBoatsUnificationInfo = addBoatsUnificationInfo;
+        this.generateLogToPlankRecipe = generateLogToPlankRecipe;
     }
 
     @NotNull
@@ -166,7 +174,7 @@ public final class WoodTypeEntry {
     }
 
     public Item[] getLogs() {
-        return new Item[] { this.log, this.wood, this.strippedWood, this.strippedLog };
+        return new Item[]{this.log, this.wood, this.strippedWood, this.strippedLog};
     }
 
     public static class Builder {
@@ -174,6 +182,7 @@ public final class WoodTypeEntry {
         private final String modid;
         private final String woodName;
 
+        private TagKey<Item> logTag = null;
         private Item log = null;
         private Item strippedLog = null;
         private Item wood = null;
@@ -216,6 +225,7 @@ public final class WoodTypeEntry {
         private boolean addFenceGatesUnificationInfo;
         private boolean addStairsUnificationInfo;
         private boolean addBoatsUnificationInfo;
+        private boolean generateLogToPlankRecipe = true;
 
         /**
          * @param modid    the modid adding recipes for the wood
@@ -226,6 +236,17 @@ public final class WoodTypeEntry {
             Preconditions.checkArgument(!woodName.isEmpty(), "Wood name cannot be empty.");
             this.modid = modid;
             this.woodName = woodName;
+        }
+
+        /**
+         * Add an entry for TagKey of logs
+         *
+         * @param logTag the TagKey to add
+         * @return this
+         */
+        public Builder logTag(@NotNull TagKey<Item> logTag) {
+            this.logTag = logTag;
+            return this;
         }
 
         /**
@@ -493,12 +514,29 @@ public final class WoodTypeEntry {
         }
 
         /**
+         * Specify if log -> planks recipe should be generated
+         *
+         * @param enabled if log -> planks recipe should be enabled
+         * @return this
+         */
+        public Builder generateLogToPlankRecipe(boolean enabled) {
+            this.generateLogToPlankRecipe = enabled;
+            return this;
+        }
+
+        /**
          * @return a new wood type entry, if valid
          */
         @NotNull
         public WoodTypeEntry build() {
             Preconditions.checkArgument(planks != null, "Planks cannot be empty.");
-            return new WoodTypeEntry(modid, woodName, log, strippedLog, wood, strippedWood,
+
+            // add default tag if logTag is null
+            if (logTag == null)
+                logTag = TagUtil.optionalTag(BuiltInRegistries.ITEM,
+                        new ResourceLocation(modid, woodName + "_logs"));
+
+            return new WoodTypeEntry(modid, woodName, logTag, log, strippedLog, wood, strippedWood,
                     removeCharcoalRecipe, addCharcoalRecipe,
                     planks, planksRecipeName,
                     door, doorRecipeName,
@@ -511,7 +549,8 @@ public final class WoodTypeEntry {
                     addLogOreDict, addPlanksOreDict, addDoorsOreDict, addSlabsOreDict,
                     addFencesOreDict, addFenceGatesOreDict, addStairsOreDict, addPlanksUnificationInfo,
                     addDoorsUnificationInfo, addSlabsUnificationInfo, addFencesUnificationInfo,
-                    addFenceGatesUnificationInfo, addStairsUnificationInfo, addBoatsUnificationInfo);
+                    addFenceGatesUnificationInfo, addStairsUnificationInfo, addBoatsUnificationInfo,
+                    generateLogToPlankRecipe);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/WoodTypeEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/WoodTypeEntry.java
@@ -174,7 +174,7 @@ public final class WoodTypeEntry {
     }
 
     public Item[] getLogs() {
-        return new Item[]{this.log, this.wood, this.strippedWood, this.strippedLog};
+        return new Item[] { this.log, this.wood, this.strippedWood, this.strippedLog };
     }
 
     public static class Builder {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -350,7 +350,7 @@ public class WoodMachineRecipes {
      */
     public static void registerWoodTypeRecipe(Consumer<FinishedRecipe> provider, @NotNull WoodTypeEntry entry) {
         final String name = entry.woodName;
-        final Item[] logs_ = entry.getLogs();
+        final Item[] logs = entry.getLogs();
 
         // noinspection ConstantValue can be null if someone does an oopsie and doesn't set it.
         if (entry.planks == null) {
@@ -358,27 +358,27 @@ public class WoodMachineRecipes {
         }
 
         // log-associated recipes
-        for (int i = 0; i < logs_.length; i++) {
-            if (logs_[i] != null) {
+        for (int i = 0; i < logs.length; i++) {
+            if (logs[i] != null) {
                 // nerf regular log -> plank crafting, if enabled
                 boolean hasPlanksRecipe = entry.planksRecipeName != null;
                 if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
                     VanillaRecipeHelper.addShapelessRecipe(provider,
                             hasPlanksRecipe ? entry.planksRecipeName : name + "_planks_" + i,
-                            new ItemStack(entry.planks, 2), logs_[i]);
+                            new ItemStack(entry.planks, 2), logs[i]);
                 } else if (!hasPlanksRecipe) {
                     VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks_" + i,
-                            new ItemStack(entry.planks, 4), logs_[i]);
+                            new ItemStack(entry.planks, 4), logs[i]);
                 }
 
                 // log -> plank saw crafting
                 VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw_" + i,
                         new ItemStack(entry.planks, ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
-                        "s", "L", 'L', logs_[i]);
+                        "s", "L", 'L', logs[i]);
 
                 // log -> plank cutting
                 CUTTER_RECIPES.recipeBuilder(name + "_planks_" + i)
-                        .inputItems(logs_[i])
+                        .inputItems(logs[i])
                         .outputItems(new ItemStack(entry.planks, 6))
                         .outputItems(dust, Wood, 2)
                         .duration(200)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -362,22 +362,24 @@ public class WoodMachineRecipes {
             if (logs[i] != null) {
                 // nerf regular log -> plank crafting, if enabled
                 boolean hasPlanksRecipe = entry.planksRecipeName != null;
+                final String postfix = i == 0 ? "" : "_" + i;
                 if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
                     VanillaRecipeHelper.addShapelessRecipe(provider,
-                            hasPlanksRecipe ? entry.planksRecipeName : name + "_planks_" + i,
+                            hasPlanksRecipe ? entry.planksRecipeName : name + "_planks" + postfix,
                             new ItemStack(entry.planks, 2), logs[i]);
+
                 } else if (!hasPlanksRecipe) {
-                    VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks_" + i,
+                    VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks" + postfix,
                             new ItemStack(entry.planks, 4), logs[i]);
                 }
 
                 // log -> plank saw crafting
-                VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw_" + i,
+                VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw" + postfix,
                         new ItemStack(entry.planks, ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
                         "s", "L", 'L', logs[i]);
 
                 // log -> plank cutting
-                CUTTER_RECIPES.recipeBuilder(name + "_planks_" + i)
+                CUTTER_RECIPES.recipeBuilder(name + "_planks" + postfix)
                         .inputItems(logs[i])
                         .outputItems(new ItemStack(entry.planks, 6))
                         .outputItems(dust, Wood, 2)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -15,7 +15,6 @@ import com.gregtechceu.gtceu.data.recipe.WoodTypeEntry;
 
 import com.lowdragmc.lowdraglib.side.fluid.forge.FluidHelperImpl;
 
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
@@ -144,6 +143,7 @@ public class WoodMachineRecipes {
                             .build(),
                     new WoodTypeEntry.Builder(mcModId, "bamboo")
                             .planks(Items.BAMBOO_PLANKS, "bamboo_planks")
+                            .logTag(TagUtil.createItemTag("bamboo_blocks", true))
                             .log(Items.BAMBOO_BLOCK).removeCharcoalRecipe()
                             .strippedLog(Items.STRIPPED_BAMBOO_BLOCK)
                             .door(Items.BAMBOO_DOOR, "bamboo_door")
@@ -187,6 +187,7 @@ public class WoodMachineRecipes {
                             .build(),
                     new WoodTypeEntry.Builder(mcModId, "crimson")
                             .planks(Items.CRIMSON_PLANKS, "crimson_planks")
+                            .logTag(TagUtil.createItemTag("crimson_stems", true))
                             .log(Items.CRIMSON_STEM).removeCharcoalRecipe()
                             .strippedLog(Items.STRIPPED_CRIMSON_STEM)
                             .wood(Items.CRIMSON_HYPHAE)
@@ -201,6 +202,7 @@ public class WoodMachineRecipes {
                             .build(),
                     new WoodTypeEntry.Builder(mcModId, "warped")
                             .planks(Items.WARPED_PLANKS, "warped_planks")
+                            .logTag(TagUtil.createItemTag("warped_stems", true))
                             .log(Items.WARPED_STEM).removeCharcoalRecipe()
                             .strippedLog(Items.STRIPPED_WARPED_STEM)
                             .wood(Items.WARPED_HYPHAE)
@@ -226,6 +228,7 @@ public class WoodMachineRecipes {
                             .fenceGate(GTBlocks.RUBBER_FENCE_GATE.asItem(), null)
                             .stairs(GTBlocks.RUBBER_STAIRS.asItem(), null).addStairsRecipe()
                             // .boat(GTItems.RUBBER_BOAT.asItem(), null) // TODO someone forgot boat textures.
+                            .generateLogToPlankRecipe(false) // rubber log does not have a tag
                             .registerAllTags()
                             .registerAllUnificationInfo()
                             .build(),
@@ -239,6 +242,7 @@ public class WoodMachineRecipes {
                             .stairs(GTBlocks.TREATED_WOOD_STAIRS.asItem(), null).addStairsRecipe()
                             // .boat(GTItems.TREATED_WOOD_BOAT.asItem(), null) // TODO someone forgot boat textures.
                             .material(TreatedWood)
+                            .generateLogToPlankRecipe(false)
                             .registerAllTags()
                             .registerAllUnificationInfo()
                             .build());
@@ -353,8 +357,7 @@ public class WoodMachineRecipes {
      */
     public static void registerWoodTypeRecipe(Consumer<FinishedRecipe> provider, @NotNull WoodTypeEntry entry) {
         final String name = entry.woodName;
-        TagKey<Item> logTag = TagUtil.optionalTag(BuiltInRegistries.ITEM,
-                new ResourceLocation(entry.modid, name + "_logs"));
+        TagKey<Item> logTag = entry.logTag;
         boolean hasPlanksRecipe = entry.planksRecipeName != null;
 
         // noinspection ConstantValue can be null if someone does an oopsie and doesn't set it.
@@ -362,28 +365,30 @@ public class WoodMachineRecipes {
             throw new IllegalStateException("Could not find planks form of WoodTypeEntry '" + name + "'.");
         }
 
-        if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
-            VanillaRecipeHelper.addShapelessRecipe(provider,
-                    hasPlanksRecipe ? entry.planksRecipeName : name + "_planks",
-                    new ItemStack(entry.planks, 2), logTag);
-        } else if (!hasPlanksRecipe) {
-            VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks",
-                    new ItemStack(entry.planks, 4), logTag);
+        if (entry.generateLogToPlankRecipe) {
+            if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
+                VanillaRecipeHelper.addShapelessRecipe(provider,
+                        hasPlanksRecipe ? entry.planksRecipeName : name + "_planks",
+                        new ItemStack(entry.planks, 2), logTag);
+            } else if (!hasPlanksRecipe) {
+                VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks",
+                        new ItemStack(entry.planks, 4), logTag);
+            }
+
+            // log -> plank saw crafting
+            VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw",
+                    new ItemStack(entry.planks, ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
+                    "s", "L", 'L', logTag);
+
+            // log -> plank cutting
+            CUTTER_RECIPES.recipeBuilder(name + "_planks")
+                    .inputItems(logTag)
+                    .outputItems(new ItemStack(entry.planks, 6))
+                    .outputItems(dust, Wood, 2)
+                    .duration(200)
+                    .EUt(VA[ULV])
+                    .save(provider);
         }
-
-        // log -> plank saw crafting
-        VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw",
-                new ItemStack(entry.planks, ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
-                "s", "L", 'L', logTag);
-
-        // log -> plank cutting
-        CUTTER_RECIPES.recipeBuilder(name + "_planks")
-                .inputItems(logTag)
-                .outputItems(new ItemStack(entry.planks, 6))
-                .outputItems(dust, Wood, 2)
-                .duration(200)
-                .EUt(VA[ULV])
-                .save(provider);
 
         // door
         if (entry.door != null) {
@@ -599,6 +604,28 @@ public class WoodMachineRecipes {
                 "aa", 'a', GTBlocks.RUBBER_PLANK.asStack());
         VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_plate",
                 GTBlocks.TREATED_WOOD_PRESSURE_PLATE.asStack(), "aa", 'a', GTBlocks.TREATED_WOOD_PLANK.asStack());
+
+        // add Recipes for rubber log
+        if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
+            VanillaRecipeHelper.addShapelessRecipe(provider,
+                    "rubber_planks",
+                    GTBlocks.RUBBER_PLANK.asStack(2), GTBlocks.RUBBER_LOG.asItem());
+        } else {
+            VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_planks",
+                    GTBlocks.RUBBER_PLANK.asStack(4), GTBlocks.RUBBER_LOG.asItem());
+        }
+
+        VanillaRecipeHelper.addShapedRecipe(provider, "rubber_planks_saw",
+                GTBlocks.RUBBER_PLANK.asStack(ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
+                "s", "L", 'L', GTBlocks.RUBBER_LOG.asItem());
+
+        CUTTER_RECIPES.recipeBuilder("rubber_planks")
+                .inputItems(GTBlocks.RUBBER_LOG.asItem())
+                .outputItems(GTBlocks.RUBBER_PLANK.asStack(6))
+                .outputItems(dust, Wood, 2)
+                .duration(200)
+                .EUt(VA[ULV])
+                .save(provider);
     }
 
     public static void hardWoodRecipes(Consumer<ResourceLocation> registry) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -17,6 +17,7 @@ import com.lowdragmc.lowdraglib.side.fluid.forge.FluidHelperImpl;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.common.Tags;
@@ -349,6 +350,7 @@ public class WoodMachineRecipes {
      */
     public static void registerWoodTypeRecipe(Consumer<FinishedRecipe> provider, @NotNull WoodTypeEntry entry) {
         final String name = entry.woodName;
+        final Item[] logs_ = entry.getLogs();
 
         // noinspection ConstantValue can be null if someone does an oopsie and doesn't set it.
         if (entry.planks == null) {
@@ -356,27 +358,27 @@ public class WoodMachineRecipes {
         }
 
         // log-associated recipes
-        for (var log_ : entry.getLogs()) {
-            if (log_ != null) {
+        for (int i = 0; i < logs_.length; i++) {
+            if (logs_[i] != null) {
                 // nerf regular log -> plank crafting, if enabled
                 boolean hasPlanksRecipe = entry.planksRecipeName != null;
                 if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
                     VanillaRecipeHelper.addShapelessRecipe(provider,
-                            hasPlanksRecipe ? entry.planksRecipeName : name + "_planks",
-                            new ItemStack(entry.planks, 2), log_);
+                            hasPlanksRecipe ? entry.planksRecipeName : name + "_planks_" + i,
+                            new ItemStack(entry.planks, 2), logs_[i]);
                 } else if (!hasPlanksRecipe) {
-                    VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks",
-                            new ItemStack(entry.planks, 4), log_);
+                    VanillaRecipeHelper.addShapelessRecipe(provider, name + "_planks_" + i,
+                            new ItemStack(entry.planks, 4), logs_[i]);
                 }
 
                 // log -> plank saw crafting
-                VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw",
+                VanillaRecipeHelper.addShapedRecipe(provider, name + "_planks_saw_" + i,
                         new ItemStack(entry.planks, ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
-                        "s", "L", 'L', log_);
+                        "s", "L", 'L', logs_[i]);
 
                 // log -> plank cutting
-                CUTTER_RECIPES.recipeBuilder(name + "_planks")
-                        .inputItems(log_)
+                CUTTER_RECIPES.recipeBuilder(name + "_planks_" + i)
+                        .inputItems(logs_[i])
                         .outputItems(new ItemStack(entry.planks, 6))
                         .outputItems(dust, Wood, 2)
                         .duration(200)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -362,8 +362,6 @@ public class WoodMachineRecipes {
             throw new IllegalStateException("Could not find planks form of WoodTypeEntry '" + name + "'.");
         }
 
-        GTCEu.LOGGER.info("Tag String is: {}", logTag);
-
         if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
             VanillaRecipeHelper.addShapelessRecipe(provider,
                     hasPlanksRecipe ? entry.planksRecipeName : name + "_planks",

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -607,8 +607,7 @@ public class WoodMachineRecipes {
 
         // add Recipes for rubber log
         if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
-            VanillaRecipeHelper.addShapelessRecipe(provider,
-                    "rubber_planks",
+            VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_planks",
                     GTBlocks.RUBBER_PLANK.asStack(2), GTBlocks.RUBBER_LOG.asItem());
         } else {
             VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_planks",


### PR DESCRIPTION
## What
This is a bug because of changes in #1370. 
Notice that originally, Resource Location uses a string like this:`name + "_planks"`.
However there are more than one element in getLogs(), so if we use this, later registration will overwrite former recipes, making it only possible for us to use `stripedLog` to craft.

## Implementation Details
I instead used a index based for loop, and add the index to the resource location string.

## Outcome
So that this bug is totally fixed, we can use any kind of log in the recipe.
However I am not sure if this is approporiate, maybe we should instead Tuples to store the Items and the name of them (i.e. "log", "stripted_log").
Also I don't think the underscore in the variable name (logs_) make sense, I'll delete that later.