### PR TITLE
Added gradle task for versioning and edited workflows

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Get Version
         id: var
         run: |
-          MESSAGE=$(ls build/libs/* | grep dev.jar -v | grep sources.jar -v | grep slim.jar -v | awk -F 'gtceu-|-SNAPSHOT.jar' '{print $2}')
-          mv "build/libs/gtceu-$MESSAGE-SNAPSHOT.jar" "build/libs/gtceu-$MESSAGE-build_${{ github.run_number }}-SNAPSHOT.jar"
-          mv "build/libs/gtceu-$MESSAGE-SNAPSHOT-slim.jar" "build/libs/gtceu-$MESSAGE-build_${{ github.run_number }}-SNAPSHOT-slim.jar"
-          echo "version=$MESSAGE-build_${{ github.run_number }}" >> $GITHUB_OUTPUT
+          VER=$(./gradlew -q printVersion)
+          BUILD_VER=$VER-build_${{ github.run_number }}
+          for jar in ./build/libs/*; do mv "$jar" "${jar/${VER}-SNAPSHOT/${BUILD_VER}-SNAPSHOT}";done 2>/dev/null
+          echo "version=$BUILD_VER" >> $GITHUB_OUTPUT
 
       - name: Release
         id: release

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -49,9 +49,7 @@ jobs:
       - if: ${{ inputs.publishCurseForgeAndModrinth }}
         name: Get Version
         id: var
-        run: |
-          MESSAGE=$(ls build/libs/* | grep dev.jar -v | grep sources.jar -v | grep shadow.jar -v | grep slim.jar -v | awk -F 'gtceu-|.jar' '{print $2}')
-          echo version=$MESSAGE >> $GITHUB_OUTPUT
+        run: echo "version=$(./gradlew -q printVersion)" >> $GITHUB_OUTPUT
 
       - if: ${{ inputs.publishCurseForgeAndModrinth }}
         name: mc-publish-forge

--- a/gradle/scripts/publishing.gradle
+++ b/gradle/scripts/publishing.gradle
@@ -9,7 +9,7 @@ publishing {
         mavenJava(MavenPublication) {
             groupId = project.maven_group
             artifactId = project.archivesBaseName
-            version = project.mod_version
+            version = project.version
 
             from components.java
 

--- a/gradle/scripts/resources.gradle
+++ b/gradle/scripts/resources.gradle
@@ -10,6 +10,12 @@ def mod_description = getConfig("mod_description")
 def mod_url = getConfig("mod_url")
 def mod_issue_tracker = getConfig("mod_issue_tracker")
 
+task printVersion {
+    doLast {
+        println libs.versions.minecraft.get() + "-" + mod_version
+    }
+}
+
 // This block of code expands all declared replace properties in the specified resource targets.
 // A missing property will result in an error. Properties are expanded using ${} Groovy notation.
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {


### PR DESCRIPTION
## What
No more grep

## Implementation Details
Runs new gradle task `printVersion` whenever it needs the version number in the form `{mc-ver}-{mod-ver}`, e.g. `1.20.1-1.4.2`