### PR TITLE
Desaturate the Titanium Material

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -839,7 +839,7 @@ public class ElementMaterials {
 
         Titanium = new Material.Builder(GTCEu.id("titanium")) // todo Ore? Look at EBF recipe here if we do Ti ores
                 .ingot(3).fluid()
-                .color(0xee3be8).secondaryColor(0xff64bc).iconSet(METALLIC)
+                .color(0xed8eea).secondaryColor(0xff64bc).iconSet(METALLIC)
                 .appendFlags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_GEAR, GENERATE_FRAME)
                 .element(GTElements.Ti)
                 .toolStats(ToolProperty.Builder.of(8.0F, 6.0F, 1536, 3)


### PR DESCRIPTION
As it says on the tin, made it closer to the casing coloring.
It's still slightly more saturated than the casing but that's fine, casings should have some color fading due to being heavily worked as a block in production (to some degree).
If complaints still arise in discrepancies I will go and recolor everything titanium related that needs it.