### PR TITLE
wrap Jade AE2 compatibility providers in a mod loaded check

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.jade;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.common.blockentity.FluidPipeBlockEntity;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.integration.jade.provider.*;
@@ -39,8 +40,10 @@ public class GTJadePlugin implements IWailaPlugin {
         registration.registerBlockDataProvider(new HazardCleanerBlockProvider(), BlockEntity.class);
         registration.registerBlockDataProvider(new TransformerBlockProvider(), BlockEntity.class);
         registration.registerBlockDataProvider(new PrimitivePumpBlockProvider(), BlockEntity.class);
-        registration.registerBlockDataProvider(new MEPatternBufferProxyProvider(), BlockEntity.class);
-        registration.registerBlockDataProvider(new MEPatternBufferProvider(), BlockEntity.class);
+        if (GTCEu.isAE2Loaded()) {
+            registration.registerBlockDataProvider(new MEPatternBufferProxyProvider(), BlockEntity.class);
+            registration.registerBlockDataProvider(new MEPatternBufferProvider(), BlockEntity.class);
+        }
 
         registration.registerFluidStorage(FluidPipeStorageProvider.INSTANCE, FluidPipeBlockEntity.class);
     }
@@ -63,8 +66,10 @@ public class GTJadePlugin implements IWailaPlugin {
         registration.registerBlockComponent(new HazardCleanerBlockProvider(), Block.class);
         registration.registerBlockComponent(new TransformerBlockProvider(), Block.class);
         registration.registerBlockComponent(new PrimitivePumpBlockProvider(), Block.class);
-        registration.registerBlockComponent(new MEPatternBufferProxyProvider(), Block.class);
-        registration.registerBlockComponent(new MEPatternBufferProvider(), Block.class);
+        if (GTCEu.isAE2Loaded()) {
+            registration.registerBlockComponent(new MEPatternBufferProxyProvider(), Block.class);
+            registration.registerBlockComponent(new MEPatternBufferProvider(), Block.class);
+        }
 
         registration.registerFluidStorageClient(FluidPipeStorageProvider.INSTANCE);
     }


### PR DESCRIPTION
## What
add a mod load check before registering AE2 compatibility-related providers to Jade.

## Outcome
fixes #1779