### PR TITLE
Change changelog configs to use @s

### DIFF
--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -15,7 +15,7 @@
   ],
   "sort": "ASC",
   "template": "## What's Changed\n#{{CHANGELOG}}",
-  "pr_template": "- #{{TITLE}} by #{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "ignore_labels": ["ignore changelog"],
   "max_pull_requests": 1000,
   "max_back_track_time_days": 90

--- a/.github/json/config.json
+++ b/.github/json/config.json
@@ -15,7 +15,7 @@
   ],
   "sort": "ASC",
   "template": "## Version [#{{TO_TAG}}](#{{RELEASE_DIFF}})\n#{{CHANGELOG}} ",
-  "pr_template": "- #{{TITLE}} by #{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "- No changes",
   "ignore_labels": ["ignore changelog"],
   "tag_resolver": {


### PR DESCRIPTION
## What
Changes the changelog generation configs to use `@s` for contributors