### PR TITLE
Fix Power Substation display when there is no input or output

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/PowerSubstationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/PowerSubstationMachine.java
@@ -175,7 +175,7 @@ public class PowerSubstationMachine extends WorkableMultiblockMachine
 
                 // Passive drain
                 long energyPassiveDrained = energyBank.drain(getPassiveDrain());
-                netOutLastSec -= energyPassiveDrained;
+                netOutLastSec += energyPassiveDrained;
 
                 // Debank to Dynamo Hatches
                 long energyDebanked = energyBank


### PR DESCRIPTION
## What
Passive drain was being subtracted from the netOut of the Power Substation causing the display to read "Time to fill" when there is no input or output for the Power Substation even though the stored charge was going down.

## Implementation Details
Passive drain is now a positive netOut

## Outcome
Power Substation now displayed "Time to Drain" when there is no input or output for the Power Substation.

## Additional Information
Before:
![image](https://github.com/user-attachments/assets/a97db64b-a7c4-4cbc-97cd-be7dcf5674e0)

After:
![image](https://github.com/user-attachments/assets/48d6864f-ffcd-473c-9b28-1ce6044f6078)