### PR TITLE
Fix when item's burn time * 12 > Integer.MAX_VALUE,it can't be burned.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -38,10 +38,17 @@ public class FuelRecipes {
             var burnTime = GTUtil.getItemBurnTime(item);
             if (burnTime > 0 && !addedItems.contains(item)) {
                 var resLoc = BuiltInRegistries.ITEM.getKey(item);
-                STEAM_BOILER_RECIPES.recipeBuilder(GTCEu.id(resLoc.getNamespace() + "_" + resLoc.getPath()))
-                        .inputItems(item)
-                        .duration(burnTime * 12)
-                        .save(provider);
+                if (burnTime * 12L > Integer.MAX_VALUE) {
+                    LARGE_BOILER_RECIPES.recipeBuilder(GTCEu.id(resLoc.getNamespace() + "_" + resLoc.getPath()))
+                            .inputItems(item)
+                            .duration(burnTime / 80)
+                            .save(provider);
+                } else {
+                    STEAM_BOILER_RECIPES.recipeBuilder(GTCEu.id(resLoc.getNamespace() + "_" + resLoc.getPath()))
+                            .inputItems(item)
+                            .duration(burnTime * 12)
+                            .save(provider);
+                }
             }
         }
 


### PR DESCRIPTION
## What

Fix when item's burn time * 12 > Integer.MAX_VALUE,it can't be burned.

## Implementation Details

Avaritia's star fuel have a burn time with Integer.MAX_VALUE, it can't be burned in GTM's machines.

## Outcome

star fuel now can burn in GTM's machines with LARGE_BOILER_RECIPES.

## Additional Information
_This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of._

## Potential Compatibility Issues
_This section is for defining possible compatibility issues. It must be used when there are API changes, item/block/material/machine changes, or recipe changes._

**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**