### PR TITLE
remove errant gradle-home-cache-cleanup parameter from build setup

### DIFF
--- a/.github/actions/build_setup/action.yml
+++ b/.github/actions/build_setup/action.yml
@@ -39,7 +39,6 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
       with:
-        gradle-home-cache-cleanup: true
         cache-write-only: ${{ inputs.update-cache }}
         generate-job-summary: false
         gradle-home-cache-includes: |

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/RecipeCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/RecipeCondition.java
@@ -29,17 +29,6 @@ public abstract class RecipeCondition {
     public static final Codec<RecipeCondition> CODEC = GTRegistries.RECIPE_CONDITIONS.codec()
             .dispatch(RecipeCondition::getType, RecipeConditionType::getCodec);
 
-    @Nullable
-    public static RecipeCondition create(Class<? extends RecipeCondition> clazz) {
-        if (clazz == null) return null;
-        try {
-            return clazz.newInstance();
-        } catch (Exception ignored) {
-            GTCEu.LOGGER.error("condition {} has no NonArgsConstructor", clazz);
-            return null;
-        }
-    }
-
     public static <
             RC extends RecipeCondition> Products.P1<RecordCodecBuilder.Mu<RC>, Boolean> isReverse(RecordCodecBuilder.Instance<RC> instance) {
         return instance.group(Codec.BOOL.optionalFieldOf("reverse", false).forGetter(val -> val.isReverse));

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/RecipeCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/RecipeCondition.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.api.recipe.condition;
 
-import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
@@ -17,7 +16,6 @@ import com.mojang.datafixers.Products;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author KilaBash

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/SerializerBigInteger.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/SerializerBigInteger.java
@@ -21,8 +21,7 @@ public class SerializerBigInteger implements IContentSerializer<BigInteger> {
         } catch (Exception e) {
             return DataResult.error(e::getMessage, Lifecycle.stable());
         }
-    },
-            BigInteger::toString);
+    }, BigInteger::toString);
 
     public static SerializerBigInteger INSTANCE = new SerializerBigInteger();
 


### PR DESCRIPTION
## What
to fix actions
also contains a removal of an unused, dysfunctional and deprecated method