### PR TITLE
more readable number display for fusion

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -44,6 +44,7 @@ import net.minecraftforge.fml.ModLoader;
 import com.simibubi.create.AllBlocks;
 import org.jetbrains.annotations.Nullable;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -665,7 +666,8 @@ public class GTRecipeTypes {
             .setProgressBar(GuiTextures.PROGRESS_BAR_FUSION, LEFT_TO_RIGHT)
             .setSound(GTSoundEntries.ARC)
             .setOffsetVoltageText(true)
-            .addDataInfo(data -> LocalizationUtils.format("gtceu.recipe.eu_to_start", data.getLong("eu_to_start")));
+            .addDataInfo(data -> LocalizationUtils.format("gtceu.recipe.eu_to_start",
+                    NumberFormat.getCompactNumberInstance().format(data.getLong("eu_to_start"))));
 
     public static final GTRecipeType DUMMY_RECIPES = new GTRecipeType(GTCEu.id("dummy"), DUMMY);
 


### PR DESCRIPTION
I felt like the starting energy for fusion was displayed in an unreadable way, so this changes the way that particular number is formatted. 

With this change the starting energies look like this: 
![image](https://github.com/user-attachments/assets/1c125e5b-0bee-4932-bf13-a0490c9ed658)

I think it makes it much easier to tell at a glance which tier of reactor is needed to run the recipes.