### PR TITLE
Misc Recipe Fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -892,6 +892,18 @@ public class RecipeAddition {
                     'R', new UnificationEntry(TagPrefix.rod, GTMaterials.Iron),
                     'L', new UnificationEntry(TagPrefix.rodLong, GTMaterials.Iron),
                     'P', new UnificationEntry(TagPrefix.plate, GTMaterials.Wood));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, "bow", new ItemStack(Items.BOW), "hLS", "LRS", "fLS",
+                    'L', new UnificationEntry(TagPrefix.rodLong, GTMaterials.Wood),
+                    'S', new ItemStack(Items.STRING),
+                    'R', new UnificationEntry(TagPrefix.ring, GTMaterials.Iron));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, "crossbow", new ItemStack(Items.CROSSBOW), "RIR", "STS",
+                    "sRf",
+                    'R', new UnificationEntry(TagPrefix.rodLong, GTMaterials.Wood),
+                    'S', new ItemStack(Items.STRING),
+                    'T', new ItemStack(Items.TRIPWIRE_HOOK),
+                    'I', new UnificationEntry(ring, Iron));
         } else {
             ASSEMBLER_RECIPES.recipeBuilder("compass")
                     .inputItems(dust, Redstone)
@@ -906,6 +918,21 @@ public class RecipeAddition {
                     .outputItems(new ItemStack(Items.CLOCK))
                     .duration(100).EUt(4).save(provider);
         }
+
+        ASSEMBLER_RECIPES.recipeBuilder("bow")
+                .inputItems(new ItemStack(Items.STRING, 3))
+                .inputItems(Items.STICK, 3)
+                .outputItems(new ItemStack(Items.BOW, 1))
+                .circuitMeta(10)
+                .duration(100).EUt(4).save(provider);
+
+        ASSEMBLER_RECIPES.recipeBuilder("crossbow")
+                .inputItems(new ItemStack(Items.STRING, 2))
+                .inputItems(Items.STICK, 3)
+                .inputItems(Items.TRIPWIRE_HOOK)
+                .outputItems(new ItemStack(Items.CROSSBOW, 1))
+                .circuitMeta(11)
+                .duration(100).EUt(4).save(provider);
     }
 
     private static void harderRods(Consumer<FinishedRecipe> provider) {
@@ -1043,18 +1070,6 @@ public class RecipeAddition {
             VanillaRecipeHelper.addShapedRecipe(provider, "lead", new ItemStack(Items.LEAD), "SSS", "SBS", "SSS",
                     'S', new ItemStack(Items.STRING),
                     'B', new ItemStack(Items.SLIME_BALL));
-
-            VanillaRecipeHelper.addShapedRecipe(provider, "bow", new ItemStack(Items.BOW), "hLS", "LRS", "fLS",
-                    'L', new UnificationEntry(TagPrefix.rodLong, GTMaterials.Wood),
-                    'S', new ItemStack(Items.STRING),
-                    'R', new UnificationEntry(TagPrefix.ring, GTMaterials.Iron));
-
-            VanillaRecipeHelper.addShapedRecipe(provider, "crossbow", new ItemStack(Items.CROSSBOW), "RIR", "STS",
-                    "sRf",
-                    'R', new UnificationEntry(TagPrefix.rodLong, GTMaterials.Wood),
-                    'S', new ItemStack(Items.STRING),
-                    'T', new ItemStack(Items.TRIPWIRE_HOOK),
-                    'I', new UnificationEntry(ring, Iron));
 
             VanillaRecipeHelper.addShapedRecipe(provider, "item_frame", new ItemStack(Items.ITEM_FRAME), "SRS", "TLT",
                     "TTT",

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -578,7 +578,7 @@ public class RecipeAddition {
             GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("daylight_detector")
                     .inputItems(rod, RedAlloy)
                     .inputItems(new ItemStack(Blocks.GLASS, 3))
-                    .inputItems(ingot, NetherQuartz, 3)
+                    .inputItems(gem, NetherQuartz, 3)
                     .inputItems(ItemTags.PLANKS)
                     .outputItems(new ItemStack(Blocks.DAYLIGHT_DETECTOR))
                     .duration(200).EUt(16).save(provider);
@@ -586,7 +586,7 @@ public class RecipeAddition {
             GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("daylight_detector_certus")
                     .inputItems(rod, RedAlloy)
                     .inputItems(new ItemStack(Blocks.GLASS, 3))
-                    .inputItems(ingot, CertusQuartz, 3)
+                    .inputItems(gem, CertusQuartz, 3)
                     .inputItems(ItemTags.PLANKS)
                     .outputItems(new ItemStack(Blocks.DAYLIGHT_DETECTOR))
                     .duration(200).EUt(16).save(provider);
@@ -594,7 +594,7 @@ public class RecipeAddition {
             GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("daylight_detector_quartzite")
                     .inputItems(rod, RedAlloy)
                     .inputItems(new ItemStack(Blocks.GLASS, 3))
-                    .inputItems(ingot, Quartzite, 3)
+                    .inputItems(gem, Quartzite, 3)
                     .inputItems(ItemTags.PLANKS)
                     .outputItems(new ItemStack(Blocks.DAYLIGHT_DETECTOR))
                     .duration(200).EUt(16).save(provider);
@@ -705,7 +705,7 @@ public class RecipeAddition {
 
             ASSEMBLER_RECIPES.recipeBuilder("calibrated_sculk_sensor")
                     .inputItems(new ItemStack(Blocks.SCULK_SENSOR))
-                    .inputItems(ingot, Amethyst)
+                    .inputItems(gem, Amethyst)
                     .inputItems(plate, Amethyst)
                     .outputItems(new ItemStack(Blocks.CALIBRATED_SCULK_SENSOR))
                     .duration(200).EUt(16).save(provider);
@@ -1331,8 +1331,8 @@ public class RecipeAddition {
 
             VanillaRecipeHelper.addShapedRecipe(provider, "lightning_rod", new ItemStack(Blocks.LIGHTNING_ROD), " B ",
                     "fRh", " R ",
-                    'R', rod, Copper,
-                    'B', plateDouble, Copper);
+                    'R', new UnificationEntry(rod, Copper),
+                    'B', new UnificationEntry(plateDouble, Copper));
 
             ASSEMBLER_RECIPES.recipeBuilder("lightning_rod")
                     .inputItems(rod, Copper, 2)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -303,6 +303,30 @@ public class RecipeAddition {
                     'L', Blocks.MANGROVE_SLAB.asItem(),
                     'C', new UnificationEntry(TagPrefix.spring, GTMaterials.Iron));
 
+            VanillaRecipeHelper.addShapedRecipe(provider, "cherry_pressure_plate",
+                    new ItemStack(Blocks.CHERRY_PRESSURE_PLATE, 2), "SrS", "LCL", "SdS",
+                    'S', new UnificationEntry(TagPrefix.bolt, GTMaterials.Wood),
+                    'L', Blocks.CHERRY_SLAB.asItem(),
+                    'C', new UnificationEntry(TagPrefix.spring, GTMaterials.Iron));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, "bamboo_pressure_plate",
+                    new ItemStack(Blocks.BAMBOO_PRESSURE_PLATE, 2), "SrS", "LCL", "SdS",
+                    'S', new UnificationEntry(TagPrefix.bolt, GTMaterials.Wood),
+                    'L', Blocks.BAMBOO_SLAB.asItem(),
+                    'C', new UnificationEntry(TagPrefix.spring, GTMaterials.Iron));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_pressure_plate",
+                    new ItemStack(GTBlocks.RUBBER_PRESSURE_PLATE, 2), "SrS", "LCL", "SdS",
+                    'S', new UnificationEntry(TagPrefix.bolt, GTMaterials.Wood),
+                    'L', GTBlocks.RUBBER_SLAB.asItem(),
+                    'C', new UnificationEntry(TagPrefix.spring, GTMaterials.Iron));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_pressure_plate",
+                    new ItemStack(GTBlocks.TREATED_WOOD_PRESSURE_PLATE, 2), "SrS", "LCL", "SdS",
+                    'S', new UnificationEntry(TagPrefix.bolt, GTMaterials.Wood),
+                    'L', GTBlocks.TREATED_WOOD_SLAB.asItem(),
+                    'C', new UnificationEntry(TagPrefix.spring, GTMaterials.Iron));
+
             VanillaRecipeHelper.addShapedRecipe(provider, "heavy_weighted_pressure_plate",
                     new ItemStack(Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE), "ShS", "LCL", "SdS",
                     'S', new UnificationEntry(TagPrefix.screw, GTMaterials.Steel),
@@ -375,6 +399,30 @@ public class RecipeAddition {
                     .outputItems(new ItemStack(Blocks.MANGROVE_PRESSURE_PLATE, 2))
                     .duration(100).EUt(VA[ULV]).save(provider);
 
+            GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("cherry_pressure_plate")
+                    .inputItems(TagPrefix.spring, GTMaterials.Iron)
+                    .inputItems(new ItemStack(Blocks.CHERRY_SLAB, 2))
+                    .outputItems(new ItemStack(Blocks.CHERRY_PRESSURE_PLATE, 2))
+                    .duration(100).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("bamboo_pressure_plate")
+                    .inputItems(TagPrefix.spring, GTMaterials.Iron)
+                    .inputItems(new ItemStack(Blocks.BAMBOO_SLAB, 2))
+                    .outputItems(new ItemStack(Blocks.BAMBOO_PRESSURE_PLATE, 2))
+                    .duration(100).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("rubber_pressure_plate")
+                    .inputItems(TagPrefix.spring, GTMaterials.Iron)
+                    .inputItems(new ItemStack(GTBlocks.RUBBER_SLAB, 2))
+                    .outputItems(new ItemStack(GTBlocks.RUBBER_PRESSURE_PLATE, 2))
+                    .duration(100).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("treated_wood_pressure_plate")
+                    .inputItems(TagPrefix.spring, GTMaterials.Iron)
+                    .inputItems(new ItemStack(GTBlocks.TREATED_WOOD_SLAB, 2))
+                    .outputItems(new ItemStack(GTBlocks.TREATED_WOOD_PRESSURE_PLATE, 2))
+                    .duration(100).EUt(VA[ULV]).save(provider);
+
             GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("light_weighted_pressure_plate")
                     .inputItems(TagPrefix.spring, GTMaterials.Steel)
                     .inputItems(TagPrefix.plate, GTMaterials.Gold)
@@ -426,6 +474,12 @@ public class RecipeAddition {
             VanillaRecipeHelper.addShapedRecipe(provider, "bamboo_button", new ItemStack(Blocks.BAMBOO_BUTTON, 6), "sP",
                     'P', new ItemStack(Blocks.BAMBOO_PRESSURE_PLATE));
 
+            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_button", new ItemStack(GTBlocks.RUBBER_BUTTON, 6), "sP",
+                    'P', new ItemStack(GTBlocks.RUBBER_PRESSURE_PLATE));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_button", new ItemStack(GTBlocks.TREATED_WOOD_BUTTON, 6), "sP",
+                    'P', new ItemStack(GTBlocks.TREATED_WOOD_PRESSURE_PLATE));
+
             GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("stone_button")
                     .inputItems(new ItemStack(Blocks.STONE_PRESSURE_PLATE))
                     .outputItems(new ItemStack(Blocks.STONE_BUTTON, 12))
@@ -474,6 +528,26 @@ public class RecipeAddition {
             GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("mangrove_button")
                     .inputItems(new ItemStack(Blocks.MANGROVE_PRESSURE_PLATE))
                     .outputItems(new ItemStack(Blocks.MANGROVE_BUTTON, 12))
+                    .duration(25).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("cherry_button")
+                    .inputItems(new ItemStack(Blocks.CHERRY_PRESSURE_PLATE))
+                    .outputItems(new ItemStack(Blocks.CHERRY_BUTTON, 12))
+                    .duration(25).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("bamboo_button")
+                    .inputItems(new ItemStack(Blocks.BAMBOO_PRESSURE_PLATE))
+                    .outputItems(new ItemStack(Blocks.BAMBOO_BUTTON, 12))
+                    .duration(25).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("rubber_button")
+                    .inputItems(new ItemStack(GTBlocks.RUBBER_PRESSURE_PLATE))
+                    .outputItems(new ItemStack(GTBlocks.RUBBER_BUTTON, 12))
+                    .duration(25).EUt(VA[ULV]).save(provider);
+
+            GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("treated_wood_button")
+                    .inputItems(new ItemStack(GTBlocks.TREATED_WOOD_PRESSURE_PLATE))
+                    .outputItems(new ItemStack(GTBlocks.TREATED_WOOD_BUTTON, 12))
                     .duration(25).EUt(VA[ULV]).save(provider);
 
             VanillaRecipeHelper.addShapedRecipe(provider, "lever", new ItemStack(Blocks.LEVER), "B", "S",

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -474,10 +474,12 @@ public class RecipeAddition {
             VanillaRecipeHelper.addShapedRecipe(provider, "bamboo_button", new ItemStack(Blocks.BAMBOO_BUTTON, 6), "sP",
                     'P', new ItemStack(Blocks.BAMBOO_PRESSURE_PLATE));
 
-            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_button", new ItemStack(GTBlocks.RUBBER_BUTTON, 6), "sP",
+            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_button", new ItemStack(GTBlocks.RUBBER_BUTTON, 6),
+                    "sP",
                     'P', new ItemStack(GTBlocks.RUBBER_PRESSURE_PLATE));
 
-            VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_button", new ItemStack(GTBlocks.TREATED_WOOD_BUTTON, 6), "sP",
+            VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_button",
+                    new ItemStack(GTBlocks.TREATED_WOOD_BUTTON, 6), "sP",
                     'P', new ItemStack(GTBlocks.TREATED_WOOD_PRESSURE_PLATE));
 
             GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("stone_button")
@@ -1444,39 +1446,57 @@ public class RecipeAddition {
                     .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 6).inputItems(dust, Redstone, 2)
                     .inputItems(plate, Quartzite).outputItems(new ItemStack(Blocks.OBSERVER)).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("lantern").duration(100).EUt(VA[LV])
-                    .inputItems(Items.TORCH).inputFluids(Iron.getFluid(GTValues.L / 9 * 8)).outputItems(new ItemStack(Blocks.LANTERN)).save(provider);
+                    .inputItems(Items.TORCH).inputFluids(Iron.getFluid(GTValues.L / 9 * 8))
+                    .outputItems(new ItemStack(Blocks.LANTERN)).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("tinted_glass").duration(100).EUt(VA[LV])
-                    .inputItems(Items.AMETHYST_SHARD, 2).inputItems(Items.GLASS).outputItems(new ItemStack(Blocks.TINTED_GLASS)).save(provider);
+                    .inputItems(Items.AMETHYST_SHARD, 2).inputItems(Items.GLASS)
+                    .outputItems(new ItemStack(Blocks.TINTED_GLASS)).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("stonecutter").duration(100).EUt(VA[LV])
-                    .inputItems(Items.STONE, 3).inputFluids(Iron.getFluid(GTValues.L)).outputItems(new ItemStack(Blocks.STONECUTTER)).save(provider);
+                    .inputItems(Items.STONE, 3).inputFluids(Iron.getFluid(GTValues.L))
+                    .outputItems(new ItemStack(Blocks.STONECUTTER)).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("cartography_table").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.PLANKS, 4).inputItems(Items.PAPER, 2).outputItems(new ItemStack(Blocks.CARTOGRAPHY_TABLE)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.PLANKS, 4).inputItems(Items.PAPER, 2)
+                    .outputItems(new ItemStack(Blocks.CARTOGRAPHY_TABLE)).circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("fletching_table").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.PLANKS, 4).inputItems(Items.FLINT, 2).outputItems(new ItemStack(Blocks.FLETCHING_TABLE)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.PLANKS, 4).inputItems(Items.FLINT, 2)
+                    .outputItems(new ItemStack(Blocks.FLETCHING_TABLE)).circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("smithing_table").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.PLANKS, 4).inputFluids(Iron.getFluid(GTValues.L * 2)).outputItems(new ItemStack(Blocks.SMITHING_TABLE)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.PLANKS, 4).inputFluids(Iron.getFluid(GTValues.L * 2))
+                    .outputItems(new ItemStack(Blocks.SMITHING_TABLE)).circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("grindstone").duration(100).EUt(VA[LV])
-                    .inputItems(Tags.Items.RODS_WOODEN, 2).inputItems(Items.STONE_SLAB).inputItems(ItemTags.PLANKS, 2).outputItems(new ItemStack(Blocks.GRINDSTONE)).circuitMeta(7).save(provider);
+                    .inputItems(Tags.Items.RODS_WOODEN, 2).inputItems(Items.STONE_SLAB).inputItems(ItemTags.PLANKS, 2)
+                    .outputItems(new ItemStack(Blocks.GRINDSTONE)).circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("loom").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.PLANKS, 2).inputItems(Items.STRING, 2).outputItems(new ItemStack(Blocks.LOOM)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.PLANKS, 2).inputItems(Items.STRING, 2).outputItems(new ItemStack(Blocks.LOOM))
+                    .circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("smoker").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.LOGS, 4).inputItems(Items.FURNACE).outputItems(new ItemStack(Blocks.SMOKER)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.LOGS, 4).inputItems(Items.FURNACE).outputItems(new ItemStack(Blocks.SMOKER))
+                    .circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("blast_furnace").duration(100).EUt(VA[LV])
-                    .inputItems(Items.SMOOTH_STONE, 3).inputItems(Items.FURNACE).inputFluids(Iron.getFluid(GTValues.L * 5)).outputItems(new ItemStack(Blocks.BLAST_FURNACE)).save(provider);
+                    .inputItems(Items.SMOOTH_STONE, 3).inputItems(Items.FURNACE)
+                    .inputFluids(Iron.getFluid(GTValues.L * 5)).outputItems(new ItemStack(Blocks.BLAST_FURNACE))
+                    .save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("composter").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.WOODEN_SLABS, 7).outputItems(new ItemStack(Blocks.COMPOSTER)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.WOODEN_SLABS, 7).outputItems(new ItemStack(Blocks.COMPOSTER)).circuitMeta(7)
+                    .save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("lodestone").duration(100).EUt(VA[LV])
-                    .inputItems(Items.CHISELED_STONE_BRICKS, 8).inputItems(Items.NETHERITE_INGOT).outputItems(new ItemStack(Blocks.LODESTONE)).save(provider);
+                    .inputItems(Items.CHISELED_STONE_BRICKS, 8).inputItems(Items.NETHERITE_INGOT)
+                    .outputItems(new ItemStack(Blocks.LODESTONE)).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("scaffolding").duration(100).EUt(VA[LV])
-                    .inputItems(Items.BAMBOO, 6).inputItems(Items.STRING).outputItems(new ItemStack(Blocks.SCAFFOLDING, 6)).circuitMeta(7).save(provider);
+                    .inputItems(Items.BAMBOO, 6).inputItems(Items.STRING)
+                    .outputItems(new ItemStack(Blocks.SCAFFOLDING, 6)).circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("beehive").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.PLANKS, 6).inputItems(Items.HONEYCOMB, 3).outputItems(new ItemStack(Blocks.BEEHIVE)).circuitMeta(7).save(provider);
+                    .inputItems(ItemTags.PLANKS, 6).inputItems(Items.HONEYCOMB, 3)
+                    .outputItems(new ItemStack(Blocks.BEEHIVE)).circuitMeta(7).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("chiseled_bookshelf").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.PLANKS, 6).inputItems(ItemTags.WOODEN_SLABS, 3).outputItems(new ItemStack(Blocks.CHISELED_BOOKSHELF)).circuitMeta(9).save(provider);
+                    .inputItems(ItemTags.PLANKS, 6).inputItems(ItemTags.WOODEN_SLABS, 3)
+                    .outputItems(new ItemStack(Blocks.CHISELED_BOOKSHELF)).circuitMeta(9).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("lectern").duration(100).EUt(VA[LV])
-                    .inputItems(ItemTags.WOODEN_SLABS, 4).inputItems(Items.BOOKSHELF).outputItems(new ItemStack(Blocks.LECTERN)).circuitMeta(10).save(provider);
+                    .inputItems(ItemTags.WOODEN_SLABS, 4).inputItems(Items.BOOKSHELF)
+                    .outputItems(new ItemStack(Blocks.LECTERN)).circuitMeta(10).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("respawn_anchor").duration(100).EUt(VA[LV])
-                    .inputItems(Items.CRYING_OBSIDIAN, 6).inputItems(Items.GLOWSTONE, 3).outputItems(new ItemStack(Blocks.RESPAWN_ANCHOR)).save(provider);
+                    .inputItems(Items.CRYING_OBSIDIAN, 6).inputItems(Items.GLOWSTONE, 3)
+                    .outputItems(new ItemStack(Blocks.RESPAWN_ANCHOR)).save(provider);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -920,21 +920,6 @@ public class RecipeAddition {
                     .outputItems(new ItemStack(Items.CLOCK))
                     .duration(100).EUt(4).save(provider);
         }
-
-        ASSEMBLER_RECIPES.recipeBuilder("bow")
-                .inputItems(new ItemStack(Items.STRING, 3))
-                .inputItems(Items.STICK, 3)
-                .outputItems(new ItemStack(Items.BOW, 1))
-                .circuitMeta(10)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("crossbow")
-                .inputItems(new ItemStack(Items.STRING, 2))
-                .inputItems(Items.STICK, 3)
-                .inputItems(Items.TRIPWIRE_HOOK)
-                .outputItems(new ItemStack(Items.CROSSBOW, 1))
-                .circuitMeta(11)
-                .duration(100).EUt(4).save(provider);
     }
 
     private static void harderRods(Consumer<FinishedRecipe> provider) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1427,7 +1427,6 @@ public class RecipeAddition {
             }
 
         } else {
-            // TODO: add non-harderMiscRecipes assembler recipes for 1.14 blocks
             ASSEMBLER_RECIPES.recipeBuilder("crafting_table").duration(80).EUt(6).circuitMeta(4)
                     .inputItems(ItemTags.PLANKS, 4).outputItems(new ItemStack(Blocks.CRAFTING_TABLE)).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("furnace").circuitMeta(8).inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 8)
@@ -1450,6 +1449,40 @@ public class RecipeAddition {
             ASSEMBLER_RECIPES.recipeBuilder("observer_quartzite").duration(100).EUt(VA[LV])
                     .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 6).inputItems(dust, Redstone, 2)
                     .inputItems(plate, Quartzite).outputItems(new ItemStack(Blocks.OBSERVER)).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("lantern").duration(100).EUt(VA[LV])
+                    .inputItems(Items.TORCH).inputFluids(Iron.getFluid(GTValues.L / 9 * 8)).outputItems(new ItemStack(Blocks.LANTERN)).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("tinted_glass").duration(100).EUt(VA[LV])
+                    .inputItems(Items.AMETHYST_SHARD, 2).inputItems(Items.GLASS).outputItems(new ItemStack(Blocks.TINTED_GLASS)).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("stonecutter").duration(100).EUt(VA[LV])
+                    .inputItems(Items.STONE, 3).inputFluids(Iron.getFluid(GTValues.L)).outputItems(new ItemStack(Blocks.STONECUTTER)).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("cartography_table").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.PLANKS, 4).inputItems(Items.PAPER, 2).outputItems(new ItemStack(Blocks.CARTOGRAPHY_TABLE)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("fletching_table").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.PLANKS, 4).inputItems(Items.FLINT, 2).outputItems(new ItemStack(Blocks.FLETCHING_TABLE)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("smithing_table").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.PLANKS, 4).inputFluids(Iron.getFluid(GTValues.L * 2)).outputItems(new ItemStack(Blocks.SMITHING_TABLE)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("grindstone").duration(100).EUt(VA[LV])
+                    .inputItems(Tags.Items.RODS_WOODEN, 2).inputItems(Items.STONE_SLAB).inputItems(ItemTags.PLANKS, 2).outputItems(new ItemStack(Blocks.GRINDSTONE)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("loom").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.PLANKS, 2).inputItems(Items.STRING, 2).outputItems(new ItemStack(Blocks.LOOM)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("smoker").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.LOGS, 4).inputItems(Items.FURNACE).outputItems(new ItemStack(Blocks.SMOKER)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("blast_furnace").duration(100).EUt(VA[LV])
+                    .inputItems(Items.SMOOTH_STONE, 3).inputItems(Items.FURNACE).inputFluids(Iron.getFluid(GTValues.L * 5)).outputItems(new ItemStack(Blocks.BLAST_FURNACE)).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("composter").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.WOODEN_SLABS, 7).outputItems(new ItemStack(Blocks.COMPOSTER)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("lodestone").duration(100).EUt(VA[LV])
+                    .inputItems(Items.CHISELED_STONE_BRICKS, 8).inputItems(Items.NETHERITE_INGOT).outputItems(new ItemStack(Blocks.LODESTONE)).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("scaffolding").duration(100).EUt(VA[LV])
+                    .inputItems(Items.BAMBOO, 6).inputItems(Items.STRING).outputItems(new ItemStack(Blocks.SCAFFOLDING, 6)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("beehive").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.PLANKS, 6).inputItems(Items.HONEYCOMB, 3).outputItems(new ItemStack(Blocks.BEEHIVE)).circuitMeta(7).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("chiseled_bookshelf").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.PLANKS, 6).inputItems(ItemTags.WOODEN_SLABS, 3).outputItems(new ItemStack(Blocks.CHISELED_BOOKSHELF)).circuitMeta(9).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("lectern").duration(100).EUt(VA[LV])
+                    .inputItems(ItemTags.WOODEN_SLABS, 4).inputItems(Items.BOOKSHELF).outputItems(new ItemStack(Blocks.LECTERN)).circuitMeta(10).save(provider);
+            ASSEMBLER_RECIPES.recipeBuilder("respawn_anchor").duration(100).EUt(VA[LV])
+                    .inputItems(Items.CRYING_OBSIDIAN, 6).inputItems(Items.GLOWSTONE, 3).outputItems(new ItemStack(Blocks.RESPAWN_ANCHOR)).save(provider);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1277,12 +1277,6 @@ public class RecipeAddition {
                     .outputItems(new ItemStack(Blocks.BELL))
                     .duration(200).EUt(16).save(provider);
 
-            ASSEMBLER_RECIPES.recipeBuilder("conduit")
-                    .inputItems(new ItemStack(Items.HEART_OF_THE_SEA))
-                    .inputItems(new ItemStack(Items.NAUTILUS_SHELL, 8))
-                    .outputItems(new ItemStack(Blocks.CONDUIT))
-                    .duration(200).EUt(16).save(provider);
-
             VanillaRecipeHelper.addShapedRecipe(provider, "candle", new ItemStack(Blocks.CANDLE), "r",
                     "S", "W",
                     'S', new ItemStack(Items.STRING),

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -271,6 +271,7 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:chain"));
         registry.accept(new ResourceLocation("minecraft:respawn_anchor"));
         registry.accept(new ResourceLocation("minecraft:lodestone"));
+        registry.accept(new ResourceLocation("minecraft:chiseled_bookshelf"));
     }
 
     private static void hardGlassRecipes(Consumer<ResourceLocation> registry) {
@@ -347,7 +348,6 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:chiseled_red_sandstone"));
         registry.accept(new ResourceLocation("minecraft:smooth_red_sandstone"));
         registry.accept(new ResourceLocation("minecraft:bookshelf"));
-        registry.accept(new ResourceLocation("minecraft:chiseled_bookshelf"));
         registry.accept(new ResourceLocation("minecraft:quartz_pillar"));
         registry.accept(new ResourceLocation("minecraft:sea_lantern"));
         registry.accept(new ResourceLocation("minecraft:white_wool_from_string"));

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -96,7 +96,6 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:lapis_block"));
         registry.accept(new ResourceLocation("minecraft:lapis_lazuli"));
         registry.accept(new ResourceLocation("minecraft:quartz_block"));
-        registry.accept(new ResourceLocation("minecraft:quartz_block"));
         registry.accept(new ResourceLocation("minecraft:clay"));
         registry.accept(new ResourceLocation("minecraft:nether_brick"));
         registry.accept(new ResourceLocation("minecraft:glowstone"));
@@ -107,6 +106,7 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:snow_block"));
         registry.accept(new ResourceLocation("minecraft:netherite_block"));
         registry.accept(new ResourceLocation("minecraft:netherite_ingot_from_netherite_block"));
+        registry.accept(new ResourceLocation("minecraft:dripstone_block"));
     }
 
     private static void harderBrickRecipes(Consumer<ResourceLocation> registry) {
@@ -267,6 +267,8 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:recovery_compass"));
         registry.accept(new ResourceLocation("minecraft:spyglass"));
         registry.accept(new ResourceLocation("minecraft:chain"));
+        registry.accept(new ResourceLocation("minecraft:respawn_anchor"));
+        registry.accept(new ResourceLocation("minecraft:lodestone"));
     }
 
     private static void hardGlassRecipes(Consumer<ResourceLocation> registry) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -74,6 +74,7 @@ public class RecipeRemoval {
         // removed these for parity with the other torch recipes
         registry.accept(new ResourceLocation("minecraft:soul_torch"));
         registry.accept(new ResourceLocation("minecraft:soul_lantern"));
+        registry.accept(new ResourceLocation("minecraft:leather_horse_armor"));
     }
 
     private static void disableManualCompression(Consumer<ResourceLocation> registry) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -182,6 +182,8 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:clock"));
         registry.accept(new ResourceLocation("minecraft:shears"));
         registry.accept(new ResourceLocation("minecraft:shield"));
+        registry.accept(new ResourceLocation("minecraft:crossbow"));
+        registry.accept(new ResourceLocation("minecraft:bow"));
         for (String type : new String[] { "iron", "golden", "diamond" }) {
             registry.accept(new ResourceLocation("minecraft:" + type + "_shovel"));
             registry.accept(new ResourceLocation("minecraft:" + type + "_pickaxe"));
@@ -225,7 +227,6 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:polished_diorite"));
         registry.accept(new ResourceLocation("minecraft:polished_andesite"));
         registry.accept(new ResourceLocation("minecraft:lead"));
-        registry.accept(new ResourceLocation("minecraft:bow"));
         registry.accept(new ResourceLocation("minecraft:item_frame"));
         registry.accept(new ResourceLocation("minecraft:painting"));
         registry.accept(new ResourceLocation("minecraft:chest_minecart"));

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -158,6 +158,8 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:crimson_pressure_plate"));
         registry.accept(new ResourceLocation("minecraft:warped_pressure_plate"));
         registry.accept(new ResourceLocation("minecraft:mangrove_pressure_plate"));
+        registry.accept(new ResourceLocation("minecraft:cherry_pressure_plate"));
+        registry.accept(new ResourceLocation("minecraft:bamboo_pressure_plate"));
         registry.accept(new ResourceLocation("minecraft:heavy_weighted_pressure_plate"));
         registry.accept(new ResourceLocation("minecraft:light_weighted_pressure_plate"));
         registry.accept(new ResourceLocation("minecraft:stone_button"));

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -1119,6 +1119,12 @@ public class MachineRecipeLoader {
                 .duration(150).EUt(2)
                 .save(provider);
 
+        MACERATOR_RECIPES.recipeBuilder("macerate_obsidian")
+                .inputItems(new ItemStack(Blocks.OBSIDIAN))
+                .outputItems(dust, Obsidian)
+                .duration(150).EUt(2)
+                .save(provider);
+
         // TODO Stone-type tags?
         // if (!OreDictionary.getOres("stoneSoapstone").isEmpty())
         // MACERATOR_RECIPES.recipeBuilder()

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -942,6 +942,21 @@ public class VanillaStandardRecipes {
                 .outputItems(new ItemStack(Items.NAME_TAG))
                 .duration(100).EUt(VA[ULV]).save(provider);
 
+        ASSEMBLER_RECIPES.recipeBuilder("bow")
+                .inputItems(new ItemStack(Items.STRING, 3))
+                .inputItems(Items.STICK, 3)
+                .outputItems(new ItemStack(Items.BOW, 1))
+                .circuitMeta(10)
+                .duration(100).EUt(4).save(provider);
+
+        ASSEMBLER_RECIPES.recipeBuilder("crossbow")
+                .inputItems(new ItemStack(Items.STRING, 2))
+                .inputItems(Items.STICK, 3)
+                .inputItems(Items.TRIPWIRE_HOOK)
+                .outputItems(new ItemStack(Items.CROSSBOW, 1))
+                .circuitMeta(11)
+                .duration(100).EUt(4).save(provider);
+
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder("snowball").duration(128).EUt(4).notConsumable(SHAPE_MOLD_BALL)
                 .inputFluids(Water.getFluid(250)).outputItems(new ItemStack(Items.SNOWBALL)).save(provider);
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder("snowball_distilled").duration(128).EUt(4)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -396,13 +396,6 @@ public class VanillaStandardRecipes {
                 .duration(100).EUt(4)
                 .save(provider);
 
-        // todo trapdoors
-        // ASSEMBLER_RECIPES.recipeBuilder()
-        // .inputItems(ItemTags.PLANKS, 3).circuitMeta(3)
-        // .outputItems(new ItemStack(Blocks.TRAPDOOR, 2))
-        // .duration(100).EUt(4)
-        // .save(provider);
-
         ASSEMBLER_RECIPES.recipeBuilder("chest")
                 .inputItems(ItemTags.PLANKS, 8)
                 .outputItems(new ItemStack(Blocks.CHEST))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -812,7 +812,8 @@ public class VanillaStandardRecipes {
                 .duration(100).EUt(4)
                 .save(provider);
 
-        VanillaRecipeHelper.addShapedRecipe(provider, "leather_horse_armor", new ItemStack(Items.LEATHER_HORSE_ARMOR), "hdH",
+        VanillaRecipeHelper.addShapedRecipe(provider, "leather_horse_armor", new ItemStack(Items.LEATHER_HORSE_ARMOR),
+                "hdH",
                 "PCP", "LSL",
                 'H', new ItemStack(Items.LEATHER_HELMET),
                 'P', new ItemStack(Items.LEATHER),

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -940,12 +940,6 @@ public class VanillaStandardRecipes {
                 .outputItems(new ItemStack(Items.NAME_TAG))
                 .duration(100).EUt(VA[ULV]).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("bow")
-                .inputItems(new ItemStack(Items.STRING, 3))
-                .inputItems(Items.STICK, 3)
-                .outputItems(new ItemStack(Items.BOW, 1))
-                .duration(100).EUt(4).save(provider);
-
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder("snowball").duration(128).EUt(4).notConsumable(SHAPE_MOLD_BALL)
                 .inputFluids(Water.getFluid(250)).outputItems(new ItemStack(Items.SNOWBALL)).save(provider);
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder("snowball_distilled").duration(128).EUt(4)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -819,6 +819,14 @@ public class VanillaStandardRecipes {
                 .duration(100).EUt(4)
                 .save(provider);
 
+        VanillaRecipeHelper.addShapedRecipe(provider, "leather_horse_armor", new ItemStack(Items.LEATHER_HORSE_ARMOR), "hdH",
+                "PCP", "LSL",
+                'H', new ItemStack(Items.LEATHER_HELMET),
+                'P', new ItemStack(Items.LEATHER),
+                'C', new ItemStack(Items.LEATHER_CHESTPLATE),
+                'L', new ItemStack(Items.LEATHER_LEGGINGS),
+                'S', new UnificationEntry(screw, Iron));
+
         VanillaRecipeHelper.addShapedRecipe(provider, "iron_horse_armor", new ItemStack(Items.IRON_HORSE_ARMOR), "hdH",
                 "PCP", "LSL",
                 'H', new ItemStack(Items.IRON_HELMET),

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -1172,6 +1172,12 @@ public class VanillaStandardRecipes {
         ASSEMBLER_RECIPES.recipeBuilder("hopper_minecart").EUt(4).duration(100)
                 .inputItems(new ItemStack(Items.MINECART)).inputItems(new ItemStack(Blocks.HOPPER))
                 .outputItems(new ItemStack(Items.HOPPER_MINECART)).save(provider);
+
+        ASSEMBLER_RECIPES.recipeBuilder("conduit")
+                .inputItems(new ItemStack(Items.HEART_OF_THE_SEA))
+                .inputItems(new ItemStack(Items.NAUTILUS_SHELL, 8))
+                .outputItems(new ItemStack(Blocks.CONDUIT))
+                .duration(200).EUt(16).save(provider);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -444,84 +444,6 @@ public class VanillaStandardRecipes {
                 .outputItems(new ItemStack(Blocks.SOUL_LANTERN))
                 .duration(100).EUt(1).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("oak_fence")
-                .inputItems(new ItemStack(Blocks.OAK_PLANKS, 1))
-                .outputItems(new ItemStack(Blocks.OAK_FENCE))
-                .circuitMeta(1)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("spruce_fence")
-                .inputItems(new ItemStack(Blocks.SPRUCE_PLANKS, 1))
-                .outputItems(new ItemStack(Blocks.SPRUCE_FENCE))
-                .circuitMeta(1)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("birch_fence")
-                .inputItems(new ItemStack(Blocks.BIRCH_PLANKS, 1))
-                .outputItems(new ItemStack(Blocks.BIRCH_FENCE))
-                .circuitMeta(1)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("jungle_fence")
-                .inputItems(new ItemStack(Blocks.JUNGLE_PLANKS, 1))
-                .outputItems(new ItemStack(Blocks.JUNGLE_FENCE))
-                .circuitMeta(1)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("acacia_fence")
-                .inputItems(new ItemStack(Blocks.ACACIA_PLANKS, 1))
-                .outputItems(new ItemStack(Blocks.ACACIA_FENCE))
-                .circuitMeta(1)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("dark_oak_fence")
-                .inputItems(new ItemStack(Blocks.DARK_OAK_PLANKS, 1))
-                .outputItems(new ItemStack(Blocks.DARK_OAK_FENCE))
-                .circuitMeta(1)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("oak_fence_gate")
-                .inputItems(new ItemStack(Blocks.OAK_PLANKS, 2))
-                .inputItems(Items.STICK, 2)
-                .outputItems(new ItemStack(Blocks.OAK_FENCE_GATE))
-                .circuitMeta(2)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("spruce_fence_gate")
-                .inputItems(new ItemStack(Blocks.SPRUCE_PLANKS, 2))
-                .inputItems(Items.STICK, 2)
-                .outputItems(new ItemStack(Blocks.SPRUCE_FENCE_GATE))
-                .circuitMeta(2)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("birch_fence_gate")
-                .inputItems(new ItemStack(Blocks.BIRCH_PLANKS, 2))
-                .inputItems(Items.STICK, 2)
-                .outputItems(new ItemStack(Blocks.BIRCH_FENCE_GATE))
-                .circuitMeta(2)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("jungle_fence_gate")
-                .inputItems(new ItemStack(Blocks.JUNGLE_PLANKS, 2))
-                .inputItems(Items.STICK, 2)
-                .outputItems(new ItemStack(Blocks.JUNGLE_FENCE_GATE))
-                .circuitMeta(2)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("acacia_fence_gate")
-                .inputItems(new ItemStack(Blocks.ACACIA_PLANKS, 2))
-                .inputItems(Items.STICK, 2)
-                .outputItems(new ItemStack(Blocks.ACACIA_FENCE_GATE))
-                .circuitMeta(2)
-                .duration(100).EUt(4).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("dark_oak_fence_gate")
-                .inputItems(new ItemStack(Blocks.DARK_OAK_PLANKS, 2))
-                .inputItems(Items.STICK, 2)
-                .outputItems(new ItemStack(Blocks.DARK_OAK_FENCE_GATE))
-                .circuitMeta(2)
-                .duration(100).EUt(4).save(provider);
-
         VanillaRecipeHelper.addShapedRecipe(provider, "sticky_resin_torch", new ItemStack(Blocks.TORCH, 3), "X", "Y",
                 'X', STICKY_RESIN, 'Y', new ItemStack(Items.STICK));
         VanillaRecipeHelper.addShapedRecipe(provider, "torch_sulfur", new ItemStack(Blocks.TORCH, 2), "C", "S", 'C',
@@ -548,25 +470,6 @@ public class VanillaStandardRecipes {
                 .inputItems(dust, Sulfur).outputItems(new ItemStack(Blocks.TORCH, 2)).duration(100).save(provider);
         ASSEMBLER_RECIPES.recipeBuilder("torch_phosphorus").EUt(4).inputItems(new ItemStack(Items.STICK))
                 .inputItems(dust, Phosphorus).outputItems(new ItemStack(Blocks.TORCH, 6)).duration(100).save(provider);
-
-        ASSEMBLER_RECIPES.recipeBuilder("oak_stairs").EUt(4).duration(100).circuitMeta(7)
-                .inputItems(new ItemStack(Blocks.OAK_PLANKS, 6)).outputItems(new ItemStack(Blocks.OAK_STAIRS, 4))
-                .save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("spruce_stairs").EUt(4).duration(100).circuitMeta(7)
-                .inputItems(new ItemStack(Blocks.SPRUCE_PLANKS, 6)).outputItems(new ItemStack(Blocks.SPRUCE_STAIRS, 4))
-                .save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("birch_stairs").EUt(4).duration(100).circuitMeta(7)
-                .inputItems(new ItemStack(Blocks.BIRCH_PLANKS, 6)).outputItems(new ItemStack(Blocks.BIRCH_STAIRS, 4))
-                .save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("jungle_stairs").EUt(4).duration(100).circuitMeta(7)
-                .inputItems(new ItemStack(Blocks.JUNGLE_PLANKS, 6)).outputItems(new ItemStack(Blocks.JUNGLE_STAIRS, 4))
-                .save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("acacia_stairs").EUt(4).duration(100).circuitMeta(7)
-                .inputItems(new ItemStack(Blocks.ACACIA_PLANKS, 6)).outputItems(new ItemStack(Blocks.ACACIA_STAIRS, 4))
-                .save(provider);
-        ASSEMBLER_RECIPES.recipeBuilder("dark_oak_stairs").EUt(4).duration(100).circuitMeta(7)
-                .inputItems(new ItemStack(Blocks.DARK_OAK_PLANKS, 6))
-                .outputItems(new ItemStack(Blocks.DARK_OAK_STAIRS, 4)).save(provider);
 
         ASSEMBLER_RECIPES.recipeBuilder("ladder").EUt(4).duration(40).circuitMeta(7)
                 .inputItems(new ItemStack(Items.STICK, 7)).outputItems(new ItemStack(Blocks.LADDER, 2)).save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -631,7 +631,7 @@ public class WoodMachineRecipes {
                         .outputItems(entry.trapdoor, 2)
                         .duration(200).EUt(4).save(provider);
             } else {
-                if (!hasTrapdoorRecipe) {
+                if(!hasTrapdoorRecipe) {
                     VanillaRecipeHelper.addShapedRecipe(provider, recipeName, new ItemStack(entry.trapdoor, 2),
                             "PPP", "PPP",
                             'P', entry.planks);
@@ -893,6 +893,9 @@ public class WoodMachineRecipes {
                     // hard plank -> boat crafting
                     if (entry.boatRecipeName != null) {
                         registry.accept(new ResourceLocation(entry.modid, entry.boatRecipeName));
+                    }
+                    if(entry.chestBoatRecipeName != null) {
+                        registry.accept(new ResourceLocation(entry.modid, entry.chestBoatRecipeName));
                     }
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -23,7 +23,6 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.fluids.FluidUtil;
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -23,6 +23,7 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.fluids.FluidUtil;
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -631,7 +631,7 @@ public class WoodMachineRecipes {
                         .outputItems(entry.trapdoor, 2)
                         .duration(200).EUt(4).save(provider);
             } else {
-                if(!hasTrapdoorRecipe) {
+                if (!hasTrapdoorRecipe) {
                     VanillaRecipeHelper.addShapedRecipe(provider, recipeName, new ItemStack(entry.trapdoor, 2),
                             "PPP", "PPP",
                             'P', entry.planks);
@@ -825,12 +825,14 @@ public class WoodMachineRecipes {
                     'L', GTBlocks.TREATED_WOOD_PLANK.asItem());
         }
 
-        if(!ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes) {
+        if (!ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes) {
             VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_button", GTBlocks.RUBBER_BUTTON.asStack(),
                     GTBlocks.RUBBER_PLANK.asStack());
-            VanillaRecipeHelper.addShapelessRecipe(provider, "treated_wood_button", GTBlocks.TREATED_WOOD_BUTTON.asStack(),
+            VanillaRecipeHelper.addShapelessRecipe(provider, "treated_wood_button",
+                    GTBlocks.TREATED_WOOD_BUTTON.asStack(),
                     GTBlocks.TREATED_WOOD_PLANK.asStack());
-            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_pressure_plate", GTBlocks.RUBBER_PRESSURE_PLATE.asStack(),
+            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_pressure_plate",
+                    GTBlocks.RUBBER_PRESSURE_PLATE.asStack(),
                     "aa", 'a', GTBlocks.RUBBER_PLANK.asStack());
             VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_plate",
                     GTBlocks.TREATED_WOOD_PRESSURE_PLATE.asStack(), "aa", 'a', GTBlocks.TREATED_WOOD_PLANK.asStack());
@@ -896,7 +898,7 @@ public class WoodMachineRecipes {
                     if (entry.boatRecipeName != null) {
                         registry.accept(new ResourceLocation(entry.modid, entry.boatRecipeName));
                     }
-                    if(entry.chestBoatRecipeName != null) {
+                    if (entry.chestBoatRecipeName != null) {
                         registry.accept(new ResourceLocation(entry.modid, entry.chestBoatRecipeName));
                     }
                 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -825,14 +825,16 @@ public class WoodMachineRecipes {
                     'L', GTBlocks.TREATED_WOOD_PLANK.asItem());
         }
 
-        VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_button", GTBlocks.RUBBER_BUTTON.asStack(),
-                GTBlocks.RUBBER_PLANK.asStack());
-        VanillaRecipeHelper.addShapelessRecipe(provider, "treated_wood_button", GTBlocks.TREATED_WOOD_BUTTON.asStack(),
-                GTBlocks.TREATED_WOOD_PLANK.asStack());
-        VanillaRecipeHelper.addShapedRecipe(provider, "rubber_pressure_plate", GTBlocks.RUBBER_PRESSURE_PLATE.asStack(),
-                "aa", 'a', GTBlocks.RUBBER_PLANK.asStack());
-        VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_plate",
-                GTBlocks.TREATED_WOOD_PRESSURE_PLATE.asStack(), "aa", 'a', GTBlocks.TREATED_WOOD_PLANK.asStack());
+        if(!ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes) {
+            VanillaRecipeHelper.addShapelessRecipe(provider, "rubber_button", GTBlocks.RUBBER_BUTTON.asStack(),
+                    GTBlocks.RUBBER_PLANK.asStack());
+            VanillaRecipeHelper.addShapelessRecipe(provider, "treated_wood_button", GTBlocks.TREATED_WOOD_BUTTON.asStack(),
+                    GTBlocks.TREATED_WOOD_PLANK.asStack());
+            VanillaRecipeHelper.addShapedRecipe(provider, "rubber_pressure_plate", GTBlocks.RUBBER_PRESSURE_PLATE.asStack(),
+                    "aa", 'a', GTBlocks.RUBBER_PLANK.asStack());
+            VanillaRecipeHelper.addShapedRecipe(provider, "treated_wood_plate",
+                    GTBlocks.TREATED_WOOD_PRESSURE_PLATE.asStack(), "aa", 'a', GTBlocks.TREATED_WOOD_PLANK.asStack());
+        }
 
         // add Recipes for rubber log
         if (ConfigHolder.INSTANCE.recipes.nerfWoodCrafting) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/BrewingRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/BrewingRecipes.java
@@ -60,11 +60,13 @@ public class BrewingRecipes {
                 .inputFluids(Water.getFluid(750)).outputFluids(Biomass.getFluid(750)).save(provider);
         BREWING_RECIPES.recipeBuilder("biomass_from_kelp").duration(160).EUt(3).inputItems(Blocks.KELP.asItem())
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
-        BREWING_RECIPES.recipeBuilder("biomass_from_sea_pickle").duration(160).EUt(3).inputItems(Blocks.SEA_PICKLE.asItem())
+        BREWING_RECIPES.recipeBuilder("biomass_from_sea_pickle").duration(160).EUt(3)
+                .inputItems(Blocks.SEA_PICKLE.asItem())
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
         BREWING_RECIPES.recipeBuilder("biomass_from_sweet_berries").duration(160).EUt(3).inputItems(Items.SWEET_BERRIES)
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
-        BREWING_RECIPES.recipeBuilder("biomass_from_crimson_fungus").duration(160).EUt(3).inputItems(Items.CRIMSON_FUNGUS)
+        BREWING_RECIPES.recipeBuilder("biomass_from_crimson_fungus").duration(160).EUt(3)
+                .inputItems(Items.CRIMSON_FUNGUS)
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
         BREWING_RECIPES.recipeBuilder("biomass_from_warped_fungus").duration(160).EUt(3).inputItems(Items.WARPED_FUNGUS)
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
@@ -72,8 +74,8 @@ public class BrewingRecipes {
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
         BREWING_RECIPES.recipeBuilder("biomass_from_pitcher_pod").duration(160).EUt(3).inputItems(Items.PITCHER_POD)
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
-        BREWING_RECIPES.recipeBuilder("biomass_from_torchflower_seeds").duration(160).EUt(3).inputItems(Items.TORCHFLOWER_SEEDS)
+        BREWING_RECIPES.recipeBuilder("biomass_from_torchflower_seeds").duration(160).EUt(3)
+                .inputItems(Items.TORCHFLOWER_SEEDS)
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
-
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/BrewingRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/BrewingRecipes.java
@@ -58,6 +58,22 @@ public class BrewingRecipes {
                 .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
         BREWING_RECIPES.recipeBuilder("biomass_from_bio_chaff").EUt(4).duration(128).inputItems(BIO_CHAFF)
                 .inputFluids(Water.getFluid(750)).outputFluids(Biomass.getFluid(750)).save(provider);
-        // TODO 1.13+ plants
+        BREWING_RECIPES.recipeBuilder("biomass_from_kelp").duration(160).EUt(3).inputItems(Blocks.KELP.asItem())
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_sea_pickle").duration(160).EUt(3).inputItems(Blocks.SEA_PICKLE.asItem())
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_sweet_berries").duration(160).EUt(3).inputItems(Items.SWEET_BERRIES)
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_crimson_fungus").duration(160).EUt(3).inputItems(Items.CRIMSON_FUNGUS)
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_warped_fungus").duration(160).EUt(3).inputItems(Items.WARPED_FUNGUS)
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_glow_berries").duration(160).EUt(3).inputItems(Items.GLOW_BERRIES)
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_pitcher_pod").duration(160).EUt(3).inputItems(Items.PITCHER_POD)
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+        BREWING_RECIPES.recipeBuilder("biomass_from_torchflower_seeds").duration(160).EUt(3).inputItems(Items.TORCHFLOWER_SEEDS)
+                .inputFluids(Water.getFluid(20)).outputFluids(Biomass.getFluid(20)).save(provider);
+
     }
 }


### PR DESCRIPTION
## What
Fixes various broken or missing recipes, and certain inconsistencies in others.

## Outcome
- Remove duplicate default trapdoor recipes
- Disable default chest boat recipe when `hardWoodRecipes` is enabled
- Disable default pressure plate and button recipes for cherry, bamboo, rubber & treated wood when `hardWoodRecipes` is enabled
- Add missing hard recipes for cherry, bamboo, rubber, & treated wood pressure plates & buttons
- Add macerator recipe for obsidian dust
- Disable dripstone crafting table compression when `disableManualCompression` is enabled
- Disable default lodestone & respawn anchor recipes when `hardMiscRecipes` is enabled
- Move hard bow & crossbow recipes into `hardToolAndArmorRecipes` instead of `hardMiscRecipes`
- Fix broken hard mode recipes for lightning rod, daylight detector, & calibrated skulk sensor
- Add recipe for leather horse armor to match other horse armors
- Add default assembler recipes for 1.13+ blocks
- Make hard conduit assembler recipe the default assembler recipe
- Add biomass recipes for various 1.13+ plants
- Cleanup fence, fence gate, & stair recipe gen