### PR TITLE
Hide converters if they're disabled

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -2674,7 +2674,11 @@ public class GTMachines {
     }
 
     public static MachineDefinition[] registerConverter(int amperage) {
-        return registerTieredMachines(amperage + "a_energy_converter",
+        if (!ConfigHolder.INSTANCE.compat.energy.enablePlatformConverters) {
+            REGISTRATE.creativeModeTab(() -> null);
+        }
+
+        MachineDefinition[] converters = registerTieredMachines(amperage + "a_energy_converter",
                 (holder, tier) -> new ConverterMachine(holder, tier, amperage),
                 (tier, builder) -> builder
                         .rotationState(RotationState.ALL)
@@ -2693,6 +2697,12 @@ public class GTMachines {
                         .compassNode("converter")
                         .register(),
                 ALL_TIERS);
+
+        if (!ConfigHolder.INSTANCE.compat.energy.enablePlatformConverters) {
+            REGISTRATE.creativeModeTab(() -> MACHINE);
+        }
+
+        return converters;
     }
 
     public static Component explosion() {


### PR DESCRIPTION
## What
In 1.12, the converter config disables recipes and hides them from the creative tab/from JEI. In GTm, only recipes were disabled.

## Implementation Details
I think using `REGISTRATE.setCreativeTab` is correct, but I couldn't find existing methods that would hide them.

## Outcome
More 1.12 parity.