### PR TITLE
MEPatternBufferPartMachine fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AETextInputButtonWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AETextInputButtonWidget.java
@@ -84,7 +84,7 @@ public class AETextInputButtonWidget extends WidgetGroup {
                 })
                 .setTexture(
                         new GuiTextureGroup(GuiTextures.VANILLA_BUTTON, new TextTexture("✎")),
-                        new GuiTextureGroup(GuiTextures.VANILLA_BUTTON, new TextTexture("✎")))
+                        new GuiTextureGroup(GuiTextures.VANILLA_BUTTON, new TextTexture("✔")))
                 .setHoverTooltips(hoverTexts));
         this.addWidget(textField);
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -397,7 +397,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
             } else {
                 return new PatternContainerGroup(
                         AEItemKey.of(GTAEMachines.ME_PATTERN_BUFFER.getItem()),
-                        Component.literal(customName),
+                        GTAEMachines.ME_PATTERN_BUFFER.get().getDefinition().getItem().getDescription(),
                         Collections.emptyList());
             }
         }


### PR DESCRIPTION
## What
fix pattern group name when not have controller and customName, use PATTERN_BUFFER name.
let set custom name button with confirm texture, Let users to better understand how to use it.

## Additional Information
![image](https://github.com/user-attachments/assets/43ec6af1-f08b-4523-9e5c-38302021fd7b)
![image](https://github.com/user-attachments/assets/82b54071-0e5d-46a8-8efd-c7ba17b10d49)
