### PR TITLE
fix recipe viewer pages for ores sometimes not functioning among other issues

### DIFF
--- a/.github/actions/build_setup/action.yml
+++ b/.github/actions/build_setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   update-cache:
     description: If cache should be updated
     required: false
-    default: true
+    default: 'false'
 
 runs:
   using: 'composite'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,11 +42,11 @@ dependencies {
     // REI
     modCompileOnly forge.rei.plugin
     modCompileOnly forge.rei.api
-    modImplementation forge.rei.forge
+    modCompileOnly forge.rei.forge
 
     // EMI
     modCompileOnly("dev.emi:emi-forge:${forge.versions.emi.get()}:api")
-    modCompileOnly forge.emi
+    modImplementation forge.emi
 
     // TOP
     modCompileOnly(forge.theoneprobe) { transitive = false }
@@ -73,9 +73,9 @@ dependencies {
     include(forge.configuration)
 
     // Shimmer
-    modImplementation(forge.shimmer.forge) { transitive = false }
-    modImplementation("maven.modrinth:embeddium:0.3.19+mc1.20.1")
-    modImplementation("maven.modrinth:oculus:1.20.1-1.7.0")
+    modCompileOnly(forge.shimmer.forge) { transitive = false }
+    modCompileOnly("maven.modrinth:embeddium:0.3.19+mc1.20.1")
+    modCompileOnly("maven.modrinth:oculus:1.20.1-1.7.0")
 
     // Runtime only testing mods
     //modRuntimeOnly(forge.worldStripper)

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockfluid/BedrockFluidDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockfluid/BedrockFluidDefinition.java
@@ -2,7 +2,6 @@ package com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid;
 
 import com.gregtechceu.gtceu.api.data.worldgen.BiomeWeightModifier;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
-import com.gregtechceu.gtceu.common.data.GTBedrockFluids;
 import com.gregtechceu.gtceu.utils.RegistryUtil;
 
 import net.minecraft.core.Holder;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockfluid/BedrockFluidDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockfluid/BedrockFluidDefinition.java
@@ -24,6 +24,7 @@ import dev.latvian.mods.rhino.util.HideFromJS;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -206,10 +207,15 @@ public class BedrockFluidDefinition {
             return this.dimensions(new HashSet<>(RegistryUtil.resolveResourceKeys(Registries.DIMENSION, dimensions)));
         }
 
-        public BedrockFluidDefinition register() {
-            var definition = new BedrockFluidDefinition(weight, minimumYield, maximumYield, depletionAmount,
+        @ApiStatus.Internal
+        public BedrockFluidDefinition build() {
+            return new BedrockFluidDefinition(weight, minimumYield, maximumYield, depletionAmount,
                     depletionChance, depletedYield, fluid, biomes, dimensions);
-            GTBedrockFluids.toReRegister.put(name, definition);
+        }
+
+        public BedrockFluidDefinition register() {
+            var definition = build();
+            GTRegistries.BEDROCK_FLUID_DEFINITIONS.registerOrOverride(name, definition);
             return definition;
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockore/BedrockOreDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockore/BedrockOreDefinition.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.worldgen.BiomeWeightModifier;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
-import com.gregtechceu.gtceu.common.data.GTOres;
 import com.gregtechceu.gtceu.utils.RegistryUtil;
 
 import net.minecraft.core.Holder;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockore/BedrockOreDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockore/BedrockOreDefinition.java
@@ -220,7 +220,7 @@ public class BedrockOreDefinition {
         public BedrockOreDefinition register() {
             var definition = new BedrockOreDefinition(weight, size, yield, depletionAmount, depletionChance,
                     depletedYield, materials, biomes, dimensions);
-            GTOres.toReRegisterBedrock.put(name, definition);
+            GTRegistries.BEDROCK_ORE_DEFINITIONS.registerOrOverride(name, definition);
             return definition;
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
@@ -114,7 +114,8 @@ public class GTBedrockFluids {
         toReRegister.forEach(GTRegistries.BEDROCK_FLUID_DEFINITIONS::registerOrOverride);
     }
 
-    public static BedrockFluidDefinition create(ResourceLocation id, Consumer<BedrockFluidDefinition.Builder> consumer) {
+    public static BedrockFluidDefinition create(ResourceLocation id,
+                                                Consumer<BedrockFluidDefinition.Builder> consumer) {
         BedrockFluidDefinition.Builder builder = BedrockFluidDefinition.builder(id);
         consumer.accept(builder);
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBedrockFluids.java
@@ -14,12 +14,14 @@ import net.minecraft.world.level.biome.Biomes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * @author KilaBash
  * @date 2023/7/11
  * @implNote GTBedrockFluids
  */
+@SuppressWarnings("unused")
 public class GTBedrockFluids {
 
     public static final Map<ResourceLocation, BedrockFluidDefinition> toReRegister = new HashMap<>();
@@ -27,7 +29,7 @@ public class GTBedrockFluids {
     //////////////////////////////////////
     // ******** OVERWORLD ********//
     //////////////////////////////////////
-    public static BedrockFluidDefinition HEAVY_OIL = BedrockFluidDefinition.builder(GTCEu.id("heavy_oil_deposit"))
+    public static BedrockFluidDefinition HEAVY_OIL = create(GTCEu.id("heavy_oil_deposit"), builder -> builder
             .fluid(GTMaterials.OilHeavy::getFluid)
             .weight(15)
             .yield(100, 200)
@@ -36,30 +38,27 @@ public class GTBedrockFluids {
             .depletedYield(20)
             .biomes(5, BiomeTags.IS_OCEAN)
             .biomes(10, CustomTags.IS_SANDY)
-            .dimensions(overworld())
-            .register();
+            .dimensions(overworld()));
 
-    public static BedrockFluidDefinition LIGHT_OIL = BedrockFluidDefinition.builder(GTCEu.id("light_oil_deposit"))
+    public static BedrockFluidDefinition LIGHT_OIL = create(GTCEu.id("light_oil_deposit"), builder -> builder
             .fluid(GTMaterials.OilLight::getFluid)
             .weight(25)
             .yield(175, 300)
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(25)
-            .dimensions(overworld())
-            .register();
+            .dimensions(overworld()));
 
-    public static BedrockFluidDefinition NATURAL_GAS = BedrockFluidDefinition.builder(GTCEu.id("natural_gas_deposit"))
+    public static BedrockFluidDefinition NATURAL_GAS = create(GTCEu.id("natural_gas_deposit"), builder -> builder
             .fluid(GTMaterials.NaturalGas::getFluid)
             .weight(15)
             .yield(100, 175)
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(20)
-            .dimensions(overworld())
-            .register();
+            .dimensions(overworld()));
 
-    public static BedrockFluidDefinition OIL = BedrockFluidDefinition.builder(GTCEu.id("oil_deposit"))
+    public static BedrockFluidDefinition OIL = create(GTCEu.id("oil_deposit"), builder -> builder
             .fluid(GTMaterials.Oil::getFluid)
             .weight(20)
             .yield(175, 300)
@@ -68,20 +67,18 @@ public class GTBedrockFluids {
             .depletedYield(25)
             .biomes(5, BiomeTags.IS_OCEAN)
             .biomes(5, CustomTags.IS_SANDY)
-            .dimensions(overworld())
-            .register();
+            .dimensions(overworld()));
 
-    public static BedrockFluidDefinition RAW_OIL = BedrockFluidDefinition.builder(GTCEu.id("raw_oil_deposit"))
+    public static BedrockFluidDefinition RAW_OIL = create(GTCEu.id("raw_oil_deposit"), builder -> builder
             .fluid(GTMaterials.RawOil::getFluid)
             .weight(20)
             .yield(200, 300)
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(25)
-            .dimensions(overworld())
-            .register();
+            .dimensions(overworld()));
 
-    public static BedrockFluidDefinition SALT_WATER = BedrockFluidDefinition.builder(GTCEu.id("salt_water_deposit"))
+    public static BedrockFluidDefinition SALT_WATER = create(GTCEu.id("salt_water_deposit"), builder -> builder
             .fluid(GTMaterials.SaltWater::getFluid)
             .weight(0)
             .yield(50, 100)
@@ -90,35 +87,40 @@ public class GTBedrockFluids {
             .depletedYield(15)
             .dimensions(overworld())
             .biomes(200, Biomes.DEEP_OCEAN, Biomes.DEEP_COLD_OCEAN, Biomes.DEEP_FROZEN_OCEAN)
-            .biomes(150, BiomeTags.IS_OCEAN)
-            .register();
+            .biomes(150, BiomeTags.IS_OCEAN));
 
     //////////////////////////////////////
     // ******** NETHER ********//
     //////////////////////////////////////
-    public static BedrockFluidDefinition LAVA = BedrockFluidDefinition.builder(GTCEu.id("lava_deposit"))
+    public static BedrockFluidDefinition LAVA = create(GTCEu.id("lava_deposit"), builder -> builder
             .fluid(GTMaterials.Lava::getFluid)
             .weight(65)
             .yield(125, 250)
             .depletionAmount(1)
             .depletionChance(100)
             .depletedYield(30)
-            .dimensions(nether())
-            .register();
+            .dimensions(nether()));
 
-    public static BedrockFluidDefinition NETHER_NATURAL_GAS = BedrockFluidDefinition
-            .builder(GTCEu.id("nether_natural_gas_deposit"))
-            .fluid(GTMaterials.NaturalGas::getFluid)
-            .weight(35)
-            .yield(150, 300)
-            .depletionAmount(1)
-            .depletionChance(100)
-            .depletedYield(40)
-            .dimensions(nether())
-            .register();
+    public static BedrockFluidDefinition NETHER_NATURAL_GAS = create(GTCEu.id("nether_natural_gas_deposit"),
+            builder -> builder.fluid(GTMaterials.NaturalGas::getFluid)
+                    .weight(35)
+                    .yield(150, 300)
+                    .depletionAmount(1)
+                    .depletionChance(100)
+                    .depletedYield(40)
+                    .dimensions(nether()));
 
     public static void init() {
         toReRegister.forEach(GTRegistries.BEDROCK_FLUID_DEFINITIONS::registerOrOverride);
+    }
+
+    public static BedrockFluidDefinition create(ResourceLocation id, Consumer<BedrockFluidDefinition.Builder> consumer) {
+        BedrockFluidDefinition.Builder builder = BedrockFluidDefinition.builder(id);
+        consumer.accept(builder);
+
+        BedrockFluidDefinition definition = builder.build();
+        toReRegister.put(id, definition);
+        return definition;
     }
 
     public static Set<ResourceKey<Level>> nether() {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -54,7 +54,6 @@ public class GTOres {
     private static int largestIndicatorOffset = 0;
 
     private static final Map<ResourceLocation, GTOreDefinition> toReRegister = new HashMap<>();
-    public static final Map<ResourceLocation, BedrockOreDefinition> toReRegisterBedrock = new HashMap<>();
 
     //////////////////////////////////////
     // ******** End Vein *********//

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.worldgen.*;
-import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.indicators.SurfaceIndicatorGenerator;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.veins.NoopVeinGenerator;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockFluidLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockFluidLoader.java
@@ -34,16 +34,14 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 
-public class FluidVeinLoader extends SimpleJsonResourceReloadListener {
+public class BedrockFluidLoader extends SimpleJsonResourceReloadListener {
 
-    public static FluidVeinLoader INSTANCE;
     public static final Gson GSON_INSTANCE = Deserializers.createFunctionSerializer().create();
     private static final String FOLDER = "gtceu/fluid_veins";
     protected static final Logger LOGGER = LogManager.getLogger();
 
-    public FluidVeinLoader() {
+    public BedrockFluidLoader() {
         super(GSON_INSTANCE, FOLDER);
-        INSTANCE = this;
     }
 
     @Override
@@ -59,7 +57,7 @@ public class FluidVeinLoader extends SimpleJsonResourceReloadListener {
         ModLoader.get().postEvent(
                 new GTCEuAPI.RegisterEvent<>(GTRegistries.BEDROCK_FLUID_DEFINITIONS, BedrockFluidDefinition.class));
         if (GTCEu.isKubeJSLoaded()) {
-            RunKJSEventInSeparateClassBecauseForgeIsDumb.fireKJSEvent();
+            KJSCallWrapper.fireKJSEvent();
         }
         RegistryOps<JsonElement> ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
         for (Map.Entry<ResourceLocation, JsonElement> entry : resourceList.entrySet()) {
@@ -91,10 +89,7 @@ public class FluidVeinLoader extends SimpleJsonResourceReloadListener {
         return BedrockFluidDefinition.FULL_CODEC.parse(ops, json).getOrThrow(false, LOGGER::error);
     }
 
-    /**
-     * Holy shit this is dumb, thanks forge for trying to classload things that are never called!
-     */
-    public static final class RunKJSEventInSeparateClassBecauseForgeIsDumb {
+    public static final class KJSCallWrapper {
 
         public static void fireKJSEvent() {
             GTCEuServerEvents.FLUID_VEIN_MODIFICATION.post(ScriptType.SERVER, new GTFluidVeinEventJS());

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
@@ -6,7 +6,6 @@ import com.gregtechceu.gtceu.api.addon.AddonFinder;
 import com.gregtechceu.gtceu.api.addon.IGTAddon;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
-import com.gregtechceu.gtceu.common.data.GTOres;
 import com.gregtechceu.gtceu.common.network.GTNetwork;
 import com.gregtechceu.gtceu.common.network.packets.SPacketSyncFluidVeins;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuServerEvents;

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
@@ -39,14 +39,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class BedrockOreLoader extends SimpleJsonResourceReloadListener {
 
-    public static BedrockOreLoader INSTANCE;
     public static final Gson GSON_INSTANCE = Deserializers.createFunctionSerializer().create();
     private static final String FOLDER = "gtceu/bedrock_ore_veins";
     protected static final Logger LOGGER = LogManager.getLogger();
 
     public BedrockOreLoader() {
         super(GSON_INSTANCE, FOLDER);
-        INSTANCE = this;
     }
 
     @Override
@@ -56,14 +54,14 @@ public class BedrockOreLoader extends SimpleJsonResourceReloadListener {
             GTRegistries.BEDROCK_ORE_DEFINITIONS.unfreeze();
         }
         GTRegistries.BEDROCK_ORE_DEFINITIONS.registry().clear();
-        GTOres.toReRegisterBedrock.forEach(GTRegistries.BEDROCK_ORE_DEFINITIONS::registerOrOverride);
 
         AddonFinder.getAddons().forEach(IGTAddon::registerBedrockOreVeins);
         ModLoader.get().postEvent(
                 new GTCEuAPI.RegisterEvent<>(GTRegistries.BEDROCK_ORE_DEFINITIONS, BedrockOreDefinition.class));
         if (GTCEu.isKubeJSLoaded()) {
-            RunKJSEventInSeparateClassBecauseForgeIsDumb.fireKJSEvent();
+            KJSCallWrapper.fireKJSEvent();
         }
+
         RegistryOps<JsonElement> ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
         for (Map.Entry<ResourceLocation, JsonElement> entry : resourceList.entrySet()) {
             ResourceLocation location = entry.getKey();
@@ -93,10 +91,7 @@ public class BedrockOreLoader extends SimpleJsonResourceReloadListener {
         return BedrockOreDefinition.FULL_CODEC.parse(ops, json).getOrThrow(false, LOGGER::error);
     }
 
-    /**
-     * Holy shit this is dumb, thanks forge for trying to classload things that are never called!
-     */
-    public static final class RunKJSEventInSeparateClassBecauseForgeIsDumb {
+    public static final class KJSCallWrapper {
 
         public static void fireKJSEvent() {
             GTCEuServerEvents.BEDROCK_ORE_VEIN_MODIFICATION.post(ScriptType.SERVER, new GTBedrockOreVeinEventJS());

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/GTOreLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/GTOreLoader.java
@@ -36,16 +36,14 @@ import org.apache.logging.log4j.Logger;
 import java.util.Iterator;
 import java.util.Map;
 
-public class OreDataLoader extends SimpleJsonResourceReloadListener {
+public class GTOreLoader extends SimpleJsonResourceReloadListener {
 
-    public static OreDataLoader INSTANCE;
     public static final Gson GSON_INSTANCE = Deserializers.createFunctionSerializer().create();
     private static final String FOLDER = "gtceu/ore_veins";
     protected static final Logger LOGGER = LogManager.getLogger();
 
-    public OreDataLoader() {
+    public GTOreLoader() {
         super(GSON_INSTANCE, FOLDER);
-        INSTANCE = this;
     }
 
     @Override
@@ -61,7 +59,7 @@ public class OreDataLoader extends SimpleJsonResourceReloadListener {
         AddonFinder.getAddons().forEach(IGTAddon::registerOreVeins);
         ModLoader.get().postEvent(new GTCEuAPI.RegisterEvent<>(GTRegistries.ORE_VEINS, GTOreDefinition.class));
         if (GTCEu.isKubeJSLoaded()) {
-            RunKJSEventInSeparateClassBecauseForgeIsDumb.fireKJSEvent();
+            KJSCallWrapper.fireKJSEvent();
         }
 
         RegistryOps<JsonElement> ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
@@ -113,10 +111,7 @@ public class OreDataLoader extends SimpleJsonResourceReloadListener {
         return GTOreDefinition.FULL_CODEC.parse(ops, json).getOrThrow(false, LOGGER::error);
     }
 
-    /**
-     * Holy shit this is dumb, thanks forge for trying to classload things that are never called!
-     */
-    public static final class RunKJSEventInSeparateClassBecauseForgeIsDumb {
+    public static final class KJSCallWrapper {
 
         public static void fireKJSEvent() {
             GTCEuServerEvents.ORE_VEIN_MODIFICATION.post(ScriptType.SERVER, new GTOreVeinEventJS());

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -33,8 +33,8 @@ import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketRemoveHazardZo
 import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketSyncLevelHazards;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
-import com.gregtechceu.gtceu.data.loader.FluidVeinLoader;
-import com.gregtechceu.gtceu.data.loader.OreDataLoader;
+import com.gregtechceu.gtceu.data.loader.BedrockFluidLoader;
+import com.gregtechceu.gtceu.data.loader.GTOreLoader;
 import com.gregtechceu.gtceu.utils.TaskHandler;
 
 import net.minecraft.core.Direction;
@@ -215,8 +215,8 @@ public class ForgeCommonEventListener {
 
     @SubscribeEvent
     public static void registerReloadListeners(AddReloadListenerEvent event) {
-        event.addListener(new OreDataLoader());
-        event.addListener(new FluidVeinLoader());
+        event.addListener(new GTOreLoader());
+        event.addListener(new BedrockFluidLoader());
         event.addListener(new BedrockOreLoader());
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -32,8 +32,8 @@ import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketAddHazardZone;
 import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketRemoveHazardZone;
 import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketSyncLevelHazards;
 import com.gregtechceu.gtceu.config.ConfigHolder;
-import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.BedrockFluidLoader;
+import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.GTOreLoader;
 import com.gregtechceu.gtceu.utils.TaskHandler;
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTOreVeinWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTOreVeinWidget.java
@@ -153,7 +153,7 @@ public class GTOreVeinWidget extends WidgetGroup {
                 SlotWidget dimSlot = new SlotWidget(transfer, i,
                         5 + (16 + interval) * (i - row * rowSlots),
                         yPosition + 18 * row,
-                        false, false).setIngredientIO(IngredientIO.INPUT);
+                        false, false).setIngredientIO(IngredientIO.CATALYST);
                 transfer.setStackInSlot(i, markerItem);
                 if (ConfigHolder.INSTANCE.compat.showDimensionTier) {
                     dimSlot.setOverlay(


### PR DESCRIPTION
## What
fix recipe viewer pages for custom bedrock fluids / ores not working without a reload
fix custom bedrock fluids / ores disappearing on world load
fix github build action being unbearably slow (caching was disabled)

## Outcome
fixes #1543 
fixes #1595 