### PR TITLE
Misc recipe fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1528,7 +1528,7 @@ public class RecipeAddition {
         VanillaRecipeHelper.addShapedRecipe(provider, "polished_deepslate_slab_saw",
                 new ItemStack(Blocks.POLISHED_DEEPSLATE_SLAB), "sS", 'S', new ItemStack(Blocks.POLISHED_DEEPSLATE));
         VanillaRecipeHelper.addShapedRecipe(provider, "deepslate_brick_slab_saw",
-                new ItemStack(Blocks.DEEPSLATE_BRICKS), "sS", 'S', new ItemStack(Blocks.DEEPSLATE_BRICK_SLAB));
+                new ItemStack(Blocks.DEEPSLATE_BRICK_SLAB), "sS", 'S', new ItemStack(Blocks.DEEPSLATE_BRICKS    ));
         VanillaRecipeHelper.addShapedRecipe(provider, "deepslate_tile_slab_saw",
                 new ItemStack(Blocks.DEEPSLATE_TILE_SLAB), "sS", 'S', new ItemStack(Blocks.DEEPSLATE_TILES));
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1528,7 +1528,7 @@ public class RecipeAddition {
         VanillaRecipeHelper.addShapedRecipe(provider, "polished_deepslate_slab_saw",
                 new ItemStack(Blocks.POLISHED_DEEPSLATE_SLAB), "sS", 'S', new ItemStack(Blocks.POLISHED_DEEPSLATE));
         VanillaRecipeHelper.addShapedRecipe(provider, "deepslate_brick_slab_saw",
-                new ItemStack(Blocks.DEEPSLATE_BRICK_SLAB), "sS", 'S', new ItemStack(Blocks.DEEPSLATE_BRICKS    ));
+                new ItemStack(Blocks.DEEPSLATE_BRICK_SLAB), "sS", 'S', new ItemStack(Blocks.DEEPSLATE_BRICKS));
         VanillaRecipeHelper.addShapedRecipe(provider, "deepslate_tile_slab_saw",
                 new ItemStack(Blocks.DEEPSLATE_TILE_SLAB), "sS", 'S', new ItemStack(Blocks.DEEPSLATE_TILES));
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1176,7 +1176,7 @@ public class RecipeAddition {
 
             ASSEMBLER_RECIPES.recipeBuilder("composter")
                     .inputItems(ItemTags.PLANKS, 4)
-                    .circuitMeta(1)
+                    .circuitMeta(23)
                     .outputItems(new ItemStack(Blocks.COMPOSTER))
                     .duration(80).EUt(6).save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -145,11 +145,6 @@ public class RecipeAddition {
                 "PsP", "PSP",
                 'P', ItemTags.PLANKS,
                 'S', ItemTags.WOODEN_SLABS);
-
-        ASSEMBLER_RECIPES.recipeBuilder("barrel")
-                .inputItems(ItemTags.PLANKS, 7)
-                .outputItems(new ItemStack(Blocks.BARREL))
-                .duration(100).EUt(4).save(provider);
     }
 
     private static void hardIronRecipes(Consumer<FinishedRecipe> provider) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -578,16 +578,12 @@ public class VanillaStandardRecipes {
         ASSEMBLER_RECIPES.recipeBuilder("ladder").EUt(4).duration(40).circuitMeta(7)
                 .inputItems(new ItemStack(Items.STICK, 7)).outputItems(new ItemStack(Blocks.LADDER, 2)).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("chest_minecart").EUt(4).duration(100).inputItems(new ItemStack(Items.MINECART))
-                .inputItems(Tags.Items.CHESTS_WOODEN).outputItems(new ItemStack(Items.CHEST_MINECART)).save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("furnace_minecart").EUt(4).duration(100)
-                .inputItems(new ItemStack(Items.MINECART)).inputItems(new ItemStack(Blocks.FURNACE))
-                .outputItems(new ItemStack(Items.FURNACE_MINECART)).save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("tnt_minecart").EUt(4).duration(100).inputItems(new ItemStack(Items.MINECART))
-                .inputItems(new ItemStack(Blocks.TNT)).outputItems(new ItemStack(Items.TNT_MINECART)).save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("hopper_minecart").EUt(4).duration(100)
-                .inputItems(new ItemStack(Items.MINECART)).inputItems(new ItemStack(Blocks.HOPPER))
-                .outputItems(new ItemStack(Items.HOPPER_MINECART)).save(provider);
+        ASSEMBLER_RECIPES.recipeBuilder("barrel")
+                .inputItems(ItemTags.PLANKS, 7)
+                .outputItems(new ItemStack(Blocks.BARREL))
+                .circuitMeta(3)
+                .duration(100).EUt(4)
+                .save(provider);
     }
 
     /**
@@ -1228,12 +1224,21 @@ public class VanillaStandardRecipes {
                 .outputItems(new ItemStack(Blocks.CANDLE, 2))
                 .duration(20).EUt(1).save(provider);
 
-        // I realise this recipe may genuinely NEVER be used by someone, so feel free to remove them.
-        // At the same time, they don't really change anything by being there? Idk
         FORGE_HAMMER_RECIPES.recipeBuilder("disc_fragment_5")
                 .inputItems(new ItemStack(Items.MUSIC_DISC_5))
                 .outputItems(new ItemStack(Items.DISC_FRAGMENT_5, 9))
                 .duration(100).EUt(6).save(provider);
+
+        ASSEMBLER_RECIPES.recipeBuilder("chest_minecart").EUt(4).duration(100).inputItems(new ItemStack(Items.MINECART))
+                .inputItems(Tags.Items.CHESTS_WOODEN).outputItems(new ItemStack(Items.CHEST_MINECART)).save(provider);
+        ASSEMBLER_RECIPES.recipeBuilder("furnace_minecart").EUt(4).duration(100)
+                .inputItems(new ItemStack(Items.MINECART)).inputItems(new ItemStack(Blocks.FURNACE))
+                .outputItems(new ItemStack(Items.FURNACE_MINECART)).save(provider);
+        ASSEMBLER_RECIPES.recipeBuilder("tnt_minecart").EUt(4).duration(100).inputItems(new ItemStack(Items.MINECART))
+                .inputItems(new ItemStack(Blocks.TNT)).outputItems(new ItemStack(Items.TNT_MINECART)).save(provider);
+        ASSEMBLER_RECIPES.recipeBuilder("hopper_minecart").EUt(4).duration(100)
+                .inputItems(new ItemStack(Items.MINECART)).inputItems(new ItemStack(Blocks.HOPPER))
+                .outputItems(new ItemStack(Items.HOPPER_MINECART)).save(provider);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -581,7 +581,7 @@ public class VanillaStandardRecipes {
         ASSEMBLER_RECIPES.recipeBuilder("barrel")
                 .inputItems(ItemTags.PLANKS, 7)
                 .outputItems(new ItemStack(Blocks.BARREL))
-                .circuitMeta(3)
+                .circuitMeta(24)
                 .duration(100).EUt(4)
                 .save(provider);
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -643,7 +643,7 @@ public class WoodMachineRecipes {
             ASSEMBLER_RECIPES.recipeBuilder(name + "_fence")
                     .inputItems(entry.planks)
                     .outputItems(entry.fence)
-                    .circuitMeta(1)
+                    .circuitMeta(13)
                     .duration(100).EUt(4)
                     .save(provider);
         }


### PR DESCRIPTION
## What
- Changes circuit for a bunch of wood recipes to prevent conflicts
- Makes the barrel assembler recipe available in normal mode
- Moves the minecart recipes from `VanillaStandardRecipes#woodRecipes` to `VanillaStandardRecipes#miscRecipes` since it makes better sense
- Fix deepslate bricks slab saw recipe

## Outcomes
Fixes #2049