### PR TITLE
Add config for disabling enchanted tools

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2062,6 +2062,7 @@
   "config.gtceu.option.enableResearch": "ɥɔɹɐǝsǝᴚǝןqɐuǝ",
   "config.gtceu.option.enableTieredCasings": "sbuısɐƆpǝɹǝı⟘ǝןqɐuǝ",
   "config.gtceu.option.enableWorldAccelerators": "sɹoʇɐɹǝןǝɔɔⱯpןɹoMǝןqɐuǝ",
+  "config.gtceu.option.enchantedTools": "sןoo⟘pǝʇuɐɥɔuǝ",
   "config.gtceu.option.energy": "ʎbɹǝuǝ",
   "config.gtceu.option.energyConsumption": "uoıʇdɯnsuoƆʎbɹǝuǝ",
   "config.gtceu.option.energyUsageMultiplier": "ɹǝıןdıʇןnWǝbɐs∩ʎbɹǝuǝ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2062,6 +2062,7 @@
   "config.gtceu.option.enableResearch": "enableResearch",
   "config.gtceu.option.enableTieredCasings": "enableTieredCasings",
   "config.gtceu.option.enableWorldAccelerators": "enableWorldAccelerators",
+  "config.gtceu.option.enchantedTools": "enchantedTools",
   "config.gtceu.option.energy": "energy",
   "config.gtceu.option.energyConsumption": "energyConsumption",
   "config.gtceu.option.energyUsageMultiplier": "energyUsageMultiplier",

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/ToolProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/ToolProperty.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.item.tool.MaterialToolTier;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import net.minecraft.world.item.enchantment.Enchantment;
 
@@ -140,7 +141,9 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     }
 
     public void addEnchantmentForTools(Enchantment enchantment, int level) {
-        enchantments.put(enchantment, level);
+        if (ConfigHolder.INSTANCE.recipes.enchantedTools) {
+            enchantments.put(enchantment, level);
+        }
     }
 
     public MaterialToolTier getTier(Material material) {

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -121,6 +121,11 @@ public class ConfigHolder {
                 "Whether to nerf the output amounts of the first circuit in a set to 1 (from 2) and SoC to 2 (from 4).",
                 "Default: false" })
         public boolean harderCircuitRecipes = false;
+        @Configurable
+        @Configurable.Comment({
+                "Whether tools should have enchants or not. Like the flint sword getting fire aspect.",
+                "Default: true" })
+        public boolean enchantedTools = true;
     }
 
     public static class CompatibilityConfigs {


### PR DESCRIPTION
## What
Implements #1486 

## Implementation Details
Look over the place I added the if, not sure if it's the best. But seems to work fine.

## Outcome
Added a config option to disable enchants innately added to tools.

## Additional Information
-

## Potential Compatibility Issues
Shouldn't have any. The config is set to true by default. Meaning that recipes give enchants