### PR TITLE
fix kubejs output replacement not working

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
@@ -317,7 +317,7 @@ public class GTRecipeComponents {
         }
 
         @Override
-        public boolean isInput(RecipeJS recipe, InputItem value, ReplacementMatch match) {
+        public boolean isOutput(RecipeJS recipe, InputItem value, ReplacementMatch match) {
             return match instanceof ItemMatch m && value.validForMatching() && m.contains(value.ingredient);
         }
 


### PR DESCRIPTION
## What
fixes the KubeJS replacement methods with output matches not working with GT recipes.

## Implementation Details
one (1) wrong method name corrected

## Outcome
bug fixed 👍

## Additional Information
![image](https://cdn.discordapp.com/attachments/701354865657643070/1270811392399900785/image.png?ex=66b50ed6&is=66b3bd56&hm=1d763986f8addb80da24d83d294e2cb64bdf0fefd3d8e87c6fd4897b242b1bfd&)