### PR TITLE
Misc fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 
 import com.google.common.collect.Table;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
@@ -104,19 +105,25 @@ class RecipeRunner {
                     this.content.slots.computeIfAbsent(cont.slotName, s -> new ArrayList<>()).add(cont.content);
                 }
             } else {
-                chancedContents.add(cont);
+                // unparallel the chanced contents - bandaid fix
+                chancedContents.add(cont.copy(cap, ContentModifier.multiplier(1.0 / recipe.parallels)));
             }
         }
+
+        // Roll the dice for every parallel
+        List<Content> rolls = new ArrayList<>();
         int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-        chancedContents = logic.roll(chancedContents, function,
-                recipeTier, holder.getChanceTier(), this.chanceCaches.get(cap));
-        if (chancedContents != null) {
-            for (Content cont : chancedContents) {
-                if (cont.slotName == null) {
-                    this.content.content.add(cont.content);
-                } else {
-                    this.content.slots.computeIfAbsent(cont.slotName, s -> new ArrayList<>()).add(cont.content);
-                }
+        for (int parallels = recipe.parallels; parallels > 0; parallels--) {
+            List<Content> roll = logic.roll(chancedContents, function,
+                    recipeTier, holder.getChanceTier(), this.chanceCaches.get(cap));
+            if (roll != null) rolls.addAll(roll);
+        }
+
+        for (Content cont : rolls) {
+            if (cont.slotName == null) {
+                this.content.content.add(cont.content);
+            } else {
+                this.content.slots.computeIfAbsent(cont.slotName, s -> new ArrayList<>()).add(cont.content);
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
-import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
@@ -84,7 +83,7 @@ public class Content {
 
     @OnlyIn(Dist.CLIENT)
     public void drawRangeAmount(GuiGraphics graphics, float x, float y, int width, int height) {
-        if (content instanceof SizedIngredient sized && sized.getInner() instanceof IntProviderIngredient ingredient) {
+        if (content instanceof IntProviderIngredient ingredient) {
             graphics.pose().pushPose();
             graphics.pose().translate(0, 0, 400);
             graphics.pose().scale(0.5f, 0.5f, 1);


### PR DESCRIPTION
## What
Fixes #1907 & #1909 - Adds chance rolls to each parallel of a recipe

Also fixes the ranged output text for recipes

## Implementation Details
The chanced content of a recipe gets unparalleled by multiplying it by 1/parallel. From empirical testing: no crashing, probability rolls seem good. Ugly fix but otherwise the parallel modifiers would all have to be rewritten so that chanced outputs don't get multiplied before being sent through.

## Outcome
onion more happy

## Additional Information
![image](https://github.com/user-attachments/assets/90437477-99a4-415c-bf96-fe9867e06ecf)