### PR TITLE
Fixed bedrock ore miner not overclocking

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
@@ -2,16 +2,21 @@ package com.gregtechceu.gtceu.common.machine.multiblock.electric;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.capability.IEnergyContainer;
+import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
+import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.machine.trait.BedrockOreMinerLogic;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -56,7 +61,11 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
     }
 
     public int getEnergyTier() {
-        return Math.min(this.tier + 1, Math.max(this.tier, getOverclockTier()));
+        var energyContainer = this.getCapabilitiesProxy().get(IO.IN, EURecipeCapability.CAP);
+        if (energyContainer == null) return this.tier;
+        var energyCont = new EnergyContainerList(energyContainer.stream().filter(IEnergyContainer.class::isInstance)
+                .map(IEnergyContainer.class::cast).toList());
+        return Math.min(this.tier + 1, Math.max(this.tier, GTUtil.getFloorTierByVoltage(energyCont.getInputVoltage())));
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes bedrock ore miner being unable to overclock

## Implementation Details
Used the getEnergyTier implementation from the Fluid Drilling rig to fix this issue, as that overclocks properly

## Outcome
Allows bedrock ore miner to overclock to IV

## Additional Information
Fixes #1323 

## Potential Compatibility Issues
Shouldn't cause compatibility issues