### PR TITLE
add research methods to GTRecipeTypeBuilder

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
@@ -41,6 +41,7 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
     private transient final Byte2ObjectMap<IGuiTexture> slotOverlays;
     @Nullable
     protected SoundEntry sound;
+    protected boolean hasResearchSlot;
     protected int maxTooltips;
     protected boolean isFuelRecipeType;
 
@@ -59,6 +60,7 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         steamMoveType = ProgressTexture.FillDirection.LEFT_TO_RIGHT;
         slotOverlays = new Byte2ObjectArrayMap<>();
         this.sound = null;
+        this.hasResearchSlot = false;
         this.maxTooltips = 3;
         this.isFuelRecipeType = false;
         this.smallRecipeMap = null;
@@ -133,6 +135,11 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         return this;
     }
 
+    public GTRecipeTypeBuilder setHasResearchSlot(boolean hasResearchSlot) {
+        this.hasResearchSlot = hasResearchSlot;
+        return this;
+    }
+
     public GTRecipeTypeBuilder setMaxTooltips(int maxTooltips) {
         this.maxTooltips = maxTooltips;
         return this;
@@ -168,6 +175,7 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         type.getRecipeUI().setSteamProgressBarTexture(steamProgressBarTexture);
         type.getRecipeUI().setSteamMoveType(steamMoveType);
         type.setSound(sound);
+        type.setHasResearchSlot(hasResearchSlot);
         type.setMaxTooltips(maxTooltips);
         type.setFuelRecipeType(isFuelRecipeType);
         type.setSmallRecipeMap(smallRecipeMap);


### PR DESCRIPTION
## What
Adds `setHasResearchSlot()` to KubeJS Recipe Type Builder, allowing non-Assembly Line recipes to use the research system. However it does not auto generate the scanner/research station recipes.

##Implementation Details
Copies the code for adding a research slot from `GTRecipeType.java` to `GTRecipeTypeBuilder.java`.

## Outcome
Closes: #1518 

## Potential Compatibility Issues
There shouldn't be any issues as this is just adding another capability onto the KubeJS recipe type builder