### PR TITLE
Fix respawn anchor recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1315,7 +1315,7 @@ public class RecipeAddition {
 
             VanillaRecipeHelper.addShapedRecipe(provider, "respawn_anchor", new ItemStack(Items.RESPAWN_ANCHOR), "CCC",
                     "GGG", "CCC",
-                    'L', new ItemStack(Items.CRYING_OBSIDIAN),
+                    'C', new ItemStack(Items.CRYING_OBSIDIAN),
                     'G', new UnificationEntry(plate, Glowstone));
 
             ASSEMBLER_RECIPES.recipeBuilder("respawn_anchor")


### PR DESCRIPTION
Oops forgot to change symbol for crying obsidian in respawn anchor recipe

Changed it from L to C like it is in the recipe