### PR TITLE
Changed Ingredient tree creation behavior

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
@@ -373,15 +373,6 @@ public class GTRecipeLookup {
             } else {
                 cache.put(mappedIngredient, new WeakReference<>(mappedIngredient));
             }
-
-            // hardcode a tree specialization for the intersection ingredient
-            if (mappedIngredient instanceof MapIntersectionIngredient intersection) {
-                for (Ingredient inner : intersection.ingredients) {
-                    List<AbstractMapIngredient> converted = ItemRecipeCapability.CAP.convertToMapIngredient(inner);
-                    retrieveCachedIngredient(list, converted, cache);
-                }
-                added = true;
-            }
         }
         if (!added) {
             list.add(ingredients);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
@@ -11,7 +11,6 @@ import com.lowdragmc.lowdraglib.Platform;
 
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 
 import com.mojang.datafixers.util.Either;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
@@ -362,7 +362,6 @@ public class GTRecipeLookup {
     protected static void retrieveCachedIngredient(@NotNull List<List<AbstractMapIngredient>> list,
                                                    @NotNull List<AbstractMapIngredient> ingredients,
                                                    @NotNull WeakHashMap<AbstractMapIngredient, WeakReference<AbstractMapIngredient>> cache) {
-        boolean added = false;
         for (int i = 0; i < ingredients.size(); i++) {
             AbstractMapIngredient mappedIngredient = ingredients.get(i);
             // attempt to use the cached value if possible, otherwise cache for the next time
@@ -373,9 +372,7 @@ public class GTRecipeLookup {
                 cache.put(mappedIngredient, new WeakReference<>(mappedIngredient));
             }
         }
-        if (!added) {
-            list.add(ingredients);
-        }
+        list.add(ingredients);
     }
 
     /**


### PR DESCRIPTION
## What
While caching the ingredients for recipes and adding them to the recipe lookup map, IntersectionIngredients were split up into their constituent MapIngredients. This caused the recursive recipe lookup to be unable to find recipes that used an IntersectionIngredient. See [`GTRecipeLookup#recurseIngredientTreeFindRecipeCollisions`](https://github.com/GregTechCEu/GregTech-Modern/blob/1815527d7ca4785a9e91f5dad1c2ef96a8bbbb67/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java#L189) for more details

Now, it no longer splits Intersection Ingredients
Fixes #1839 

## Outcome
Oin happy 😄 