### PR TITLE
Fix Recipe NBT Serialization

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/syncdata/GTRecipePayload.java
+++ b/src/main/java/com/gregtechceu/gtceu/syncdata/GTRecipePayload.java
@@ -30,24 +30,26 @@ public class GTRecipePayload extends ObjectTypedPayload<GTRecipe> {
     public Tag serializeNBT() {
         CompoundTag tag = new CompoundTag();
         tag.putString("id", payload.id.toString());
-        tag.put("recipe", GTRecipeSerializer.CODEC.encodeStart(NbtOps.INSTANCE, payload).result().orElse(new CompoundTag()));
+        tag.put("recipe",
+                GTRecipeSerializer.CODEC.encodeStart(NbtOps.INSTANCE, payload).result().orElse(new CompoundTag()));
         return tag;
     }
 
     @Override
     public void deserializeNBT(Tag tag) {
         RecipeManager recipeManager = Platform.getMinecraftServer().getRecipeManager();
-        if(tag instanceof CompoundTag compoundTag) {
+        if (tag instanceof CompoundTag compoundTag) {
             payload = GTRecipeSerializer.CODEC.parse(NbtOps.INSTANCE, compoundTag.get("recipe")).result().orElse(null);
-            if(payload != null) {
+            if (payload != null) {
                 payload.id = new ResourceLocation(compoundTag.getString("id"));
             }
         } else if (tag instanceof StringTag stringTag) { // Backwards Compatibility
             var recipe = recipeManager.byKey(new ResourceLocation(stringTag.getAsString())).orElse(null);
             if (recipe instanceof GTRecipe gtRecipe) {
                 payload = gtRecipe;
-            } else if(recipe instanceof SmeltingRecipe smeltingRecipe) {
-                payload = GTRecipeTypes.FURNACE_RECIPES.toGTrecipe(new ResourceLocation(stringTag.getAsString()), smeltingRecipe);
+            } else if (recipe instanceof SmeltingRecipe smeltingRecipe) {
+                payload = GTRecipeTypes.FURNACE_RECIPES.toGTrecipe(new ResourceLocation(stringTag.getAsString()),
+                        smeltingRecipe);
             } else {
                 payload = null;
             }
@@ -68,7 +70,7 @@ public class GTRecipePayload extends ObjectTypedPayload<GTRecipe> {
     @Override
     public void readPayload(FriendlyByteBuf buf) {
         var id = buf.readResourceLocation();
-        if(buf.isReadable()) {
+        if (buf.isReadable()) {
             this.payload = GTRecipeSerializer.SERIALIZER.fromNetwork(id, buf);
         } else { // Backwards Compatibility
             RecipeManager recipeManager;

--- a/src/main/java/com/gregtechceu/gtceu/syncdata/GTRecipePayload.java
+++ b/src/main/java/com/gregtechceu/gtceu/syncdata/GTRecipePayload.java
@@ -1,18 +1,16 @@
 package com.gregtechceu.gtceu.syncdata;
 
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeSerializer;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 
 import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.syncdata.payload.ObjectTypedPayload;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.nbt.ByteArrayTag;
-import net.minecraft.nbt.StringTag;
-import net.minecraft.nbt.Tag;
+import net.minecraft.nbt.*;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.SmeltingRecipe;
 
@@ -30,18 +28,30 @@ public class GTRecipePayload extends ObjectTypedPayload<GTRecipe> {
     @Nullable
     @Override
     public Tag serializeNBT() {
-        return StringTag.valueOf(payload.id.toString());
+        CompoundTag tag = new CompoundTag();
+        tag.putString("id", payload.id.toString());
+        tag.put("recipe", GTRecipeSerializer.CODEC.encodeStart(NbtOps.INSTANCE, payload).result().orElse(new CompoundTag()));
+        return tag;
     }
 
     @Override
     public void deserializeNBT(Tag tag) {
         RecipeManager recipeManager = Platform.getMinecraftServer().getRecipeManager();
-        if (tag instanceof StringTag stringTag) {
-            Recipe<?> recipe = recipeManager.byKey(new ResourceLocation(stringTag.getAsString())).orElse(null);
-            if (recipe instanceof GTRecipe gtRecipe) payload = gtRecipe;
-            else if (recipe instanceof SmeltingRecipe smeltingRecipe) payload = GTRecipeTypes.FURNACE_RECIPES
-                    .toGTrecipe(new ResourceLocation(stringTag.getAsString()), smeltingRecipe);
-        } else if (tag instanceof ByteArrayTag byteArray) {
+        if(tag instanceof CompoundTag compoundTag) {
+            payload = GTRecipeSerializer.CODEC.parse(NbtOps.INSTANCE, compoundTag.get("recipe")).result().orElse(null);
+            if(payload != null) {
+                payload.id = new ResourceLocation(compoundTag.getString("id"));
+            }
+        } else if (tag instanceof StringTag stringTag) { // Backwards Compatibility
+            var recipe = recipeManager.byKey(new ResourceLocation(stringTag.getAsString())).orElse(null);
+            if (recipe instanceof GTRecipe gtRecipe) {
+                payload = gtRecipe;
+            } else if(recipe instanceof SmeltingRecipe smeltingRecipe) {
+                payload = GTRecipeTypes.FURNACE_RECIPES.toGTrecipe(new ResourceLocation(stringTag.getAsString()), smeltingRecipe);
+            } else {
+                payload = null;
+            }
+        } else if (tag instanceof ByteArrayTag byteArray) { // Backwards Compatibility
             ByteBuf copiedDataBuffer = Unpooled.copiedBuffer(byteArray.getAsByteArray());
             FriendlyByteBuf buf = new FriendlyByteBuf(copiedDataBuffer);
             payload = (GTRecipe) recipeManager.byKey(buf.readResourceLocation()).orElse(null);
@@ -52,16 +62,22 @@ public class GTRecipePayload extends ObjectTypedPayload<GTRecipe> {
     @Override
     public void writePayload(FriendlyByteBuf buf) {
         buf.writeResourceLocation(this.payload.id);
+        GTRecipeSerializer.SERIALIZER.toNetwork(buf, this.payload);
     }
 
     @Override
     public void readPayload(FriendlyByteBuf buf) {
-        RecipeManager recipeManager;
-        if (!Platform.isClient()) {
-            recipeManager = Platform.getMinecraftServer().getRecipeManager();
-        } else {
-            recipeManager = Minecraft.getInstance().getConnection().getRecipeManager();
+        var id = buf.readResourceLocation();
+        if(buf.isReadable()) {
+            this.payload = GTRecipeSerializer.SERIALIZER.fromNetwork(id, buf);
+        } else { // Backwards Compatibility
+            RecipeManager recipeManager;
+            if (!Platform.isClient()) {
+                recipeManager = Platform.getMinecraftServer().getRecipeManager();
+            } else {
+                recipeManager = Minecraft.getInstance().getConnection().getRecipeManager();
+            }
+            this.payload = (GTRecipe) recipeManager.byKey(id).orElse(null);
         }
-        this.payload = (GTRecipe) recipeManager.byKey(buf.readResourceLocation()).orElse(null);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/syncdata/GTRecipePayload.java
+++ b/src/main/java/com/gregtechceu/gtceu/syncdata/GTRecipePayload.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.syncdata;
 
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 
 import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.syncdata.payload.ObjectTypedPayload;
@@ -11,7 +12,9 @@ import net.minecraft.nbt.StringTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.SmeltingRecipe;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -34,7 +37,10 @@ public class GTRecipePayload extends ObjectTypedPayload<GTRecipe> {
     public void deserializeNBT(Tag tag) {
         RecipeManager recipeManager = Platform.getMinecraftServer().getRecipeManager();
         if (tag instanceof StringTag stringTag) {
-            payload = (GTRecipe) recipeManager.byKey(new ResourceLocation(stringTag.getAsString())).orElse(null);
+            Recipe<?> recipe = recipeManager.byKey(new ResourceLocation(stringTag.getAsString())).orElse(null);
+            if (recipe instanceof GTRecipe gtRecipe) payload = gtRecipe;
+            else if (recipe instanceof SmeltingRecipe smeltingRecipe) payload = GTRecipeTypes.FURNACE_RECIPES
+                    .toGTrecipe(new ResourceLocation(stringTag.getAsString()), smeltingRecipe);
         } else if (tag instanceof ByteArrayTag byteArray) {
             ByteBuf copiedDataBuffer = Unpooled.copiedBuffer(byteArray.getAsByteArray());
             FriendlyByteBuf buf = new FriendlyByteBuf(copiedDataBuffer);


### PR DESCRIPTION
## What
Fixes gt furnaces voiding all covers and items when loading in world with running recipes

## Implementation Details
fix a wrong cast with furnace -> gt recipe types in the recipe payload

## Outcome
no more broken furnaces
