### PR TITLE
ME IO Part Direction Fix

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
@@ -38,7 +38,7 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine implements IMac
     private KeyStorage internalBuffer; // Do not use KeyCounter, use our simple implementation
 
     public MEOutputHatchPartMachine(IMachineBlockEntity holder, Object... args) {
-        super(holder, IO.IN, args);
+        super(holder, IO.OUT, args);
     }
 
     /////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
@@ -54,7 +54,7 @@ public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine impleme
     private BlockPos bufferPos;
 
     public MEPatternBufferProxyPartMachine(IMachineBlockEntity holder) {
-        super(holder, GTValues.LuV, IO.BOTH);
+        super(holder, GTValues.LuV, IO.IN);
         this.itemProxyHandler = new MEPatternBufferProxyRecipeHandler<>(this, IO.IN, ItemRecipeCapability.CAP);
         this.fluidProxyHandler = new MEPatternBufferProxyRecipeHandler<>(this, IO.IN, FluidRecipeCapability.CAP);
     }


### PR DESCRIPTION
## What
ME output hatches and pattern proxies had the wrong IO direction for their capabilities

## Outcome
no more me output hatch in the input base section
