### PR TITLE
Fail gracefully when JEI fluid tooltip code changes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/jei/FluidHelperMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/jei/FluidHelperMixin.java
@@ -17,7 +17,8 @@ public class FluidHelperMixin {
 
     @Inject(method = "getTooltip(Lmezz/jei/api/gui/builder/ITooltipBuilder;Lnet/minecraftforge/fluids/FluidStack;Lnet/minecraft/world/item/TooltipFlag;)V",
             at = @At("TAIL"),
-            remap = false)
+            remap = false,
+            require = 0)
     private void gtceu$injectFluidTooltips(ITooltipBuilder tooltip, FluidStack ingredient, TooltipFlag tooltipFlag,
                                            CallbackInfo ci) {
         TooltipsHandler.appendFluidTooltips(ingredient.getFluid(), ingredient.getAmount(), tooltip::add, tooltipFlag);


### PR DESCRIPTION
## What
JEI's code is under active development, and GregTech's mixins into its code are set up in a way that they will crash if the JEI code doesn't exactly match what is expected. This makes the relationship between the two mods brittle and causes crashes.

By marking the `@Inject` as not requiring the target, GregTech CEu Modern will continue to run even if JEI's code changes. Instead of the game crashing, the fluid tooltips will just stop working, which is a much less severe issue for players.

## Implementation Details
Alternatively, the default require could be set to 0 here to benefit all mixins:
https://github.com/GregTechCEu/GregTech-Modern/blob/8cc8e82a741a49d0bafd4585d266474087e81a45/src/main/resources/gtceu.mixins.json#L67

I didn't look over the other mixins so I only wanted to change this one. 
This one can fail without severely impacting the game, but I am not sure about the others.

## Outcome
This will fix several past and future incompatibilities between JEI and GregTech CEu Modern.