### PR TITLE
Add Programmed Circuits to GTEmiRecipe Catalysts

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -553,6 +553,9 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                         tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
                     }
                 });
+                if (io == IO.IN && this.of(content.content) instanceof IntCircuitIngredient) {
+                    slot.setIngredientIO(IngredientIO.CATALYST);
+                }
             }
         }
     }


### PR DESCRIPTION
## What
This PR sets any programmed circuit ingredients to use the EMI `IngredientIO.CATALYST` type, which marks them as catalysts in any EMI recipes. This means that they will not show in recipe trees, allowing for much easier machine batch-crafting.

Resolves #2160 