### PR TITLE
Make fisher consume string

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -276,7 +276,7 @@ public class FisherMachine extends TieredEnergyMachine
                 useBait |= tryFillCache(itemStack);
 
             if (useBait)
-                this.baitHandler.extractItem(0, 1, false);
+                this.baitHandler.getStackInSlot(0).shrink(1);
             updateFishingUpdateSubscription();
             progress = -1;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -276,7 +276,7 @@ public class FisherMachine extends TieredEnergyMachine
                 useBait |= tryFillCache(itemStack);
 
             if (useBait)
-                this.baitHandler.getStackInSlot(0).shrink(1);
+                this.baitHandler.storage.extractItem(0, 1, false);
             updateFishingUpdateSubscription();
             progress = -1;
         }


### PR DESCRIPTION
## What
The fisher does not consume string for recipes currently. This PR makes it so it does

## Implementation Details
My knowledge of programming is limited so it only consumes the string at the end of an operation instead of at the start

## Outcome
Consumes string yippee