### PR TITLE
Modified to prevent things like extruder/solidifier molds from auto-filling ae2 patterns

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -553,7 +553,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                         tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
                     }
                 });
-                if (io == IO.IN && this.of(content.content) instanceof IntCircuitIngredient || content.chance == 0) {
+                if (io == IO.IN && (content.chance == 0 || this.of(content.content) instanceof IntCircuitIngredient)) {
                     slot.setIngredientIO(IngredientIO.CATALYST);
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -553,7 +553,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                         tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
                     }
                 });
-                if (io == IO.IN && this.of(content.content) instanceof IntCircuitIngredient) {
+                if (io == IO.IN && this.of(content.content) instanceof IntCircuitIngredient || content.chance == 0) {
                     slot.setIngredientIO(IngredientIO.CATALYST);
                 }
             }


### PR DESCRIPTION
Added a line to mark anything not consumed as a catalyst. This prevents things like extruder/solidifier molds from going in to ae2 patterns when shift clicking from a recipe book mod.

Fixes #2190