### PR TITLE
Fix standard OC modifier for EUt outputs

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -81,7 +81,7 @@ public class RecipeHelper {
         }
         EUt = getOutputEUt(recipe);
         if (EUt > 0) {
-            performOverclocking(logic, recipe, EUt, maxOverclockVoltage, params, result);
+            performOverclocking(logic, recipe, -EUt, maxOverclockVoltage, params, result);
         }
         return recipe;
     }
@@ -95,7 +95,7 @@ public class RecipeHelper {
     public static void performOverclocking(OverclockingLogic logic, @NotNull GTRecipe recipe, long EUt,
                                            long maxOverclockVoltage,
                                            @NotNull OCParams params, @NotNull OCResult result) {
-        int recipeTier = GTUtil.getTierByVoltage(EUt);
+        int recipeTier = GTUtil.getTierByVoltage(Math.abs(EUt));
         int maximumTier = logic.getOverclockForTier(maxOverclockVoltage);
         // The maximum number of overclocks is determined by the difference between the tier the recipe is running at,
         // and the maximum tier that the machine can overclock to.


### PR DESCRIPTION
## What
Fix standard OC modifier for EUt outputs - EUt outputs were being converted into tickInputs and therefore failing to match the original recipe.