### PR TITLE
Adjust recipe handler priority

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IFilteredHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IFilteredHandler.java
@@ -5,8 +5,14 @@ import java.util.function.Predicate;
 
 public interface IFilteredHandler<K> extends Predicate<K> {
 
-    Comparator<IFilteredHandler<?>> PRIORITY_COMPARATOR = Comparator.comparingInt(IFilteredHandler::getPriority);
-    int NO_PRIORITY = Integer.MIN_VALUE;
+    Comparator<IFilteredHandler<?>> PRIORITY_COMPARATOR = Comparator
+            .<IFilteredHandler<?>>comparingInt(IFilteredHandler::getPriority).reversed();
+
+    int HIGHEST = Integer.MAX_VALUE;
+    int HIGH = Integer.MAX_VALUE / 2;
+    int NORMAL = 0;
+    int LOW = Integer.MIN_VALUE / 2;
+    int LOWEST = Integer.MIN_VALUE;
 
     /**
      * Test an ingredient for filtering & priority.
@@ -24,6 +30,6 @@ public interface IFilteredHandler<K> extends Predicate<K> {
      * The priority of this recipe handler.
      */
     default int getPriority() {
-        return NO_PRIORITY;
+        return NORMAL;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -168,7 +168,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
 
     @Override
     public int getPriority() {
-        return !isLocked() || lockedFluid.getFluid().isEmpty() ? super.getPriority() : Integer.MAX_VALUE - getTanks();
+        return !isLocked() || lockedFluid.getFluid().isEmpty() ? super.getPriority() : HIGH - getTanks();
     }
 
     public boolean isLocked() {


### PR DESCRIPTION
## What
Adjust the sorting of handlers and provide more levels of priority.

## Implementation Details
Change the order from ascending to descending and set the default priority to zero.

## Additional Information
I believe it should be sorted in descending order. If my understanding is incorrect, please close this PR.