### PR TITLE
Rework Pump Machine logic to fix issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -442,8 +442,8 @@ public class GTMachines {
                             Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity",
                                     FormattingUtil.formatNumbers(16 * FluidHelper.getBucket() * Math.max(1, tier))),
                             Component.translatable("gtceu.universal.tooltip.working_area",
-                                    PumpMachine.BASE_PUMP_RANGE + PumpMachine.EXTRA_PUMP_RANGE * tier,
-                                    PumpMachine.BASE_PUMP_RANGE + PumpMachine.EXTRA_PUMP_RANGE * tier))
+                                    PumpMachine.getMaxPumpRadius(tier),
+                                    PumpMachine.getMaxPumpRadius(tier)))
                     .compassNode("pump")
                     .register(),
             LV, MV, HV, EV);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -442,8 +442,8 @@ public class GTMachines {
                             Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity",
                                     FormattingUtil.formatNumbers(16 * FluidHelper.getBucket() * Math.max(1, tier))),
                             Component.translatable("gtceu.universal.tooltip.working_area",
-                                    PumpMachine.getMaxPumpRadius(tier),
-                                    PumpMachine.getMaxPumpRadius(tier)))
+                                    PumpMachine.getMaxPumpRadius(tier) * 2,
+                                    PumpMachine.getMaxPumpRadius(tier) * 2))
                     .compassNode("pump")
                     .register(),
             LV, MV, HV, EV);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/PumpMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/PumpMachine.java
@@ -27,22 +27,39 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.annotation.RequireRerender;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.fluids.IFluidBlock;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
+import java.util.List;
+import java.util.Queue;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -61,7 +78,8 @@ public class PumpMachine extends TieredEnergyMachine implements IAutoOutputFluid
     public static final int PUMP_SPEED_BASE = 80;
     private final Deque<BlockPos> fluidSourceBlocks = new ArrayDeque<>();
     private final Deque<BlockPos> blocksToCheck = new ArrayDeque<>();
-    private boolean initializedQueue = false;
+    private PumpQueue pumpQueue = null;
+    private final boolean initializedQueue = false;
     @Getter
     @Persisted
     private int pumpHeadY;
@@ -128,59 +146,274 @@ public class PumpMachine extends TieredEnergyMachine implements IAutoOutputFluid
         return BASE_PUMP_RANGE + EXTRA_PUMP_RANGE * getTier();
     }
 
-    private boolean isStraightInPumpRange(BlockPos checkPos) {
-        BlockPos pos = getPos();
-        return checkPos.getX() == pos.getX() &&
-                checkPos.getZ() == pos.getZ() &&
-                pos.getY() < checkPos.getY() &&
-                pos.getY() + pumpHeadY >= checkPos.getY();
+    /**
+     * Returns a list of directions, starting with Up and then horizontal directions with the directions most matching
+     * the vector first.
+     */
+    private List<Direction> biasedInVecDirections(RandomSource randomSource, Vec3i vec, boolean goUp) {
+        List<Direction> searchList = new ArrayList<>();
+        if (goUp) {
+            searchList.add(Direction.UP);
+        }
+
+        ObjectArrayList<Direction.Axis> axes = new ObjectArrayList<>();
+        int zValue = Math.abs(vec.getZ());
+        int xValue = Math.abs(vec.getX());
+        if (zValue > xValue) {
+            axes.add(Direction.Axis.Z);
+            axes.add(Direction.Axis.X);
+        } else if (zValue < xValue) {
+            axes.add(Direction.Axis.X);
+            axes.add(Direction.Axis.Z);
+        } else {
+            axes.add(Direction.Axis.Z);
+            axes.add(Direction.Axis.X);
+            Util.shuffle(axes, randomSource);
+        }
+
+        Direction lastDirection = null;
+        for (int i = 0; i < 2; i++) {
+            Direction.Axis axis = axes.get(i);
+            int value;
+            if (axis.equals(Direction.Axis.Z)) {
+                value = vec.getZ();
+            } else {
+                value = vec.getX();
+            }
+
+            Direction direction;
+            if (value < 0) {
+                direction = Direction.fromAxisAndDirection(axis, Direction.AxisDirection.NEGATIVE);
+            } else if (value > 0) {
+                direction = Direction.fromAxisAndDirection(axis, Direction.AxisDirection.POSITIVE);
+            } else {
+                direction = Direction.fromAxisAndDirection(axis, Util.getRandom(Direction.AxisDirection.values(), randomSource));
+            }
+            searchList.add(direction);
+            if (i == 0) {
+                lastDirection = direction.getOpposite();
+            } else {
+                searchList.add(direction.getOpposite());
+            }
+
+        }
+        searchList.add(lastDirection);
+
+        return searchList;
     }
 
-    private void updateQueueState(int blocksToCheckAmount) {
-        BlockPos selfPos = getPos().below(pumpHeadY);
+    private record PumpQueue(Queue<Deque<BlockPos>> queue, FluidType fluidType) {}
 
-        for (int i = 0; i < blocksToCheckAmount; i++) {
-            BlockPos checkPos = null;
-            int amountIterated = 0;
-            do {
-                if (checkPos != null) {
-                    blocksToCheck.push(checkPos);
-                    amountIterated++;
-                }
-                checkPos = blocksToCheck.poll();
+    private record SearchResult(BlockPos pos, boolean isSource) {}
 
-            } while (checkPos != null &&
-                    !getLevel().isLoaded(checkPos) &&
-                    amountIterated < blocksToCheck.size());
-            if (checkPos != null) {
-                checkFluidBlockAt(selfPos, checkPos);
-            } else break;
-        }
+    /**
+     *
+     */
+    @Nullable
+    private SearchResult searchNext(Level level, BlockPos headPosBelow, BlockPos searchHead, FluidType fluidType, int maxPumpRange, boolean goUp, Set<BlockPos> checked) {
+        // Vector from the pump head to the search head, so points in the direction away from the pump head
+        Vec3i subVec = searchHead.subtract(headPosBelow);
 
-        if (fluidSourceBlocks.isEmpty()) {
-            if (getOffsetTimer() % 20 == 0) {
-                BlockPos downPos = selfPos.below(1);
-                if (downPos.getY() >= getLevel().getMinBuildHeight()) {
-                    var downBlock = getLevel().getBlockState(downPos);
-                    if (downBlock.getBlock() instanceof LiquidBlock) {
-                        this.pumpHeadY++;
-                        if (getLevel() instanceof ServerLevel serverLevel &&
-                                serverLevel.getBlockState(selfPos).isAir()) {
-                            serverLevel.setBlockAndUpdate(selfPos, GTBlocks.MINER_PIPE.getDefaultState());
-                        }
+        List<Direction> searchList = biasedInVecDirections(level.getRandom(), subVec, goUp);
+
+        for (Direction direction : searchList) {
+            BlockPos check = searchHead.relative(direction);
+            // The pos at the same y-level as the spot to check, but the x and z of the pump
+            // This is to compute the square distance only in the horizontal plane
+            BlockPos pumpY = headPosBelow.atY(check.getY());
+
+            // Skip if outside pump range or not loaded or already checked
+            if (check.distSqr(pumpY) > maxPumpRange * maxPumpRange || checked.contains(check) || !level.isLoaded(check)) {
+                continue;
+            }
+
+            // Make sure we don't look at it again
+            checked.add(check);
+
+            BlockState state = level.getBlockState(check);
+            FluidState fluidState;
+
+            // If it's not a fluid of the right type, we stop
+            if ((fluidState = state.getFluidState()).getFluidType() == fluidType && state.getBlock() instanceof LiquidBlock liquidBlock) {
+                // Remember all the sources we find
+                boolean isSource = fluidState.isSource();
+                if (isSource) {
+                    var fluidHandler = new FluidBlockTransfer(liquidBlock, level, check);
+                    FluidStack drainStack = fluidHandler.drain(Integer.MAX_VALUE, true);
+                    if (!drainStack.isEmpty()) {
+                        return new SearchResult(check, true);
                     }
                 }
-
-                // schedule queue rebuild because we changed our position and no fluid is available
-                this.initializedQueue = false;
-            }
-
-            if (!initializedQueue || getOffsetTimer() % 6000 == 0) {
-                this.initializedQueue = true;
-                // just add ourselves to check list and see how this will go
-                this.blocksToCheck.add(selfPos);
+                return new SearchResult(check, false);
             }
         }
+
+        return null;
+    }
+
+    /**
+     * Update the pump queue if it is empty.
+     * @param fluidType Use this if the pump queue must have the same fluid type because it was already decided in the
+     *                  pump cycle.
+     */
+    private void updatePumpQueue(@Nullable FluidType fluidType) {
+        if (getLevel() == null) return;
+
+        if (pumpQueue != null && !pumpQueue.queue().isEmpty()) {
+            return;
+        }
+
+        BlockPos headPos = getPos().below(pumpHeadY);
+
+        BlockPos downPos = headPos.below(1);
+        var downBlock = getLevel().getBlockState(downPos);
+
+        if (!(downBlock.getBlock() instanceof LiquidBlock)) {
+            pumpQueue = null;
+            return;
+        }
+
+        if (fluidType != null && downBlock.getFluidState().getFluidType() != fluidType) {
+            pumpQueue = null;
+            return;
+        }
+
+        pumpQueue = buildPumpQueue(getLevel(), headPos, downBlock.getFluidState().getFluidType(), queueSize(), true);
+    }
+
+    /**
+     * Does a "depth-first"-ish search to find a path to a source. It prioritizes going up and away from the pump head.
+     * If the path it finds only contains sources at the level below the pump head, it will keep looking until it finds
+     * one that has a source at a higher location. If it cannot find one, it will return the original path.
+     */
+    private PumpQueue buildPumpQueue(Level level, BlockPos headPos, FluidType fluidType, int queueSourceAmount, boolean upSources) {
+        Set<BlockPos> checked = new ObjectOpenHashSet<>();
+
+        BlockPos headPosBelow = headPos.below();
+
+        checked.add(headPos);
+        checked.add(headPosBelow);
+
+        int maxPumpRange = getMaxPumpRange();
+
+        List<BlockPos> pathStack = new ArrayList<>();
+
+        Deque<BlockPos> nonSources = new ArrayDeque<>();
+        Deque<BlockPos> pathToLastSource = new ArrayDeque<>();
+        Deque<BlockPos> sourceStack = new ArrayDeque<>();
+
+        pathStack.add(headPosBelow);
+        nonSources.add(headPosBelow);
+
+        int iterations = 0;
+        int previousSources = 0;
+        Queue<Deque<BlockPos>> paths = new ArrayDeque<>();
+        List<BlockPos> sources = new ArrayList<>();
+        // We do at most 1000 iterations to try and find source blocks
+        while (!pathStack.isEmpty() && iterations < 1000) {
+            // Peeks at the tail
+            BlockPos searchHead = pathStack.get(pathStack.size() - 1);
+
+            SearchResult next = searchNext(level, headPosBelow, searchHead, fluidType, maxPumpRange, upSources, checked);
+
+            iterations++;
+
+            if (next == null) {
+                boolean continueSearch = sources.size() < queueSourceAmount;
+
+                int addedSources = sources.size() - previousSources;
+                previousSources = sources.size();
+                if (addedSources > 0) {
+                    var toAdd = new ArrayDeque<>(pathToLastSource);
+                    // This is always the headPosBelow, which we do not want to include
+                    toAdd.removeFirst();
+                    paths.add(toAdd);
+                }
+
+                if (!continueSearch) {
+                    return new PumpQueue(paths, fluidType);
+                }
+
+                // Now we need to rewind our stack
+                BlockPos last = pathStack.remove(pathStack.size() - 1);
+                BlockPos lastSource = sourceStack.peekLast();
+                if (last.equals(lastSource)) {
+                    BlockPos prevSource = sourceStack.removeLast();
+                    // Rebuild nonSources until previous source
+                    for (int i = pathStack.size() - 1; i >= 0; i--) {
+                        BlockPos p = pathStack.get(i);
+                        if (!p.equals(prevSource)) {
+                            nonSources.addFirst(p);
+                        } else {
+                            break;
+                        }
+                    }
+                // If the last is a source, then nonSources will be empty regardless
+                } else if (!nonSources.isEmpty()) {
+                    nonSources.removeLast();
+                }
+            } else {
+                // Add the next
+                pathStack.add(next.pos());
+                // If we are in search up mode, we only count it as a source if it's up
+                if (next.isSource() && (!upSources || next.pos().getY() > headPosBelow.getY())) {
+                    sources.add(next.pos());
+                    // Found a source, so add all the non-source blocks we passed since the last one
+                    pathToLastSource.addAll(nonSources);
+                    // Also add the source itself
+                    pathToLastSource.add(next.pos());
+                    // Reset non-sources because we just added them and found a source
+                    nonSources.clear();
+                    sources.add(next.pos());
+                } else {
+                    // Not a source, but we want to track it
+                    nonSources.add(next.pos());
+                }
+
+            }
+        }
+        if (upSources) {
+            // If we found none, we try again without the restriction
+            if (paths.isEmpty()) {
+                return buildPumpQueue(level, headPos, fluidType, queueSourceAmount, false);
+            }
+
+            return new PumpQueue(paths, fluidType);
+        }
+
+        // Only after everything except the block directly below the pipe is pumped, do we want to pump it
+        // Otherwise we might advance the pump head prematurely
+        if (paths.isEmpty() && level.getBlockState(headPosBelow).getFluidState().isSource()) {
+            return new PumpQueue(new ArrayDeque<>(List.of(new ArrayDeque<>(List.of(headPosBelow)))), fluidType);
+        }
+
+        return new PumpQueue(paths, fluidType);
+    }
+
+    /**
+     * Advances the pump head if the block below is air and the pump queue is empty.
+     */
+    private boolean canAdvancePumpHead() {
+        // position of the pump head, i.e. the position of the lowest mining pipe
+        BlockPos headPos = getPos().below(pumpHeadY);
+
+        if (pumpQueue == null || pumpQueue.queue.isEmpty()) {
+            Level level;
+            if((level = getLevel()) != null) {
+                BlockPos downPos = headPos.below(1);
+                var downBlock = level.getBlockState(downPos);
+
+                if (downBlock.isAir()) {
+                    this.pumpHeadY++;
+
+                    if (level instanceof ServerLevel serverLevel) {
+                        serverLevel.setBlockAndUpdate(downPos, GTBlocks.MINER_PIPE.getDefaultState());
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override
@@ -194,49 +427,81 @@ public class PumpMachine extends TieredEnergyMachine implements IAutoOutputFluid
         }
     }
 
-    private void checkFluidBlockAt(BlockPos pumpHeadPos, BlockPos checkPos) {
-        var blockHere = getLevel().getBlockState(checkPos);
-        boolean shouldCheckNeighbours = isStraightInPumpRange(checkPos);
+    record SourceState(BlockState state, BlockPos pos) {}
 
-        if (blockHere.getBlock() instanceof LiquidBlock liquidBlock &&
-                liquidBlock.getFluidState(blockHere).isSource()) {
-            var fluidHandler = new FluidBlockTransfer(liquidBlock, getLevel(), checkPos);
-            FluidStack drainStack = fluidHandler.drain(Integer.MAX_VALUE, true);
-            if (!drainStack.isEmpty()) {
-                this.fluidSourceBlocks.add(checkPos);
-            }
-            shouldCheckNeighbours = true;
+    /**
+     * Does a full pump cycle, trying to do the required number of pumps. It will rebuild the queue if it becomes
+     * empty without having fulfilled its required number of pumps. All paths computed in the queue are checked
+     * if they are still valid and consist only of the right fluid.
+     */
+    private void pumpCycle() {
+        Level level;
+        if ((level = getLevel()) == null) {
+            return;
         }
+        // Will only update if the queue is empty
+        updatePumpQueue(null);
+        int pumps = pumpsPerCycle();
 
-        if (shouldCheckNeighbours) {
-            int maxPumpRange = getMaxPumpRange();
-            for (var facing : GTUtil.DIRECTIONS) {
-                BlockPos offsetPos = checkPos.relative(facing);
-                if (offsetPos.distSqr(pumpHeadPos) > maxPumpRange * maxPumpRange)
-                    continue; // do not add blocks outside bounds
-                if (!fluidSourceBlocks.contains(offsetPos) &&
-                        !blocksToCheck.contains(offsetPos)) {
-                    this.blocksToCheck.add(offsetPos);
+        // We try to pump `pumps` amount of source blocks, using multiple paths if necessary
+        boolean pumped = false;
+        // We keep looking at paths as long as we still have pumps to go
+        while (pumps > 0 && pumpQueue != null && !pumpQueue.queue().isEmpty()) {
+            Deque<BlockPos> pumpPath = pumpQueue.queue().peek();
+            Deque<SourceState> states = new ArrayDeque<>();
+
+            // We iterate through the positions to check if it is still a valid path, saving the states
+            for (BlockPos pos : pumpPath) {
+                // Stop once an unloaded block is found
+                if (!level.isLoaded(pos)) {
+                    break;
+                }
+                BlockState state = level.getBlockState(pos);
+                if (state.getBlock() instanceof LiquidBlock liquidBlock &&
+                        (liquidBlock.getFluidState(state)).getFluidType() == pumpQueue.fluidType()) {
+                    states.add(new SourceState(state, pos));
+                } else {
+                    break;
                 }
             }
-        }
-    }
 
-    private void tryPumpFirstBlock() {
-        BlockPos fluidBlockPos = fluidSourceBlocks.poll();
-        if (fluidBlockPos == null) return;
-        var blockHere = getLevel().getBlockState(fluidBlockPos);
-        if (blockHere.getBlock() instanceof LiquidBlock liquidBlock &&
-                liquidBlock.getFluidState(blockHere).isSource()) {
-            var fluidHandler = new FluidBlockTransfer(liquidBlock, getLevel(), fluidBlockPos);
-            FluidStack drainStack = fluidHandler.drain(Integer.MAX_VALUE, true);
-            if (!drainStack.isEmpty() && cache.fillInternal(drainStack, true) == drainStack.getAmount()) {
-                cache.fillInternal(drainStack, false);
-                fluidHandler.drain(drainStack, false);
-                getLevel().setBlockAndUpdate(fluidBlockPos, Blocks.AIR.defaultBlockState());
-                this.fluidSourceBlocks.remove(fluidBlockPos);
-                energyContainer.changeEnergy(-GTValues.V[getTier()] * 2);
+            // We remove from the end until we find a matching state, everything after must be no longer valid
+            while (pumps > 0 && !pumpPath.isEmpty()) {
+                BlockPos pos = pumpPath.removeLast();
+                SourceState sourceState = states.peekLast();
+                if (sourceState != null && pos.equals(sourceState.pos())) {
+                    states.removeLast();
+                    FluidState fluidState = sourceState.state().getFluidState();
+                    if (sourceState.state().getBlock() instanceof LiquidBlock liquidBlock && fluidState.isSource()) {
+                        var fluidHandler = new FluidBlockTransfer(liquidBlock, getLevel(), pos);
+                        FluidStack drainStack = fluidHandler.drain(Integer.MAX_VALUE, true);
+                        if (!drainStack.isEmpty() && cache.fillInternal(drainStack, true) == drainStack.getAmount()) {
+                            cache.fillInternal(drainStack, false);
+                            fluidHandler.drain(drainStack, false);
+                            getLevel().setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+                            this.fluidSourceBlocks.remove(pos);
+                            pumped = true;
+                            pumps--;
+                        }
+                    }
+                }
             }
+
+            if (pumpPath.isEmpty()) {
+                pumpQueue.queue().remove();
+            }
+
+            // If we have pumps left over and there is still more to be pumped at the current level
+            // (But it wasn't in the queue because maybe it's the final source block below the pump head)
+            // We still want to be able to pump
+            if (pumps > 0 && pumpQueue.queue().isEmpty()) {
+                updatePumpQueue(pumpQueue.fluidType());
+            }
+        }
+
+        // Use energy if any pumps happened at all
+        if (pumped) {
+            energyContainer.changeEnergy(-GTValues.V[getTier()] * 2);
         }
     }
 
@@ -249,14 +514,41 @@ public class PumpMachine extends TieredEnergyMachine implements IAutoOutputFluid
         if (energyContainer.getEnergyStored() < GTValues.V[getTier()] * 2) {
             return;
         }
-        updateQueueState(getTier());
-        if (getOffsetTimer() % getPumpingCycleLength() == 0 && !fluidSourceBlocks.isEmpty()) {
-            tryPumpFirstBlock();
+        // Try to put 5 times as many in the queue as there are pumps in the cycle
+        // In practice only EV tier has more than 1 pump per cycle
+        // The queue can contain at most the y-levels at the pump head or just the y-level below, so for many oil veins
+        // It will not be the ideal size
+        boolean advanced = false;
+        if (getOffsetTimer() % (getPumpingCycleLength() * 2L) == 0) {
+            advanced = canAdvancePumpHead();
+        }
+        if (!advanced && getOffsetTimer() % getPumpingCycleLength() == 0) {
+            pumpCycle();
         }
     }
 
+    private int queueSize() {
+        return 5*pumpsPerCycle();
+    }
+
+    private float ticksPerPump() {
+        // How many ticks pass per pump. This is the ideal amount and thus can be less than 1
+        // For LV this is 80/1 = 80
+        float tierMultiplier = (float) (1 << (getTier() - 1));
+        return PUMP_SPEED_BASE / tierMultiplier;
+    }
+
+    private int pumpsPerCycle() {
+        // The pumping cycle length can not be less than 20, so to ensure we still have the right amount of pumps
+        // We need to compensate with pumps per cycle
+
+        return (int) (getPumpingCycleLength() / ticksPerPump());
+    }
+
     private int getPumpingCycleLength() {
-        return PUMP_SPEED_BASE / (1 << (getTier() - 1));
+        // For basic pumps this means once every 80 ticks
+        // It never pumps more than once every 20 ticks, but pumps more per cycle to compensate
+        return Math.max(20, (int) ticksPerPump());
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
Hi everyone! New contributor here. Not new to Java or modding or software, but new to GTCEu. This is a (somewhat) ambitious overhaul of the internal logic for the Pump (the machine, not the cover).

If you want me to make an issue first, I understand, but I was planning on making a patch for my own world so I jumped straight into implementing it.

## What
Pumps have some behavior quirks in GTCEu Modern. Partly this is due to clear bugs, partly this is because GT pumps have always behaved maybe not as you would expect (I remember issues on GCTE and earlier also having occasional problems). This implements a brand new Pump Machine logic. It will be slightly slower than the previous implementation, but it's still optimized.

## Bugs solved by this PR
The previous implementation contained a porting bug. In 1.12 GCTEu there are mining pipes and it checks for transparent blocks to move the pump head down. In modern, it only lowers the pump head if there is liquid right beneath it. Consequently, the mining pipe is never actually set even though there is code for it. This means that when rejoining a world, the pump will generally stop working as it lost the pump head information and now there is air between the liquid and the pump, so it will do nothing.

From the previous implementation and the implementation in 1.12, I could not really glean what the intended behavior was. Is it only supposed to work if there are source blocks right below? What if there is a layer of source blocks one layer higher than where the pipe is, should those be included? It was quite unclear. Trying to ask around and search on the Discord didn't give me many hints either.

## Implementation Details
The previous queue of blocks to check and known fluid source blocks is replaced by the "Pump Queue", which consists of 1 or more paths from the pump head (the source block below the mining pipe) towards source blocks. It does a depth-first(ish) search, biased up and away from the pump head. To prevent weird order of removing source blocks, it first only checks if it can find sources in the layer above the pump head. 

The main rule is: `For a source block to be mineable by the pump, it must be connected to the liquid block below the pump head through other liquid blocks of the same type, those can be either source or non-source`. This means that a source block much higher up, but that flows down and connects to the block below the pump head would also be mind. In fact, it would probably be mined first, "cleaning up" the vein. The oil vein is mined top-down. Only source blocks at the layer below the pump head or above can be pumped.

The implementation is somewhat complicated for performance reasons. It will try to find enough paths so that it has 5 pump cycles queued up without having to do another search. At pump time, it will go through the queued up paths to see if they are still valid. It will first try to only find source blocks above the pump head. If there are none, it will also look at the layer below the pump head (but nothing below that). The pump queue is updated whenever it's empty. If it empties before a pump cycle did the amount of pumps it wants, it will also rebuild.

Currently the highest tier pump will only pump once every 20 ticks and as such only do a search once every 20 ticks. See comments in the code for some more details. For a normal vein, the iterations it does to find enough paths are only a few dozen at most (a standard oil vein always less than 10 or so), so it's not too bad at all. I also tested it in the Nether, where pumps up lava from the Nether nicely. You can also really see the paths there.

## Outcome
Pump has overhauled logic, allowing veins to be consistently pumped with a single pump.

## Additional Information
I can provide additional info if necessary. Since I'm relatively unaware of a lot of GTCEu internals, I hope there's not any glaring issues. 

## Potential Compatibility Issues
None, only PumpMachine is changed. If this refers also to porting it to 1.21, it will require some tiny changes due to FluidHandler and stuff now being inside GTCEu itself (instead of ldlib).

## Unanswered questions
* How is range supposed to work? The way it was implemented is that while it says the working area is 64x64 (which to me says a square of 64x64 blocks) in the tooltip, it actually is a circle of radius 64. Is that intended?
* Should the queue be persisted? Right now it's just a field in the class.
* Can the previous data structures in the class (fluidSourceBlocks and blocksToCheck and initializedQueue) be safely removed? I assume since they aren't saved it's totally fine but I haven't removed them just to be sure.
* The pump speed might need some balancing. Lower tiers are fine, but EV will now pump 2 blocks every 20 ticks. However, it only advances the pump head every 40 ticks. So while going down an oil vein it is: 2 blocks -> 2 blocks -> final block on layer -> advance pump, so 100 ticks for 5 blocks or nearly twice as slow as what you would expect. I just made pretty arbitrary choices here, any opinions?
