### PR TITLE
Fix Frame Block being deleted upon shift-click with pipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/MaterialBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MaterialBlock.java
@@ -240,7 +240,8 @@ public class MaterialBlock extends AppearanceBlock {
 
     @Override
     public boolean canBeReplaced(BlockState state, BlockPlaceContext useContext) {
-        if (this.tagPrefix == TagPrefix.frameGt && useContext.getItemInHand().getItem() instanceof PipeBlockItem)
+        if (this.tagPrefix == TagPrefix.frameGt && useContext.getItemInHand().getItem() instanceof PipeBlockItem &&
+                !useContext.getPlayer().isCrouching())
             return true;
         return super.canBeReplaced(state, useContext);
     }


### PR DESCRIPTION
## What
fixes the pipe/frame box shift click interaction accidently voiding frame boxes
