### PR TITLE
Fixed improper behaviors

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -26,6 +26,8 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 
+import lombok.Getter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -45,6 +47,8 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
 
     // runtime
     protected EnergyContainerList energyContainer;
+    @Getter
+    protected int tier;
 
     public WorkableElectricMultiblockMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
@@ -57,18 +61,21 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
     public void onStructureInvalid() {
         super.onStructureInvalid();
         this.energyContainer = null;
+        this.tier = 0;
     }
 
     @Override
     public void onStructureFormed() {
         super.onStructureFormed();
         this.energyContainer = getEnergyContainer();
+        this.tier = GTUtil.getFloorTierByVoltage(getMaxVoltage());
     }
 
     @Override
     public void onPartUnload() {
         super.onPartUnload();
         this.energyContainer = null;
+        this.tier = 0;
     }
 
     //////////////////////////////////////
@@ -87,7 +94,7 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
         MultiblockDisplayText.builder(textList, isFormed())
                 .setWorkingStatus(recipeLogic.isWorkingEnabled(), recipeLogic.isActive())
                 .addEnergyUsageLine(energyContainer)
-                .addEnergyTierLine(GTUtil.getTierByVoltage(getMaxVoltage()))
+                .addEnergyTierLine(tier)
                 .addMachineModeLine(getRecipeType())
                 .addParallelsLine(numParallels)
                 .addWorkingStatusLine()
@@ -178,14 +185,6 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
     //////////////////////////////////////
     // ****** RECIPE LOGIC *******//
     //////////////////////////////////////
-
-    /**
-     * Get energy tier.
-     */
-    @Override
-    public int getTier() {
-        return GTUtil.getFloorTierByVoltage(getMaxVoltage());
-    }
 
     public EnergyContainerList getEnergyContainer() {
         List<IEnergyContainer> containers = new ArrayList<>();

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -60,7 +60,11 @@ public class RecipeHelper {
     }
 
     public static int getPreOCRecipeEuTier(GTRecipe recipe) {
-        return getRecipeEUtTier(recipe) - recipe.ocTier;
+        long EUt = getInputEUt(recipe);
+        if (EUt == 0) EUt = getOutputEUt(recipe);
+        if (recipe.parallels > 1) EUt /= recipe.parallels;
+        EUt >>= (recipe.ocTier * 2);
+        return GTUtil.getTierByVoltage(EUt);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -110,16 +110,13 @@ class RecipeRunner {
             }
         }
 
-        // Roll the dice for every parallel
-        List<Content> rolls = new ArrayList<>();
         int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-        for (int parallels = recipe.parallels; parallels > 0; parallels--) {
-            List<Content> roll = logic.roll(chancedContents, function,
-                    recipeTier, holder.getChanceTier(), this.chanceCaches.get(cap));
-            if (roll != null) rolls.addAll(roll);
-        }
+        int holderTier = holder.getChanceTier();
+        var cache = this.chanceCaches.get(cap);
+        chancedContents = logic.roll(chancedContents, function, recipeTier, holderTier, cache, recipe.parallels, cap);
 
-        for (Content cont : rolls) {
+        if (chancedContents == null) return;
+        for (Content cont : chancedContents) {
             if (cont.slotName == null) {
                 this.content.content.add(cont.content);
             } else {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveBlastFurnaceMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveBlastFurnaceMachine.java
@@ -1,10 +1,13 @@
 package com.gregtechceu.gtceu.common.machine.multiblock.primitive;
 
 import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.UITemplate;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.feature.IUIMachine;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
@@ -37,6 +40,18 @@ public class PrimitiveBlastFurnaceMachine extends PrimitiveWorkableMachine imple
 
     public PrimitiveBlastFurnaceMachine(IMachineBlockEntity holder, Object... args) {
         super(holder, args);
+    }
+
+    @Override
+    protected NotifiableItemStackHandler createImportItemHandler(Object... args) {
+        return new NotifiableItemStackHandler(this, getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN,
+                IO.NONE);
+    }
+
+    @Override
+    protected NotifiableItemStackHandler createExportItemHandler(Object... args) {
+        return new NotifiableItemStackHandler(this, getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP), IO.OUT,
+                IO.NONE);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
@@ -57,23 +57,21 @@ public class PrimitiveWorkableMachine extends WorkableMultiblockMachine
     }
 
     protected NotifiableItemStackHandler createImportItemHandler(Object... args) {
-        return new NotifiableItemStackHandler(this, getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN,
-                IO.NONE);
+        return new NotifiableItemStackHandler(this, getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN);
     }
 
     protected NotifiableItemStackHandler createExportItemHandler(Object... args) {
-        return new NotifiableItemStackHandler(this, getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP), IO.OUT,
-                IO.NONE);
+        return new NotifiableItemStackHandler(this, getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP), IO.OUT);
     }
 
     protected NotifiableFluidTank createImportFluidHandler(Object... args) {
         return new NotifiableFluidTank(this, getRecipeType().getMaxInputs(FluidRecipeCapability.CAP),
-                32 * FluidHelper.getBucket(), IO.IN, IO.NONE);
+                32 * FluidHelper.getBucket(), IO.IN);
     }
 
     protected NotifiableFluidTank createExportFluidHandler(Object... args) {
         return new NotifiableFluidTank(this, getRecipeType().getMaxOutputs(FluidRecipeCapability.CAP),
-                32 * FluidHelper.getBucket(), IO.OUT, IO.NONE);
+                32 * FluidHelper.getBucket(), IO.OUT);
     }
 
     @Override


### PR DESCRIPTION
## What
Reworks the chance logic (yet again) due to performance concerns. The chanced output of a parallel recipe is now deterministic. The batch will produce a guaranteed output based on chanced% and will only roll once.

This PR also reverts the changes made to the `PrimitiveMultiblockMachine` which were made in an attempt to disable extraction and insertion through the controller block. This came with the side effect of breaking the coke oven hatch.
These changes have been applied directly to the `PrimitiveBlastFurnace` at the very least as a stopgap until further work is done on the issue.

## Implementation Details
Also adds tier caching to `WorkableElectricMultiblockMachine`s instead of computing the tier every time `getTier()` is called. The tier is set on the structure being formed and unset when broken.