### PR TITLE
fix bedrock veins that have been removed crashing the game

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockore/OreVeinWorldEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/bedrockore/OreVeinWorldEntry.java
@@ -47,7 +47,7 @@ public class OreVeinWorldEntry {
         var tag = new CompoundTag();
         tag.putInt("oreYield", oreYield);
         tag.putInt("operationsRemaining", operationsRemaining);
-        if (definition != null) {
+        if (definition != null && GTRegistries.BEDROCK_ORE_DEFINITIONS.getKey(definition) != null) {
             tag.putString("vein", GTRegistries.BEDROCK_ORE_DEFINITIONS.getKey(definition).toString());
         }
         return tag;


### PR DESCRIPTION
## What
instead of disappearing
fixes #1339 

## Implementation Details
added a null check that the fluid veins had

## Outcome
no crash?