### PR TITLE
Fix Assembly Line ordering for certain orientations

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
@@ -72,7 +72,8 @@ public enum RelativeDirection {
             case LEFT -> {
                 Direction facing;
                 if (frontAxis == Direction.Axis.Y) {
-                    facing = upwardsFacing.getClockWise();
+                    facing = frontFacing.getStepY() > 0 ? upwardsFacing.getClockWise() :
+                            upwardsFacing.getCounterClockWise();
                 } else {
                     facing = switch (upwardsFacing) {
                         case NORTH -> frontFacing.getCounterClockWise();
@@ -86,7 +87,8 @@ public enum RelativeDirection {
             case RIGHT -> {
                 Direction facing;
                 if (frontAxis == Direction.Axis.Y) {
-                    facing = upwardsFacing.getCounterClockWise();
+                    facing = frontFacing.getStepY() > 0 ? upwardsFacing.getCounterClockWise() :
+                            upwardsFacing.getClockWise();
                 } else {
                     facing = switch (upwardsFacing) {
                         case NORTH -> frontFacing.getClockWise();


### PR DESCRIPTION
## What
fix for #2118 

## Implementation Details
RelativeDirection#getSorter was using the wrong upwards facing values when front facing was down

## Outcome
you can make assembly lines again