### PR TITLE
Quantum Storage Fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -304,7 +304,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
                 var drained = cache.extractItem(0, player.isShiftKeyDown() ? stored.getItem().getMaxStackSize() : 1,
                         false);
                 if (!drained.isEmpty()) {
-                    if (player.addItem(drained)) {
+                    if (!player.addItem(drained)) {
                         Block.popResource(world, getPos().relative(getFrontFacing()), drained);
                     }
                 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -132,7 +132,9 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
 
             private long handleVoiding(long filled, FluidStack resource) {
                 if (filled < resource.getAmount() && isVoiding && isFluidValid(0, resource)) {
-                    return resource.getAmount();
+                    if(stored.isEmpty() || stored.isFluidEqual(resource)) {
+                        return resource.getAmount();
+                    }
                 }
 
                 return filled;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -132,7 +132,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
 
             private long handleVoiding(long filled, FluidStack resource) {
                 if (filled < resource.getAmount() && isVoiding && isFluidValid(0, resource)) {
-                    if(stored.isEmpty() || stored.isFluidEqual(resource)) {
+                    if (stored.isEmpty() || stored.isFluidEqual(resource)) {
                         return resource.getAmount();
                     }
                 }


### PR DESCRIPTION
## What
Fixes #1901
Fixes #1950 

## Implementation Details
For the Quantum chest, a boolean-check was mistakenly inverted.
For the Quantum tank, the tank was not checking to see if the fluid being inserted was even the correct fluid before being transferred. Quantum tanks should not be accepting (and therefore should not be voiding) a fluid that it does not contain.