### PR TITLE
XEI-Cleanups

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -124,13 +124,10 @@ public class GTRecipeWidget extends WidgetGroup {
             capability.getKey().addXEIInfo(this, xOffset, recipe, capability.getValue(), true, false, yOff);
         }
 
-        yOffset = yOff.getValue();
         for (RecipeCondition condition : recipe.conditions) {
             if (condition.getTooltips() == null) continue;
             if (condition instanceof DimensionCondition dimCondition) {
-                addWidget(new LabelWidget(3 - xOffset, yOffset += LINE_HEIGHT + 4,
-                        Component.translatable("recipe.condition.dimension_marker.tooltip")));
-                addWidget(dimCondition.setupDimensionMarkers(53 - xOffset, yOffset - 4)
+                addWidget(dimCondition.setupDimensionMarkers(recipe.recipeType.getRecipeUI().getJEISize().width - xOffset - 44, recipe.recipeType.getRecipeUI().getJEISize().height - 32)
                         .setBackgroundTexture(IGuiTexture.EMPTY));
             } else addWidget(new LabelWidget(3 - xOffset, yOffset += LINE_HEIGHT, condition.getTooltips().getString()));
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -127,7 +127,9 @@ public class GTRecipeWidget extends WidgetGroup {
         for (RecipeCondition condition : recipe.conditions) {
             if (condition.getTooltips() == null) continue;
             if (condition instanceof DimensionCondition dimCondition) {
-                addWidget(dimCondition.setupDimensionMarkers(recipe.recipeType.getRecipeUI().getJEISize().width - xOffset - 44, recipe.recipeType.getRecipeUI().getJEISize().height - 32)
+                addWidget(dimCondition
+                        .setupDimensionMarkers(recipe.recipeType.getRecipeUI().getJEISize().width - xOffset - 44,
+                                recipe.recipeType.getRecipeUI().getJEISize().height - 32)
                         .setBackgroundTexture(IGuiTexture.EMPTY));
             } else addWidget(new LabelWidget(3 - xOffset, yOffset += LINE_HEIGHT, condition.getTooltips().getString()));
         }


### PR DESCRIPTION
The planet display for dimensions was extremely prone to fly off most recipes and then get rendered under the next recipe.

This moves the planet  Icon closer to the Overclock button, it is deliberately locked to a particular place to avoid overlapping the one instance a coil widget is shown.