### PR TITLE
Add debug option for superflat ore gen

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2236,6 +2236,7 @@
   "config.gtceu.option.disableManualCompression": "uoıssǝɹdɯoƆןɐnuɐWǝןqɐsıp",
   "config.gtceu.option.doBedrockOres": "sǝɹOʞɔoɹpǝᗺop",
   "config.gtceu.option.doProcessingArray": "ʎɐɹɹⱯbuıssǝɔoɹԀop",
+  "config.gtceu.option.doSuperflatOres": "sǝɹOʇɐןɟɹǝdnSop",
   "config.gtceu.option.doTerrainExplosion": "uoısoןdxƎuıɐɹɹǝ⟘op",
   "config.gtceu.option.doesExplosionDamagesTerrain": "uıɐɹɹǝ⟘sǝbɐɯɐᗡuoısoןdxƎsǝop",
   "config.gtceu.option.dumpAssets": "sʇǝssⱯdɯnp",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2236,6 +2236,7 @@
   "config.gtceu.option.disableManualCompression": "disableManualCompression",
   "config.gtceu.option.doBedrockOres": "doBedrockOres",
   "config.gtceu.option.doProcessingArray": "doProcessingArray",
+  "config.gtceu.option.doSuperflatOres": "doSuperflatOres",
   "config.gtceu.option.doTerrainExplosion": "doTerrainExplosion",
   "config.gtceu.option.doesExplosionDamagesTerrain": "doesExplosionDamagesTerrain",
   "config.gtceu.option.dumpAssets": "dumpAssets",

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
@@ -1,7 +1,7 @@
 package com.gregtechceu.gtceu.api.data.worldgen.ores;
 
-import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
@@ -1,5 +1,7 @@
 package com.gregtechceu.gtceu.api.data.worldgen.ores;
 
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.SectionPos;
@@ -10,6 +12,7 @@ import net.minecraft.world.level.chunk.BulkSectionAccess;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.level.levelgen.FlatLevelSource;
 import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
 import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 
@@ -43,6 +46,8 @@ public class OrePlacer {
      * once all of its chunks have been generated.
      */
     public void placeOres(WorldGenLevel level, ChunkGenerator chunkGenerator, ChunkAccess chunk) {
+        if (!ConfigHolder.INSTANCE.dev.doSuperflatOres && chunkGenerator instanceof FlatLevelSource) return;
+
         var random = new XoroshiroRandomSource(level.getSeed() ^ chunk.getPos().toLong());
         var generatedVeins = oreGenCache.consumeChunkVeins(level, chunkGenerator, chunk);
         var generatedIndicators = oreGenCache.consumeChunkIndicators(level, chunkGenerator, chunk);

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -661,6 +661,9 @@ public class ConfigHolder {
                 "Default: false (no placement printout in debug.log)" })
         public boolean debugWorldgen = false;
         @Configurable
+        @Configurable.Comment({ "Generate ores in superflat worlds?", "Default: false" })
+        public boolean doSuperflatOres = false;
+        @Configurable
         @Configurable.Comment({ "Dump all registered GT recipes?", "Default: false" })
         public boolean dumpRecipes = false;
         @Configurable


### PR DESCRIPTION
@krossgg rejoice

## What
- Adds new debug config option to enable ore generation on superflat worlds (disabled by default)
- Stop surface indicators generating on superflat

## Implementation Details
Added a new config option
From my testing, it works as intended