### PR TITLE
Bump up the LDLib to fix  XEI compat + fix pattern preview widget

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -54,7 +54,7 @@ dependencyResolutionManagement {
         def vineFlowerVersion = "1.+"
         def macheteVersion = "1.+"
         def configurationVersion = "2.2.0"
-        def ldLibVersion = "1.0.27.b"
+        def ldLibVersion = "1.0.28.a"
         def mixinextrasVersion = "0.2.0"
         def shimmerVersion = "0.2.4"
         def lombokPluginVersion = "8.7.1"

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
@@ -87,6 +87,7 @@ public class PatternPreviewWidget extends WidgetGroup {
                 .setXBarStyle(GuiTextures.SLIDER_BACKGROUND, GuiTextures.BUTTON)
                 .setScrollable(true)
                 .setDraggable(true);
+        scrollableWidgetGroup.setScrollWheelDirection(DraggableScrollableWidgetGroup.ScrollWheelDirection.HORIZONTAL);
         scrollableWidgetGroup.setScrollYOffset(0);
         addWidget(scrollableWidgetGroup);
 
@@ -181,7 +182,7 @@ public class PatternPreviewWidget extends WidgetGroup {
         setupScene(pattern);
         if (slotWidgets != null) {
             for (SlotWidget slotWidget : slotWidgets) {
-                removeWidget(slotWidget);
+                scrollableWidgetGroup.removeWidget(slotWidget);
             }
         }
         slotWidgets = new SlotWidget[Math.min(pattern.parts.size(), 18)];


### PR DESCRIPTION
## What
latest ldlib:
* Fix JEI, support recipe focus for all IRecipeSlotIngredient widgets, including cycle, tags, etc.
* Fix JEI, support both jei internal tooltips and ldlib widget tooltips.
* Fix item and fluid drop into PhantomWidget issues with JEI and emi

* Fix pattern preview duplicate slots + switch to the HORIZONTAL wheel 

## Implementation Details
* Rendering of the slot back to ldlib to ensure that it meets the widget's expectations. 
* Add jei's focus for ldlib slots
* Use Tooltips from both jei and ldlib widget itself

## Outcome


## Additional Information


## Potential Compatibility Issues
