### PR TITLE
Change Maintenance Hatch Recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
@@ -431,7 +431,7 @@ public class MetaTileEntityMachineRecipeLoader {
 
         ASSEMBLER_RECIPES.recipeBuilder("maintenance_hatch")
                 .inputItems(HULL[LV])
-                .circuitMeta(1)
+                .circuitMeta(8)
                 .outputItems(MAINTENANCE_HATCH)
                 .duration(100).EUt(VA[LV]).save(provider);
 


### PR DESCRIPTION
## What
Fixes #1854  (:Clueless:)

## Implementation Details
Change Maintenance hatch recipes circuit to `8` to match 1.12 and fix overlap in recipes

## Outcome
Fixed