### PR TITLE
Fixing CircuitInventory for buffers again. Please no one else change …

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -108,11 +108,11 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
     @DescSynced // Maybe an Expansion Option in the future? a bit redundant for rn. Maybe Packdevs want to add their own
                 // version.
     private final ItemStackTransfer patternInventory = new ItemStackTransfer(MAX_PATTERN_COUNT);
-    //DO NOT remove this and use a default circuitInventory. It will cause the circuit inventory to vanish entirely and crash clients as well as cause unintended behaviors.
+    // DO NOT remove this and use a default circuitInventory. It will cause the circuit inventory to vanish entirely and
+    // crash clients as well as cause unintended behaviors.
     @Getter
     @Persisted
     protected final NotifiableItemStackHandler circuitInventorySimulated;
-
 
     @Getter
     @Persisted


### PR DESCRIPTION
If someone else changes this method again I will gnaw at your ankles.
using the super circuitInventory causes nasty behaviors that crashes the buffer hatch