### PR TITLE
1.21 - Glass tags fix and updated gitignore "run/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 *.ipr
 runs/
+run/
 *.iws
 out/
 *.iml

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
@@ -17,7 +17,7 @@ public class CustomTags {
 
     // Added Vanilla tags
     public static final TagKey<Item> TAG_PISTONS = TagUtil.createItemTag("pistons");
-    public static final TagKey<Item> GLASS_BLOCKS = TagUtil.createItemTag("glass");
+    public static final TagKey<Item> GLASS_BLOCKS = TagUtil.createItemTag("glass_blocks");
     public static final TagKey<Item> GLASS_PANES = TagUtil.createItemTag("glass_panes");
     public static final TagKey<Item> SEEDS = TagUtil.createItemTag("seeds");
     public static final TagKey<Item> CONCRETE_ITEM = TagUtil.createItemTag("concrete");
@@ -101,7 +101,7 @@ public class CustomTags {
     public static final TagKey<Block> ENDSTONE_ORE_REPLACEABLES = TagUtil.createBlockTag("end_stone_ore_replaceables");
     public static final TagKey<Block> CONCRETE_BLOCK = TagUtil.createBlockTag("concrete");
     public static final TagKey<Block> CONCRETE_POWDER_BLOCK = TagUtil.createBlockTag("concrete_powder");
-    public static final TagKey<Block> GLASS_BLOCKS_BLOCK = TagUtil.createBlockTag("glass");
+    public static final TagKey<Block> GLASS_BLOCKS_BLOCK = TagUtil.createBlockTag("glass_blocks");
     public static final TagKey<Block> GLASS_PANES_BLOCK = TagUtil.createBlockTag("glass_panes");
     public static final TagKey<Block> CREATE_SEATS = TagUtil.optionalTag(Registries.BLOCK,
             ResourceLocation.fromNamespaceAndPath(GTValues.MODID_CREATE, "seats"));


### PR DESCRIPTION
## What
Fixes the glass block and item tags

## Implementation Details
-

## Outcome
Just makes it compatible with neoforge. Fabric used to have the same tag.

## Additional Information
![4OQH2dfm4nKn6Qbo](https://github.com/GregTechCEu/GregTech-Modern/assets/61988002/1af99da7-f8dc-4420-8f70-23ca07a4e8d8)

## Potential Compatibility Issues
-