### PR TITLE
fix assembly line duplicating the recipe output infinitely

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -350,6 +350,10 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
     public void setupRecipe(GTRecipe recipe) {
         if (handleFuelRecipe()) {
             if (!machine.beforeWorking(recipe)) {
+                setStatus(Status.IDLE);
+                progress = 0;
+                duration = 0;
+                isActive = false;
                 return;
             }
             recipe.preWorking(this.machine);


### PR DESCRIPTION
## What
fix bug recipe logic bug, RecipeLogic has not been reset when `machine.beforeWorking` return false.

## Outcome
fixed #1604 
