### PR TITLE
Change Maintenance Hatch recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
@@ -431,7 +431,7 @@ public class MetaTileEntityMachineRecipeLoader {
 
         ASSEMBLER_RECIPES.recipeBuilder("maintenance_hatch")
                 .inputItems(HULL[LV])
-                .circuitMeta(1)
+                .circuitMeta(8)
                 .outputItems(MAINTENANCE_HATCH)
                 .duration(100).EUt(VA[LV]).save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -191,7 +191,7 @@ public class GTRecipeWidget extends WidgetGroup {
             // sadly we still need a custom override here, since computation uses duration and EU/t very differently
             if (recipe.data.getBoolean("duration_is_total_cwu") &&
                     recipe.tickInputs.containsKey(CWURecipeCapability.CAP)) {
-                int minimumCWUt = Math.min(recipe.tickInputs.get(CWURecipeCapability.CAP).stream()
+                int minimumCWUt = Math.max(recipe.tickInputs.get(CWURecipeCapability.CAP).stream()
                         .map(Content::getContent).mapToInt(CWURecipeCapability.CAP::of).sum(), 1);
                 texts.add(Component.translatable("gtceu.recipe.max_eu",
                         FormattingUtil.formatNumbers(euTotal / minimumCWUt)));


### PR DESCRIPTION
## What
Fixes #1854 

## Implementation Details
Change Maintenance hatch recipes circuit to `8` to match 1.12 and fix overlap in recipes

## Outcome
Fixed
