### PR TITLE
remove "equality jank" from item ingredients as well

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/MapItemTagIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/MapItemTagIngredient.java
@@ -21,10 +21,6 @@ public class MapItemTagIngredient extends AbstractMapIngredient {
         if (super.equals(obj)) {
             return tag == ((MapItemTagIngredient) obj).tag;
         }
-        // equality jank
-        if (obj instanceof MapItemStackIngredient ingredient) {
-            return ingredient.stack.is(tag);
-        }
         return false;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/ItemStackHashStrategy.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/ItemStackHashStrategy.java
@@ -44,13 +44,6 @@ public interface ItemStackHashStrategy extends Hash.Strategy<ItemStack> {
                 .build();
     }
 
-    static ItemStackHashStrategy comparingItemTagCount() {
-        return builder().compareItem(true)
-                .compareTag(true)
-                .compareCount(true)
-                .build();
-    }
-
     /**
      * Builder pattern class for generating customized ItemStackHashStrategy
      */


### PR DESCRIPTION
## What
fixes a bug with machines sometimes
copy of #1142 for items

## Implementation Details
removed 4 lines

## Outcome
no more circuit recipes not working I hope