### PR TITLE
Removal of Subtick from RHF

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCyMMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCyMMachines.java
@@ -796,9 +796,7 @@ public class GCyMMachines {
                     Component.translatable("gtceu.electric_blast_furnace")))
             .rotationState(RotationState.ALL)
             .recipeType(BLAST_RECIPES)
-            .recipeModifiers(GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.SUBTICK_PARALLEL,
-                    GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.NON_PERFECT_OVERCLOCK),
-                    GTRecipeModifiers::ebfOverclock)
+            .recipeModifiers(GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers::ebfOverclock)
             .appearanceBlock(CASING_HIGH_TEMPERATURE_SMELTING)
             .pattern(definition -> {
                 TraceabilityPredicate casing = blocks(CASING_HIGH_TEMPERATURE_SMELTING.get()).setMinGlobalLimited(360);


### PR DESCRIPTION
RHF was never meant to subtick. this caused some weird recipe behavior due to how heating OC's worked