### PR TITLE
Fix alloy smelting block to ingot input amount and voltage

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
@@ -330,10 +330,10 @@ public class MaterialRecipeHandler {
 
         if (!ChemicalHelper.get(block, material).isEmpty()) {
             ALLOY_SMELTER_RECIPES.recipeBuilder("alloy_smelt_" + material.getName() + "_to_ingot")
-                    .EUt(VA[ULV]).duration((int) material.getMass() * 9)
+                    .EUt(VA[ULV]).duration((int) material.getMass() * (int) (block.getMaterialAmount(material) / M))
                     .inputItems(block, material)
                     .notConsumable(GTItems.SHAPE_MOLD_INGOT)
-                    .outputItems(ingot, material, 9)
+                    .outputItems(ingot, material, (int) (block.getMaterialAmount(material) / M))
                     .save(provider);
 
             COMPRESSOR_RECIPES.recipeBuilder("compress_" + material.getName() + "_to_block")


### PR DESCRIPTION
## What
Alloy smelting a block to an ingot was set to always be 9. This does not work for materials where the block is only 4 ingots (like gems). This PR changes it to use the block material amount instead

## Implementation Details
Changed hardcoded integer 9 to ``(int) (block.getMaterialAmount(material) / M``

## Potential Compatibility Issues
None hopefully