### PR TITLE
fix overworld manganese vein's min- & maximum Y-level

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -660,10 +660,10 @@ public class GTOres {
                     .withBlock(new DikeBlockDefinition(Grossular, 3, -50, -5))
                     .withBlock(new DikeBlockDefinition(Spessartine, 2, -40, -15))
                     .withBlock(new DikeBlockDefinition(Pyrolusite, 2, -40, -15))
-                    .withBlock(new DikeBlockDefinition(Tantalite, 1, -30, -5))
-                    .minYLevel(-50).maxYLevel(-5))
+                    .withBlock(new DikeBlockDefinition(Tantalite, 1, -30, -5)))
             .surfaceIndicatorGenerator(indicator -> indicator
                     .surfaceRock(Grossular)
+                    .density(0.15f)
                     .radius(3)));
 
     public static final GTOreDefinition MICA_VEIN = create("mica_vein", vein -> vein


### PR DESCRIPTION
Cleanup for consistency and potential overlap with custom oregen through kubejs. Also added surfacerock density to it.

## What
Removes the min and maxYLevel
https://discord.com/channels/701354865217110096/1089296351906504835/1257991847041826857

## Implementation Details

## Outcome

## Additional Information

## Potential Compatibility Issues