### PR TITLE
Fix circuit tag in energy cluster recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/BatteryRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/BatteryRecipes.java
@@ -389,7 +389,7 @@ public class BatteryRecipes {
         ASSEMBLY_LINE_RECIPES.recipeBuilder("energy_cluster")
                 .inputItems(WETWARE_CIRCUIT_BOARD)
                 .inputItems(plate, Americium, 16)
-                .inputItems(WETWARE_SUPER_COMPUTER_UV, 4)
+                .inputItems(CustomTags.UV_CIRCUITS, 4)
                 .inputItems(ENERGY_MODULE)
                 .inputItems(FIELD_GENERATOR_ZPM)
                 .inputItems(ULTRA_HIGH_POWER_INTEGRATED_CIRCUIT, 32)


### PR DESCRIPTION
## What
Made this recipe use circuit tag, instead of wetware processor supercomputer

## Additional Information
I don't actually know if this recipe is a intentional design or not
