### PR TITLE
update LDLib to fix server freezing sometimes (and various other issues)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -58,7 +58,7 @@ dependencyResolutionManagement {
         def vineFlowerVersion = "1.+"
         def macheteVersion = "1.+"
         def configurationVersion = "2.2.0"
-        def ldLibVersion = "1.0.28.a"
+        def ldLibVersion = "1.0.30.a"
         def mixinextrasVersion = "0.2.0"
         def shimmerVersion = "0.2.4"
         def lombokPluginVersion = "8.7.1"

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
@@ -260,6 +260,7 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
     public void search(String s, Consumer<Object> consumer) {
         var added = new HashSet<String>();
         for (var item : this.items) {
+            if (Thread.currentThread().isInterrupted()) return;
             var id = mode.getUniqueID(item);
             if (!added.contains(id)) {
                 added.add(id);

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldSavedData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldSavedData.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 
 import com.lowdragmc.lowdraglib.Platform;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldSavedData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldSavedData.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.pattern;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 
+import com.lowdragmc.lowdraglib.Platform;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
@@ -112,6 +113,7 @@ public class MultiblockWorldSavedData extends SavedData {
 
     private void searchingTask() {
         try {
+            if (Platform.isServerNotSafe()) return;
             IN_SERVICE.set(true);
             for (var controller : controllers) {
                 controller.asyncCheckPattern(periodID);
@@ -125,7 +127,7 @@ public class MultiblockWorldSavedData extends SavedData {
     }
 
     public static boolean isThreadService() {
-        return IN_SERVICE.get();
+        return IN_SERVICE.get() && !Platform.isServerNotSafe();
     }
 
     public void releaseExecutorService() {

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -20,6 +20,7 @@ import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
+import com.gregtechceu.gtceu.api.pattern.MultiblockWorldSavedData;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.capability.EnvironmentalHazardSavedData;
 import com.gregtechceu.gtceu.common.capability.LocalizedHazardSavedData;
@@ -75,6 +76,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.event.level.ChunkWatchEvent;
 import net.minecraftforge.event.level.LevelEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
@@ -249,6 +251,17 @@ public class ForgeCommonEventListener {
     public static void worldUnload(LevelEvent.Unload event) {
         if (event.getLevel() instanceof ServerLevel serverLevel) {
             TaskHandler.onWorldUnLoad(serverLevel);
+            MultiblockWorldSavedData.getOrCreate(serverLevel).releaseExecutorService();
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerStopping(ServerStoppingEvent event) {
+        var levels = event.getServer().getAllLevels();
+        for (var level : levels) {
+            if (!level.isClientSide()) {
+                MultiblockWorldSavedData.getOrCreate(level).releaseExecutorService();
+            }
         }
     }
 


### PR DESCRIPTION
Bump up the ldlib to fix below issues:
1. fix jei compat with only JEI APIs using
2. fix widget server crash (drawOverlay() is not marked as a client only method)
3. fix the server freezes while the server is not running (Async Thread)
4. fix unsafe thread interrupt for the search engine (some of unofficial jvm doesn't support `Thread.stop` anymore)