### PR TITLE
Fix ME Pattern Buffer Proxies not having the hand animation when opening the GUI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
@@ -14,6 +14,7 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.integration.ae2.machine.trait.MEPatternBufferProxyRecipeHandler;
 
 import com.lowdragmc.lowdraglib.gui.modular.ModularUI;
+import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
@@ -49,6 +50,7 @@ public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine impleme
 
     @Persisted
     @Getter
+    @DescSynced
     private BlockPos bufferPos;
 
     public MEPatternBufferProxyPartMachine(IMachineBlockEntity holder) {
@@ -114,7 +116,7 @@ public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine impleme
     @Override
     public boolean shouldOpenUI(Player player, InteractionHand hand, BlockHitResult hit) {
         var buffer = getBuffer();
-        return buffer != null && super.shouldOpenUI(player, hand, hit);
+        return buffer != null;
     }
 
     @Override


### PR DESCRIPTION
## What
The ME Pattern Buffer Proxy now properly animates the hand when opening its GUI
Resolves #1991

## Implementation Details
Syncs the position of the linked pattern buffer to the client and removes a useless super call that would always return true.

## Outcome
Less nit picking