### PR TITLE
Rubber Wood/Log Fixes

### DIFF
--- a/src/generated/resources/data/gtceu/tags/blocks/rubber_logs.json
+++ b/src/generated/resources/data/gtceu/tags/blocks/rubber_logs.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "gtceu:rubber_log",
+    "gtceu:stripped_rubber_log",
+    "gtceu:rubber_wood",
+    "gtceu:stripped_rubber_wood"
+  ]
+}

--- a/src/generated/resources/data/gtceu/tags/blocks/rubber_logs.json
+++ b/src/generated/resources/data/gtceu/tags/blocks/rubber_logs.json
@@ -1,8 +1,0 @@
-{
-  "values": [
-    "gtceu:rubber_log",
-    "gtceu:stripped_rubber_log",
-    "gtceu:rubber_wood",
-    "gtceu:stripped_rubber_wood"
-  ]
-}

--- a/src/generated/resources/data/gtceu/tags/items/rubber_logs.json
+++ b/src/generated/resources/data/gtceu/tags/items/rubber_logs.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "gtceu:rubber_log",
+    "gtceu:stripped_rubber_log",
+    "gtceu:rubber_wood",
+    "gtceu:stripped_rubber_wood"
+  ]
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/block/RubberLogBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/RubberLogBlock.java
@@ -1,11 +1,16 @@
 package com.gregtechceu.gtceu.common.block;
 
+import com.gregtechceu.gtceu.common.data.GTBlocks;
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -35,5 +40,13 @@ public class RubberLogBlock extends RotatedPillarBlock {
             return state.setValue(NATURAL, natural);
         }
         return state;
+    }
+
+    @Override
+    public @Nullable BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction, boolean simulate) {
+        if(toolAction == ToolActions.AXE_STRIP) {
+            return GTBlocks.STRIPPED_RUBBER_LOG.getDefaultState().setValue(RotatedPillarBlock.AXIS, state.getValue(RotatedPillarBlock.AXIS));
+        }
+        return super.getToolModifiedState(state, context, toolAction, simulate);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/block/RubberLogBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/RubberLogBlock.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.common.block;
 
 import com.gregtechceu.gtceu.common.data.GTBlocks;
+
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.Block;
@@ -10,6 +11,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -43,9 +45,11 @@ public class RubberLogBlock extends RotatedPillarBlock {
     }
 
     @Override
-    public @Nullable BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction, boolean simulate) {
-        if(toolAction == ToolActions.AXE_STRIP) {
-            return GTBlocks.STRIPPED_RUBBER_LOG.getDefaultState().setValue(RotatedPillarBlock.AXIS, state.getValue(RotatedPillarBlock.AXIS));
+    public @Nullable BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction,
+                                                     boolean simulate) {
+        if (toolAction == ToolActions.AXE_STRIP) {
+            return GTBlocks.STRIPPED_RUBBER_LOG.getDefaultState().setValue(RotatedPillarBlock.AXIS,
+                    state.getValue(RotatedPillarBlock.AXIS));
         }
         return super.getToolModifiedState(state, context, toolAction, simulate);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/block/RubberWoodBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/RubberWoodBlock.java
@@ -1,22 +1,27 @@
 package com.gregtechceu.gtceu.common.block;
 
 import com.gregtechceu.gtceu.common.data.GTBlocks;
+
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+
 import org.jetbrains.annotations.Nullable;
 
 public class RubberWoodBlock extends RotatedPillarBlock {
+
     public RubberWoodBlock(Properties properties) {
         super(properties);
     }
 
     @Override
-    public @Nullable BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction, boolean simulate) {
-        if(toolAction == ToolActions.AXE_STRIP) {
-            return GTBlocks.STRIPPED_RUBBER_WOOD.getDefaultState().setValue(RotatedPillarBlock.AXIS, state.getValue(RotatedPillarBlock.AXIS));
+    public @Nullable BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction,
+                                                     boolean simulate) {
+        if (toolAction == ToolActions.AXE_STRIP) {
+            return GTBlocks.STRIPPED_RUBBER_WOOD.getDefaultState().setValue(RotatedPillarBlock.AXIS,
+                    state.getValue(RotatedPillarBlock.AXIS));
         }
         return super.getToolModifiedState(state, context, toolAction, simulate);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/block/RubberWoodBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/RubberWoodBlock.java
@@ -1,0 +1,23 @@
+package com.gregtechceu.gtceu.common.block;
+
+import com.gregtechceu.gtceu.common.data.GTBlocks;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.block.RotatedPillarBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.ToolAction;
+import net.minecraftforge.common.ToolActions;
+import org.jetbrains.annotations.Nullable;
+
+public class RubberWoodBlock extends RotatedPillarBlock {
+    public RubberWoodBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public @Nullable BlockState getToolModifiedState(BlockState state, UseOnContext context, ToolAction toolAction, boolean simulate) {
+        if(toolAction == ToolActions.AXE_STRIP) {
+            return GTBlocks.STRIPPED_RUBBER_WOOD.getDefaultState().setValue(RotatedPillarBlock.AXIS, state.getValue(RotatedPillarBlock.AXIS));
+        }
+        return super.getToolModifiedState(state, context, toolAction, simulate);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -1020,10 +1020,10 @@ public class GTBlocks {
                                                     .hasProperty(RubberLogBlock.NATURAL, true)))
                                     .when(LootItemRandomChanceCondition.randomChance(0.85F))))))
             .lang("Rubber Log")
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.OVERWORLD_NATURAL_LOGS)
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.OVERWORLD_NATURAL_LOGS, TagUtil.createModBlockTag("rubber_logs"))
             .blockstate((ctx, provider) -> provider.logBlock(ctx.get()))
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN)
+            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
             .onRegister(compassNode(GTCompassSections.GENERATIONS))
             .build()
             .register();
@@ -1073,20 +1073,20 @@ public class GTBlocks {
             .initialProperties(() -> Blocks.STRIPPED_SPRUCE_LOG)
             .lang("Stripped Rubber Log")
             .blockstate((ctx, provider) -> provider.logBlock(ctx.get()))
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE)
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE, TagUtil.createModBlockTag("rubber_logs"))
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN)
+            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
             .build()
             .register();
-    public static final BlockEntry<RotatedPillarBlock> RUBBER_WOOD = REGISTRATE
-            .block("rubber_wood", RotatedPillarBlock::new)
+    public static final BlockEntry<RubberWoodBlock> RUBBER_WOOD = REGISTRATE
+            .block("rubber_wood", RubberWoodBlock::new)
             .initialProperties(() -> Blocks.SPRUCE_WOOD)
             .lang("Rubber Wood")
             .blockstate((ctx, provider) -> provider.axisBlock(ctx.get(),
                     provider.blockTexture(GTBlocks.RUBBER_LOG.get()), provider.blockTexture(GTBlocks.RUBBER_LOG.get())))
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE)
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE, TagUtil.createModBlockTag("rubber_logs"))
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN)
+            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
             .build()
             .register();
     public static final BlockEntry<RotatedPillarBlock> STRIPPED_RUBBER_WOOD = REGISTRATE
@@ -1095,9 +1095,9 @@ public class GTBlocks {
             .lang("Stripped Rubber Wood")
             .blockstate((ctx, provider) -> provider.axisBlock(ctx.get(), provider.blockTexture(ctx.get()),
                     provider.blockTexture(ctx.get())))
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE)
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE, TagUtil.createModBlockTag("rubber_logs"))
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN)
+            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
             .build()
             .register();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -1020,10 +1020,10 @@ public class GTBlocks {
                                                     .hasProperty(RubberLogBlock.NATURAL, true)))
                                     .when(LootItemRandomChanceCondition.randomChance(0.85F))))))
             .lang("Rubber Log")
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.OVERWORLD_NATURAL_LOGS, TagUtil.createModBlockTag("rubber_logs"))
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.OVERWORLD_NATURAL_LOGS)
             .blockstate((ctx, provider) -> provider.logBlock(ctx.get()))
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
+            .tag(ItemTags.LOGS_THAT_BURN, CustomTags.RUBBER_LOGS)
             .onRegister(compassNode(GTCompassSections.GENERATIONS))
             .build()
             .register();
@@ -1073,9 +1073,9 @@ public class GTBlocks {
             .initialProperties(() -> Blocks.STRIPPED_SPRUCE_LOG)
             .lang("Stripped Rubber Log")
             .blockstate((ctx, provider) -> provider.logBlock(ctx.get()))
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE, TagUtil.createModBlockTag("rubber_logs"))
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE)
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
+            .tag(ItemTags.LOGS_THAT_BURN, CustomTags.RUBBER_LOGS)
             .build()
             .register();
     public static final BlockEntry<RubberWoodBlock> RUBBER_WOOD = REGISTRATE
@@ -1084,9 +1084,9 @@ public class GTBlocks {
             .lang("Rubber Wood")
             .blockstate((ctx, provider) -> provider.axisBlock(ctx.get(),
                     provider.blockTexture(GTBlocks.RUBBER_LOG.get()), provider.blockTexture(GTBlocks.RUBBER_LOG.get())))
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE, TagUtil.createModBlockTag("rubber_logs"))
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE)
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
+            .tag(ItemTags.LOGS_THAT_BURN, CustomTags.RUBBER_LOGS)
             .build()
             .register();
     public static final BlockEntry<RotatedPillarBlock> STRIPPED_RUBBER_WOOD = REGISTRATE
@@ -1095,9 +1095,9 @@ public class GTBlocks {
             .lang("Stripped Rubber Wood")
             .blockstate((ctx, provider) -> provider.axisBlock(ctx.get(), provider.blockTexture(ctx.get()),
                     provider.blockTexture(ctx.get())))
-            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE, TagUtil.createModBlockTag("rubber_logs"))
+            .tag(BlockTags.LOGS_THAT_BURN, BlockTags.MINEABLE_WITH_AXE)
             .item()
-            .tag(ItemTags.LOGS_THAT_BURN, TagUtil.createModItemTag("rubber_logs"))
+            .tag(ItemTags.LOGS_THAT_BURN, CustomTags.RUBBER_LOGS)
             .build()
             .register();
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
@@ -91,7 +91,7 @@ public class CustomTags {
 
     public static final TagKey<Item> PPE_ARMOR = TagUtil.createModItemTag("ppe_armor");
     public static final TagKey<Item> STEP_BOOTS = TagUtil.createModItemTag("step_boots");
-
+    public static final TagKey<Item> RUBBER_LOGS = TagUtil.createModItemTag("rubber_logs");
     // Platform-dependent tags
     public static final TagKey<Block> NEEDS_WOOD_TOOL = TagUtil.createBlockTag("needs_wood_tool");
     public static final TagKey<Block> NEEDS_GOLD_TOOL = TagUtil.createBlockTag("needs_gold_tool");

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CraftingRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CraftingRecipeLoader.java
@@ -94,8 +94,6 @@ public class CraftingRecipeLoader {
         // Items.PAPER, 'R', new UnificationEntry(springSmall, Iron), 'B', new UnificationEntry(bolt, Iron), 'S', new
         // UnificationEntry(screw, Iron), 'W', new UnificationEntry(plate, Wood));
 
-        VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_wood_planks", GTBlocks.RUBBER_PLANK.asStack(4),
-                GTBlocks.RUBBER_LOG.asStack());
         VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_planks", GTBlocks.TREATED_WOOD_PLANK.asStack(8),
                 "PPP", "PBP", "PPP", 'P', ItemTags.PLANKS, 'B', Creosote.getBucket());
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -771,10 +771,6 @@ public class WoodMachineRecipes {
         VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_plate",
                 GTBlocks.TREATED_WOOD_PRESSURE_PLATE.asStack(), "aa", 'a', GTBlocks.TREATED_WOOD_PLANK.asStack());
 
-        VanillaRecipeHelper.addShapedRecipe(provider, "rubber_planks_saw",
-                GTBlocks.RUBBER_PLANK.asStack(ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
-                "s", "L", 'L', GTBlocks.RUBBER_LOG.asItem());
-
         VanillaRecipeHelper.addShapedRecipe(provider, "rubber_wood",
                 GTBlocks.RUBBER_WOOD.asStack(3),
                 "LL", "LL", 'L', GTBlocks.RUBBER_LOG.asStack());
@@ -782,14 +778,6 @@ public class WoodMachineRecipes {
         VanillaRecipeHelper.addShapedRecipe(provider, "stripped_rubber_wood",
                 GTBlocks.STRIPPED_RUBBER_WOOD.asStack(3),
                 "LL", "LL", 'L', GTBlocks.STRIPPED_RUBBER_LOG.asStack());
-
-        CUTTER_RECIPES.recipeBuilder("rubber_planks")
-                .inputItems(GTBlocks.RUBBER_LOG.asItem())
-                .outputItems(GTBlocks.RUBBER_PLANK.asStack(6))
-                .outputItems(dust, Wood, 2)
-                .duration(200)
-                .EUt(VA[ULV])
-                .save(provider);
     }
 
     public static void hardWoodRecipes(Consumer<ResourceLocation> registry) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -263,7 +263,6 @@ public class WoodMachineRecipes {
                             .chestBoat(GTItems.RUBBER_CHEST_BOAT.asItem(), null)
                             .sign(GTBlocks.RUBBER_SIGN.asItem(), null)
                             .hangingSign(GTBlocks.RUBBER_HANGING_SIGN.asItem(), null)
-                            .generateLogToPlankRecipe(false) // rubber log does not have a tag
                             .registerAllTags()
                             .registerAllUnificationInfo()
                             .build(),
@@ -772,18 +771,17 @@ public class WoodMachineRecipes {
         VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_plate",
                 GTBlocks.TREATED_WOOD_PRESSURE_PLATE.asStack(), "aa", 'a', GTBlocks.TREATED_WOOD_PLANK.asStack());
 
-        // add Recipes for rubber log
-        if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {
-            VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_planks",
-                    GTBlocks.RUBBER_PLANK.asStack(2), GTBlocks.RUBBER_LOG.asItem());
-        } else {
-            VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_planks",
-                    GTBlocks.RUBBER_PLANK.asStack(4), GTBlocks.RUBBER_LOG.asItem());
-        }
-
         VanillaRecipeHelper.addShapedRecipe(provider, "rubber_planks_saw",
                 GTBlocks.RUBBER_PLANK.asStack(ConfigHolder.INSTANCE.recipes.nerfWoodCrafting ? 4 : 6),
                 "s", "L", 'L', GTBlocks.RUBBER_LOG.asItem());
+
+        VanillaRecipeHelper.addShapedRecipe(provider, "rubber_wood",
+                GTBlocks.RUBBER_WOOD.asStack(3),
+                "LL", "LL", 'L', GTBlocks.RUBBER_LOG.asStack());
+
+        VanillaRecipeHelper.addShapedRecipe(provider, "stripped_rubber_wood",
+                GTBlocks.STRIPPED_RUBBER_WOOD.asStack(3),
+                "LL", "LL", 'L', GTBlocks.STRIPPED_RUBBER_LOG.asStack());
 
         CUTTER_RECIPES.recipeBuilder("rubber_planks")
                 .inputItems(GTBlocks.RUBBER_LOG.asItem())


### PR DESCRIPTION
## What
Fixes various issues related to rubber logs & wood.

## Outcome
- Add `gtceu:rubber_logs` ~~block &~~ item tag for rubber wood, rubber log, stripped rubber log & stripped rubber wood.
- This tag is now used in recipes where only rubber logs were allowed (ex. logs -> planks).
- Allow Rubber Logs & Wood to be stripped.
- Add crafting recipes for Rubber Wood & Stripped Rubber Wood.