### PR TITLE
Typo fix and KJS update to b79

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
         def reiVersion = "16.0.729"
         def emiVersion = "1.1.10"
         def ae2Version = "18.1.3-alpha"
-        def kjsVersion = "2100.7.0-build.71"
+        def kjsVersion = "2100.7.0-build.79"
         def auVersion = "1.20.1-0.6.0"
 
         // NeoForge

--- a/src/main/java/com/gregtechceu/gtceu/api/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/tag/TagPrefix.java
@@ -120,7 +120,7 @@ public class TagPrefix {
                     GTCEu.id("block/red_granite"));
 
     public static final TagPrefix oreMarble = oreTagPrefix("marble", BlockTags.MINEABLE_WITH_PICKAXE)
-            .langValue("Red Granite %s Ore")
+            .langValue("Marble %s Ore")
             .registerOre(
                     () -> GTBlocks.MARBLE.getDefaultState(), () -> GTMaterials.Marble, BlockBehaviour.Properties.of()
                             .mapColor(MapColor.QUARTZ).requiresCorrectToolForDrops().strength(3.0F, 3.0F),


### PR DESCRIPTION
## What
Fixes marble ore names from red granite and upping kjs to 79

## Implementation Details
nay

## Outcome
see above

## Additional Information

## Potential Compatibility Issues
