### PR TITLE
fix ingredient cache growing out of control

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
@@ -446,7 +446,7 @@ public class GTRecipeLookup {
                     }
                     List<Object> compressed = cap.compressIngredients(handler.getContents());
                     for (Object content : compressed) {
-                        retrieveCachedIngredient(list, cap.convertToMapIngredient(content), ingredientRoot);
+                        list.add(cap.convertToMapIngredient(content));
                     }
                 }
             }


### PR DESCRIPTION
## What
fixes immense lag from keeping a server online for long periods of time

## Implementation Details
only the recipe tree's ingredients should be cached, oops!

## Outcome
way less lag