### PR TITLE
Remove any connected miner pipes when the machine is removed

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/MinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/MinerMachine.java
@@ -130,6 +130,8 @@ public class MinerMachine extends WorkableTieredMachine
 
     @Override
     public void onMachineRemoved() {
+        //Remove the miner pipes below this miner
+        getRecipeLogic().onRemove();
         clearInventory(exportItems.storage);
         clearInventory(chargerInventory);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/MinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/MinerMachine.java
@@ -130,7 +130,7 @@ public class MinerMachine extends WorkableTieredMachine
 
     @Override
     public void onMachineRemoved() {
-        //Remove the miner pipes below this miner
+        // Remove the miner pipes below this miner
         getRecipeLogic().onRemove();
         clearInventory(exportItems.storage);
         clearInventory(chargerInventory);


### PR DESCRIPTION
## What
Fixes a bug where miner pipes would linger indefinitely after a miner is broken, unless the miner is replaced above its leftover pipes.

## Implementation Details
Uses the existing `MinerLogic#onRemove` method to remove all connected miner pipes when the miner is removed.

## Outcome
It's, like, fixed.