### PR TITLE
Miscallaneous fixes & tweaks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -1,6 +1,9 @@
 package com.gregtechceu.gtceu.client;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
+import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
+import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
 import com.gregtechceu.gtceu.api.gui.compass.GTCompassUIConfig;
 import com.gregtechceu.gtceu.api.gui.compass.GTRecipeViewCreator;
 import com.gregtechceu.gtceu.api.gui.compass.MultiblockAction;
@@ -18,6 +21,7 @@ import com.lowdragmc.lowdraglib.gui.compass.component.RecipeComponent;
 import net.minecraft.client.renderer.blockentity.HangingSignRenderer;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
 import net.minecraft.client.renderer.entity.ThrownItemRenderer;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.EntityRenderersEvent;
@@ -26,6 +30,9 @@ import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
 /**
  * @author KilaBash
  * @date 2023/7/30
@@ -33,6 +40,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
  */
 @OnlyIn(Dist.CLIENT)
 public class ClientProxy extends CommonProxy {
+
+    public static final BiMap<ResourceLocation, GTOreDefinition> CLIENT_ORE_VEINS = HashBiMap.create();
+    public static final BiMap<ResourceLocation, BedrockFluidDefinition> CLIENT_FLUID_VEINS = HashBiMap.create();
+    public static final BiMap<ResourceLocation, BedrockOreDefinition> CLIENT_BEDROCK_ORE_VEINS = HashBiMap.create();
 
     public ClientProxy() {
         super();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -130,7 +130,7 @@ public class GTOres {
                     .placement(SurfaceIndicatorGenerator.IndicatorPlacement.ABOVE)));
 
     public static final GTOreDefinition SCHEELITE_VEIN = create("scheelite_vein", vein -> vein
-            .clusterSize(UniformInt.of(32, 40)).density(0.7f).weight(20)
+            .clusterSize(UniformInt.of(50, 64)).density(0.7f).weight(20)
             .layer(WorldGenLayers.ENDSTONE)
             .heightRangeUniform(20, 60)
             .biomes(BiomeTags.IS_END)
@@ -185,7 +185,7 @@ public class GTOres {
                     .placement(SurfaceIndicatorGenerator.IndicatorPlacement.ABOVE)));
 
     public static final GTOreDefinition BERYLLIUM_VEIN = create("beryllium_vein", vein -> vein
-            .clusterSize(UniformInt.of(32, 40)).density(0.75f).weight(30)
+            .clusterSize(UniformInt.of(50, 64)).density(0.75f).weight(30)
             .layer(WorldGenLayers.NETHERRACK)
             .heightRangeUniform(5, 30)
             .biomes(BiomeTags.IS_NETHER)
@@ -213,7 +213,7 @@ public class GTOres {
                     .placement(SurfaceIndicatorGenerator.IndicatorPlacement.BELOW)));
 
     public static final GTOreDefinition MANGANESE_VEIN = create("manganese_vein", vein -> vein
-            .clusterSize(UniformInt.of(32, 40)).density(0.75f).weight(20)
+            .clusterSize(UniformInt.of(50, 64)).density(0.75f).weight(20)
             .layer(WorldGenLayers.NETHERRACK)
             .heightRangeUniform(20, 30)
             .biomes(BiomeTags.IS_NETHER)
@@ -467,7 +467,7 @@ public class GTOres {
                     .surfaceRock(GarnetSand)));
 
     public static final GTOreDefinition GARNET_VEIN = create("garnet_vein", vein -> vein
-            .clusterSize(UniformInt.of(32, 40)).density(0.75f).weight(40)
+            .clusterSize(UniformInt.of(50, 64)).density(0.75f).weight(40)
             .layer(WorldGenLayers.STONE)
             .heightRangeUniform(-10, 50)
             .biomes(BiomeTags.IS_OVERWORLD)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -669,7 +669,8 @@ public class GTRecipeTypes {
             .addDataInfo(data -> LocalizationUtils.format("gtceu.recipe.eu_to_start",
                     NumberFormat.getCompactNumberInstance().format(data.getLong("eu_to_start"))));
 
-    public static final GTRecipeType DUMMY_RECIPES = new GTRecipeType(GTCEu.id("dummy"), DUMMY);
+    public static final GTRecipeType DUMMY_RECIPES = register("dummy", DUMMY)
+            .setXEIVisible(false);
 
     //////////////////////////////////////
     // ****** Integration *******//

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncBedrockOreVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncBedrockOreVeins.java
@@ -62,7 +62,9 @@ public class SPacketSyncBedrockOreVeins implements IPacket {
         }
         GTRegistries.BEDROCK_ORE_DEFINITIONS.registry().clear();
         for (var entry : veins.entrySet()) {
-            GTRegistries.BEDROCK_ORE_DEFINITIONS.registerOrOverride(entry.getKey(), entry.getValue());
+            if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.containKey(entry.getKey())) {
+                GTRegistries.BEDROCK_ORE_DEFINITIONS.register(entry.getKey(), entry.getValue());
+            }
         }
         if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
             GTRegistries.BEDROCK_ORE_DEFINITIONS.freeze();

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncBedrockOreVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncBedrockOreVeins.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.common.network.packets;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 
 import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.networking.IHandlerContext;
@@ -57,17 +57,7 @@ public class SPacketSyncBedrockOreVeins implements IPacket {
 
     @Override
     public void execute(IHandlerContext handler) {
-        if (GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
-            GTRegistries.BEDROCK_ORE_DEFINITIONS.unfreeze();
-        }
-        GTRegistries.BEDROCK_ORE_DEFINITIONS.registry().clear();
-        for (var entry : veins.entrySet()) {
-            if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.containKey(entry.getKey())) {
-                GTRegistries.BEDROCK_ORE_DEFINITIONS.register(entry.getKey(), entry.getValue());
-            }
-        }
-        if (!GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
-            GTRegistries.BEDROCK_ORE_DEFINITIONS.freeze();
-        }
+        ClientProxy.CLIENT_BEDROCK_ORE_VEINS.clear();
+        ClientProxy.CLIENT_BEDROCK_ORE_VEINS.putAll(veins);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncFluidVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncFluidVeins.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.common.network.packets;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 
 import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.networking.IHandlerContext;
@@ -57,17 +57,7 @@ public class SPacketSyncFluidVeins implements IPacket {
 
     @Override
     public void execute(IHandlerContext handler) {
-        if (GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
-            GTRegistries.BEDROCK_FLUID_DEFINITIONS.unfreeze();
-        }
-        GTRegistries.BEDROCK_FLUID_DEFINITIONS.registry().clear();
-        for (var entry : veins.entrySet()) {
-            if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.containKey(entry.getKey())) {
-                GTRegistries.BEDROCK_FLUID_DEFINITIONS.register(entry.getKey(), entry.getValue());
-            }
-        }
-        if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
-            GTRegistries.BEDROCK_FLUID_DEFINITIONS.freeze();
-        }
+        ClientProxy.CLIENT_FLUID_VEINS.clear();
+        ClientProxy.CLIENT_FLUID_VEINS.putAll(veins);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncFluidVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncFluidVeins.java
@@ -62,7 +62,9 @@ public class SPacketSyncFluidVeins implements IPacket {
         }
         GTRegistries.BEDROCK_FLUID_DEFINITIONS.registry().clear();
         for (var entry : veins.entrySet()) {
-            GTRegistries.BEDROCK_FLUID_DEFINITIONS.registerOrOverride(entry.getKey(), entry.getValue());
+            if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.containKey(entry.getKey())) {
+                GTRegistries.BEDROCK_FLUID_DEFINITIONS.register(entry.getKey(), entry.getValue());
+            }
         }
         if (!GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
             GTRegistries.BEDROCK_FLUID_DEFINITIONS.freeze();

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncOreVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncOreVeins.java
@@ -60,7 +60,9 @@ public class SPacketSyncOreVeins implements IPacket {
         }
         GTRegistries.ORE_VEINS.registry().clear();
         for (var entry : veins.entrySet()) {
-            GTRegistries.ORE_VEINS.registerOrOverride(entry.getKey(), entry.getValue());
+            if (!GTRegistries.ORE_VEINS.containKey(entry.getKey())) {
+                GTRegistries.ORE_VEINS.register(entry.getKey(), entry.getValue());
+            }
         }
         if (!GTRegistries.ORE_VEINS.isFrozen()) {
             GTRegistries.ORE_VEINS.freeze();

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncOreVeins.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketSyncOreVeins.java
@@ -2,8 +2,9 @@ package com.gregtechceu.gtceu.common.network.packets;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 
+import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.networking.IHandlerContext;
 import com.lowdragmc.lowdraglib.networking.IPacket;
 
@@ -31,7 +32,7 @@ public class SPacketSyncOreVeins implements IPacket {
 
     @Override
     public void encode(FriendlyByteBuf buf) {
-        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, GTRegistries.builtinRegistry());
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
         int size = veins.size();
         buf.writeVarInt(size);
         for (var entry : veins.entrySet()) {
@@ -44,7 +45,7 @@ public class SPacketSyncOreVeins implements IPacket {
 
     @Override
     public void decode(FriendlyByteBuf buf) {
-        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, GTRegistries.builtinRegistry());
+        RegistryOps<Tag> ops = RegistryOps.create(NbtOps.INSTANCE, Platform.getFrozenRegistry());
         Stream.generate(() -> {
             ResourceLocation id = buf.readResourceLocation();
             CompoundTag tag = buf.readAnySizeNbt();
@@ -55,17 +56,7 @@ public class SPacketSyncOreVeins implements IPacket {
 
     @Override
     public void execute(IHandlerContext handler) {
-        if (GTRegistries.ORE_VEINS.isFrozen()) {
-            GTRegistries.ORE_VEINS.unfreeze();
-        }
-        GTRegistries.ORE_VEINS.registry().clear();
-        for (var entry : veins.entrySet()) {
-            if (!GTRegistries.ORE_VEINS.containKey(entry.getKey())) {
-                GTRegistries.ORE_VEINS.register(entry.getKey(), entry.getValue());
-            }
-        }
-        if (!GTRegistries.ORE_VEINS.isFrozen()) {
-            GTRegistries.ORE_VEINS.freeze();
-        }
+        ClientProxy.CLIENT_ORE_VEINS.clear();
+        ClientProxy.CLIENT_ORE_VEINS.putAll(veins);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
@@ -71,9 +71,6 @@ public class GTDynamicDataPack implements PackResources {
         if (ConfigHolder.INSTANCE.dev.dumpRecipes) {
             writeJson(recipeId, "recipes", parent, recipeJson);
         }
-        if (DATA.containsKey(recipeId)) {
-            GTCEu.LOGGER.error("duplicated recipe: {}", recipeId);
-        }
         DATA.put(getRecipeLocation(recipeId), recipeJson.toString().getBytes(StandardCharsets.UTF_8));
         if (recipe.serializeAdvancement() != null) {
             JsonObject advancement = recipe.serializeAdvancement();

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PolarizingRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PolarizingRecipeHandler.java
@@ -39,7 +39,7 @@ public class PolarizingRecipeHandler {
                     .inputItems(polarizingPrefix, material)
                     .outputItems(magneticStack)
                     .duration((int) ((int) material.getMass() * polarizingPrefix.getMaterialAmount(material) / M))
-                    .EUt(8L * getVoltageMultiplier(material))
+                    .EUt(getVoltageMultiplier(material))
                     .save(provider);
 
             VanillaRecipeHelper.addSmeltingRecipe(provider,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -197,7 +197,7 @@ public class VanillaStandardRecipes {
         VanillaRecipeHelper.addShapedRecipe(provider, "glass_pane", new ItemStack(Blocks.GLASS_PANE, 2), "sG", 'G',
                 new ItemStack(Blocks.GLASS));
 
-        CUTTER_RECIPES.recipeBuilder("cut_glass_panes").duration(50).EUt(VA[ULV])
+        CUTTER_RECIPES.recipeBuilder("cut_glass_block_to_plate").duration(50).EUt(VA[ULV])
                 .inputItems(new ItemStack(Blocks.GLASS, 3))
                 .outputItems(new ItemStack(Blocks.GLASS_PANE, 8))
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTOreVeinWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTOreVeinWidget.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
@@ -190,12 +191,12 @@ public class GTOreVeinWidget extends WidgetGroup {
     }
 
     public String getOreName(GTOreDefinition oreDefinition) {
-        ResourceLocation id = GTRegistries.ORE_VEINS.getKey(oreDefinition);
+        ResourceLocation id = ClientProxy.CLIENT_ORE_VEINS.inverse().get(oreDefinition);
         return id.getPath();
     }
 
     public String getFluidName(BedrockFluidDefinition fluid) {
-        ResourceLocation id = GTRegistries.BEDROCK_FLUID_DEFINITIONS.getKey(fluid);
+        ResourceLocation id = ClientProxy.CLIENT_FLUID_VEINS.inverse().get(fluid);
         return id.getPath();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockFluid.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockFluid.java
@@ -1,7 +1,7 @@
 package com.gregtechceu.gtceu.integration.emi.orevein;
 
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
 
 import com.lowdragmc.lowdraglib.emi.ModularEmiRecipe;
@@ -28,6 +28,6 @@ public class GTBedrockFluid extends ModularEmiRecipe<WidgetGroup> {
 
     @Override
     public @Nullable ResourceLocation getId() {
-        return GTRegistries.BEDROCK_FLUID_DEFINITIONS.getKey(fluid);
+        return ClientProxy.CLIENT_FLUID_VEINS.inverse().get(fluid);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockFluidEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockFluidEmiCategory.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.integration.emi.orevein;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 
@@ -21,7 +21,7 @@ public class GTBedrockFluidEmiCategory extends EmiRecipeCategory {
     }
 
     public static void registerDisplays(EmiRegistry registry) {
-        for (BedrockFluidDefinition fluid : GTRegistries.BEDROCK_FLUID_DEFINITIONS) {
+        for (BedrockFluidDefinition fluid : ClientProxy.CLIENT_FLUID_VEINS.values()) {
             registry.addRecipe(new GTBedrockFluid(fluid));
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTEmiOreVein.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTEmiOreVein.java
@@ -1,7 +1,7 @@
 package com.gregtechceu.gtceu.integration.emi.orevein;
 
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
 
 import com.lowdragmc.lowdraglib.emi.ModularEmiRecipe;
@@ -31,7 +31,7 @@ public class GTEmiOreVein extends ModularEmiRecipe<WidgetGroup> {
 
     @Override
     public @Nullable ResourceLocation getId() {
-        return GTRegistries.ORE_VEINS.getKey(oreDefinition);
+        return ClientProxy.CLIENT_ORE_VEINS.inverse().get(oreDefinition);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTOreVeinEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTOreVeinEmiCategory.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.integration.emi.orevein;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.common.data.GTItems;
 
 import net.minecraft.network.chat.Component;
@@ -21,7 +21,7 @@ public class GTOreVeinEmiCategory extends EmiRecipeCategory {
     }
 
     public static void registerDisplays(EmiRegistry registry) {
-        for (GTOreDefinition oreDefinition : GTRegistries.ORE_VEINS) {
+        for (GTOreDefinition oreDefinition : ClientProxy.CLIENT_ORE_VEINS.values()) {
             registry.addRecipe(new GTEmiOreVein(oreDefinition));
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTBedrockFluidInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTBedrockFluidInfoCategory.java
@@ -1,7 +1,7 @@
 package com.gregtechceu.gtceu.integration.jei.orevein;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
@@ -33,7 +33,7 @@ public class GTBedrockFluidInfoCategory extends ModularUIRecipeCategory<GTBedroc
     }
 
     public static void registerRecipes(IRecipeRegistration registry) {
-        registry.addRecipes(RECIPE_TYPE, GTRegistries.BEDROCK_FLUID_DEFINITIONS.values().stream()
+        registry.addRecipes(RECIPE_TYPE, ClientProxy.CLIENT_FLUID_VEINS.values().stream()
                 .map(GTBedrockFluidInfoWrapper::new)
                 .toList());
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTOreVeinInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTOreVeinInfoCategory.java
@@ -3,7 +3,7 @@ package com.gregtechceu.gtceu.integration.jei.orevein;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
@@ -38,7 +38,7 @@ public class GTOreVeinInfoCategory extends ModularUIRecipeCategory<GTOreVeinInfo
     }
 
     public static void registerRecipes(IRecipeRegistration registry) {
-        registry.addRecipes(RECIPE_TYPE, GTRegistries.ORE_VEINS.values().stream()
+        registry.addRecipes(RECIPE_TYPE, ClientProxy.CLIENT_ORE_VEINS.values().stream()
                 .map(GTOreVeinInfoWrapper::new)
                 .toList());
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTBedrockFluidDisplayCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTBedrockFluidDisplayCategory.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.integration.rei.orevein;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
@@ -59,7 +59,7 @@ public class GTBedrockFluidDisplayCategory extends ModularUIDisplayCategory<GTBe
     }
 
     public static void registerDisplays(DisplayRegistry registry) {
-        for (BedrockFluidDefinition fluid : GTRegistries.BEDROCK_FLUID_DEFINITIONS) {
+        for (BedrockFluidDefinition fluid : ClientProxy.CLIENT_FLUID_VEINS.values()) {
             registry.add(new GTBedrockFluidDisplay(fluid));
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTOreVeinDisplayCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTOreVeinDisplayCategory.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.integration.rei.orevein;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.client.ClientProxy;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.integration.GTOreVeinWidget;
 
@@ -59,7 +59,7 @@ public class GTOreVeinDisplayCategory extends ModularUIDisplayCategory<GTOreVein
     }
 
     public static void registerDisplays(DisplayRegistry registry) {
-        for (GTOreDefinition oreDefinition : GTRegistries.ORE_VEINS) {
+        for (GTOreDefinition oreDefinition : ClientProxy.CLIENT_ORE_VEINS.values()) {
             registry.add(new GTOreVeinDisplay(oreDefinition));
         }
     }


### PR DESCRIPTION
## What
- fixed the glass pane cutter recipe conflict
fixes #1718 
- fixed polarizer using 8x as much EU as intended
- made all small dike veins larger, like I did to the lapis vein
- fixed the fluid drill sometimes crashing on world load
fixes #1717 
- fixed bedrock fluid veins disappearing in singleplayer

## Implementation Details
glass pane issue fix is using the same recipe id as the wrong recipe, thus overwriting the bad one.
fluid drill issue was fixed by registering the DUMMY recipe type & then hiding it from recipe viewers.
client now holds it's vein lists separate of the server.

## Outcome
less issues?