### PR TITLE
more realgar in copper-tin veins

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -407,7 +407,7 @@ public class GTOres {
                     .oreBlock(new VeinBlockDefinition(Zeolite, 2))
                     .oreBlock(new VeinBlockDefinition(Cassiterite, 2))
                     .rareBlock(new VeinBlockDefinition(Realgar, 1))
-                    .rareBlockChance(0.05f)
+                    .rareBlockChance(0.1f)
                     .veininessThreshold(0.01f)
                     .maxRichnessThreshold(0.175f)
                     .minRichness(0.7f)


### PR DESCRIPTION
## What
adds more realgar to copper-tin veins, solves #2222


## Implementation Details
just doubled the rare ore chance of copper-tin veins, since realgar is the only rare ore in these veins it should be ok.

## Outcome
before: tiny soyjak realgar (29 in vein)
![before-29](https://github.com/user-attachments/assets/3b4151e4-d459-4d8b-859f-64b45f88e8f4)

after: massive chad realgar (186 in vein)
![after-186](https://github.com/user-attachments/assets/e3973d62-f740-48e7-85f1-621a35244ed2)
