### PR TITLE
Fix Aluminium Cell not showing Fluid

### DIFF
--- a/src/main/resources/assets/gtceu/models/item/aluminium_fluid_cell.json
+++ b/src/main/resources/assets/gtceu/models/item/aluminium_fluid_cell.json
@@ -3,8 +3,7 @@
   "parent": "forge:item/default",
   "textures": {
     "base": "gtceu:item/aluminium_fluid_cell/base",
-    "fluid": "gtceu:item/aluminium_fluid_cell/overlay",
-    "cover": "gtceu:item/aluminium_fluid_cell/base"
+    "fluid": "gtceu:item/aluminium_fluid_cell/overlay"
   },
   "fluid": "minecraft:empty"
 }


### PR DESCRIPTION
## What
Fixes #2124

## Implementation Details
there was an extra layer in the alu cell model

## Outcome
you can see the fluid in alu cells again