### PR TITLE
Revert "Fixes RHF from using incorrect EU rates"

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCyMMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCyMMachines.java
@@ -796,8 +796,7 @@ public class GCyMMachines {
                     Component.translatable("gtceu.electric_blast_furnace")))
             .rotationState(RotationState.ALL)
             .recipeType(BLAST_RECIPES)
-            .recipeModifiers(GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.SUBTICK_PARALLEL,
-                    GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.NON_PERFECT_OVERCLOCK),
+            .recipeModifiers(GTRecipeModifiers.SUBTICK_PARALLEL, GTRecipeModifiers.PARALLEL_HATCH,
                     GTRecipeModifiers::ebfOverclock)
             .appearanceBlock(CASING_HIGH_TEMPERATURE_SMELTING)
             .pattern(definition -> {


### PR DESCRIPTION
Actually just breaks the RHF more, seems the issue is arising directly from the EBFCoilOC