### PR TITLE
Tuned Tool Highlight Grid behavior

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -334,7 +334,7 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
     @Override
     public boolean shouldRenderGrid(Player player, BlockPos pos, BlockState state, ItemStack held,
                                     Set<GTToolType> toolTypes) {
-        if (toolTypes.contains(getPipeTuneTool()) || toolTypes.contains(GTToolType.SCREWDRIVER)) return true;
+        if (toolTypes.contains(getPipeTuneTool())) return true;
         for (CoverBehavior cover : coverContainer.getCovers()) {
             if (cover.shouldRenderGrid(player, pos, state, held, toolTypes)) return true;
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -505,8 +505,11 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     @Override
     public boolean shouldRenderGrid(Player player, BlockPos pos, BlockState state, ItemStack held,
                                     Set<GTToolType> toolTypes) {
-        if (toolTypes.contains(GTToolType.WRENCH) || toolTypes.contains(GTToolType.SCREWDRIVER)) return true;
+        if (toolTypes.contains(GTToolType.WRENCH)) return true;
         if (toolTypes.contains(GTToolType.HARD_HAMMER) && this instanceof IMufflableMachine) return true;
+        if (toolTypes.contains(GTToolType.SCREWDRIVER) &&
+                (this instanceof IAutoOutputItem || this instanceof IAutoOutputFluid))
+            return true;
         for (CoverBehavior cover : coverContainer.getCovers()) {
             if (cover.shouldRenderGrid(player, pos, state, held, toolTypes)) return true;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/rotation/CustomBlockRotations.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/rotation/CustomBlockRotations.java
@@ -49,8 +49,8 @@ public class CustomBlockRotations {
         }
 
         @Override
-        public boolean showXOnSide(BlockState state, Direction facing) {
-            return state.getValue(HorizontalDirectionalBlock.FACING) == facing;
+        public boolean showSideTip(BlockState state, Direction side) {
+            return side.getAxis() != Direction.Axis.Y && state.getValue(HorizontalDirectionalBlock.FACING) != side;
         }
     };
 
@@ -70,8 +70,8 @@ public class CustomBlockRotations {
         }
 
         @Override
-        public boolean showXOnSide(BlockState state, Direction facing) {
-            return state.getValue(DirectionalBlock.FACING) == facing;
+        public boolean showSideTip(BlockState state, Direction side) {
+            return state.getValue(DirectionalBlock.FACING) != side;
         }
     };
 
@@ -111,8 +111,8 @@ public class CustomBlockRotations {
             }
 
             @Override
-            public boolean showXOnSide(BlockState state, Direction facing) {
-                return state.getValue(HopperBlock.FACING) == facing;
+            public boolean showSideTip(BlockState state, Direction side) {
+                return side != Direction.UP && state.getValue(HopperBlock.FACING) != side;
             }
         }),
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/rotation/ICustomRotationBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/rotation/ICustomRotationBehavior.java
@@ -21,7 +21,7 @@ public interface ICustomRotationBehavior {
     }
 
     /** Whether to draw an X on a provided side in the 9-sectioned highlight grid. */
-    default boolean showXOnSide(BlockState state, Direction facing) {
+    default boolean showSideTip(BlockState state, Direction side) {
         return false;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BlockBreakerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BlockBreakerMachine.java
@@ -448,6 +448,10 @@ public class BlockBreakerMachine extends TieredEnergyMachine
             }
         } else if (toolTypes.contains(GTToolType.SOFT_MALLET)) {
             return isWorkingEnabled ? GuiTextures.TOOL_PAUSE : GuiTextures.TOOL_START;
+        } else if (toolTypes.contains(GTToolType.SCREWDRIVER)) {
+            if (side == getOutputFacingItems()) {
+                return GuiTextures.TOOL_ALLOW_INPUT;
+            }
         }
         return super.sideTips(player, pos, state, toolTypes, side);
     }


### PR DESCRIPTION
## What
Tool Highlight Grid will now only appear on most blocks if an interaction is present 
Grid will also now appear on vanilla blocks that can be rotated by GT wrenches

## Implementation Details
`CustomBlockRotation#showXOnSide` was not being used and thus was repurposed for use with sidetips.

## Additional Information
_With Screwdriver when pipe has no covers:_

![image](https://github.com/user-attachments/assets/52c2dab7-772a-42ee-b104-863635607394)

_With Wrench:_ 

![image](https://github.com/user-attachments/assets/6f009e78-d3ed-4f5f-bbb8-4e0d5fb5641e)
