### PR TITLE
Fixed research recipes showing incorrect max EU

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -191,7 +191,7 @@ public class GTRecipeWidget extends WidgetGroup {
             // sadly we still need a custom override here, since computation uses duration and EU/t very differently
             if (recipe.data.getBoolean("duration_is_total_cwu") &&
                     recipe.tickInputs.containsKey(CWURecipeCapability.CAP)) {
-                int minimumCWUt = Math.min(recipe.tickInputs.get(CWURecipeCapability.CAP).stream()
+                int minimumCWUt = Math.max(recipe.tickInputs.get(CWURecipeCapability.CAP).stream()
                         .map(Content::getContent).mapToInt(CWURecipeCapability.CAP::of).sum(), 1);
                 texts.add(Component.translatable("gtceu.recipe.max_eu",
                         FormattingUtil.formatNumbers(euTotal / minimumCWUt)));


### PR DESCRIPTION
## What
Fixes #1842 

## Implementation Details
`Math.min` was used instead of `Math.max` so the "EUtotal" was always being divided by 1. I presume this math operation is here to act as a default value in the edge case where the min CWUt ended up as 0 or negative.  Changing it to `max` fixes this behavior.

## Outcome
Max EU used is shown correctly