### PR TITLE
Add config toggle for fortune on ores

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2301,6 +2301,7 @@
   "config.gtceu.option.nerfWoodCrafting": "buıʇɟɐɹƆpooMɟɹǝu",
   "config.gtceu.option.orderedAssemblyLineFluids": "spınןℲǝuıꞀʎןqɯǝssⱯpǝɹǝpɹo",
   "config.gtceu.option.orderedAssemblyLineItems": "sɯǝʇIǝuıꞀʎןqɯǝssⱯpǝɹǝpɹo",
+  "config.gtceu.option.oreFortuneDrops": "sdoɹᗡǝunʇɹoℲǝɹo",
   "config.gtceu.option.oreGenerationChunkCacheSize": "ǝzıSǝɥɔɐƆʞunɥƆuoıʇɐɹǝuǝ⅁ǝɹo",
   "config.gtceu.option.oreIndicatorChunkCacheSize": "ǝzıSǝɥɔɐƆʞunɥƆɹoʇɐɔıpuIǝɹo",
   "config.gtceu.option.oreVeinGridSize": "ǝzıSpıɹ⅁uıǝΛǝɹo",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2301,6 +2301,7 @@
   "config.gtceu.option.nerfWoodCrafting": "nerfWoodCrafting",
   "config.gtceu.option.orderedAssemblyLineFluids": "orderedAssemblyLineFluids",
   "config.gtceu.option.orderedAssemblyLineItems": "orderedAssemblyLineItems",
+  "config.gtceu.option.oreFortuneDrops": "oreFortuneDrops",
   "config.gtceu.option.oreGenerationChunkCacheSize": "oreGenerationChunkCacheSize",
   "config.gtceu.option.oreIndicatorChunkCacheSize": "oreIndicatorChunkCacheSize",
   "config.gtceu.option.oreVeinGridSize": "oreVeinGridSize",

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -554,6 +554,9 @@ public class ConfigHolder {
     public static class GameplayConfigs {
 
         @Configurable
+        @Configurable.Comment({ "Enable fortune for ore drops", "Default: false" })
+        public boolean oreFortuneDrops = false;
+        @Configurable
         @Configurable.Comment({ "Enable hazardous materials", "Default: true" })
         public boolean hazardsEnabled = true;
         @Configurable

--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -213,10 +213,10 @@ public class MixinHelpers {
                                     LootItem.lootTableItem(dropItem.getItem())
                                             .apply(SetItemCountFunction
                                                     .setCount(ConstantValue.exactly(oreMultiplier)))));
+                    // disable fortune by default for balance reasons.
+                    // (for now, until we can think of a better solution.)
                     if (ConfigHolder.INSTANCE.gameplay.oreFortuneDrops) {
-                        builder.apply(ApplyBonusCount.addOreBonusCount(Enchantments.BLOCK_FORTUNE)); // disable fortune
-                                                                                                     // by
-                        // default for balance reasons. (for now, until we can think of a better solution.)
+                        builder.apply(ApplyBonusCount.addOreBonusCount(Enchantments.BLOCK_FORTUNE));
                     }
 
                     Supplier<Material> outputDustMat = type.material();

--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -213,8 +213,11 @@ public class MixinHelpers {
                                     LootItem.lootTableItem(dropItem.getItem())
                                             .apply(SetItemCountFunction
                                                     .setCount(ConstantValue.exactly(oreMultiplier)))));
-                    // .apply(ApplyBonusCount.addOreBonusCount(Enchantments.BLOCK_FORTUNE)))); //disable fortune for
-                    // balance reasons. (for now, until we can think of a better solution.)
+                    if (ConfigHolder.INSTANCE.gameplay.oreFortuneDrops) {
+                        builder.apply(ApplyBonusCount.addOreBonusCount(Enchantments.BLOCK_FORTUNE)); // disable fortune
+                                                                                                     // by
+                        // default for balance reasons. (for now, until we can think of a better solution.)
+                    }
 
                     Supplier<Material> outputDustMat = type.material();
                     LootPool.Builder pool = LootPool.lootPool();


### PR DESCRIPTION
## What
Mfw the mod adds fortune to tools but its useless
Adds a config option for fortune working on ore drops (off by default)

## Implementation Details
Added a new config option and an if statement to block loot drop MixinHelper to apply fortune if ``oreFortuneDrops`` is true

## Outcome
Turning on ``oreFortuneDrops`` makes fortune work on ores