### PR TITLE
Jetpack Fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedJetpack.java
@@ -1,22 +1,13 @@
 package com.gregtechceu.gtceu.common.item.armor;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
-import com.gregtechceu.gtceu.api.capability.IElectricItem;
-import com.gregtechceu.gtceu.utils.input.KeyBind;
 
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
-
-import org.jetbrains.annotations.NotNull;
 
 public class AdvancedJetpack extends Jetpack {
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedJetpack.java
@@ -25,49 +25,6 @@ public class AdvancedJetpack extends Jetpack {
     }
 
     @Override
-    public void onArmorTick(Level world, Player player, @NotNull ItemStack item) {
-        IElectricItem cont = GTCapabilityHelper.getElectricItem(item);
-        if (cont == null) {
-            return;
-        }
-
-        CompoundTag data = item.getOrCreateTag();
-        // Assume no tags exist if we don't see the enabled tag
-        if(!data.contains("enabled")) {
-            data.putBoolean("enabled", true);
-            data.putBoolean("hover", false);
-            data.putByte("toggleTimer", (byte) 0);
-        }
-
-        boolean jetpackEnabled = data.getBoolean("enabled");
-        boolean hoverMode = data.getBoolean("hover");
-        byte toggleTimer = data.getByte("toggleTimer");
-
-        String messageKey = null;
-        if(toggleTimer == 0) {
-            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
-                jetpackEnabled = !jetpackEnabled;
-                messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
-                data.putBoolean("enabled", jetpackEnabled);
-            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
-                hoverMode = !hoverMode;
-                messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
-                data.putBoolean("hover", hoverMode);
-            }
-
-            if(messageKey != null) {
-                toggleTimer = 5;
-                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
-            }
-        }
-
-        if (toggleTimer > 0) toggleTimer--;
-        data.putByte("toggleTimer", toggleTimer);
-
-        performFlying(player, jetpackEnabled, hoverMode, item);
-    }
-
-    @Override
     public double getSprintEnergyModifier() {
         return 2.5D;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedJetpack.java
@@ -25,44 +25,46 @@ public class AdvancedJetpack extends Jetpack {
     }
 
     @Override
-    public void onArmorTick(Level world, Player player, @NotNull ItemStack stack) {
-        IElectricItem cont = GTCapabilityHelper.getElectricItem(stack);
+    public void onArmorTick(Level world, Player player, @NotNull ItemStack item) {
+        IElectricItem cont = GTCapabilityHelper.getElectricItem(item);
         if (cont == null) {
             return;
         }
-        CompoundTag data = stack.getOrCreateTag();
-        boolean hoverMode = data.contains("hover") && data.getBoolean("hover");
-        byte toggleTimer = data.contains("toggleTimer") ? data.getByte("toggleTimer") : 0;
-        boolean jetpackEnabled = !data.contains("enabled") || data.getBoolean("enabled");
 
-        if (toggleTimer == 0 && KeyBind.ARMOR_HOVER.isKeyDown(player)) {
-            hoverMode = !hoverMode;
-            toggleTimer = 5;
-            data.putBoolean("hover", hoverMode);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable")), true);
-            }
+        CompoundTag data = item.getOrCreateTag();
+        // Assume no tags exist if we don't see the enabled tag
+        if(!data.contains("enabled")) {
+            data.putBoolean("enabled", true);
+            data.putBoolean("hover", false);
+            data.putByte("toggleTimer", (byte) 0);
         }
 
-        if (toggleTimer == 0 && KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
-            jetpackEnabled = !jetpackEnabled;
-            toggleTimer = 5;
-            data.putBoolean("enabled", jetpackEnabled);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable")),
-                        true);
+        boolean jetpackEnabled = data.getBoolean("enabled");
+        boolean hoverMode = data.getBoolean("hover");
+        byte toggleTimer = data.getByte("toggleTimer");
+
+        String messageKey = null;
+        if(toggleTimer == 0) {
+            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+                jetpackEnabled = !jetpackEnabled;
+                messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
+                data.putBoolean("enabled", jetpackEnabled);
+            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+                hoverMode = !hoverMode;
+                messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
+                data.putBoolean("hover", hoverMode);
+            }
+
+            if(messageKey != null) {
+                toggleTimer = 5;
+                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
-
-        performFlying(player, jetpackEnabled, hoverMode, stack);
 
         if (toggleTimer > 0) toggleTimer--;
-
-        data.putBoolean("hover", hoverMode);
-        data.putBoolean("enabled", jetpackEnabled);
         data.putByte("toggleTimer", toggleTimer);
+
+        performFlying(player, jetpackEnabled, hoverMode, item);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
@@ -49,48 +49,48 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
         }
 
         CompoundTag data = item.getOrCreateTag();
-        boolean hoverMode = data.contains("hover") && data.getBoolean("hover");
-        byte toggleTimer = data.contains("toggleTimer") ? data.getByte("toggleTimer") : 0;
-        boolean canShare = data.contains("canShare") && data.getBoolean("canShare");
-        boolean jetpackEnabled = !data.contains("enabled") || data.getBoolean("enabled");
+        // Assume no tags exist if we don't see the enabled tag
+        if(!data.contains("enabled")) {
+            data.putBoolean("enabled", true);
+            data.putBoolean("hover", false);
+            data.putByte("toggleTimer", (byte) 0);
+            data.putBoolean("canShare", false);
+        }
 
-        if (toggleTimer == 0 && KeyBind.ARMOR_HOVER.isKeyDown(player)) {
-            hoverMode = !hoverMode;
-            toggleTimer = 5;
-            data.putBoolean("hover", hoverMode);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable")), true);
+        boolean jetpackEnabled = data.getBoolean("enabled");
+        boolean hoverMode = data.getBoolean("hover");
+        byte toggleTimer = data.getByte("toggleTimer");
+        boolean canShare = data.getBoolean("canShare");
+
+        String messageKey = null;
+        if(toggleTimer == 0) {
+            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+                jetpackEnabled = !jetpackEnabled;
+                messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
+                data.putBoolean("enabled", jetpackEnabled);
+            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+                hoverMode = !hoverMode;
+                messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
+                data.putBoolean("hover", hoverMode);
+            } else if(KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
+                canShare = !canShare;
+                if(canShare && cont.getCharge() == 0) { // Only allow for charging to be enabled if charge is nonzero
+                    messageKey = "metaarmor.nms.share.error";
+                    canShare = false;
+                } else {
+                    messageKey = "metaarmor.nms.share." + (canShare ? "enable" : "disable");
+                }
+                data.putBoolean("canShare", canShare);
+            }
+
+            if(messageKey != null) {
+                toggleTimer = 5;
+                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 
-        if (toggleTimer == 0 && KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
-            jetpackEnabled = !jetpackEnabled;
-            toggleTimer = 5;
-            data.putBoolean("enabled", jetpackEnabled);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable")),
-                        true);
-            }
-        }
-
-        if (toggleTimer == 0 && KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
-            canShare = !canShare;
-            toggleTimer = 5;
-            if (!world.isClientSide) {
-                if (canShare && cont.getCharge() == 0)
-                    player.displayClientMessage(Component.translatable("metaarmor.nms.share.error"), true);
-                else if (canShare)
-                    player.displayClientMessage(Component.translatable("metaarmor.nms.share.enable"), true);
-                else
-                    player.displayClientMessage(Component.translatable("metaarmor.nms.share.disable"), true);
-            }
-
-            // Only allow for charging to be enabled if charge is nonzero
-            canShare = canShare && (cont.getCharge() != 0);
-            data.putBoolean("canShare", canShare);
-        }
+        if (toggleTimer > 0) toggleTimer--;
+        data.putByte("toggleTimer", toggleTimer);
 
         performFlying(player, jetpackEnabled, hoverMode, item);
 
@@ -135,13 +135,6 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                 }
             }
         }
-
-        if (toggleTimer > 0) toggleTimer--;
-
-        data.putBoolean("canShare", canShare);
-        data.putBoolean("hover", hoverMode);
-        data.putBoolean("enabled", jetpackEnabled);
-        data.putByte("toggleTimer", toggleTimer);
 
         timer++;
         if (timer == Long.MAX_VALUE)

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
@@ -50,7 +50,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
 
         CompoundTag data = item.getOrCreateTag();
         // Assume no tags exist if we don't see the enabled tag
-        if(!data.contains("enabled")) {
+        if (!data.contains("enabled")) {
             data.putBoolean("enabled", true);
             data.putBoolean("hover", false);
             data.putByte("toggleTimer", (byte) 0);
@@ -63,18 +63,18 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
         boolean canShare = data.getBoolean("canShare");
 
         String messageKey = null;
-        if(toggleTimer == 0) {
-            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+        if (toggleTimer == 0) {
+            if (KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
                 jetpackEnabled = !jetpackEnabled;
                 messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
                 data.putBoolean("enabled", jetpackEnabled);
-            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+            } else if (KeyBind.ARMOR_HOVER.isKeyDown(player)) {
                 hoverMode = !hoverMode;
                 messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
                 data.putBoolean("hover", hoverMode);
-            } else if(KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
+            } else if (KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
                 canShare = !canShare;
-                if(canShare && cont.getCharge() == 0) { // Only allow for charging to be enabled if charge is nonzero
+                if (canShare && cont.getCharge() == 0) { // Only allow for charging to be enabled if charge is nonzero
                     messageKey = "metaarmor.nms.share.error";
                     canShare = false;
                 } else {
@@ -83,9 +83,9 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                 data.putBoolean("canShare", canShare);
             }
 
-            if(messageKey != null) {
+            if (messageKey != null) {
                 toggleTimer = 5;
-                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
+                if (!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedQuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedQuarkTechSuite.java
@@ -48,48 +48,48 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
         }
 
         CompoundTag data = item.getOrCreateTag();
-        boolean hoverMode = data.contains("hover") && data.getBoolean("hover");
-        byte toggleTimer = data.contains("toggleTimer") ? data.getByte("toggleTimer") : 0;
-        boolean canShare = data.contains("canShare") && data.getBoolean("canShare");
-        boolean jetpackEnabled = !data.contains("enabled") || data.getBoolean("enabled");
+        // Assume no tags exist if we don't see the enabled tag
+        if(!data.contains("enabled")) {
+            data.putBoolean("enabled", true);
+            data.putBoolean("hover", false);
+            data.putByte("toggleTimer", (byte) 0);
+            data.putBoolean("canShare", false);
+        }
 
-        if (toggleTimer == 0 && KeyBind.ARMOR_HOVER.isKeyDown(player)) {
-            hoverMode = !hoverMode;
-            toggleTimer = 5;
-            data.putBoolean("hover", hoverMode);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable")), true);
+        boolean jetpackEnabled = data.getBoolean("enabled");
+        boolean hoverMode = data.getBoolean("hover");
+        byte toggleTimer = data.getByte("toggleTimer");
+        boolean canShare = data.getBoolean("canShare");
+
+        String messageKey = null;
+        if(toggleTimer == 0) {
+             if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+                jetpackEnabled = !jetpackEnabled;
+                messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
+                data.putBoolean("enabled", jetpackEnabled);
+            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+                hoverMode = !hoverMode;
+                messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
+                data.putBoolean("hover", hoverMode);
+            } else if(KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
+                canShare = !canShare;
+                if(canShare && cont.getCharge() == 0) { // Only allow for charging to be enabled if charge is nonzero
+                    messageKey = "metaarmor.qts.share.error";
+                    canShare = false;
+                } else {
+                    messageKey = "metaarmor.qts.share." + (canShare ? "enable" : "disable");
+                }
+                data.putBoolean("canShare", canShare);
+            }
+
+            if(messageKey != null) {
+                toggleTimer = 5;
+                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 
-        if (toggleTimer == 0 && KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
-            canShare = !canShare;
-            toggleTimer = 5;
-            if (!world.isClientSide) {
-                if (canShare && cont.getCharge() == 0)
-                    player.displayClientMessage(Component.translatable("metaarmor.qts.share.error"), true);
-                else if (canShare)
-                    player.displayClientMessage(Component.translatable("metaarmor.qts.share.enable"), true);
-                else
-                    player.displayClientMessage(Component.translatable("metaarmor.qts.share.disable"), true);
-            }
-
-            // Only allow for charging to be enabled if charge is nonzero
-            canShare = canShare && (cont.getCharge() != 0);
-            data.putBoolean("canShare", canShare);
-        }
-
-        if (toggleTimer == 0 && KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
-            jetpackEnabled = !jetpackEnabled;
-            toggleTimer = 5;
-            data.putBoolean("enabled", jetpackEnabled);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable")),
-                        true);
-            }
-        }
+        if (toggleTimer > 0) toggleTimer--;
+        data.putByte("toggleTimer", toggleTimer);
 
         performFlying(player, jetpackEnabled, hoverMode, item);
 
@@ -138,13 +138,6 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
                 }
             }
         }
-
-        if (toggleTimer > 0) toggleTimer--;
-
-        data.putBoolean("canShare", canShare);
-        data.putBoolean("hover", hoverMode);
-        data.putBoolean("enabled", jetpackEnabled);
-        data.putByte("toggleTimer", toggleTimer);
 
         timer++;
         if (timer == Long.MAX_VALUE)
@@ -249,7 +242,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
      * }
      * return new ArmorProperties(8, getDamageAbsorption() * getAbsorption(armor), damageLimit);
      * }
-     * 
+     *
      * @Override
      * public boolean handleUnblockableDamage(EntityLivingBase entity, @NotNull ItemStack armor, DamageSource source,
      * double damage, EntityEquipmentSlot equipmentSlot) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedQuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedQuarkTechSuite.java
@@ -49,7 +49,7 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
 
         CompoundTag data = item.getOrCreateTag();
         // Assume no tags exist if we don't see the enabled tag
-        if(!data.contains("enabled")) {
+        if (!data.contains("enabled")) {
             data.putBoolean("enabled", true);
             data.putBoolean("hover", false);
             data.putByte("toggleTimer", (byte) 0);
@@ -62,18 +62,18 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
         boolean canShare = data.getBoolean("canShare");
 
         String messageKey = null;
-        if(toggleTimer == 0) {
-             if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+        if (toggleTimer == 0) {
+            if (KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
                 jetpackEnabled = !jetpackEnabled;
                 messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
                 data.putBoolean("enabled", jetpackEnabled);
-            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+            } else if (KeyBind.ARMOR_HOVER.isKeyDown(player)) {
                 hoverMode = !hoverMode;
                 messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
                 data.putBoolean("hover", hoverMode);
-            } else if(KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
+            } else if (KeyBind.ARMOR_CHARGING.isKeyDown(player)) {
                 canShare = !canShare;
-                if(canShare && cont.getCharge() == 0) { // Only allow for charging to be enabled if charge is nonzero
+                if (canShare && cont.getCharge() == 0) { // Only allow for charging to be enabled if charge is nonzero
                     messageKey = "metaarmor.qts.share.error";
                     canShare = false;
                 } else {
@@ -82,9 +82,9 @@ public class AdvancedQuarkTechSuite extends QuarkTechSuite implements IJetpack {
                 data.putBoolean("canShare", canShare);
             }
 
-            if(messageKey != null) {
+            if (messageKey != null) {
                 toggleTimer = 5;
-                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
+                if (!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/IJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/IJetpack.java
@@ -71,8 +71,8 @@ public interface IJetpack {
         double deltaY = player.getDeltaMovement().y();
 
         if ((!flightEnabled || !hover) && player.getY() < player.level().getMinBuildHeight() - 5) {
-                performEHover(stack, player);
-        } else if(!flightEnabled) {
+            performEHover(stack, player);
+        } else if (!flightEnabled) {
             return;
         }
 
@@ -101,7 +101,7 @@ public interface IJetpack {
             } else {
                 if (flyKeyDown && descendKeyDown) {
                     potentialY = 0;
-                } else if( flyKeyDown ) {
+                } else if (flyKeyDown) {
                     potentialY = getVerticalSpeed() * (player.isInWater() ? 0.4D : 1.0D);
                 } else { // Free fall, don't need to edit motion
                     editMotion = false;
@@ -127,14 +127,15 @@ public interface IJetpack {
                 if (KeyBind.VANILLA_RIGHT.isKeyDown(player)) movement = movement.add(-speedSideways, 0, 0);
 
                 var dist = movement.length();
-                if(dist >= 1.0E-7) {
+                if (dist >= 1.0E-7) {
                     player.moveRelative((float) dist, movement);
-                    if(!editMotion) editMotion = true;
+                    if (!editMotion) editMotion = true;
                 }
             }
 
-            if(editMotion) {
-                int energyUsed = (int) Math.round(getEnergyPerUse() * (player.isSprinting() ? getSprintEnergyModifier() : 1));
+            if (editMotion) {
+                int energyUsed = (int) Math
+                        .round(getEnergyPerUse() * (player.isSprinting() ? getSprintEnergyModifier() : 1));
                 drainEnergy(stack, energyUsed);
                 ArmorUtils.spawnParticle(player.level(), player, getParticle(), -0.6D);
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/IJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/IJetpack.java
@@ -70,97 +70,83 @@ public interface IJetpack {
     default void performFlying(@NotNull Player player, boolean flightEnabled, boolean hover, ItemStack stack) {
         double deltaY = player.getDeltaMovement().y();
 
-        if (!hover || !flightEnabled) {
-            if (player.position().y() < player.level().getMinBuildHeight() - 5) {
+        if ((!flightEnabled || !hover) && player.getY() < player.level().getMinBuildHeight() - 5) {
                 performEHover(stack, player);
-            } else {
-                if (!player.isCreative() && player.fallDistance - 1.2f >= player.getHealth()) {
-                    if (!player.onGround() && !player.isSwimming()) {
-                        performEHover(stack, player);
-                    }
-                }
-            }
-        }
-
-        if (!flightEnabled) {
+        } else if(!flightEnabled) {
             return;
         }
 
         boolean flyKeyDown = KeyBind.VANILLA_JUMP.isKeyDown(player);
         boolean descendKeyDown = KeyBind.VANILLA_SNEAK.isKeyDown(player);
-
-        double hoverSpeed = descendKeyDown ? getVerticalHoverSpeed() : getVerticalHoverSlowSpeed();
         double currentAccel = getVerticalAcceleration() * (deltaY < 0.3D ? 2.5D : 1.0D);
-        double currentSpeedVertical = getVerticalSpeed() * (player.isInWater() ? 0.4D : 1.0D);
 
-        if (!player.onGround() && canUseEnergy(stack, getEnergyPerUse())) {
-            drainEnergy(stack, (int) (player.isSprinting() ?
-                    Math.round(getEnergyPerUse() * getSprintEnergyModifier()) : getEnergyPerUse()));
+        if (!player.onGround() && player.getSleepingPos().isEmpty() && canUseEnergy(stack, getEnergyPerUse())) {
+            double potentialY = 0;
+            boolean editMotion = true;
 
-            double potentialY;
-            boolean editMotion = false;
-            if (hasEnergy(stack)) {
-                if (hover) {
-                    if (flyKeyDown && descendKeyDown) {
-                        potentialY = getVerticalHoverSlowSpeed();
-                    } else if (flyKeyDown) {
-                        potentialY = getVerticalHoverSpeed();
-                    } else if (descendKeyDown) {
-                        potentialY = -getVerticalHoverSpeed();
-                    } else {
-                        potentialY = 0.0;
-                    }
-
-                    if (player.isFallFlying()) { // if the player is hovering negate fall motion
-                        player.stopFallFlying();
-                    }
-                    editMotion = true;
+            if (hover) {
+                if (flyKeyDown && descendKeyDown) {
+                    potentialY = getVerticalHoverSlowSpeed();
+                } else if (flyKeyDown) {
+                    potentialY = getVerticalHoverSpeed();
+                } else if (descendKeyDown) {
+                    potentialY = -getVerticalHoverSpeed();
                 } else {
-                    if (flyKeyDown) {
-                        potentialY = currentSpeedVertical;
-                        editMotion = true;
-                        if (descendKeyDown) {
-                            potentialY -= currentSpeedVertical;
-                        }
-                    } else {
-                        potentialY = -hoverSpeed;
-                    }
-                }
-                potentialY = Math.min(deltaY + currentAccel, potentialY);
-                if (editMotion)
-                    setYMotion(player, potentialY);
-
-                float speedSideways = (float) (player.isShiftKeyDown() ? getSidewaysSpeed() * 0.5f :
-                        getSidewaysSpeed());
-                float speedForward = (float) (player.isSprinting() ? speedSideways * getSprintSpeedModifier() :
-                        speedSideways);
-
-                // make sure they arent using elytra movement
-                if (!player.isFallFlying()) {
-                    if (KeyBind.VANILLA_FORWARD.isKeyDown(player)) {
-                        player.moveRelative(speedForward, new Vec3(0, 0, speedForward));
-                    }
-                    if (KeyBind.VANILLA_BACKWARD.isKeyDown(player)) {
-                        player.moveRelative(speedSideways * 0.8f, new Vec3(0, 0, -speedForward));
-                    }
-                    if (KeyBind.VANILLA_LEFT.isKeyDown(player)) {
-                        player.moveRelative(speedSideways, new Vec3(speedSideways, 0, 0));
-                    }
-                    if (KeyBind.VANILLA_RIGHT.isKeyDown(player)) {
-                        player.moveRelative(-speedSideways, new Vec3(speedSideways, 0, 0));
-                    }
+                    potentialY = -getVerticalHoverSlowSpeed();
                 }
 
-                // ensure that the player is actually using the jetpack to cancel fall damage
-                if (!player.level().isClientSide && (hover || flyKeyDown)) {
-                    player.fallDistance = 0;
-                    if (player instanceof ServerPlayer serverPlayer) {
-                        serverPlayer.connection.aboveGroundTickCount = 0;
-                    }
+                if (player.isFallFlying()) { // if the player is hovering negate fall motion
+                    player.stopFallFlying();
                 }
-
+            } else {
+                if (flyKeyDown && descendKeyDown) {
+                    potentialY = 0;
+                } else if( flyKeyDown ) {
+                    potentialY = getVerticalSpeed() * (player.isInWater() ? 0.4D : 1.0D);
+                } else { // Free fall, don't need to edit motion
+                    editMotion = false;
+                }
             }
-            ArmorUtils.spawnParticle(player.level(), player, getParticle(), -0.6D);
+
+            if (editMotion) {
+                potentialY = Math.min(deltaY + currentAccel, potentialY);
+                setYMotion(player, potentialY);
+            }
+
+            float speedSideways = (float) (player.isShiftKeyDown() ? getSidewaysSpeed() * 0.5f :
+                    getSidewaysSpeed());
+            float speedForward = (float) (player.isSprinting() ? speedSideways * getSprintSpeedModifier() :
+                    speedSideways);
+
+            // Make sure they aren't using elytra movement
+            if (!player.isFallFlying()) {
+                Vec3 movement = new Vec3(0, 0, 0);
+                if (KeyBind.VANILLA_FORWARD.isKeyDown(player)) movement = movement.add(0, 0, speedForward);
+                if (KeyBind.VANILLA_BACKWARD.isKeyDown(player)) movement = movement.add(0, 0, -speedSideways * 0.8f);
+                if (KeyBind.VANILLA_LEFT.isKeyDown(player)) movement = movement.add(speedSideways, 0, 0);
+                if (KeyBind.VANILLA_RIGHT.isKeyDown(player)) movement = movement.add(-speedSideways, 0, 0);
+
+                var dist = movement.length();
+                if(dist >= 1.0E-7) {
+                    player.moveRelative((float) dist, movement);
+                    if(!editMotion) editMotion = true;
+                }
+            }
+
+            if(editMotion) {
+                int energyUsed = (int) Math.round(getEnergyPerUse() * (player.isSprinting() ? getSprintEnergyModifier() : 1));
+                drainEnergy(stack, energyUsed);
+                ArmorUtils.spawnParticle(player.level(), player, getParticle(), -0.6D);
+            }
+
+            // ensure that the player is actually using the jetpack to cancel fall damage
+            if (!player.level().isClientSide && (hover || flyKeyDown)) {
+                player.fallDistance = 0;
+                if (player instanceof ServerPlayer serverPlayer) {
+                    serverPlayer.connection.aboveGroundTickCount = 0;
+                }
+            }
+
         }
     }
 
@@ -169,17 +155,14 @@ public interface IJetpack {
         player.setDeltaMovement(motion.x(), value, motion.z());
     }
 
-    private static void performEHover(ItemStack stack, Player player) {
+    static void performEHover(ItemStack stack, Player player) {
         CompoundTag tag = stack.getOrCreateTag();
-        if (tag.contains("enabled"))
-            tag.putBoolean("enabled", true);
-        if (tag.contains("hover"))
-            tag.putBoolean("hover", true);
+        tag.putBoolean("enabled", true);
+        tag.putBoolean("hover", true);
         player.displayClientMessage(Component.translatable("metaarmor.jetpack.emergency_hover_mode"), true);
-        stack.setTag(tag);
+        player.fallDistance = 0;
 
         if (!player.level().isClientSide) {
-            player.fallDistance = 0;
             if (player instanceof ServerPlayer) {
                 ((ServerPlayer) player).connection.aboveGroundTickCount = 0;
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/Jetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/Jetpack.java
@@ -51,7 +51,7 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
 
         CompoundTag data = item.getOrCreateTag();
         // Assume no tags exist if we don't see the enabled tag
-        if(!data.contains("enabled")) {
+        if (!data.contains("enabled")) {
             data.putBoolean("enabled", true);
             data.putBoolean("hover", false);
             data.putByte("toggleTimer", (byte) 0);
@@ -62,20 +62,20 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
         byte toggleTimer = data.getByte("toggleTimer");
 
         String messageKey = null;
-        if(toggleTimer == 0) {
-            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+        if (toggleTimer == 0) {
+            if (KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
                 jetpackEnabled = !jetpackEnabled;
                 messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
                 data.putBoolean("enabled", jetpackEnabled);
-            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+            } else if (KeyBind.ARMOR_HOVER.isKeyDown(player)) {
                 hoverMode = !hoverMode;
                 messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
                 data.putBoolean("hover", hoverMode);
             }
 
-            if(messageKey != null) {
+            if (messageKey != null) {
                 toggleTimer = 5;
-                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
+                if (!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/Jetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/Jetpack.java
@@ -43,40 +43,46 @@ public class Jetpack extends ArmorLogicSuite implements IJetpack {
     }
 
     @Override
-    public void onArmorTick(Level world, Player player, @NotNull ItemStack stack) {
-        CompoundTag data = stack.getOrCreateTag();
-        boolean hoverMode = data.contains("hover") && data.getBoolean("hover");
-        byte toggleTimer = data.contains("toggleTimer") ? data.getByte("toggleTimer") : 0;
-        boolean jetpackEnabled = !data.contains("enabled") || data.getBoolean("enabled");
-
-        if (toggleTimer == 0 && KeyBind.ARMOR_HOVER.isKeyDown(player)) {
-            hoverMode = !hoverMode;
-            toggleTimer = 5;
-            data.putBoolean("hover", hoverMode);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable")), true);
-            }
+    public void onArmorTick(Level world, Player player, @NotNull ItemStack item) {
+        IElectricItem cont = GTCapabilityHelper.getElectricItem(item);
+        if (cont == null) {
+            return;
         }
 
-        if (toggleTimer == 0 && KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
-            jetpackEnabled = !jetpackEnabled;
-            toggleTimer = 5;
-            data.putBoolean("enabled", jetpackEnabled);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable")),
-                        true);
-            }
+        CompoundTag data = item.getOrCreateTag();
+        // Assume no tags exist if we don't see the enabled tag
+        if(!data.contains("enabled")) {
+            data.putBoolean("enabled", true);
+            data.putBoolean("hover", false);
+            data.putByte("toggleTimer", (byte) 0);
         }
 
-        performFlying(player, jetpackEnabled, hoverMode, stack);
+        boolean jetpackEnabled = data.getBoolean("enabled");
+        boolean hoverMode = data.getBoolean("hover");
+        byte toggleTimer = data.getByte("toggleTimer");
+
+        String messageKey = null;
+        if(toggleTimer == 0) {
+            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+                jetpackEnabled = !jetpackEnabled;
+                messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
+                data.putBoolean("enabled", jetpackEnabled);
+            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+                hoverMode = !hoverMode;
+                messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
+                data.putBoolean("hover", hoverMode);
+            }
+
+            if(messageKey != null) {
+                toggleTimer = 5;
+                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
+            }
+        }
 
         if (toggleTimer > 0) toggleTimer--;
-
-        data.putBoolean("hover", hoverMode);
-        data.putBoolean("enabled", jetpackEnabled);
         data.putByte("toggleTimer", toggleTimer);
+
+        performFlying(player, jetpackEnabled, hoverMode, item);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/PowerlessJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/PowerlessJetpack.java
@@ -72,33 +72,38 @@ public class PowerlessJetpack implements IArmorLogic, IJetpack, IItemHUDProvider
             return;
 
         CompoundTag data = stack.getOrCreateTag();
-        byte toggleTimer = 0;
 
         if (data.contains("burnTimer")) burnTimer = data.getShort("burnTimer");
-        if (data.contains("toggleTimer")) toggleTimer = data.getByte("toggleTimer");
-        boolean hoverMode = data.contains("hover") && data.getBoolean("hover");
-        boolean jetpackEnabled = !data.contains("enabled") || data.getBoolean("enabled");
+        if(!data.contains("enabled")) {
+            data.putBoolean("enabled", true);
+            data.putBoolean("hover", false);
+            data.putByte("toggleTimer", (byte) 0);
+        }
 
-        if (toggleTimer == 0 && KeyBind.ARMOR_HOVER.isKeyDown(player)) {
-            hoverMode = !hoverMode;
-            toggleTimer = 5;
-            data.putBoolean("hover", hoverMode);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable")), true);
+        boolean jetpackEnabled = data.getBoolean("enabled");
+        boolean hoverMode = data.getBoolean("hover");
+        byte toggleTimer = data.getByte("toggleTimer");
+
+        String messageKey = null;
+        if(toggleTimer == 0) {
+            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+                jetpackEnabled = !jetpackEnabled;
+                messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
+                data.putBoolean("enabled", jetpackEnabled);
+            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+                hoverMode = !hoverMode;
+                messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
+                data.putBoolean("hover", hoverMode);
+            }
+
+            if(messageKey != null) {
+                toggleTimer = 5;
+                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 
-        if (toggleTimer == 0 && KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
-            jetpackEnabled = !jetpackEnabled;
-            toggleTimer = 5;
-            data.putBoolean("enabled", jetpackEnabled);
-            if (!world.isClientSide) {
-                player.displayClientMessage(
-                        Component.translatable("metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable")),
-                        true);
-            }
-        }
+        if (toggleTimer > 0) toggleTimer--;
+        data.putByte("toggleTimer", toggleTimer);
 
         // This causes a caching issue. currentRecipe is only set to null in findNewRecipe, so the fuel is never updated
         // Rewrite in Armor Rework
@@ -106,14 +111,7 @@ public class PowerlessJetpack implements IArmorLogic, IJetpack, IItemHUDProvider
             findNewRecipe(stack);
 
         performFlying(player, jetpackEnabled, hoverMode, stack);
-
-        if (toggleTimer > 0)
-            toggleTimer--;
-
-        data.putBoolean("hover", hoverMode);
-        data.putBoolean("enabled", jetpackEnabled);
         data.putShort("burnTimer", (short) burnTimer);
-        data.putByte("toggleTimer", toggleTimer);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/PowerlessJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/PowerlessJetpack.java
@@ -74,7 +74,7 @@ public class PowerlessJetpack implements IArmorLogic, IJetpack, IItemHUDProvider
         CompoundTag data = stack.getOrCreateTag();
 
         if (data.contains("burnTimer")) burnTimer = data.getShort("burnTimer");
-        if(!data.contains("enabled")) {
+        if (!data.contains("enabled")) {
             data.putBoolean("enabled", true);
             data.putBoolean("hover", false);
             data.putByte("toggleTimer", (byte) 0);
@@ -85,20 +85,20 @@ public class PowerlessJetpack implements IArmorLogic, IJetpack, IItemHUDProvider
         byte toggleTimer = data.getByte("toggleTimer");
 
         String messageKey = null;
-        if(toggleTimer == 0) {
-            if(KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
+        if (toggleTimer == 0) {
+            if (KeyBind.JETPACK_ENABLE.isKeyDown(player)) {
                 jetpackEnabled = !jetpackEnabled;
                 messageKey = "metaarmor.jetpack.flight." + (jetpackEnabled ? "enable" : "disable");
                 data.putBoolean("enabled", jetpackEnabled);
-            } else if(KeyBind.ARMOR_HOVER.isKeyDown(player)) {
+            } else if (KeyBind.ARMOR_HOVER.isKeyDown(player)) {
                 hoverMode = !hoverMode;
                 messageKey = "metaarmor.jetpack.hover." + (hoverMode ? "enable" : "disable");
                 data.putBoolean("hover", hoverMode);
             }
 
-            if(messageKey != null) {
+            if (messageKey != null) {
                 toggleTimer = 5;
-                if(!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
+                if (!world.isClientSide) player.displayClientMessage(Component.translatable(messageKey), true);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -29,6 +29,7 @@ import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.common.data.machines.GTAEMachines;
 import com.gregtechceu.gtceu.common.item.ToggleEnergyConsumerBehavior;
+import com.gregtechceu.gtceu.common.item.armor.IJetpack;
 import com.gregtechceu.gtceu.common.network.GTNetwork;
 import com.gregtechceu.gtceu.common.network.packets.*;
 import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketAddHazardZone;
@@ -44,6 +45,7 @@ import com.gregtechceu.gtceu.utils.TaskHandler;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -269,24 +271,24 @@ public class ForgeCommonEventListener {
     @SubscribeEvent(priority = EventPriority.LOW)
     public static void onEntityLivingFallEvent(LivingFallEvent event) {
         if (event.getEntity() instanceof ServerPlayer player) {
-            ItemStack armor = player.getItemBySlot(EquipmentSlot.FEET);
-            ItemStack jet = player.getItemBySlot(EquipmentSlot.CHEST);
-
             if (player.fallDistance < 3.2f)
                 return;
 
-            if (!armor.isEmpty() && armor.getItem() instanceof ArmorComponentItem valueItem) {
-                valueItem.getArmorLogic().damageArmor(player, armor, player.damageSources().fall(),
-                        (int) (player.fallDistance - 1.2f), EquipmentSlot.FEET);
+            ItemStack boots = player.getItemBySlot(EquipmentSlot.FEET);
+            ItemStack chest = player.getItemBySlot(EquipmentSlot.CHEST);
+
+            if(boots.is(CustomTags.STEP_BOOTS) && boots.getItem() instanceof ArmorComponentItem armor) {
+                armor.getArmorLogic().damageArmor(player, boots, player.damageSources().fall(), (int) (player.fallDistance - 1.2f), EquipmentSlot.FEET);
                 player.fallDistance = 0;
                 event.setCanceled(true);
-            } else if (!jet.isEmpty() && jet.getItem() instanceof ArmorComponentItem valueItem &&
-                    jet.getOrCreateTag().contains("flyMode")) {
-                        valueItem.getArmorLogic().damageArmor(player, jet, player.damageSources().fall(),
-                                (int) (player.fallDistance - 1.2f), EquipmentSlot.FEET);
-                        player.fallDistance = 0;
-                        event.setCanceled(true);
-                    }
+            } else if(chest.getItem() instanceof ArmorComponentItem armor &&
+                        armor.getArmorLogic() instanceof IJetpack jetpack &&
+                        jetpack.canUseEnergy(chest, jetpack.getEnergyPerUse()) &&
+                        player.fallDistance >= player.getHealth() + 3.2f) {
+                IJetpack.performEHover(chest, player);
+                player.fallDistance = 0;
+                event.setCanceled(true);
+            }
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -45,7 +45,6 @@ import com.gregtechceu.gtceu.utils.TaskHandler;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -277,18 +276,19 @@ public class ForgeCommonEventListener {
             ItemStack boots = player.getItemBySlot(EquipmentSlot.FEET);
             ItemStack chest = player.getItemBySlot(EquipmentSlot.CHEST);
 
-            if(boots.is(CustomTags.STEP_BOOTS) && boots.getItem() instanceof ArmorComponentItem armor) {
-                armor.getArmorLogic().damageArmor(player, boots, player.damageSources().fall(), (int) (player.fallDistance - 1.2f), EquipmentSlot.FEET);
+            if (boots.is(CustomTags.STEP_BOOTS) && boots.getItem() instanceof ArmorComponentItem armor) {
+                armor.getArmorLogic().damageArmor(player, boots, player.damageSources().fall(),
+                        (int) (player.fallDistance - 1.2f), EquipmentSlot.FEET);
                 player.fallDistance = 0;
                 event.setCanceled(true);
-            } else if(chest.getItem() instanceof ArmorComponentItem armor &&
-                        armor.getArmorLogic() instanceof IJetpack jetpack &&
-                        jetpack.canUseEnergy(chest, jetpack.getEnergyPerUse()) &&
-                        player.fallDistance >= player.getHealth() + 3.2f) {
-                IJetpack.performEHover(chest, player);
-                player.fallDistance = 0;
-                event.setCanceled(true);
-            }
+            } else if (chest.getItem() instanceof ArmorComponentItem armor &&
+                    armor.getArmorLogic() instanceof IJetpack jetpack &&
+                    jetpack.canUseEnergy(chest, jetpack.getEnergyPerUse()) &&
+                    player.fallDistance >= player.getHealth() + 3.2f) {
+                        IJetpack.performEHover(chest, player);
+                        player.fallDistance = 0;
+                        event.setCanceled(true);
+                    }
         }
     }
 


### PR DESCRIPTION
## What
- Fixes incorrect jetpack flying behavior in `IJetpack` ( fixes #1812 )
- Fixes `onEntityLivingFallEvent` to actually cancel fall damage *only if* suit boots are worn, or to engage ehover if a jetpack is worn
- Modify jetpacks' `onArmorTick` so that NBT doesn't get overridden after an ehover

## Implementation Details
Note that the AdvancedJetpack armor tick logic is identical to the regular Jetpack, so it doesn't need to specifically be overridden

## Outcome
Jetpacks less jank