### PR TITLE
Update README.md to include ULSTICK  & Ghostipedia Texture Credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Additionally, the [Minecraft Development plugin](https://plugins.jetbrains.com/p
 
 
 ## Credited Works
-- Most textures are originally from the **[ZedTech GTCEu Resourcepack](https://github.com/brachy84/zedtech-ceu)**, with some changes made by the community.
+- Most textures are originally from [Gregtech: Refreshed](https://modrinth.com/resourcepack/gregtech-refreshed) by @ULSTICK. With some consistency edits and additions by @Ghostipedia.
+- Some textures are originally from the **[ZedTech GTCEu Resourcepack](https://github.com/brachy84/zedtech-ceu)**, with some changes made by the community.
 - New material item textures by @TTFTCUTS and @Rosethorns.
 - Wooden Forms, World Accelerators, and the Extreme Combustion Engine are from the **[GregTech: New Horizons Modpack](https://www.curseforge.com/minecraft/modpacks/gt-new-horizons)**.
 - Primitive Water Pump is from the **[IMPACT: GREGTECH EDITION Modpack](https://gtimpact.space/)**.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# GregTechCEu
-
-<a title="Join us on Discord!" href="https://discord.gg/bWSWuYvURP"><img src="https://img.shields.io/discord/701354865217110096?label=GTCEu%20Discord&amp;logo=Discord&amp;style=?flat" alt="Discord"/></a>
-
-GregTech based on Architectury for performing on Forge, Fabric, and Quilt, simultaneously.
-
-
-## Download
-[`Github Releases`](https://github.com/GregTechCEu/GregTechCEu-1.19/releases).
-[`Curseforge`](https://www.curseforge.com/minecraft/mc-mods/gregtechceu-modern/files)
-[`Modrinth`](https://modrinth.com/mod/gregtechceu-modern)
-
+<p align="center"><img src="https://github.com/user-attachments/assets/547baf4d-088b-4311-9366-80260c2d1f55" alt="Logo"></p>
+<h1 align="center">GregTech CEu: Modern</h1>
+<p align="center">GregTech:CEu built on modern Minecraft versions for Forge(1.20.1) & NeoForge(1.21+).</p>
+<h1 align="center">
+    <a href="https://www.curseforge.com/minecraft/mc-mods/gregtech-ce-unofficial"><img src="https://img.shields.io/badge/Available%20for-MC%201.20.1+%20-informational?style=for-the-badge" alt="Supported Versions"></a>
+    <a href="https://github.com/GregTechCEu/GregTech/blob/master/LICENSE"><img src="https://img.shields.io/github/license/GregTechCEu/GregTech?style=for-the-badge" alt="License"></a>
+    <a href="https://discord.gg/bWSWuYvURP"><img src="https://img.shields.io/discord/701354865217110096?color=5464ec&label=Discord&style=for-the-badge" alt="Discord"></a>
+    <br>
+    <a href="https://www.curseforge.com/minecraft/mc-mods/gregtechceu-modern"><img src="https://cf.way2muchnoise.eu/890405.svg?badge_style=for_the_badge" alt="CurseForge"></a>
+    <a href="https://modrinth.com/mod/gregtechceu-modern"><img src="https://img.shields.io/modrinth/dt/gregtechceu-modern?logo=modrinth&label=&suffix=%20&style=for-the-badge&color=2d2d2d&labelColor=5ca424&logoColor=1c1c1c" alt="Modrinth"></a>
+    <a href="https://github.com/GregTechCEu/GregTech-Modern/releases"><img src="https://img.shields.io/github/downloads/GregTechCEu/GregTech-Modern/total?sort=semver&logo=github&label=&style=for-the-badge&color=2d2d2d&labelColor=545454&logoColor=FFFFFF" alt="GitHub"></a>
+</h1>
 
 ## Documentation / Wiki
 [`Wiki`](https://gregtechceu.github.io/gtceu-modern-docs/)
@@ -19,7 +19,7 @@ GregTech based on Architectury for performing on Forge, Fabric, and Quilt, simul
 * [Todo List](https://github.com/GregTechCEu/GregTechCEu-1.19/issues/125) for potential contributors who are interested in this project
 * [Dev Q&A](https://github.com/GregTechCEu/GregTechCEu-1.19/wiki/Dev-Q&A) illustrates common questions and answers related to development.
 
-
+##
 ## IDE Requirements (when using IntelliJ IDEA)
 
 For developing this mod, the [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok) for IntelliJ IDEA is strictly required.  


### PR DESCRIPTION
Gives ULSTICK Credit for Creating GregTech: Refreshed as it is now the major set of textures used in GTModern
Gives Ghostipedia credit for texture contributions as well as consistency edits to GTR