### PR TITLE
Fixed Jade integration for Research Station Computation recipes

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2835,7 +2835,7 @@
   "gtceu.item_pipe.priority": "%dɟ§ :ʎʇıɹoıɹԀ6§",
   "gtceu.jade.cleaned_this_second": "s/%s :pɹɐzɐɥ pǝuɐǝןƆ",
   "gtceu.jade.energy_stored": "∩Ǝ %d / %d",
-  "gtceu.jade.progress_computation": "%s / %s :uoıʇɐʇndɯoƆ",
+  "gtceu.jade.progress_computation": "∩MƆ %s / %s",
   "gtceu.jade.progress_sec": "s %s / %s",
   "gtceu.jade.progress_tick": "ʇ %s / %s",
   "gtceu.jei.bedrock_fluid.heavy_oil_deposit": "ʇısodǝᗡ ןıO ʎʌɐǝH",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2835,7 +2835,7 @@
   "gtceu.item_pipe.priority": "§9Priority: §f%d",
   "gtceu.jade.cleaned_this_second": "Cleaned hazard: %s/s",
   "gtceu.jade.energy_stored": "%d / %d EU",
-  "gtceu.jade.progress_computation": "Computation: %s / %s",
+  "gtceu.jade.progress_computation": "%s / %s CWU",
   "gtceu.jade.progress_sec": "%s / %s s",
   "gtceu.jade.progress_tick": "%s / %s t",
   "gtceu.jei.bedrock_fluid.heavy_oil_deposit": "Heavy Oil Deposit",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -86,7 +86,7 @@ public class IntegrationLang {
         provider.add("gtceu.top.proxies_bound", "Buffer Proxies Bound: %s");
 
         provider.add("gtceu.jade.energy_stored", "%d / %d EU");
-        provider.add("gtceu.jade.progress_computation", "Computation: %s / %s");
+        provider.add("gtceu.jade.progress_computation", "%s / %s CWU");
         provider.add("gtceu.jade.progress_sec", "%s / %s s");
         provider.add("gtceu.jade.progress_tick", "%s / %s t");
         provider.add("gtceu.jade.cleaned_this_second", "Cleaned hazard: %s/s");


### PR DESCRIPTION
## What
The Research Station currently shows its work progress as time and not computation.

## Implementation Details
The client-side block entity does not store the correct `RecipeLogic` object, which is how the [check is currently made](https://github.com/GregTechCEu/GregTech-Modern/blob/cbd624bc1db76afc991a7cf7fb7e36c4747f482b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/WorkableBlockProvider.java#L54). Instead we need to check if the block is a Research Station on the server side and add a flag to server data.

Also, added new lang to shorten the text length and made it so that computation numbers are compacted.

## Outcome
Jade Integration now treats the `currentProgress` and `maxProgress` values for the Research Station as computation numbers rather than work time.

## Additional Information
![image](https://github.com/user-attachments/assets/2fe566b0-dd39-4530-b01a-51012a85fbea)