### PR TITLE
fix Large Bronze Boiler GUI 

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IDisplayUIMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IDisplayUIMachine.java
@@ -42,7 +42,7 @@ public interface IDisplayUIMachine extends IUIMachine, IMultiController {
         screen.addWidget(new ComponentPanelWidget(4, 17, this::addDisplayText)
                 .textSupplier(this.self().getLevel().isClientSide ? null : this::addDisplayText)
                 .setMaxWidthLimit(150)
-                .clickHandler(this::handleDisplayClick)).setSizeHeight(8);
+                .clickHandler(this::handleDisplayClick));
         return new ModularUI(176, 216, this, entityPlayer)
                 .background(GuiTextures.BACKGROUND)
                 .widget(screen)


### PR DESCRIPTION
Large bronze boiler Gui was broken in the previous update. 
this just fixes the display so you can properly see the gui again by fixing the sizeheight from 8 back to full.
Closes #2203 
