### PR TITLE
start publishing SNAPSHOT versions to the maven

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+
+  exclude:
+    labels:
+      - "1.21"
+      - "ignore changelog"
+
+  categories:
+    - title: New Features
+      labels:
+        - "type: feature"
+
+    - title: Bug Fixes
+      labels:
+        - "type: bug"
+
+    - title: Internal Changes
+      labels:
+        - "type: refactor"
+
+    - title: Translation Changes
+      labels:
+        - "type: translation"
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -9,8 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GITHUB_ACTION_NUMBER: ${{ vars.GITHUB_RUN_NUMBER }}
-      GITHUB_RUN_NUMBER: ${{ vars.GITHUB_RUN_NUMBER }}
+      MAVEN_PASS: ${{ secrets.MAVEN_PASS }}
+      MAVEN_USER: ${{ secrets.MAVEN_USER }}
+      SNAPSHOT: true
     permissions:
       contents: write
     steps:
@@ -26,17 +27,22 @@ jobs:
         with:
           arguments: build
 
+      - name: Publish to Maven
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publish
+
       - name: Get Version
         id: var
         run: |
-          MESSAGE=$(ls build/libs/* | grep sources.jar -v | grep shadow.jar -v | grep slim.jar -v | awk -F 'gtceu-|.jar' '{print $2}')
+          MESSAGE=$(ls build/libs/* | grep sources.jar -v | grep shadow.jar -v | grep slim.jar -v | awk -F 'gtceu-|-SNAPSHOT.jar' '{print $2}')
           echo "version=$MESSAGE" >> $GITHUB_OUTPUT
 
       - name: Release
         id: release
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
-          github-tag: ${{ steps.var.outputs.version }}
+          github-tag: ${{ steps.var.outputs.version }}-build_${{ vars.GITHUB_RUN_NUMBER }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             build/libs/!(*-@(dev|sources|javadoc)).jar

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -3,6 +3,10 @@ name: Auto Publish, Releasing
 on:
   workflow_dispatch:
     inputs:
+      lastReleaseTag:
+        description: 'tag of the last full release.'
+        required: true
+        type: string
       releaseType:
         description: 'release type'
         required: true
@@ -29,6 +33,8 @@ jobs:
     env:
       MAVEN_PASS: ${{ secrets.MAVEN_PASS }}
       MAVEN_USER: ${{ secrets.MAVEN_USER }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,10 +66,21 @@ jobs:
           MESSAGE=$(ls build/libs/* | grep sources.jar -v | grep shadow.jar -v | grep slim.jar -v | awk -F 'gtceu-|.jar' '{print $2}')
           echo version=$MESSAGE >> $GITHUB_OUTPUT
 
+      - name: Update CHANGELOG
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fromTag: ${{ github.ref_name }}
+          toTag: ${{ inputs.lastReleaseTag }}
+
       - if: ${{ inputs.publishCurseForgeAndModrinth }}
         name: mc-publish-forge
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
+          github-tag: ${{ steps.var.outputs.version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
           # Only include this section if you wish to publish
           # your assets on Modrinth.
           modrinth-id: 7tG215v7

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -8,7 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GITHUB_ACTION_NUMBER: ${{ vars.GITHUB_RUN_NUMBER }}
       GITHUB_RUN_NUMBER: ${{ vars.GITHUB_RUN_NUMBER }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-gradle-cache.yml
+++ b/.github/workflows/update-gradle-cache.yml
@@ -1,0 +1,30 @@
+# Updates the Gradle Cache when necessary
+name: Update Gradle Cache
+
+on:
+  push:
+    branches:
+      - master
+    paths: ['gradle/**', '**.gradle', 'gradle.properties', 'gradlew**', 'src/main/resources/accesstransformer.cfg']
+  workflow_dispatch:
+
+concurrency:
+  group: gradle-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-cache:
+    name: Update Grade Cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Build
+        uses: ./.github/actions/build_setup
+        with:
+          update-cache: true
+
+      - name: Build Project with Gradle
+        run: ./gradlew assemble --warning-mode all --build-cache

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,10 @@ tasks.register('remapSlimJar', RemapJarTask) {
 
 group = maven_group
 
-// Formats the mod version to include the loader, Minecraft version, and build number (if present)
-String buildNumber = System.getenv("GITHUB_ACTION_NUMBER")
-version = "${mod_version}" + (buildNumber != null ? "-build_${System.getenv("GITHUB_RUN_NUMBER")}" : "")
+// Formats the mod version to include the loader, Minecraft version, build number (if present), and '-SNAPSHOT-<timestamp>' if enabled.
+boolean isSnapshot = System.getenv("SNAPSHOT")
+String buildNumber = System.getenv("GITHUB_RUN_NUMBER")
+version = "${mod_version}" + (buildNumber != null ? "-build_${buildNumber}" : "") + (isSnapshot ? "-SNAPSHOT" : "")
 
 apply from: "$rootDir/gradle/scripts/architectury_loom.gradle"
 apply from: "$rootDir/gradle/scripts/capabilities.gradle"


### PR DESCRIPTION


## What
publish a SNAPSHOT version (with a timestamp) to the maven every time a PR is merged, for easier testing of addons.
also made CHANGELOG be autogenerated.

## Implementation Details
added a suffix `-SNAPSHOT` to the version if it's an autobuild. gradle handles the rest.

## Outcome
addons will have an easier time testing new versions before they release
also better changelog

## Additional Information
REMEMBER TO ADD LABELS TO YOUR PRS AFTER THIS SO CHANGELOG WORKS