### PR TITLE
Add recipe condition for adjacent blocks

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -5736,6 +5736,7 @@
   "recipe.condition.pos_y.tooltip": "Y Level: %d <= Y <= %d",
   "recipe.condition.rain.tooltip": "Rain Level: %d",
   "recipe.condition.rock_breaker.tooltip": "Fluid blocks around",
+  "recipe.condition.adjacent_block.tooltip": "Blocks around",
   "recipe.condition.rpm.tooltip": "RPM: %d",
   "recipe.condition.steam_vent.tooltip": "Clean steam vent",
   "recipe.condition.thunder.tooltip": "Thunder Level: %d",

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
@@ -27,6 +27,7 @@ public final class GTRecipeConditions {
         GTRegistries.RECIPE_CONDITIONS.register(PositionYCondition.INSTANCE.getType(), PositionYCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(RainingCondition.INSTANCE.getType(), RainingCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(RockBreakerCondition.INSTANCE.getType(), RockBreakerCondition.class);
+        GTRegistries.RECIPE_CONDITIONS.register(AdjacentBlockCondition.INSTANCE.getType(), AdjacentBlockCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(ThunderCondition.INSTANCE.getType(), ThunderCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(VentCondition.INSTANCE.getType(), VentCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(CleanroomCondition.INSTANCE.getType(), CleanroomCondition.class);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
@@ -27,7 +27,8 @@ public final class GTRecipeConditions {
         GTRegistries.RECIPE_CONDITIONS.register(PositionYCondition.INSTANCE.getType(), PositionYCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(RainingCondition.INSTANCE.getType(), RainingCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(RockBreakerCondition.INSTANCE.getType(), RockBreakerCondition.class);
-        GTRegistries.RECIPE_CONDITIONS.register(AdjacentBlockCondition.INSTANCE.getType(), AdjacentBlockCondition.class);
+        GTRegistries.RECIPE_CONDITIONS.register(AdjacentBlockCondition.INSTANCE.getType(),
+                AdjacentBlockCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(ThunderCondition.INSTANCE.getType(), ThunderCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(VentCondition.INSTANCE.getType(), VentCondition.class);
         GTRegistries.RECIPE_CONDITIONS.register(CleanroomCondition.INSTANCE.getType(), CleanroomCondition.class);

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/AdjacentBlockCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/AdjacentBlockCondition.java
@@ -1,0 +1,48 @@
+package com.gregtechceu.gtceu.common.recipe;
+
+import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
+import com.gregtechceu.gtceu.utils.GTUtil;
+import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+public class AdjacentBlockCondition extends RecipeCondition {
+
+    public final static AdjacentBlockCondition INSTANCE = new AdjacentBlockCondition();
+    @Override
+    public String getType() {
+        return "adjacent_block";
+    }
+
+    @Override
+    public Component getTooltips() {
+        return Component.translatable("recipe.condition.adjacent_block.tooltip");
+    }
+
+    @Override
+    public boolean test(@NotNull GTRecipe recipe, @NotNull RecipeLogic recipeLogic) {
+        var blockA = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockA")));
+        var blockB = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockB")));
+        boolean hasBlockA = false, hasBlockB = false;
+        var level = recipeLogic.machine.self().getLevel();
+        var pos = recipeLogic.machine.self().getPos();
+        for (Direction side : GTUtil.DIRECTIONS) {
+            if (side.getAxis() != Direction.Axis.Y) {
+                var block = level.getBlockState(pos.relative(side));
+                if (block.getBlock() == blockA) hasBlockA = true;
+                if (block.getBlock() == blockA) hasBlockB = true;
+                if (hasBlockA && hasBlockB) return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public RecipeCondition createTemplate() {
+        return new AdjacentBlockCondition();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/AdjacentBlockCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/AdjacentBlockCondition.java
@@ -4,15 +4,18 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
 import com.gregtechceu.gtceu.utils.GTUtil;
+
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+
 import org.jetbrains.annotations.NotNull;
 
 public class AdjacentBlockCondition extends RecipeCondition {
 
     public final static AdjacentBlockCondition INSTANCE = new AdjacentBlockCondition();
+
     @Override
     public String getType() {
         return "adjacent_block";


### PR DESCRIPTION
## What
Adds a new RecipeCondition that checks for blocks that are adjacent to a machine (similar to the Rock Crusher)

## Additional Information
Test machine using condition:
![image](https://github.com/user-attachments/assets/75eec5d1-83fb-473a-a098-18f55b5e8d32)

Example recipe: https://github.com/JuiceyBeans/Juiceycality/commit/16ef668d5dab8d1dbc37561649723d083e8d7edc#diff-a69f1ddfb5bffcac9b8ea155705f0a2f2cf917f0ddf890e17818422e57fe0074

## Potential Compatibility Issues
Hopefully none