### PR TITLE
Assorted fixes

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3799,6 +3799,7 @@
   "gtceu.multiblock.universal.problem.soft_mallet": ")ㄥ§ʇǝןןɐW ʇɟoSɐ§( ˙ʞɔnʇs sı buıɥʇǝɯoSㄥ§%s",
   "gtceu.multiblock.universal.problem.wire_cutter": ")ㄥ§ɹǝʇʇnƆ ǝɹıMɐ§( ˙ʇno pǝuɹnq sǝɹıMㄥ§%s",
   "gtceu.multiblock.universal.problem.wrench": ")ㄥ§ɥɔuǝɹMɐ§( ˙ǝsooן sı ǝdıԀㄥ§%s",
+  "gtceu.multiblock.universal.rotor_obstructed": "¡pǝʇɔnɹʇsqO sı ɹoʇoᴚ",
   "gtceu.multiblock.uv_fusion_reactor.description": "˙W0ㄣ9 ɟo ɯnɯıxɐɯ ɐ sɐɥ puɐ '∩Ǝ W0ㄣ ʎq sǝsɐǝɹɔuı ɹǝɟɟnq sʇı 'sɐɥ ʇı ɥɔʇɐH ʎɹǝʌǝ ɹoℲ ˙sǝɥɔʇɐH ʎbɹǝuƎ Λ∩ ǝsn ʎןuo uɐɔ ʇI ˙sǝuo ɹǝıʌɐǝɥ oʇuı sʇuǝɯǝןǝ buısnɟ ɹoɟ pǝsn ǝɹnʇɔnɹʇs ʞɔoןqıʇןnɯ ǝbɹɐן ɐ sı Ɛ ʞW ɹoʇɔɐǝᴚ uoısnℲ ǝɥ⟘",
   "gtceu.multiblock.vacuum_freezer.description": "˙ɹǝʇɐM sɐ ɥɔns 'sǝɔuɐʇsqns ɹǝɥʇo ǝzǝǝɹɟ osןɐ uɐɔ ʇı 'ɹǝʌǝʍoH ˙sʇobuI ɹɐןnbǝɹ oʇuı sʇobuI ʇoH buızǝǝɹɟ ɹoɟ pǝsn ʎןuıɐɯ ǝɹnʇɔnɹʇs ʞɔoןqıʇןnɯ ɐ sı ɹǝzǝǝɹℲ ɯnnɔɐΛ ǝɥ⟘",
   "gtceu.multiblock.validation_failed": "˙sʇndʇno/sʇnduı ɟo ʇunoɯɐ pıןɐʌuI",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3799,6 +3799,7 @@
   "gtceu.multiblock.universal.problem.soft_mallet": "%s§7Something is stuck. (§aSoft Mallet§7)",
   "gtceu.multiblock.universal.problem.wire_cutter": "%s§7Wires burned out. (§aWire Cutter§7)",
   "gtceu.multiblock.universal.problem.wrench": "%s§7Pipe is loose. (§aWrench§7)",
+  "gtceu.multiblock.universal.rotor_obstructed": "Rotor is Obstructed!",
   "gtceu.multiblock.uv_fusion_reactor.description": "The Fusion Reactor MK 3 is a large multiblock structure used for fusing elements into heavier ones. It can only use UV Energy Hatches. For every Hatch it has, its buffer increases by 40M EU, and has a maximum of 640M.",
   "gtceu.multiblock.vacuum_freezer.description": "The Vacuum Freezer is a multiblock structure mainly used for freezing Hot Ingots into regular Ingots. However, it can also freeze other substances, such as Water.",
   "gtceu.multiblock.validation_failed": "Invalid amount of inputs/outputs.",

--- a/src/generated/resources/data/gtceu/tags/items/step_boots.json
+++ b/src/generated/resources/data/gtceu/tags/items/step_boots.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "gtceu:nanomuscle_boots",
+    "gtceu:quarktech_boots"
+  ]
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorLogicSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorLogicSuite.java
@@ -4,8 +4,8 @@ import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IElectricItem;
 import com.gregtechceu.gtceu.api.item.component.ElectricStats;
 import com.gregtechceu.gtceu.api.item.component.IItemHUDProvider;
-
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
@@ -23,12 +23,12 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -65,7 +65,6 @@ public abstract class ArmorLogicSuite implements IArmorLogic, IItemHUDProvider {
         } else if (player.getStepHeight() == MAGIC_STEP_HEIGHT) {
             player.setMaxUpStep(0.6f);
         }
-
     }
 
     @Override
@@ -112,8 +111,7 @@ public abstract class ArmorLogicSuite implements IArmorLogic, IItemHUDProvider {
         });
     }
 
-    public void addInfo(ItemStack itemStack, List<Component> lines) {
-    }
+    public void addInfo(ItemStack itemStack, List<Component> lines) {}
 
     public InteractionResultHolder<ItemStack> onRightClick(Level Level, Player player, InteractionHand hand) {
         return InteractionResultHolder.pass(player.getItemInHand(hand));

--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorLogicSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorLogicSuite.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IElectricItem;
 import com.gregtechceu.gtceu.api.item.component.ElectricStats;
 import com.gregtechceu.gtceu.api.item.component.IItemHUDProvider;
-import com.gregtechceu.gtceu.data.recipe.CustomTags;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -24,8 +23,6 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.living.LivingEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -52,20 +49,6 @@ public abstract class ArmorLogicSuite implements IArmorLogic, IItemHUDProvider {
 
     @Override
     public abstract void onArmorTick(Level Level, Player player, ItemStack itemStack);
-
-    // Check if player is wearing step-assist boots and give them extra step height
-    // Could potentially be put in ClientProxy
-    @SubscribeEvent
-    @OnlyIn(Dist.CLIENT)
-    public void stepAssistHandler(@NotNull LivingEvent.LivingTickEvent event) {
-        float MAGIC_STEP_HEIGHT = 1.0023f;
-        if (event.getEntity() == null || !(event.getEntity() instanceof Player player)) return;
-        if (!player.isShiftKeyDown() && player.getItemBySlot(EquipmentSlot.FEET).is(CustomTags.STEP_BOOTS)) {
-            if (player.getStepHeight() < MAGIC_STEP_HEIGHT) player.setMaxUpStep(MAGIC_STEP_HEIGHT);
-        } else if (player.getStepHeight() == MAGIC_STEP_HEIGHT) {
-            player.setMaxUpStep(0.6f);
-        }
-    }
 
     @Override
     public int getArmorDisplay(Player player, @NotNull ItemStack armor, EquipmentSlot slot) {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorLogicSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorLogicSuite.java
@@ -22,7 +22,6 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.common.MinecraftForge;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -44,7 +43,6 @@ public abstract class ArmorLogicSuite implements IArmorLogic, IItemHUDProvider {
         this.maxCapacity = maxCapacity;
         this.tier = tier;
         this.type = type;
-        MinecraftForge.EVENT_BUS.register(this);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IRotorHolderMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IRotorHolderMachine.java
@@ -206,7 +206,7 @@ public interface IRotorHolderMachine extends IMultiPart {
     default void attachTooltips(TooltipsPanel tooltipsPanel) {
         tooltipsPanel.attachTooltips(new IFancyTooltip.Basic(
                 () -> GuiTextures.INDICATOR_NO_STEAM.get(false),
-                () -> List.of(Component.translatable("gtceu.multiblock.universal.muffler_obstructed")
+                () -> List.of(Component.translatable("gtceu.multiblock.universal.rotor_obstructed")
                         .setStyle(Style.EMPTY.withColor(ChatFormatting.RED))),
                 () -> !isFrontFaceFree(),
                 () -> null));

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -2503,6 +2503,7 @@ public class GTItems {
             .lang("NanoMuscle™ Suite Boots")
             .properties(p -> p.rarity(Rarity.UNCOMMON))
             .tag(Tags.Items.ARMORS_BOOTS)
+            .tag(CustomTags.STEP_BOOTS)
             .register();
     public static ItemEntry<ArmorComponentItem> NANO_HELMET = REGISTRATE
             .item("nanomuscle_helmet", (p) -> new ArmorComponentItem(GTArmorMaterials.ARMOR, ArmorItem.Type.HELMET, p)
@@ -2614,6 +2615,7 @@ public class GTItems {
             .properties(p -> p.rarity(Rarity.RARE))
             .tag(Tags.Items.ARMORS_BOOTS)
             .tag(CustomTags.PPE_ARMOR)
+            .tag(CustomTags.STEP_BOOTS)
             .register();
     public static ItemEntry<ArmorComponentItem> QUANTUM_HELMET = REGISTRATE
             .item("quarktech_helmet", (p) -> new ArmorComponentItem(GTArmorMaterials.ARMOR, ArmorItem.Type.HELMET, p)

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/NanoMuscleSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/NanoMuscleSuite.java
@@ -84,8 +84,6 @@ public class NanoMuscleSuite extends ArmorLogicSuite implements IStepAssist {
             }
             data.putBoolean("nightVision", nightVision);
 
-        } else if (type == ArmorItem.Type.BOOTS) {
-            updateStepHeight(player);
         }
 
         if (nightVisionTimer > 0) nightVisionTimer--;

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
@@ -199,7 +199,6 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
                     }
                 }
             }
-            updateStepHeight(player);
             data.putBoolean("boostedJump", boostedJump);
 
             if (boostedJumpTimer > 0) boostedJumpTimer--;

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1090,6 +1090,7 @@ public class LangHandler {
         provider.add("gtceu.multiblock.universal.muffler_obstructed", "Muffler Hatch is Obstructed!");
         provider.add("gtceu.multiblock.universal.muffler_obstructed.tooltip",
                 "Muffler Hatch must have a block of airspace in front of it.");
+        provider.add("gtceu.multiblock.universal.rotor_obstructed", "Rotor is Obstructed!");
         provider.add("gtceu.multiblock.universal.distinct", "Distinct Buses:");
         provider.add("gtceu.multiblock.universal.distinct.no", "No");
         provider.add("gtceu.multiblock.universal.distinct.yes", "Yes");

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
@@ -90,6 +90,7 @@ public class CustomTags {
     };
 
     public static final TagKey<Item> PPE_ARMOR = TagUtil.createModItemTag("ppe_armor");
+    public static final TagKey<Item> STEP_BOOTS = TagUtil.createModItemTag("step_boots");
 
     // Platform-dependent tags
     public static final TagKey<Block> NEEDS_WOOD_TOOL = TagUtil.createBlockTag("needs_wood_tool");

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -38,6 +38,7 @@ import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.loader.BedrockFluidLoader;
 import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.GTOreLoader;
+import com.gregtechceu.gtceu.data.recipe.CustomTags;
 import com.gregtechceu.gtceu.utils.TaskHandler;
 
 import net.minecraft.core.Direction;
@@ -62,6 +63,7 @@ import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.*;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
+import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.MobSpawnEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -285,6 +287,19 @@ public class ForgeCommonEventListener {
                         player.fallDistance = 0;
                         event.setCanceled(true);
                     }
+        }
+    }
+
+    @SubscribeEvent
+    public static void stepAssistHandler(LivingEvent.LivingTickEvent event) {
+        float MAGIC_STEP_HEIGHT = 1.0023f;
+        if (event.getEntity() == null || !(event.getEntity() instanceof Player player)) return;
+        if (!player.isCrouching() && player.getItemBySlot(EquipmentSlot.FEET).is(CustomTags.STEP_BOOTS)) {
+            if (player.getStepHeight() < MAGIC_STEP_HEIGHT) {
+                player.setMaxUpStep(MAGIC_STEP_HEIGHT);
+            }
+        } else if (player.getStepHeight() == MAGIC_STEP_HEIGHT) {
+            player.setMaxUpStep(0.6f);
         }
     }
 


### PR DESCRIPTION
## What
- Added new lang for rotor obstruction tooltip in turbine UIs, previously it used the muffler hatch obstruction message
- Fixed the step-assist behavior

## Implementation Details
Unfortunately this is only possible with an EventHandler via the Forge Event Bus, as I can't find another way to check if the boots has been taken off in order to reset the step-assist. 
To achieve this in a more robust manner, I added a new tag, gtceu:step_boots, which is used in the check. This allows for addon devs to add their own step-assist boots.

## Outcome
Fixes #1646 