### PR TITLE
Tree Felling Interaction Fixes

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2342,6 +2342,7 @@
   "config.gtceu.option.toolCraftingSounds": "spunoSbuıʇɟɐɹƆןooʇ",
   "config.gtceu.option.toolUseSounds": "spunoSǝs∩ןooʇ",
   "config.gtceu.option.tools": "sןooʇ",
+  "config.gtceu.option.treeFellingDelay": "ʎɐןǝᗡbuıןןǝℲǝǝɹʇ",
   "config.gtceu.option.tungstensteelBoilerHeatSpeed": "pǝǝdSʇɐǝHɹǝןıoᗺןǝǝʇsuǝʇsbunʇ",
   "config.gtceu.option.tungstensteelBoilerMaxTemperature": "ǝɹnʇɐɹǝdɯǝ⟘xɐWɹǝןıoᗺןǝǝʇsuǝʇsbunʇ",
   "config.gtceu.option.universalHazards": "spɹɐzɐHןɐsɹǝʌıun",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2342,6 +2342,7 @@
   "config.gtceu.option.toolCraftingSounds": "toolCraftingSounds",
   "config.gtceu.option.toolUseSounds": "toolUseSounds",
   "config.gtceu.option.tools": "tools",
+  "config.gtceu.option.treeFellingDelay": "treeFellingDelay",
   "config.gtceu.option.tungstensteelBoilerHeatSpeed": "tungstensteelBoilerHeatSpeed",
   "config.gtceu.option.tungstensteelBoilerMaxTemperature": "tungstensteelBoilerMaxTemperature",
   "config.gtceu.option.universalHazards": "universalHazards",

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -478,15 +478,16 @@ public class ToolHelper {
                 return removeBlockRoutine(state, world, player, pos, playSound);
             } else {
                 world.levelEvent(player, LevelEvent.PARTICLES_DESTROY_BLOCK, pos, Block.getId(state));
-                boolean successful = removeBlockRoutine(state, world, player, pos, playSound);
 
                 ItemStack copiedTool = tool.copy();
                 boolean canHarvest = player.hasCorrectToolForDrops(state);
-                tool.mineBlock(world, state, pos, player);
-                if (tool.isEmpty() && !copiedTool.isEmpty()) {
-                    onPlayerDestroyItem(player, copiedTool, InteractionHand.MAIN_HAND);
+                if (!tool.isEmpty()) {
+                    tool.mineBlock(world, state, pos, player);
+                    if (tool.isEmpty() && !copiedTool.isEmpty()) {
+                        onPlayerDestroyItem(player, copiedTool, InteractionHand.MAIN_HAND);
+                    }
                 }
-
+                boolean successful = removeBlockRoutine(null, world, player, pos, playSound);
                 if (successful && canHarvest) {
                     block.playerDestroy(world, player, pos, state, tile, copiedTool);
                 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -89,7 +89,7 @@ public class TreeFellingHelper {
                     if (helper.orderedBlocks.isEmpty() || helper.tool.isEmpty() ||
                             !(hasBehaviorsTag(helper.player.getMainHandItem()) &&
                                     getBehaviorsTag(helper.player.getMainHandItem()).getBoolean(TREE_FELLING_KEY))) {
-                        return;
+                        continue;
                     }
                     if (helper.tick % ConfigHolder.INSTANCE.tools.treeFellingDelay == 0)
                         ToolHelper.breakBlockRoutine(helper.player, helper.tool, helper.orderedBlocks.removeLast(),

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -1,5 +1,7 @@
 package com.gregtechceu.gtceu.api.item.tool;
 
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import net.minecraft.core.BlockPos;
@@ -21,7 +23,7 @@ import java.util.stream.Collectors;
 import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.TREE_FELLING_KEY;
 import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.getBehaviorsTag;
 
-@Mod.EventBusSubscriber
+@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, modid = GTCEu.MOD_ID)
 public class TreeFellingHelper {
 
     private final ServerPlayer player;

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.api.item.tool;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import net.minecraft.core.BlockPos;
@@ -20,8 +19,7 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.TREE_FELLING_KEY;
-import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.getBehaviorsTag;
+import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.*;
 
 @Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.FORGE, modid = GTCEu.MOD_ID)
 public class TreeFellingHelper {
@@ -89,7 +87,8 @@ public class TreeFellingHelper {
             for (var helper : helpers) {
                 if (event.level == helper.player.level()) {
                     if (helper.orderedBlocks.isEmpty() || helper.tool.isEmpty() ||
-                            !getBehaviorsTag(helper.player.getMainHandItem()).getBoolean(TREE_FELLING_KEY)) {
+                            !(hasBehaviorsTag(helper.player.getMainHandItem()) &&
+                                    getBehaviorsTag(helper.player.getMainHandItem()).getBoolean(TREE_FELLING_KEY))) {
                         return;
                     }
                     if (helper.tick % ConfigHolder.INSTANCE.tools.treeFellingDelay == 0)

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -516,6 +516,10 @@ public class ConfigHolder {
         @Configurable.Range(min = 1, max = 512)
         public int sprayCanChainLength = 16;
         @Configurable
+        @Configurable.Comment({ "Delay in ticks between each log being broken when tree felling", "Default: 2" })
+        @Configurable.Range(min = 1, max = 400)
+        public int treeFellingDelay = 2;
+        @Configurable
         @Configurable.Comment("NanoSaber Options")
         public NanoSaber nanoSaber = new NanoSaber();
         @Configurable


### PR DESCRIPTION
## What
fixes #2209
fixes #1722

## Implementation Details
Moves the log breaking in TreeFellingHelper to the level tick event instead of enqueueing server break events 

## Outcome
No longer can you swap or drop your axe to get around the tool breaking, if you swap or drop your axe it will stop the tree felling mechanic, also fixes the case where electric chainsaws would break non electric items by overwriting with its power unit
