### PR TITLE
Remove duplicate glass recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -388,12 +388,6 @@ public class MiscRecipeLoader {
                     .save(provider);
         }
 
-        // Glass Fluid Extraction
-        EXTRACTOR_RECIPES.recipeBuilder("extract_glass_block")
-                .inputItems(new ItemStack(Blocks.GLASS))
-                .outputFluids(Glass.getFluid(L))
-                .duration(20).EUt(30).save(provider);
-
         // Glass Plate in Alloy Smelter
         ALLOY_SMELTER_RECIPES.recipeBuilder("glass_plate")
                 .inputItems(dust, Glass, 2)


### PR DESCRIPTION
## What
There are two duplicate extractor recipes for liquid glass at the moment, ``extract_glass`` (which I assume is an autogen recipe) and ``extract_glass_block`` (which I have removed)

## Outcome
Removed ``gtceu:extractor/extract_glass_block``

## Potential Compatibility Issues
See above