### PR TITLE
Fixed recipe condition encoding

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeCondition.java
@@ -33,7 +33,7 @@ public abstract class RecipeCondition {
 
     public static <
             RC extends RecipeCondition> Products.P1<RecordCodecBuilder.Mu<RC>, Boolean> isReverse(RecordCodecBuilder.Instance<RC> instance) {
-        return instance.group(Codec.BOOL.fieldOf("reverse").forGetter(val -> val.isReverse));
+        return instance.group(Codec.BOOL.optionalFieldOf("reverse", false).forGetter(val -> val.isReverse));
     }
 
     @Getter

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DimensionCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DimensionCondition.java
@@ -103,7 +103,7 @@ public class DimensionCondition extends RecipeCondition {
     @Override
     public JsonObject serialize() {
         JsonObject config = super.serialize();
-        config.addProperty("dim", dimension.toString());
+        config.addProperty("dimension", dimension.toString());
         return config;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1084,10 +1084,9 @@ public class GTRecipeBuilder {
         if (!conditions.isEmpty()) {
             JsonArray array = new JsonArray();
             for (RecipeCondition condition : conditions) {
-                JsonObject cond = new JsonObject();
-                cond.addProperty("type", GTRegistries.RECIPE_CONDITIONS.getKey(condition.getType()));
-                cond.add("data", condition.serialize());
-                array.add(cond);
+                var condJson = condition.serialize();
+                condJson.addProperty("type", GTRegistries.RECIPE_CONDITIONS.getKey(condition.getType()));
+                array.add(condJson);
             }
             json.add("recipeConditions", array);
         }


### PR DESCRIPTION

## What
Recipe conditions need to be flatmapped into the JSON array along with the type Also changed the DimensionCondition to use the right key
Fixes #1988 

## Implementation Details
I don't know enough about Codecs to make the previous format of {type, data} work. I think the type of Codec used in RecipeCondition needs to be changed but idk. Works like this.