### PR TITLE
Remove the dual output hatch from the ME buffer recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
@@ -602,7 +602,6 @@ public class MetaTileEntityMachineRecipeLoader {
 
             ASSEMBLY_LINE_RECIPES.recipeBuilder("me_pattern_buffer")
                     .inputItems(DUAL_IMPORT_HATCH[LuV], 1)
-                    .inputItems(DUAL_EXPORT_HATCH[LuV], 1)
                     .inputItems(EMITTER_LuV, 1)
                     .inputItems(CustomTags.LuV_CIRCUITS, 4)
                     .inputItems(AEBlocks.PATTERN_PROVIDER.asItem(), 3)


### PR DESCRIPTION
## What
The ME Pattern buffer doesn't handle outputs anymore.

## Outcome
A recipe that makes more sense

## Potential Compatibility Issues
Not that I know of, other than players having to remake a pattern.