### PR TITLE
Fix fluid drilling rig not working with 2 hatches

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/FluidDrillLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/FluidDrillLogic.java
@@ -60,7 +60,7 @@ public class FluidDrillLogic extends RecipeLogic {
             var match = getFluidDrillRecipe();
             if (match != null) {
                 var copied = match.copy(new ContentModifier(match.duration, 0));
-                if (match.matchRecipe(this.machine).isSuccess() && copied.matchTickRecipe(this.machine).isSuccess()) {
+                if (match.matchRecipe(this.machine).isSuccess() && match.matchTickRecipe(this.machine).isSuccess()) {
                     setupRecipe(match);
                 }
             }
@@ -124,7 +124,7 @@ public class FluidDrillLogic extends RecipeLogic {
         var match = getFluidDrillRecipe();
         if (match != null) {
             var copied = match.copy(new ContentModifier(match.duration, 0));
-            if (match.matchRecipe(this.machine).isSuccess() && copied.matchTickRecipe(this.machine).isSuccess()) {
+            if (match.matchRecipe(this.machine).isSuccess() && match.matchTickRecipe(this.machine).isSuccess()) {
                 setupRecipe(match);
                 return;
             }


### PR DESCRIPTION
## What
removes a wrong tick comparison in fluid drill logic, making them not form with even amount of hatches
