### PR TITLE
Add axe mineable tags to rubber wood blocks

### DIFF
--- a/src/generated/resources/assets/gtceu/compass/nodes/materials/frame.json
+++ b/src/generated/resources/assets/gtceu/compass/nodes/materials/frame.json
@@ -4,8 +4,8 @@
     "res": "gtceu:aluminium_frame"
   },
   "items": [
-    "#forge:frames",
-    "#minecraft:climbable"
+    "#minecraft:climbable",
+    "#forge:frames"
   ],
   "page": "gtceu:materials/frame",
   "position": [

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -2,6 +2,10 @@
   "values": [
     "gtceu:pump_deck",
     "gtceu:powderbarrel",
-    "gtceu:industrial_tnt"
+    "gtceu:industrial_tnt",
+    "gtceu:stripped_rubber_log",
+    "gtceu:rubber_wood",
+    "gtceu:stripped_rubber_wood",
+    "gtceu:rubber_stairs"
   ]
 }

--- a/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -6,6 +6,7 @@
     "gtceu:stripped_rubber_log",
     "gtceu:rubber_wood",
     "gtceu:stripped_rubber_wood",
-    "gtceu:rubber_stairs"
+    "gtceu:rubber_stairs",
+    "gtceu:treated_wood_stairs"
   ]
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -1465,7 +1465,7 @@ public class GTBlocks {
             .block("treated_wood_stairs", (p) -> new StairBlock(TREATED_WOOD_PLANK::getDefaultState, p))
             .initialProperties(() -> Blocks.SPRUCE_STAIRS)
             .lang("Treated Wood Stairs")
-            .tag(BlockTags.STAIRS)
+            .tag(BlockTags.STAIRS, BlockTags.MINEABLE_WITH_AXE)
             .blockstate((ctx, prov) -> prov.stairsBlock(ctx.getEntry(),
                     prov.blockTexture(GTBlocks.TREATED_WOOD_PLANK.get())))
             .item()

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -1163,6 +1163,7 @@ public class GTBlocks {
             .initialProperties(() -> Blocks.STRIPPED_SPRUCE_LOG)
             .lang("Stripped Rubber Log")
             .blockstate((ctx, provider) -> provider.logBlock(ctx.get()))
+            .tag(BlockTags.MINEABLE_WITH_AXE)
             .simpleItem()
             .register();
     public static final BlockEntry<RotatedPillarBlock> RUBBER_WOOD = REGISTRATE
@@ -1171,6 +1172,7 @@ public class GTBlocks {
             .lang("Rubber Wood")
             .blockstate((ctx, provider) -> provider.axisBlock(ctx.get(),
                     provider.blockTexture(GTBlocks.RUBBER_LOG.get()), provider.blockTexture(GTBlocks.RUBBER_LOG.get())))
+            .tag(BlockTags.MINEABLE_WITH_AXE)
             .simpleItem()
             .register();
     public static final BlockEntry<RotatedPillarBlock> STRIPPED_RUBBER_WOOD = REGISTRATE
@@ -1179,6 +1181,7 @@ public class GTBlocks {
             .lang("Stripped Rubber Wood")
             .blockstate((ctx, provider) -> provider.axisBlock(ctx.get(), provider.blockTexture(ctx.get()),
                     provider.blockTexture(ctx.get())))
+            .tag(BlockTags.MINEABLE_WITH_AXE)
             .simpleItem()
             .register();
 
@@ -1298,7 +1301,7 @@ public class GTBlocks {
             .block("rubber_stairs", (p) -> new StairBlock(RUBBER_PLANK::getDefaultState, p))
             .initialProperties(() -> Blocks.SPRUCE_STAIRS)
             .lang("Rubber Stairs")
-            .tag(BlockTags.STAIRS)
+            .tag(BlockTags.STAIRS, BlockTags.MINEABLE_WITH_AXE)
             .blockstate((ctx, prov) -> prov.stairsBlock(ctx.getEntry(), prov.blockTexture(GTBlocks.RUBBER_PLANK.get())))
             .item()
             .tag(ItemTags.STAIRS)


### PR DESCRIPTION
## What
Some rubber blocks such as stairs, wood, stripped wood, and stripped log were not quickly mineable using an axe previously. Added ``#forge:mineable_with_axe`` to them
Also treated wood stairs too oops just checked

## Implementation Details
Added one line to builder for these blocks ``.tag(BlockTags.MINEABLE_WITH_AXE)``

## Outcome
All these blocks are now quickly mineable using an axe