### PR TITLE
fix GT recipe removal filtering

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -249,6 +249,7 @@ public class CommonProxy {
             // Register recipes & unification data again
             long startTime = System.currentTimeMillis();
             ChemicalHelper.reinitializeUnification();
+            GTRecipes.recipeRemoval();
             GTRecipes.recipeAddition(GTDynamicDataPack::addRecipe);
             // Initialize dungeon loot additions
             DungeonLootLoader.init();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipes.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 
 public class GTRecipes {
 
-    private static final Set<ResourceLocation> RECIPE_FILTERS = new ObjectOpenHashSet<>();
+    public static final Set<ResourceLocation> RECIPE_FILTERS = new ObjectOpenHashSet<>();
 
     /*
      * Called on resource reload in-game.
@@ -95,10 +95,10 @@ public class GTRecipes {
      *
      * This is also where any recipe removals should happen.
      */
-    public static void recipeRemoval(Consumer<ResourceLocation> consumer) {
-        RecipeRemoval.init(consumer);
-
+    public static void recipeRemoval() {
         RECIPE_FILTERS.clear();
-        AddonFinder.getAddons().forEach(addon -> addon.removeRecipes(consumer.andThen(RECIPE_FILTERS::add)));
+
+        RecipeRemoval.init(RECIPE_FILTERS::add);
+        AddonFinder.getAddons().forEach(addon -> addon.removeRecipes(RECIPE_FILTERS::add));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
@@ -166,12 +166,13 @@ public class GTDynamicDataPack implements PackResources {
         } else if (metaReader.getMetadataSectionName().equals("filter")) {
             JsonObject filter = new JsonObject();
             JsonArray block = new JsonArray();
-            GTRecipes.recipeRemoval((id) -> { // Collect removed recipes in here, in the pack filter section.
+            GTRecipes.RECIPE_FILTERS.forEach((id) -> { // Collect removed recipes in here, in the pack filter section.
                 JsonObject entry = new JsonObject();
                 entry.addProperty("namespace", "^" + id.getNamespace().replaceAll("[\\W]", "\\\\$0") + "$");
                 entry.addProperty("path", "^recipes/" + id.getPath().replaceAll("[\\W]", "\\\\$0") + "\\.json" + "$");
                 block.add(entry);
             });
+            GTRecipes.RECIPE_FILTERS.clear();
             filter.add("block", block);
             return metaReader.fromJson(filter);
         }


### PR DESCRIPTION
## What
fixes GT recipe removal filtering (#1352)

## Implementation Details
made all recipe removals be collected before additions and then cleared after use.

## Outcome
fixes #1352 but better