### PR TITLE
Steam and bedrock miner multi changes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -1727,7 +1727,9 @@ public class GTMachines {
             .register();
 
     public static final MultiblockMachineDefinition STEAM_GRINDER = REGISTRATE
-            .multiblock("steam_grinder", (holder) -> new SteamParallelMultiblockMachine(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount))
+            .multiblock("steam_grinder",
+                    (holder) -> new SteamParallelMultiblockMachine(holder,
+                            ConfigHolder.INSTANCE.machines.steamMultiParallelAmount))
             .rotationState(RotationState.ALL)
             .appearanceBlock(CASING_BRONZE_BRICKS)
             .recipeType(GTRecipeTypes.MACERATOR_RECIPES)
@@ -1751,7 +1753,9 @@ public class GTMachines {
             .register();
 
     public static final MultiblockMachineDefinition STEAM_OVEN = REGISTRATE
-            .multiblock("steam_oven", (holder) -> new SteamParallelMultiblockMachine(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount))
+            .multiblock("steam_oven",
+                    (holder) -> new SteamParallelMultiblockMachine(holder,
+                            ConfigHolder.INSTANCE.machines.steamMultiParallelAmount))
             .rotationState(RotationState.ALL)
             .appearanceBlock(CASING_BRONZE_BRICKS)
             .recipeType(GTRecipeTypes.FURNACE_RECIPES)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -1727,7 +1727,7 @@ public class GTMachines {
             .register();
 
     public static final MultiblockMachineDefinition STEAM_GRINDER = REGISTRATE
-            .multiblock("steam_grinder", SteamParallelMultiblockMachine::new)
+            .multiblock("steam_grinder", (holder) -> new SteamParallelMultiblockMachine(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount))
             .rotationState(RotationState.ALL)
             .appearanceBlock(CASING_BRONZE_BRICKS)
             .recipeType(GTRecipeTypes.MACERATOR_RECIPES)
@@ -1751,7 +1751,7 @@ public class GTMachines {
             .register();
 
     public static final MultiblockMachineDefinition STEAM_OVEN = REGISTRATE
-            .multiblock("steam_oven", SteamParallelMultiblockMachine::new)
+            .multiblock("steam_oven", (holder) -> new SteamParallelMultiblockMachine(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount))
             .rotationState(RotationState.ALL)
             .appearanceBlock(CASING_BRONZE_BRICKS)
             .recipeType(GTRecipeTypes.FURNACE_RECIPES)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -2759,13 +2759,13 @@ public class GTMachines {
                                     Component.translatable("gtceu.machine.bedrock_ore_miner.description"),
                                     Component.translatable("gtceu.machine.bedrock_ore_miner.depletion",
                                             FormattingUtil.formatNumbers(
-                                                    100.0 / BedrockOreMinerMachine.getDepletionChance(tier))),
+                                                    100.0 / BedrockOreMinerMachine.getDepletionChanceByTier(tier))),
                                     Component.translatable("gtceu.universal.tooltip.energy_tier_range",
                                             GTValues.VNF[tier], GTValues.VNF[tier + 1]),
                                     Component.translatable("gtceu.machine.bedrock_ore_miner.production",
-                                            BedrockOreMinerMachine.getRigMultiplier(tier),
+                                            BedrockOreMinerMachine.getRigMultiplierByTier(tier),
                                             FormattingUtil.formatNumbers(
-                                                    BedrockOreMinerMachine.getRigMultiplier(tier) * 1.5)))
+                                                    BedrockOreMinerMachine.getRigMultiplierByTier(tier) * 1.5)))
                             .appearanceBlock(() -> BedrockOreMinerMachine.getCasingState(tier))
                             .pattern((definition) -> FactoryBlockPattern.start()
                                     .aisle("XXX", "#F#", "#F#", "#F#", "###", "###", "###")
@@ -2778,7 +2778,7 @@ public class GTMachines {
                                                             .setMaxGlobalLimited(2))
                                                     .or(abilities(PartAbility.EXPORT_ITEMS).setMaxGlobalLimited(1)))
                                     .where('C', blocks(BedrockOreMinerMachine.getCasingState(tier)))
-                                    .where('F', blocks(BedrockOreMinerMachine.getFrameState(tier)))
+                                    .where('F', frames(BedrockOreMinerMachine.getMaterial(tier)))
                                     .where('#', any())
                                     .build())
                             .workableCasingRenderer(BedrockOreMinerMachine.getBaseTexture(tier),

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
@@ -55,14 +55,15 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
             case GTValues.EV -> 8;
             default -> 1;
         },
-        switch (tier) {
-            case GTValues.MV -> 1;
-            case GTValues.HV -> 4;
-            case GTValues.EV -> 16;
-            default -> 1;
-        });
+                switch (tier) {
+                    case GTValues.MV -> 1;
+                    case GTValues.HV -> 4;
+                    case GTValues.EV -> 16;
+                    default -> 1;
+                });
     }
-	public BedrockOreMinerMachine(IMachineBlockEntity holder, int tier, int depletionChance, int rigMultiplier){
+
+    public BedrockOreMinerMachine(IMachineBlockEntity holder, int tier, int depletionChance, int rigMultiplier) {
         super(holder);
         this.tier = tier;
         this.depletionChance = depletionChance;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
@@ -6,7 +6,6 @@ import com.gregtechceu.gtceu.api.capability.IEnergyContainer;
 import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
-import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
@@ -44,10 +43,30 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
 
     @Getter
     private final int tier;
+    @Getter
+    private final int depletionChance;
+    @Getter
+    private final int rigMultiplier;
 
     public BedrockOreMinerMachine(IMachineBlockEntity holder, int tier) {
+        this(holder, tier, switch (tier) {
+            case GTValues.MV -> 1;
+            case GTValues.HV -> 2;
+            case GTValues.EV -> 8;
+            default -> 1;
+        },
+        switch (tier) {
+            case GTValues.MV -> 1;
+            case GTValues.HV -> 4;
+            case GTValues.EV -> 16;
+            default -> 1;
+        });
+    }
+	public BedrockOreMinerMachine(IMachineBlockEntity holder, int tier, int depletionChance, int rigMultiplier){
         super(holder);
         this.tier = tier;
+        this.depletionChance = depletionChance;
+        this.rigMultiplier = rigMultiplier;
     }
 
     @Override
@@ -110,7 +129,18 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
         }
     }
 
-    public static int getDepletionChance(int tier) {
+    public static Material getMaterial(int tier) {
+        if (tier == GTValues.MV) return GTMaterials.Steel;
+        if (tier == GTValues.HV) return GTMaterials.Titanium;
+        if (tier == GTValues.EV) return GTMaterials.TungstenSteel;
+        return GTMaterials.Steel;
+    }
+
+    public static Block getCasingState(int tier) {
+        return GTBlocks.MATERIALS_TO_CASINGS.get(getMaterial(tier)).get();
+    }
+
+    public static int getDepletionChanceByTier(int tier) {
         if (tier == GTValues.MV)
             return 1;
         if (tier == GTValues.HV)
@@ -120,7 +150,7 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
         return 1;
     }
 
-    public static int getRigMultiplier(int tier) {
+    public static int getRigMultiplierByTier(int tier) {
         if (tier == GTValues.MV)
             return 1;
         if (tier == GTValues.HV)
@@ -128,26 +158,6 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
         if (tier == GTValues.EV)
             return 16;
         return 1;
-    }
-
-    public static Block getCasingState(int tier) {
-        if (tier == GTValues.MV)
-            return GTBlocks.CASING_STEEL_SOLID.get();
-        if (tier == GTValues.HV)
-            return GTBlocks.CASING_TITANIUM_STABLE.get();
-        if (tier == GTValues.EV)
-            return GTBlocks.CASING_TUNGSTENSTEEL_ROBUST.get();
-        return GTBlocks.CASING_STEEL_SOLID.get();
-    }
-
-    public static Block getFrameState(int tier) {
-        if (tier == GTValues.MV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
-        if (tier == GTValues.HV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Titanium).get();
-        if (tier == GTValues.EV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.TungstenSteel).get();
-        return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
     }
 
     public static ResourceLocation getBaseTexture(int tier) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
@@ -44,14 +44,16 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine implements IDisplayUIMachine {
 
-    public static final int MAX_PARALLELS = 8;
+    public int MAX_PARALLELS = ConfigHolder.INSTANCE.machines.steamMultiParallelAmount;
 
     // if in millibuckets, this is 0.5, Meaning 2mb of steam -> 1 EU
     private static final double CONVERSION_RATE = 0.5D;
 
-    public SteamParallelMultiblockMachine(IMachineBlockEntity holder, Object... args) {
-        super(holder, args);
+    public SteamParallelMultiblockMachine(IMachineBlockEntity holder, int parallelAmount) {
+        super(holder, parallelAmount);
+        MAX_PARALLELS = parallelAmount;
     }
+
 
     @Override
     public void onStructureFormed() {
@@ -78,13 +80,13 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
     @Nullable
     public static GTRecipe recipeModifier(MetaMachine machine, @NotNull GTRecipe recipe, @NotNull OCParams params,
                                           @NotNull OCResult result) {
-        if (machine instanceof SteamParallelMultiblockMachine) {
+        if (machine instanceof SteamParallelMultiblockMachine steamMachine) {
             if (RecipeHelper.getRecipeEUtTier(recipe) > GTValues.LV) {
                 return null;
             }
             int duration = recipe.duration;
             var eut = RecipeHelper.getInputEUt(recipe);
-            var parallelRecipe = GTRecipeModifiers.accurateParallel(machine, recipe, MAX_PARALLELS, false);
+            var parallelRecipe = GTRecipeModifiers.accurateParallel(machine, recipe, steamMachine.MAX_PARALLELS, false);
 
             // we remove tick inputs, as our "cost" is just steam now, just stored as EU/t
             // also set the duration to just 1.5x the original, instead of fully multiplied
@@ -114,7 +116,8 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
 
             } else if (isActive()) {
                 textList.add(Component.translatable("gtceu.multiblock.running"));
-                textList.add(Component.translatable("gtceu.multiblock.parallel", MAX_PARALLELS));
+                if(MAX_PARALLELS > 1)
+                    textList.add(Component.translatable("gtceu.multiblock.parallel", MAX_PARALLELS));
                 int currentProgress = (int) (recipeLogic.getProgressPercent() * 100);
                 double maxInSec = (float) recipeLogic.getDuration() / 20.0f;
                 double currentInSec = (float) recipeLogic.getProgress() / 20.0f;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
@@ -54,7 +54,6 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
         MAX_PARALLELS = parallelAmount;
     }
 
-
     @Override
     public void onStructureFormed() {
         super.onStructureFormed();
@@ -116,7 +115,7 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
 
             } else if (isActive()) {
                 textList.add(Component.translatable("gtceu.multiblock.running"));
-                if(MAX_PARALLELS > 1)
+                if (MAX_PARALLELS > 1)
                     textList.add(Component.translatable("gtceu.multiblock.parallel", MAX_PARALLELS));
                 int currentProgress = (int) (recipeLogic.getProgressPercent() * 100);
                 double maxInSec = (float) recipeLogic.getDuration() / 20.0f;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/BedrockOreMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/BedrockOreMinerLogic.java
@@ -123,7 +123,7 @@ public class BedrockOreMinerLogic extends RecipeLogic {
 
             int produced = Math.max(depletedYield,
                     regularYield * remainingOperations / BedrockOreVeinSavedData.MAXIMUM_VEIN_OPERATIONS);
-            produced *= BedrockOreMinerMachine.getRigMultiplier(getMachine().getTier());
+            produced *= getMachine().getRigMultiplier();
 
             // Overclocks produce 50% more ore
             if (isOverclocked()) {
@@ -166,7 +166,7 @@ public class BedrockOreMinerLogic extends RecipeLogic {
 
     protected void depleteVein() {
         if (getMachine().getLevel() instanceof ServerLevel serverLevel) {
-            int chance = BedrockOreMinerMachine.getDepletionChance(getMachine().getTier());
+            int chance = getMachine().getDepletionChance();
             var data = BedrockOreVeinSavedData.getOrCreate(serverLevel);
             // chance to deplete based on the rig
             if (chance == 1 || GTValues.RNG.nextInt(chance) == 0) {

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -435,7 +435,6 @@ public class ConfigHolder {
         })
         public int steamMultiParallelAmount = 8;
 
-
         @Configurable
         @Configurable.Comment("Small Steam Boiler Options")
         public SmallBoilers smallBoilers = new SmallBoilers();

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -429,6 +429,14 @@ public class ConfigHolder {
         public boolean enableMoreDualHatchAbility = false;
 
         @Configurable
+        @Configurable.Comment({
+                "Default maximum parallel of steam multiblocks",
+                "Default: 8"
+        })
+        public int steamMultiParallelAmount = 8;
+
+
+        @Configurable
         @Configurable.Comment("Small Steam Boiler Options")
         public SmallBoilers smallBoilers = new SmallBoilers();
         @Configurable


### PR DESCRIPTION
## What
Changes to bedrock miners as well as steam multi block registering, I made these changes for my modpack to allow custom bedrock miners as well as steam multiblocks for other people to use.

## Implementation Details
For bedrock miners you can optionally give extra arguments to customize depletion chance as well as mined multiplier, this does not touch the base registered multiblocks and is solely for creating new ones for pack developers
The default bedrock miners are also now registered more similarly to the regular ore miners, which is more clean.

Steam multiblocks can now be registered with their parallel value as an argument, this allows creating custom steam multis with 1 parallel to create a regular steam multiblock.

## Outcome
Modpack developers can now create bedrock miners with custom arguments easily, as well as creating their own steam multiblocks easily

## Additional Information
Cyb maybe doing further bedrock miner rewrites in future

## Potential Compatibility Issues
Will likely cause addons creating custom steam multiblocks to update to the new parallel arguments