### PR TITLE
fix output fluid slots accepting manual input

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -335,7 +335,7 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
                 tank.setFluidTank(new OverlayingFluidStorage(fluidTransfer, index));
             }
             tank.setIngredientIO(io == IO.IN ? IngredientIO.INPUT : IngredientIO.OUTPUT);
-            tank.setAllowClickFilled(!isXEI);
+            tank.setAllowClickFilled(!isXEI && io.support(IO.IN));
             tank.setAllowClickDrained(!isXEI);
             if (content != null) {
                 tank.setXEIChance((float) content.chance / content.maxChance);


### PR DESCRIPTION
I forgot to push this :waaGONE:

## What
fixes output fluid slots accepting manual input

## Implementation Details
half a line

## Outcome
output fluid slots in singleblock machines no longer accept fluids from buckets/drums/etc.