### PR TITLE
Add back backwards compatibility for the SteamParallelMultiblock constructor

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
@@ -49,12 +49,12 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
     // if in millibuckets, this is 0.5, Meaning 2mb of steam -> 1 EU
     private static final double CONVERSION_RATE = 0.5D;
 
-    public SteamParallelMultiblockMachine(IMachineBlockEntity holder) {
-        this(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount);
+    public SteamParallelMultiblockMachine(IMachineBlockEntity holder, Object... args) {
+        this(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount, args);
     }
 
-    public SteamParallelMultiblockMachine(IMachineBlockEntity holder, int parallelAmount) {
-        super(holder);
+    public SteamParallelMultiblockMachine(IMachineBlockEntity holder, int parallelAmount, Object... args) {
+        super(holder, args);
         maxParallels = parallelAmount;
     }
 


### PR DESCRIPTION
## What
Adds the `Object` varargs back to the constructor of `SteamParallelMultiblockMachine` constructor as to not break addons.