### PR TITLE
Fix solar boiler in JAVD void dimension

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -72,6 +72,10 @@ dependencies {
     modCompileOnly("maven.modrinth:embeddium:0.3.19+mc1.20.1")
     modCompileOnly("maven.modrinth:oculus:1.20.1-1.7.0")
 
+    // JAVD
+    modImplementation(forge.javd) { transitive = false }
+    modRuntimeOnly("curse.maven:trenzalore-870210:4848244")
+
     // Runtime only testing mods
     //modRuntimeOnly(forge.worldStripper)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,7 @@ dependencyResolutionManagement {
         def topForgeVersion = "1.20.1-10.0.1-3"
         def jadeForgeVersion = "11.6.3"
         def worldStripperForgeFile = "4578579"
+        def javdVersion = "4803995"
 
         // Libs
         def quiltMappingsVersion = "5"  // https://lambdaurora.dev/tools/import_quilt.html
@@ -105,6 +106,9 @@ dependencyResolutionManagement {
 
             def au = version("au", auVersion)
             library("almostUnified-forge", "com.almostreliable.mods", "almostunified-forge").versionRef(au)
+
+            def javd = version("javd", javdVersion)
+            library("javd", "curse.maven", "javd-370890").versionRef(javd)
         }
 
         libs {

--- a/src/main/java/com/gregtechceu/gtceu/GTCEu.java
+++ b/src/main/java/com/gregtechceu/gtceu/GTCEu.java
@@ -82,6 +82,10 @@ public class GTCEu {
         return LDLib.isModLoaded(GTValues.MODID_SHIMMER);
     }
 
+    public static boolean isJAVDLoaded() {
+        return LDLib.isModLoaded(GTValues.MODID_JAVD);
+    }
+
     @Deprecated(forRemoval = true, since = "1.0.21")
     public static boolean isHighTier() {
         return GTCEuAPI.isHighTier();

--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -114,7 +114,8 @@ public class GTValues {
             MODID_ALMOSTUNIFIED = "almostunified",
             MODID_CURIOS = "curios",
             MODID_AE2WTLIB = "ae2wtlib",
-            MODID_SHIMMER = "shimmer";
+            MODID_SHIMMER = "shimmer",
+            MODID_JAVD = "javd";
 
     /**
      * Spray painting compat modids

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -16,11 +16,13 @@ import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 import com.lowdragmc.lowdraglib.side.fluid.FluidTransferHelper;
 import com.lowdragmc.lowdraglib.side.fluid.IFluidTransfer;
 
+import com.unrealdinnerbone.javd.JAVDRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
@@ -441,7 +443,11 @@ public class GTUtil {
             return false;
         }
 
-        return world.isDay();
+        ResourceLocation javdVoidBiome = new ResourceLocation("javd", "void");
+        if (GTCEu.isJAVDLoaded() && world.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome).equals(javdVoidBiome)) {
+            GTCEu.LOGGER.info("JAVD biome detected");
+            return !world.isDay();
+        } else return world.isDay();
     }
 
     public static void appendHazardTooltips(Material material, List<Component> tooltipComponents) {

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -445,7 +445,6 @@ public class GTUtil {
 
         ResourceLocation javdVoidBiome = new ResourceLocation("javd", "void");
         if (GTCEu.isJAVDLoaded() && world.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome).equals(javdVoidBiome)) {
-            GTCEu.LOGGER.info("JAVD biome detected");
             return !world.isDay();
         } else return world.isDay();
     }

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -16,7 +16,6 @@ import com.lowdragmc.lowdraglib.side.fluid.FluidStack;
 import com.lowdragmc.lowdraglib.side.fluid.FluidTransferHelper;
 import com.lowdragmc.lowdraglib.side.fluid.IFluidTransfer;
 
-import com.unrealdinnerbone.javd.JAVDRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -444,7 +443,8 @@ public class GTUtil {
         }
 
         ResourceLocation javdVoidBiome = new ResourceLocation("javd", "void");
-        if (GTCEu.isJAVDLoaded() && world.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome).equals(javdVoidBiome)) {
+        if (GTCEu.isJAVDLoaded() &&
+                world.registryAccess().registryOrThrow(Registries.BIOME).getKey(biome).equals(javdVoidBiome)) {
             return !world.isDay();
         } else return world.isDay();
     }


### PR DESCRIPTION
## What
JAVD's dimension are technically permanight because they don't have a day/night cycle (despite it always being day), so the boiler logic doesn't work there
Monifactory uses JAVD so I thought I'd PR a fix for it  

## Implementation Details
Adds a condition that checks if the biome is JAVD void (not the same as vanilla void)
Also adds JAVD as ``modImplementation`` and Trenzalore as ``compileOnly`` to dependencies

## Outcome
Solar boilers work in JAVD's dimension now

## Potential Compatibility Issues
Hopefully none, testing it myself didn't reveal anything to be broken