### PR TITLE
Fixed filtering on auto-transfer

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -645,7 +645,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     // ****** Capability ********//
     //////////////////////////////////////
 
-    protected Predicate<ItemStack> getItemCapFilter(@Nullable Direction side) {
+    public Predicate<ItemStack> getItemCapFilter(@Nullable Direction side) {
         if (side != null) {
             var cover = getCoverContainer().getCoverAtSide(side);
             if (cover instanceof ItemFilterCover filterCover) {
@@ -655,7 +655,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
         return item -> true;
     }
 
-    protected Predicate<FluidStack> getFluidCapFilter(@Nullable Direction side) {
+    public Predicate<FluidStack> getFluidCapFilter(@Nullable Direction side) {
         if (side != null) {
             var cover = getCoverContainer().getCoverAtSide(side);
             if (cover instanceof FluidFilterCover filterCover) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -267,7 +267,8 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         var level = getMachine().getLevel();
         var pos = getMachine().getPos();
         for (Direction facing : facings) {
-            FluidTransferHelper.exportToTarget(this, Integer.MAX_VALUE, f -> true, level, pos.relative(facing),
+            FluidTransferHelper.exportToTarget(this, Integer.MAX_VALUE, getMachine().getFluidCapFilter(facing), level,
+                    pos.relative(facing),
                     facing.getOpposite());
         }
     }
@@ -276,7 +277,8 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         var level = getMachine().getLevel();
         var pos = getMachine().getPos();
         for (Direction facing : facings) {
-            FluidTransferHelper.importToTarget(this, Integer.MAX_VALUE, f -> true, level, pos.relative(facing),
+            FluidTransferHelper.importToTarget(this, Integer.MAX_VALUE, getMachine().getFluidCapFilter(facing), level,
+                    pos.relative(facing),
                     facing.getOpposite());
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -225,7 +225,8 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         var level = getMachine().getLevel();
         var pos = getMachine().getPos();
         for (Direction facing : facings) {
-            ItemTransferHelper.exportToTarget(this, Integer.MAX_VALUE, f -> true, level, pos.relative(facing),
+            ItemTransferHelper.exportToTarget(this, Integer.MAX_VALUE, getMachine().getItemCapFilter(facing), level,
+                    pos.relative(facing),
                     facing.getOpposite());
         }
     }
@@ -234,7 +235,8 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         var level = getMachine().getLevel();
         var pos = getMachine().getPos();
         for (Direction facing : facings) {
-            ItemTransferHelper.importToTarget(this, Integer.MAX_VALUE, f -> true, level, pos.relative(facing),
+            ItemTransferHelper.importToTarget(this, Integer.MAX_VALUE, getMachine().getItemCapFilter(facing), level,
+                    pos.relative(facing),
                     facing.getOpposite());
         }
     }


### PR DESCRIPTION
## What
Fixed filters not being respected on machine auto-output and auto-input

## Implementation Details
The `exportToNearby` and `importToNearby` LDLib methods were never passed the machines filter when doing auto-transfers.

## Outcome
People will be happy

## Additional Information
LDLib is funni