### PR TITLE
Fix broken treated wood recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -280,6 +280,7 @@ public class WoodMachineRecipes {
                             .sign(GTBlocks.TREATED_WOOD_SIGN.asItem(), null)
                             .hangingSign(GTBlocks.TREATED_WOOD_HANGING_SIGN.asItem(), null)
                             .material(TreatedWood)
+                            .generateLogToPlankRecipe(false)
                             .registerUnificationInfo(false, true, true, true, true, true, true, true)
                             .build());
         }


### PR DESCRIPTION
## What
Removes log -> plank crafting table & cutter recipes for treated wood planks.

## Outcome
Regular crafting table & chemical bath recipe for treated wood planks remain.