### PR TITLE
Decrease cost for crafting facade cover.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/FacadeCoverRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/FacadeCoverRecipe.java
@@ -81,6 +81,7 @@ public class FacadeCoverRecipe implements CraftingRecipe {
             if (item.isEmpty()) continue;
             if (FacadeItemBehaviour.isValidFacade(item)) {
                 FacadeItemBehaviour.setFacadeStack(itemStack, item);
+                itemStack.setCount(6);
                 break;
             }
         }


### PR DESCRIPTION
## What
It is too expensive to craft **only one**   facade cover  with one full block plus three iron plates. For GTCEu, one full block plus one plate can make 4 facade cover.

## Outcome
Now it makes 6 facade cover.