### PR TITLE
Add BlastBuilder and Vacuum Freezer recipe overrides

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.UnaryOperator;
 
 import static com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey.HAZARD;
 
@@ -1032,22 +1033,33 @@ public class Material implements Comparable<Material> {
         }
 
         public Builder blastTemp(int temp) {
+            return blast(temp);
+        }
+
+        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier) {
+            return blast(temp, gasTier);
+        }
+
+        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
+            return blast(b -> b.temp(temp, gasTier).blastStats(eutOverride));
+        }
+
+        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
+            return blast(b -> b.temp(temp, gasTier).blastStats(eutOverride, durationOverride));
+        }
+
+        public Builder blast(int temp) {
             properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp));
             return this;
         }
 
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, -1, -1));
+        public Builder blast(int temp, BlastProperty.GasTier gasTier) {
+            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier));
             return this;
         }
 
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, -1));
-            return this;
-        }
-
-        public Builder blastTemp(int temp, BlastProperty.GasTier gasTier, int eutOverride, int durationOverride) {
-            properties.setProperty(PropertyKey.BLAST, new BlastProperty(temp, gasTier, eutOverride, durationOverride));
+        public Builder blast(UnaryOperator<BlastProperty.Builder> b) {
+            properties.setProperty(PropertyKey.BLAST, b.apply(new BlastProperty.Builder()).build());
             return this;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/BlastProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/BlastProperty.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
-import org.jetbrains.annotations.NotNull;
+import lombok.Getter;
+import lombok.Setter;
 
 public class BlastProperty implements IMaterialProperty<BlastProperty> {
 
@@ -12,6 +13,7 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
      * If a Material with this Property has a Fluid, its temperature
      * will be set to this if it is the default Fluid temperature.
      */
+    @Getter
     private int blastTemperature;
 
     /**
@@ -19,6 +21,8 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
      * <p>
      * Default: null, meaning no Gas EBF recipes.
      */
+    @Setter
+    @Getter
     private GasTier gasTier = null;
 
     /**
@@ -26,6 +30,8 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
      * <p>
      * Default: -1, meaning the duration will be: material.getAverageMass() * blastTemperature / 50
      */
+    @Setter
+    @Getter
     private int durationOverride = -1;
 
     /**
@@ -33,17 +39,45 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
      * <p>
      * Default: -1, meaning the EU/t will be 120.
      */
-    private int eutOverride = -1;
+    @Setter
+    @Getter
+    private int EUtOverride = -1;
+
+    /**
+     * The duration of the EBF recipe, overriding the stock behavior.
+     * <p>
+     * Default: -1, meaning the duration will be: material.getMass() * 3
+     */
+    @Setter
+    @Getter
+    private int vacuumDurationOverride = -1;
+
+    /**
+     * The EU/t of the Vacuum Freezer recipe (if needed), overriding the stock behavior.
+     * <p>
+     * Default: -1, meaning the EU/t will be 120 EU/t.
+     */
+    @Setter
+    @Getter
+    private int vacuumEUtOverride = -1;
 
     public BlastProperty(int blastTemperature) {
         this.blastTemperature = blastTemperature;
     }
 
-    public BlastProperty(int blastTemperature, GasTier gasTier, int eutOverride, int durationOverride) {
+    public BlastProperty(int blastTemperature, GasTier gasTier) {
         this.blastTemperature = blastTemperature;
         this.gasTier = gasTier;
-        this.eutOverride = eutOverride;
+    }
+
+    public BlastProperty(int blastTemperature, GasTier gasTier, int eutOverride, int durationOverride,
+                         int vacuumEUtOverride, int vacuumDurationOverride) {
+        this.blastTemperature = blastTemperature;
+        this.gasTier = gasTier;
+        this.EUtOverride = eutOverride;
         this.durationOverride = durationOverride;
+        this.vacuumEUtOverride = vacuumEUtOverride;
+        this.vacuumDurationOverride = vacuumDurationOverride;
     }
 
     /**
@@ -53,37 +87,9 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
         this(0);
     }
 
-    public int getBlastTemperature() {
-        return blastTemperature;
-    }
-
     public void setBlastTemperature(int blastTemp) {
         if (blastTemp <= 0) throw new IllegalArgumentException("Blast Temperature must be greater than zero!");
         this.blastTemperature = blastTemp;
-    }
-
-    public GasTier getGasTier() {
-        return gasTier;
-    }
-
-    public void setGasTier(@NotNull GasTier tier) {
-        this.gasTier = tier;
-    }
-
-    public int getDurationOverride() {
-        return durationOverride;
-    }
-
-    public void setDurationOverride(int duration) {
-        this.durationOverride = duration;
-    }
-
-    public int getEUtOverride() {
-        return eutOverride;
-    }
-
-    public void setEutOverride(int eut) {
-        this.eutOverride = eut;
     }
 
     @Override
@@ -117,5 +123,55 @@ public class BlastProperty implements IMaterialProperty<BlastProperty> {
         HIGHEST;
 
         public static final GasTier[] VALUES = values();
+    }
+
+    public static class Builder {
+
+        private int temp;
+        private GasTier gasTier;
+        private int eutOverride = -1;
+        private int durationOverride = -1;
+        private int vacuumEUtOverride = -1;
+        private int vacuumDurationOverride = -1;
+
+        public Builder() {}
+
+        public Builder temp(int tempurature) {
+            this.temp = tempurature;
+            return this;
+        }
+
+        public Builder temp(int tempurature, GasTier gasTier) {
+            this.temp = tempurature;
+            this.gasTier = gasTier;
+            return this;
+        }
+
+        public Builder blastStats(int eutOverride) {
+            this.eutOverride = eutOverride;
+            return this;
+        }
+
+        public Builder blastStats(int eutOverride, int durationOverride) {
+            this.eutOverride = eutOverride;
+            this.durationOverride = durationOverride;
+            return this;
+        }
+
+        public Builder vacuumStats(int eutOverride) {
+            this.vacuumEUtOverride = eutOverride;
+            return this;
+        }
+
+        public Builder vacuumStats(int eutOverride, int durationOverride) {
+            this.vacuumEUtOverride = eutOverride;
+            this.vacuumDurationOverride = durationOverride;
+            return this;
+        }
+
+        public BlastProperty build() {
+            return new BlastProperty(temp, gasTier, eutOverride, durationOverride, vacuumEUtOverride,
+                    vacuumDurationOverride);
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.common.data.materials;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty.GasTier;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.HazardProperty;
@@ -15,7 +14,7 @@ import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.common.data.GTElements;
 import com.gregtechceu.gtceu.common.data.GTMedicalConditions;
 
-import static com.gregtechceu.gtceu.api.GTValues.LV;
+import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
@@ -39,9 +38,9 @@ public class ElementMaterials {
                 .toolStats(ToolProperty.Builder.of(6.0F, 7.5F, 768, 2)
                         .enchantability(14).build())
                 .rotorStats(100, 140, 2.0f, 128)
-                .cableProperties(GTValues.V[4], 1, 1)
+                .cableProperties(V[EV], 1, 1)
                 .fluidPipeProperties(1166, 100, true)
-                .blastTemp(1700, GasTier.LOW)
+                .blast(1700, GasTier.LOW)
                 .buildAndRegister();
 
         Americium = new Material.Builder(GTCEu.id("americium"))
@@ -179,7 +178,7 @@ public class ElementMaterials {
                 .element(GTElements.Cr)
                 .rotorStats(130, 155, 3.0f, 512)
                 .fluidPipeProperties(2180, 35, true, true, false, false)
-                .blastTemp(1700, GasTier.LOW)
+                .blast(1700, GasTier.LOW)
                 .hazard(HazardProperty.HazardTrigger.SKIN_CONTACT, GTMedicalConditions.CARCINOGEN)
                 .buildAndRegister();
 
@@ -190,7 +189,7 @@ public class ElementMaterials {
                 .color(0x5050FA).secondaryColor(0x2d2d7a).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_FINE_WIRE)
                 .element(GTElements.Co)
-                .cableProperties(GTValues.V[LV], 2, 2)
+                .cableProperties(V[LV], 2, 2)
                 .itemPipeProperties(2560, 2.0f)
                 .buildAndRegister();
 
@@ -208,7 +207,7 @@ public class ElementMaterials {
                 .appendFlags(EXT_METAL, MORTAR_GRINDABLE, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_RING,
                         GENERATE_FINE_WIRE, GENERATE_ROTOR)
                 .element(GTElements.Cu)
-                .cableProperties(GTValues.V[2], 1, 2)
+                .cableProperties(V[MV], 1, 2)
                 .fluidPipeProperties(1696, 6, true)
                 .buildAndRegister();
 
@@ -259,9 +258,11 @@ public class ElementMaterials {
                 .appendFlags(STD_METAL, GENERATE_LONG_ROD, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_FOIL,
                         GENERATE_FRAME)
                 .element(GTElements.Eu)
-                .cableProperties(GTValues.V[GTValues.UHV], 2, 32)
+                .cableProperties(V[UHV], 2, 32)
                 .fluidPipeProperties(7750, 300, true)
-                .blastTemp(6000, GasTier.MID, GTValues.VA[GTValues.IV], 180)
+                .blast(b -> b.temp(6000, GasTier.MID)
+                        .blastStats(VA[IV], 180)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         Fermium = new Material.Builder(GTCEu.id("fermium"))
@@ -313,7 +314,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_RING, MORTAR_GRINDABLE, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES,
                         GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FINE_WIRE, GENERATE_FOIL)
                 .element(GTElements.Au)
-                .cableProperties(GTValues.V[3], 3, 2)
+                .cableProperties(V[HV], 3, 2)
                 .fluidPipeProperties(1671, 25, true, true, false, false)
                 .buildAndRegister();
 
@@ -380,7 +381,9 @@ public class ElementMaterials {
                 .element(GTElements.Ir)
                 .rotorStats(130, 115, 3.0f, 2560)
                 .fluidPipeProperties(3398, 250, true, false, true, false)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1100)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[IV], 1100)
+                        .vacuumStats(VA[EV], 250))
                 .buildAndRegister();
 
         Iron = new Material.Builder(GTCEu.id("iron"))
@@ -396,7 +399,7 @@ public class ElementMaterials {
                 .toolStats(ToolProperty.Builder.of(2.0F, 2.0F, 256, 2)
                         .enchantability(14).addTypes(GTToolType.MORTAR).build())
                 .rotorStats(115, 115, 2.5f, 256)
-                .cableProperties(GTValues.V[2], 2, 3)
+                .cableProperties(V[MV], 2, 3)
                 .buildAndRegister();
 
         Krypton = new Material.Builder(GTCEu.id("krypton"))
@@ -428,7 +431,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL,
                         GENERATE_FINE_WIRE)
                 .element(GTElements.Pb)
-                .cableProperties(GTValues.V[0], 2, 2)
+                .cableProperties(V[ULV], 2, 2)
                 .fluidPipeProperties(1200, 32, true)
                 .hazard(HazardProperty.HazardTrigger.INHALATION, GTMedicalConditions.WEAK_POISON)
                 .buildAndRegister();
@@ -507,7 +510,7 @@ public class ElementMaterials {
                 .appendFlags(STD_METAL, GENERATE_ROD, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nd)
                 .rotorStats(100, 115, 2.0f, 512)
-                .blastTemp(1297, GasTier.MID)
+                .blast(1297, GasTier.MID)
                 .buildAndRegister();
 
         Neon = new Material.Builder(GTCEu.id("neon"))
@@ -530,7 +533,7 @@ public class ElementMaterials {
                 .color(0xccdff5).secondaryColor(0x59563a).iconSet(METALLIC)
                 .appendFlags(STD_METAL, MORTAR_GRINDABLE)
                 .element(GTElements.Ni)
-                .cableProperties(GTValues.V[LV], 3, 3)
+                .cableProperties(V[LV], 3, 3)
                 .itemPipeProperties(2048, 1.0f)
                 .buildAndRegister();
 
@@ -543,7 +546,8 @@ public class ElementMaterials {
                 .ingot().fluid()
                 .color(0xb494b4).secondaryColor(0x4b3f4d).iconSet(BRIGHT)
                 .element(GTElements.Nb)
-                .blastTemp(2750, GasTier.MID, GTValues.VA[GTValues.HV], 900)
+                .blast(b -> b.temp(2750, GasTier.MID)
+                        .blastStats(VA[HV], 900))
                 .buildAndRegister();
 
         Nitrogen = new Material.Builder(GTCEu.id("nitrogen"))
@@ -570,9 +574,11 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_FOIL)
                 .element(GTElements.Os)
                 .rotorStats(160, 185, 4.0f, 1280)
-                .cableProperties(GTValues.V[6], 4, 2)
+                .cableProperties(V[LuV], 4, 2)
                 .itemPipeProperties(256, 8.0f)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1000)
+                        .vacuumStats(VA[EV], 300))
                 .buildAndRegister();
 
         Oxygen = new Material.Builder(GTCEu.id("oxygen"))
@@ -593,7 +599,9 @@ public class ElementMaterials {
                 .color(0xbd92b5).secondaryColor(0x535b14).iconSet(SHINY)
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(GTElements.Pd)
-                .blastTemp(1828, GasTier.LOW, GTValues.VA[GTValues.HV], 900)
+                .blast(b -> b.temp(1828, GasTier.LOW)
+                        .blastStats(VA[HV], 900)
+                        .vacuumStats(VA[HV], 150))
                 .buildAndRegister();
 
         Phosphorus = new Material.Builder(GTCEu.id("phosphorus"))
@@ -616,7 +624,7 @@ public class ElementMaterials {
                 .color(0xfff4ba).secondaryColor(0x8d8d71).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_RING, GENERATE_SPRING_SMALL)
                 .element(GTElements.Pt)
-                .cableProperties(GTValues.V[5], 2, 1)
+                .cableProperties(V[IV], 2, 1)
                 .itemPipeProperties(512, 4.0f)
                 .buildAndRegister();
 
@@ -686,7 +694,9 @@ public class ElementMaterials {
                 .color(0xfd46b1).secondaryColor(0xDC0C58).iconSet(BRIGHT)
                 .appendFlags(EXT2_METAL, GENERATE_GEAR, GENERATE_FINE_WIRE)
                 .element(GTElements.Rh)
-                .blastTemp(2237, GasTier.MID, GTValues.VA[GTValues.EV], 1200)
+                .blast(b -> b.temp(2237, GasTier.MID)
+                        .blastStats(VA[EV], 1200)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         Roentgenium = new Material.Builder(GTCEu.id("roentgenium"))
@@ -704,7 +714,9 @@ public class ElementMaterials {
                 .color(0xa2cde0).secondaryColor(0x3c7285).iconSet(SHINY)
                 .flags(GENERATE_FOIL, GENERATE_GEAR)
                 .element(GTElements.Ru)
-                .blastTemp(2607, GasTier.MID, GTValues.VA[GTValues.EV], 900)
+                .blast(b -> b.temp(2607, GasTier.MID)
+                        .blastStats(VA[EV], 900)
+                        .vacuumStats(VA[HV], 200))
                 .buildAndRegister();
 
         Rutherfordium = new Material.Builder(GTCEu.id("rutherfordium"))
@@ -718,7 +730,9 @@ public class ElementMaterials {
                 .color(0xc2c289).secondaryColor(0x235254).iconSet(METALLIC)
                 .flags(GENERATE_LONG_ROD)
                 .element(GTElements.Sm)
-                .blastTemp(5400, GasTier.HIGH, GTValues.VA[GTValues.EV], 1500)
+                .blast(b -> b.temp(5400, GasTier.HIGH)
+                        .blastStats(VA[EV], 1500)
+                        .vacuumStats(VA[HV], 200))
                 .buildAndRegister();
 
         Scandium = new Material.Builder(GTCEu.id("scandium"))
@@ -742,7 +756,7 @@ public class ElementMaterials {
                 .color(0x707078).secondaryColor(0x10293b).iconSet(METALLIC)
                 .flags(GENERATE_FOIL)
                 .element(GTElements.Si)
-                .blastTemp(2273) // no gas tier for silicon
+                .blast(2273) // no gas tier for silicon
                 .buildAndRegister();
 
         Silver = new Material.Builder(GTCEu.id("silver"))
@@ -752,7 +766,7 @@ public class ElementMaterials {
                 .color(0xDCDCFF).secondaryColor(0x5a4705).iconSet(SHINY)
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FINE_WIRE, GENERATE_RING)
                 .element(GTElements.Ag)
-                .cableProperties(GTValues.V[3], 1, 1)
+                .cableProperties(V[HV], 1, 1)
                 .buildAndRegister();
 
         Sodium = new Material.Builder(GTCEu.id("sodium"))
@@ -833,7 +847,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL,
                         GENERATE_FINE_WIRE)
                 .element(GTElements.Sn)
-                .cableProperties(GTValues.V[1], 1, 1)
+                .cableProperties(V[LV], 1, 1)
                 .itemPipeProperties(4096, 0.5f)
                 .buildAndRegister();
 
@@ -846,7 +860,9 @@ public class ElementMaterials {
                         .enchantability(14).build())
                 .rotorStats(130, 115, 3.0f, 1600)
                 .fluidPipeProperties(2426, 150, true)
-                .blastTemp(1941, GasTier.MID, GTValues.VA[GTValues.HV], 1500)
+                .blast(b -> b.temp(1941, GasTier.MID)
+                        .blastStats(VA[HV], 1500)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         Tritium = new Material.Builder(GTCEu.id("tritium"))
@@ -865,9 +881,11 @@ public class ElementMaterials {
                         GENERATE_FRAME)
                 .element(GTElements.W)
                 .rotorStats(130, 115, 3.0f, 2560)
-                .cableProperties(GTValues.V[5], 2, 2)
+                .cableProperties(V[IV], 2, 2)
                 .fluidPipeProperties(4618, 50, true, true, false, true)
-                .blastTemp(3600, GasTier.MID, GTValues.VA[GTValues.EV], 1800)
+                .blast(b -> b.temp(3600, GasTier.MID)
+                        .blastStats(VA[EV], 1800)
+                        .vacuumStats(VA[HV], 300))
                 .buildAndRegister();
 
         Uranium238 = new Material.Builder(GTCEu.id("uranium"))
@@ -892,7 +910,7 @@ public class ElementMaterials {
                 .ingot().fluid()
                 .color(0x696d76).secondaryColor(0x240808).iconSet(METALLIC)
                 .element(GTElements.V)
-                .blastTemp(2183, GasTier.MID)
+                .blast(2183, GasTier.MID)
                 .buildAndRegister();
 
         Xenon = new Material.Builder(GTCEu.id("xenon"))
@@ -910,7 +928,7 @@ public class ElementMaterials {
                 .ingot().fluid()
                 .color(0x7d8072).secondaryColor(0x15161a).iconSet(METALLIC)
                 .element(GTElements.Y)
-                .blastTemp(1799)
+                .blast(1799)
                 .buildAndRegister();
 
         Zinc = new Material.Builder(GTCEu.id("zinc"))
@@ -934,9 +952,11 @@ public class ElementMaterials {
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nq)
                 .rotorStats(160, 105, 4.0f, 1280)
-                .cableProperties(GTValues.V[7], 2, 2)
+                .cableProperties(V[ZPM], 2, 2)
                 .fluidPipeProperties(3776, 200, true, false, true, true)
-                .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.IV], 600)
+                .blast(b -> b.temp(5000, GasTier.HIGH)
+                        .blastStats(VA[IV], 600)
+                        .vacuumStats(VA[EV], 150))
                 .buildAndRegister();
 
         NaquadahEnriched = new Material.Builder(GTCEu.id("enriched_naquadah"))
@@ -945,7 +965,9 @@ public class ElementMaterials {
                 .color(0x3C3C3C, false).secondaryColor(0x122f06).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_FOIL)
                 .element(GTElements.Nq1)
-                .blastTemp(7000, GasTier.HIGH, GTValues.VA[GTValues.IV], 1000)
+                .blast(b -> b.temp(7000, GasTier.HIGH)
+                        .blastStats(VA[IV], 1000)
+                        .vacuumStats(VA[EV], 150))
                 .buildAndRegister();
 
         Naquadria = new Material.Builder(GTCEu.id("naquadria"))
@@ -954,7 +976,9 @@ public class ElementMaterials {
                 .color(0x1E1E1E, false).secondaryColor(0x59b3ff).iconSet(RADIOACTIVE)
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_GEAR, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW)
                 .element(GTElements.Nq2)
-                .blastTemp(9000, GasTier.HIGH, GTValues.VA[GTValues.ZPM], 1200)
+                .blast(b -> b.temp(9000, GasTier.HIGH)
+                        .blastStats(VA[ZPM], 1200)
+                        .vacuumStats(VA[LuV], 200))
                 .radioactiveHazard(3)
                 .buildAndRegister();
 
@@ -978,7 +1002,7 @@ public class ElementMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_FRAME, GENERATE_RING, GENERATE_SMALL_GEAR, GENERATE_ROUND,
                         GENERATE_FOIL, GENERATE_FINE_WIRE, GENERATE_GEAR)
                 .element(GTElements.Tr)
-                .cableProperties(GTValues.V[8], 1, 8)
+                .cableProperties(V[UV], 1, 8)
                 .rotorStats(220, 220, 6.0f, 10240)
                 .buildAndRegister();
 
@@ -998,8 +1022,10 @@ public class ElementMaterials {
                 .color(0x81808a).secondaryColor(0x351d4b).iconSet(SHINY)
                 .flags(GENERATE_FOIL, GENERATE_BOLT_SCREW, GENERATE_GEAR)
                 .element(GTElements.Ke)
-                .cableProperties(GTValues.V[7], 6, 4)
-                .blastTemp(7200, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1500)
+                .cableProperties(V[ZPM], 6, 4)
+                .blast(b -> b.temp(7200, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1500)
+                        .vacuumStats(VA[IV], 300))
                 .buildAndRegister();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/FirstDegreeMaterials.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.common.data.materials;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty.GasTier;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.HazardProperty;
@@ -41,7 +40,7 @@ public class FirstDegreeMaterials {
                 .color(0xf2c079).secondaryColor(0xe45534).iconSet(BRIGHT)
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FINE_WIRE)
                 .components(Copper, 1)
-                .cableProperties(GTValues.V[2], 1, 1)
+                .cableProperties(V[MV], 1, 1)
                 .buildAndRegister();
         Copper.getProperty(PropertyKey.INGOT).setArcSmeltingInto(AnnealedCopper);
 
@@ -195,7 +194,7 @@ public class FirstDegreeMaterials {
                 .appendFlags(EXT_METAL, GENERATE_SPRING, GENERATE_FINE_WIRE)
                 .components(Copper, 1, Nickel, 1)
                 .itemPipeProperties(2048, 1)
-                .cableProperties(GTValues.V[MV], 1, 1)
+                .cableProperties(V[MV], 1, 1)
                 .buildAndRegister();
 
         DarkAsh = new Material.Builder(GTCEu.id("dark_ash"))
@@ -223,7 +222,7 @@ public class FirstDegreeMaterials {
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_FINE_WIRE, GENERATE_RING)
                 .components(Silver, 1, Gold, 1)
                 .itemPipeProperties(1024, 2)
-                .cableProperties(GTValues.V[3], 2, 2)
+                .cableProperties(V[HV], 2, 2)
                 .buildAndRegister();
 
         Emerald = new Material.Builder(GTCEu.id("emerald"))
@@ -311,8 +310,9 @@ public class FirstDegreeMaterials {
                 .color(0xC2D2DF).secondaryColor(0x4c4238).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_SPRING)
                 .components(Iron, 1, Aluminium, 1, Chromium, 1)
-                .cableProperties(GTValues.V[3], 4, 3)
-                .blastTemp(1800, GasTier.LOW, GTValues.VA[HV], 900)
+                .cableProperties(V[HV], 4, 3)
+                .blast(b -> b.temp(1800, GasTier.LOW)
+                        .blastStats(VA[HV], 900))
                 .buildAndRegister();
 
         Lazurite = new Material.Builder(GTCEu.id("lazurite"))
@@ -357,8 +357,10 @@ public class FirstDegreeMaterials {
                 .color(0xaf94b2).secondaryColor(0x5b4c6a).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_SPRING)
                 .components(Nickel, 4, Chromium, 1)
-                .cableProperties(GTValues.V[EV], 4, 4)
-                .blastTemp(2700, GasTier.LOW, GTValues.VA[HV], 1300)
+                .cableProperties(V[EV], 4, 4)
+                .blast(b -> b.temp(2700, GasTier.LOW)
+                        .blastStats(VA[EV], 1300)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         NiobiumNitride = new Material.Builder(GTCEu.id("niobium_nitride"))
@@ -366,8 +368,8 @@ public class FirstDegreeMaterials {
                 .color(0x574457).secondaryColor(0x332e3c).iconSet(BRIGHT)
                 .appendFlags(EXT_METAL, GENERATE_FOIL)
                 .components(Niobium, 1, Nitrogen, 1)
-                .cableProperties(GTValues.V[6], 1, 1)
-                .blastTemp(2846, GasTier.MID)
+                .cableProperties(V[LuV], 1, 1)
+                .blast(2846, GasTier.MID)
                 .buildAndRegister();
 
         NiobiumTitanium = new Material.Builder(GTCEu.id("niobium_titanium"))
@@ -377,8 +379,10 @@ public class FirstDegreeMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .components(Niobium, 1, Titanium, 1)
                 .fluidPipeProperties(5900, 175, true)
-                .cableProperties(GTValues.V[LuV], 4, 2)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[HV], 1500)
+                .cableProperties(V[LuV], 4, 2)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[HV], 1500)
+                        .vacuumStats(VA[HV], 200))
                 .buildAndRegister();
 
         Obsidian = new Material.Builder(GTCEu.id("obsidian"))
@@ -413,7 +417,8 @@ public class FirstDegreeMaterials {
                         .enchantment(Enchantments.SMITE, 3).build())
                 .rotorStats(100, 160, 2.0f, 196)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(1700, GasTier.LOW, GTValues.VA[MV], 1000)
+                .blast(b -> b.temp(1700, GasTier.LOW)
+                        .blastStats(VA[MV], 1000))
                 .buildAndRegister();
 
         RoseGold = new Material.Builder(GTCEu.id("rose_gold"))
@@ -427,7 +432,8 @@ public class FirstDegreeMaterials {
                         .enchantment(Enchantments.BLOCK_FORTUNE, 2).build())
                 .rotorStats(100, 170, 2.0f, 152)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(1600, GasTier.LOW, GTValues.VA[MV], 1000)
+                .blast(b -> b.temp(1600, GasTier.LOW)
+                        .blastStats(VA[MV], 1000))
                 .buildAndRegister();
 
         BlackBronze = new Material.Builder(GTCEu.id("black_bronze"))
@@ -438,7 +444,8 @@ public class FirstDegreeMaterials {
                 .components(Gold, 1, Silver, 1, Copper, 3)
                 .rotorStats(100, 155, 2.0f, 256)
                 .itemPipeProperties(1024, 2)
-                .blastTemp(2000, GasTier.LOW, GTValues.VA[MV], 1000)
+                .blast(b -> b.temp(2000, GasTier.LOW)
+                        .blastStats(VA[MV], 1000))
                 .buildAndRegister();
 
         BismuthBronze = new Material.Builder(GTCEu.id("bismuth_bronze"))
@@ -448,7 +455,8 @@ public class FirstDegreeMaterials {
                 .appendFlags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
                 .rotorStats(130, 120, 3.0f, 256)
-                .blastTemp(1100, GasTier.LOW, GTValues.VA[MV], 1000)
+                .blast(b -> b.temp(1100, GasTier.LOW)
+                        .blastStats(VA[MV], 1000))
                 .buildAndRegister();
 
         Biotite = new Material.Builder(GTCEu.id("biotite"))
@@ -495,7 +503,9 @@ public class FirstDegreeMaterials {
                 .components(Ruthenium, 4, Tungsten, 2, Molybdenum, 1)
                 .flags(GENERATE_SPRING)
                 .cableProperties(V[EV], 6, 2)
-                .blastTemp(3000, GasTier.MID, GTValues.VA[GTValues.EV], 1400)
+                .blast(b -> b.temp(3000, GasTier.MID)
+                        .blastStats(VA[EV], 1400)
+                        .vacuumStats(VA[HV], 250))
                 .buildAndRegister();
 
         Ruridit = new Material.Builder(GTCEu.id("ruridit"))
@@ -503,7 +513,9 @@ public class FirstDegreeMaterials {
                 .color(0x88b5b9).secondaryColor(0x4e885c).iconSet(BRIGHT)
                 .flags(GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_LONG_ROD, GENERATE_FRAME, GENERATE_BOLT_SCREW)
                 .components(Ruthenium, 2, Iridium, 1)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.EV], 1600)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[EV], 1600)
+                        .vacuumStats(VA[HV], 300))
                 .buildAndRegister();
 
         Ruby = new Material.Builder(GTCEu.id("ruby"))
@@ -600,7 +612,8 @@ public class FirstDegreeMaterials {
                         .enchantability(14).build())
                 .rotorStats(160, 115, 4.0f, 480)
                 .fluidPipeProperties(2428, 75, true, true, true, false)
-                .blastTemp(1700, GasTier.LOW, GTValues.VA[HV], 1100)
+                .blast(b -> b.temp(1700, GasTier.LOW)
+                        .blastStats(VA[HV], 1100))
                 .buildAndRegister();
 
         Steel = new Material.Builder(GTCEu.id("steel"))
@@ -616,8 +629,9 @@ public class FirstDegreeMaterials {
                         .enchantability(14).build())
                 .rotorStats(130, 105, 3.0f, 512)
                 .fluidPipeProperties(1855, 50, true)
-                .cableProperties(GTValues.V[EV], 2, 2)
-                .blastTemp(1000, null, GTValues.VA[MV], 800) // no gas tier for steel
+                .cableProperties(V[EV], 2, 2)
+                .blast(b -> b.temp(1000)
+                        .blastStats(VA[MV], 800)) // no gas tier for steel
                 .buildAndRegister();
 
         Stibnite = new Material.Builder(GTCEu.id("stibnite"))
@@ -667,7 +681,8 @@ public class FirstDegreeMaterials {
                         .attackSpeed(0.1F).enchantability(21).build())
                 .rotorStats(160, 130, 4.0f, 2048)
                 .itemPipeProperties(128, 16)
-                .blastTemp(2700, GasTier.MID, GTValues.VA[HV], 1300)
+                .blast(b -> b.temp(2700, GasTier.MID)
+                        .blastStats(VA[HV], 1300))
                 .buildAndRegister();
 
         Uraninite = new Material.Builder(GTCEu.id("uraninite"))
@@ -690,8 +705,10 @@ public class FirstDegreeMaterials {
                 .color(0x89aeec).secondaryColor(0x00379d).iconSet(SHINY)
                 .appendFlags(STD_METAL, GENERATE_FOIL, GENERATE_SPRING, GENERATE_SPRING_SMALL)
                 .components(Vanadium, 3, Gallium, 1)
-                .cableProperties(GTValues.V[7], 4, 2)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.EV], 1200)
+                .cableProperties(V[ZPM], 4, 2)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[EV], 1200)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         WroughtIron = new Material.Builder(GTCEu.id("wrought_iron"))
@@ -729,8 +746,10 @@ public class FirstDegreeMaterials {
                 .appendFlags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL, GENERATE_FOIL,
                         GENERATE_BOLT_SCREW)
                 .components(Yttrium, 1, Barium, 2, Copper, 3, Oxygen, 7)
-                .cableProperties(GTValues.V[8], 4, 4)
-                .blastTemp(4500, GasTier.HIGH) // todo redo this EBF process
+                .cableProperties(V[UV], 4, 4)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[IV], 1000)
+                        .vacuumStats(VA[EV], 150))
                 .buildAndRegister();
 
         NetherQuartz = new Material.Builder(GTCEu.id("nether_quartz"))
@@ -767,7 +786,7 @@ public class FirstDegreeMaterials {
                 .color(0x808080).secondaryColor(0x3d3838).iconSet(SHINY)
                 .flags(DISABLE_DECOMPOSITION, GENERATE_FOIL)
                 .components(Carbon, 1)
-                .cableProperties(GTValues.V[5], 1, 1)
+                .cableProperties(V[IV], 1, 1)
                 .buildAndRegister();
 
         TungsticAcid = new Material.Builder(GTCEu.id("tungstic_acid"))
@@ -786,7 +805,9 @@ public class FirstDegreeMaterials {
                 .components(Iridium, 3, Osmium, 1)
                 .rotorStats(130, 130, 3.0f, 3152)
                 .itemPipeProperties(64, 32)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.LuV], 900)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[LuV], 900)
+                        .vacuumStats(VA[EV], 200))
                 .buildAndRegister();
 
         LithiumChloride = new Material.Builder(GTCEu.id("lithium_chloride"))
@@ -819,7 +840,8 @@ public class FirstDegreeMaterials {
                 .color(0x938fff).secondaryColor(0x8c548c)
                 .appendFlags(STD_METAL, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Arsenic, 1, Gallium, 1)
-                .blastTemp(1200, GasTier.LOW, GTValues.VA[MV], 1200)
+                .blast(b -> b.temp(1200, GasTier.LOW)
+                        .blastStats(VA[MV], 1200))
                 .buildAndRegister();
 
         Potash = new Material.Builder(GTCEu.id("potash"))
@@ -1091,7 +1113,9 @@ public class FirstDegreeMaterials {
                         .enchantability(21).build())
                 .rotorStats(160, 155, 4.0f, 1280)
                 .fluidPipeProperties(3837, 200, true)
-                .blastTemp(3058, GasTier.MID, GTValues.VA[HV], 1500)
+                .blast(b -> b.temp(3058, GasTier.MID)
+                        .blastStats(VA[EV], 1500)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         CarbonDioxide = new Material.Builder(GTCEu.id("carbon_dioxide"))
@@ -1299,8 +1323,8 @@ public class FirstDegreeMaterials {
                 .color(0xE1B454).secondaryColor(0x223033).iconSet(METALLIC)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Manganese, 1, Phosphorus, 1)
-                .cableProperties(GTValues.V[GTValues.LV], 2, 0, true, 78)
-                .blastTemp(1200, GasTier.LOW)
+                .cableProperties(V[LV], 2, 0, true, 78)
+                .blast(1200, GasTier.LOW)
                 .buildAndRegister();
 
         MagnesiumDiboride = new Material.Builder(GTCEu.id("magnesium_diboride"))
@@ -1309,8 +1333,10 @@ public class FirstDegreeMaterials {
                 .color(0x603c1a).secondaryColor(0x423e39).iconSet(METALLIC)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Magnesium, 1, Boron, 2)
-                .cableProperties(GTValues.V[MV], 4, 0, true, 78)
-                .blastTemp(2500, GasTier.LOW, GTValues.VA[HV], 1000)
+                .cableProperties(V[MV], 4, 0, true, 78)
+                .blast(b -> b.temp(2500, GasTier.LOW)
+                        .blastStats(VA[HV], 1000)
+                        .vacuumStats(VA[MV], 200))
                 .buildAndRegister();
 
         MercuryBariumCalciumCuprate = new Material.Builder(GTCEu.id("mercury_barium_calcium_cuprate"))
@@ -1319,8 +1345,10 @@ public class FirstDegreeMaterials {
                 .color(0x928547).secondaryColor(0x3f2e2e).iconSet(SHINY)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Mercury, 1, Barium, 2, Calcium, 2, Copper, 3, Oxygen, 8)
-                .cableProperties(GTValues.V[HV], 4, 0, true, 78)
-                .blastTemp(3300, GasTier.LOW, GTValues.VA[HV], 1500)
+                .cableProperties(V[HV], 4, 0, true, 78)
+                .blast(b -> b.temp(3300, GasTier.LOW)
+                        .blastStats(VA[HV], 1500)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         UraniumTriplatinum = new Material.Builder(GTCEu.id("uranium_triplatinum"))
@@ -1329,8 +1357,10 @@ public class FirstDegreeMaterials {
                 .color(0x457045).secondaryColor(0x66ff00).iconSet(RADIOACTIVE)
                 .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Uranium238, 1, Platinum, 3)
-                .cableProperties(GTValues.V[GTValues.EV], 6, 0, true, 30)
-                .blastTemp(4400, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
+                .cableProperties(V[EV], 6, 0, true, 30)
+                .blast(b -> b.temp(4400, GasTier.MID)
+                        .blastStats(VA[EV], 1000)
+                        .vacuumStats(VA[EV], 200))
                 .buildAndRegister()
                 .setFormula("UPt3", true);
 
@@ -1340,8 +1370,10 @@ public class FirstDegreeMaterials {
                 .color(0x850e85).secondaryColor(0x332f33).iconSet(SHINY)
                 .flags(DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Samarium, 1, Iron, 1, Arsenic, 1, Oxygen, 1)
-                .cableProperties(GTValues.V[GTValues.IV], 6, 0, true, 30)
-                .blastTemp(5200, GasTier.MID, GTValues.VA[GTValues.EV], 1500)
+                .cableProperties(V[IV], 6, 0, true, 30)
+                .blast(b -> b.temp(5200, GasTier.MID)
+                        .blastStats(VA[EV], 1500)
+                        .vacuumStats(VA[IV], 200))
                 .buildAndRegister();
 
         IndiumTinBariumTitaniumCuprate = new Material.Builder(GTCEu.id("indium_tin_barium_titanium_cuprate"))
@@ -1350,8 +1382,10 @@ public class FirstDegreeMaterials {
                 .color(0x686760).secondaryColor(0x673300).iconSet(METALLIC)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING, GENERATE_FINE_WIRE)
                 .components(Indium, 4, Tin, 2, Barium, 2, Titanium, 1, Copper, 7, Oxygen, 14)
-                .cableProperties(GTValues.V[GTValues.LuV], 8, 0, true, 5)
-                .blastTemp(6000, GasTier.HIGH, GTValues.VA[GTValues.IV], 1000)
+                .cableProperties(V[LuV], 8, 0, true, 5)
+                .blast(b -> b.temp(6000, GasTier.HIGH)
+                        .blastStats(VA[IV], 1000)
+                        .vacuumStats(VA[LuV]))
                 .buildAndRegister();
 
         UraniumRhodiumDinaquadide = new Material.Builder(GTCEu.id("uranium_rhodium_dinaquadide"))
@@ -1360,8 +1394,10 @@ public class FirstDegreeMaterials {
                 .color(0x232020).secondaryColor(0xff009c).iconSet(RADIOACTIVE)
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FINE_WIRE)
                 .components(Uranium238, 1, Rhodium, 1, Naquadah, 2)
-                .cableProperties(GTValues.V[GTValues.ZPM], 8, 0, true, 5)
-                .blastTemp(9000, GasTier.HIGH, GTValues.VA[GTValues.IV], 1500)
+                .cableProperties(V[ZPM], 8, 0, true, 5)
+                .blast(b -> b.temp(9000, GasTier.HIGH)
+                        .blastStats(VA[IV], 1500)
+                        .vacuumStats(VA[ZPM], 200))
                 .buildAndRegister()
                 .setFormula("URhNq2", true);
 
@@ -1372,8 +1408,10 @@ public class FirstDegreeMaterials {
                 .color(0xc6b083).secondaryColor(0x45063d).iconSet(METALLIC)
                 .flags(DECOMPOSITION_BY_CENTRIFUGING, GENERATE_FINE_WIRE)
                 .components(NaquadahEnriched, 4, Trinium, 3, Europium, 2, Duranium, 1)
-                .cableProperties(GTValues.V[GTValues.UV], 16, 0, true, 3)
-                .blastTemp(9900, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
+                .cableProperties(V[UV], 16, 0, true, 3)
+                .blast(b -> b.temp(9900, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1200)
+                        .vacuumStats(VA[UV], 200))
                 .buildAndRegister();
 
         RutheniumTriniumAmericiumNeutronate = new Material.Builder(GTCEu.id("ruthenium_trinium_americium_neutronate"))
@@ -1382,8 +1420,10 @@ public class FirstDegreeMaterials {
                 .color(0x897b76).secondaryColor(0x00c0ff).iconSet(RADIOACTIVE)
                 .flags(DECOMPOSITION_BY_ELECTROLYZING)
                 .components(Ruthenium, 1, Trinium, 2, Americium, 1, Neutronium, 2, Oxygen, 8)
-                .cableProperties(GTValues.V[GTValues.UHV], 24, 0, true, 3)
-                .blastTemp(10800, GasTier.HIGHER)
+                .cableProperties(V[UHV], 24, 0, true, 3)
+                .blast(b -> b.temp(10800, GasTier.HIGHER)
+                        .blastStats(VA[ZPM], 1000)
+                        .vacuumStats(VA[UHV], 200))
                 .buildAndRegister();
 
         InertMetalMixture = new Material.Builder(GTCEu.id("inert_metal_mixture"))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/GCYMMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/GCYMMaterials.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty.GasTier;
 
+import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
@@ -17,7 +18,8 @@ public class GCYMMaterials {
                 .color(0x999900).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE)
                 .components(Tantalum, 1, Carbon, 1)
-                .blastTemp(4120, GasTier.MID, GTValues.VA[GTValues.EV], 1200)
+                .blast(b -> b.temp(4120, GasTier.MID)
+                        .blastStats(VA[EV], 1200))
                 .buildAndRegister();
 
         HSLASteel = new Material.Builder(GTCEu.id("hsla_steel"))
@@ -25,7 +27,8 @@ public class GCYMMaterials {
                 .color(0x686868).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE, GENERATE_ROD, GENERATE_FRAME, GENERATE_SPRING)
                 .components(Invar, 2, Vanadium, 1, Titanium, 1, Molybdenum, 1)
-                .blastTemp(1711, GasTier.LOW, GTValues.VA[GTValues.HV], 1000)
+                .blast(b -> b.temp(1711, GasTier.LOW)
+                        .blastStats(VA[GTValues.HV], 1000))
                 .buildAndRegister();
 
         MolybdenumDisilicide = new Material.Builder(GTCEu.id("molybdenum_disilicide"))
@@ -33,7 +36,8 @@ public class GCYMMaterials {
                 .color(0x564A84).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_SPRING, GENERATE_RING, GENERATE_PLATE, GENERATE_LONG_ROD)
                 .components(Molybdenum, 1, Silicon, 2)
-                .blastTemp(2300, GasTier.MID, GTValues.VA[GTValues.EV], 800)
+                .blast(b -> b.temp(2300, GasTier.MID)
+                        .blastStats(VA[EV], 800))
                 .buildAndRegister();
 
         Zeron100 = new Material.Builder(GTCEu.id("zeron_100"))
@@ -41,7 +45,8 @@ public class GCYMMaterials {
                 .color(0x294972).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE)
                 .components(Iron, 10, Nickel, 2, Tungsten, 2, Niobium, 1, Cobalt, 1)
-                .blastTemp(3693, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
+                .blast(b -> b.temp(3693, GasTier.MID)
+                        .blastStats(VA[EV], 1000))
                 .buildAndRegister();
 
         WatertightSteel = new Material.Builder(GTCEu.id("watertight_steel"))
@@ -49,7 +54,8 @@ public class GCYMMaterials {
                 .color(0x2B4B56).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE, GENERATE_ROD, GENERATE_FRAME)
                 .components(Iron, 7, Aluminium, 4, Nickel, 2, Chromium, 1, Sulfur, 1)
-                .blastTemp(3850, GasTier.MID, GTValues.VA[GTValues.EV], 800)
+                .blast(b -> b.temp(3850, GasTier.MID)
+                        .blastStats(VA[EV], 800))
                 .buildAndRegister();
 
         IncoloyMA956 = new Material.Builder(GTCEu.id("incoloy_ma_956"))
@@ -57,7 +63,8 @@ public class GCYMMaterials {
                 .color(0x2D9B66).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE, GENERATE_ROD, GENERATE_FRAME)
                 .components(VanadiumSteel, 4, Manganese, 2, Aluminium, 5, Yttrium, 2)
-                .blastTemp(3652, GasTier.MID, GTValues.VA[GTValues.EV], 800)
+                .blast(b -> b.temp(3652, GasTier.MID)
+                        .blastStats(VA[EV], 800))
                 .buildAndRegister();
 
         MaragingSteel300 = new Material.Builder(GTCEu.id("maraging_steel_300"))
@@ -65,7 +72,8 @@ public class GCYMMaterials {
                 .color(0x505B6E).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_ROD, GENERATE_FRAME)
                 .components(Iron, 16, Titanium, 1, Aluminium, 1, Nickel, 4, Cobalt, 2)
-                .blastTemp(4000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1000)
+                .blast(b -> b.temp(4000, GasTier.HIGH)
+                        .blastStats(VA[EV], 1000))
                 .buildAndRegister();
 
         HastelloyX = new Material.Builder(GTCEu.id("hastelloy_x"))
@@ -73,7 +81,8 @@ public class GCYMMaterials {
                 .color(0x5784B8).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE, GENERATE_FRAME)
                 .components(Nickel, 8, Iron, 3, Tungsten, 4, Molybdenum, 2, Chromium, 1, Niobium, 1)
-                .blastTemp(4200, GasTier.HIGH, GTValues.VA[GTValues.EV], 900)
+                .blast(b -> b.temp(4200, GasTier.HIGH)
+                        .blastStats(VA[EV], 900))
                 .buildAndRegister();
 
         Stellite100 = new Material.Builder(GTCEu.id("stellite_100"))
@@ -81,7 +90,8 @@ public class GCYMMaterials {
                 .color(0xCFCFEE).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE)
                 .components(Iron, 4, Chromium, 3, Tungsten, 2, Molybdenum, 1)
-                .blastTemp(3790, GasTier.HIGH, GTValues.VA[GTValues.EV], 1000)
+                .blast(b -> b.temp(3790, GasTier.HIGH)
+                        .blastStats(VA[EV], 1000))
                 .buildAndRegister();
 
         TitaniumCarbide = new Material.Builder(GTCEu.id("titanium_carbide"))
@@ -89,7 +99,8 @@ public class GCYMMaterials {
                 .color(0x90092F).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE)
                 .components(Titanium, 1, Carbon, 1)
-                .blastTemp(3430, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
+                .blast(b -> b.temp(3430, GasTier.MID)
+                        .blastStats(VA[EV], 1000))
                 .buildAndRegister();
 
         TitaniumTungstenCarbide = new Material.Builder(GTCEu.id("titanium_tungsten_carbide"))
@@ -97,7 +108,8 @@ public class GCYMMaterials {
                 .color(0x680B0B).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE)
                 .components(TitaniumCarbide, 2, TungstenCarbide, 1)
-                .blastTemp(3800, GasTier.HIGH, GTValues.VA[GTValues.EV], 1000)
+                .blast(b -> b.temp(3800, GasTier.HIGH)
+                        .blastStats(VA[EV], 1000))
                 .buildAndRegister();
 
         HastelloyC276 = new Material.Builder(GTCEu.id("hastelloy_c_276"))
@@ -105,7 +117,8 @@ public class GCYMMaterials {
                 .color(0xAB2F2F).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_PLATE, GENERATE_FRAME)
                 .components(Nickel, 12, Molybdenum, 8, Chromium, 7, Tungsten, 1, Cobalt, 1, Copper, 1)
-                .blastTemp(3800, GasTier.HIGH, GTValues.VA[GTValues.EV], 1000)
+                .blast(b -> b.temp(3800, GasTier.HIGH)
+                        .blastStats(VA[EV], 1000))
                 .buildAndRegister();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.ToolProperty;
 import com.gregtechceu.gtceu.api.fluids.FluidBuilder;
 
+import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
@@ -41,7 +42,8 @@ public class HigherDegreeMaterials {
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(ToolProperty.Builder.of(7.0F, 6.0F, 2560, 3)
                         .attackSpeed(0.1F).enchantability(21).build())
-                .blastTemp(1300, GasTier.LOW, GTValues.VA[GTValues.HV], 1000)
+                .blast(b -> b.temp(1300, GasTier.LOW)
+                        .blastStats(VA[HV], 1000))
                 .buildAndRegister();
 
         BlueSteel = new Material.Builder(GTCEu.id("blue_steel"))
@@ -51,7 +53,8 @@ public class HigherDegreeMaterials {
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
                 .toolStats(ToolProperty.Builder.of(15.0F, 6.0F, 1024, 3)
                         .attackSpeed(0.1F).enchantability(33).build())
-                .blastTemp(1400, GasTier.LOW, GTValues.VA[GTValues.HV], 1000)
+                .blast(b -> b.temp(1400, GasTier.LOW)
+                        .blastStats(VA[HV], 1000))
                 .buildAndRegister();
 
         Basalt = new Material.Builder(GTCEu.id("basalt"))
@@ -90,7 +93,9 @@ public class HigherDegreeMaterials {
                 .components(TungstenSteel, 5, Chromium, 1, Molybdenum, 2, Vanadium, 1)
                 .rotorStats(205, 140, 5.5f, 4000)
                 .cableProperties(GTValues.V[6], 4, 2)
-                .blastTemp(4200, GasTier.MID, GTValues.VA[GTValues.EV], 1300)
+                .blast(b -> b.temp(4200, GasTier.MID)
+                        .blastStats(VA[GTValues.EV], 1300)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         RedAlloy = new Material.Builder(GTCEu.id("red_alloy"))
@@ -117,7 +122,9 @@ public class HigherDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(5.0F, 10.0F, 3072, 4)
                         .attackSpeed(0.3F).enchantability(33).build())
                 .rotorStats(280, 140, 8.0f, 5120)
-                .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1400)
+                .blast(b -> b.temp(5000, GasTier.HIGH)
+                        .blastStats(VA[GTValues.EV], 1400)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         HSSS = new Material.Builder(GTCEu.id("hsss"))
@@ -127,7 +134,9 @@ public class HigherDegreeMaterials {
                         GENERATE_ROUND, GENERATE_FOIL, GENERATE_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
                 .rotorStats(250, 180, 7.0f, 3000)
-                .blastTemp(5000, GasTier.HIGH, GTValues.VA[GTValues.EV], 1500)
+                .blast(b -> b.temp(5000, GasTier.HIGH)
+                        .blastStats(VA[GTValues.EV], 1500)
+                        .vacuumStats(VA[EV], 200))
                 .buildAndRegister();
 
         IridiumMetalResidue = new Material.Builder(GTCEu.id("iridium_metal_residue"))
@@ -196,7 +205,7 @@ public class HigherDegreeMaterials {
                 .color(0x64B4FF).secondaryColor(0x3c7dba).iconSet(METALLIC)
                 .flags(GENERATE_PLATE, GENERATE_BOLT_SCREW, DISABLE_DECOMPOSITION)
                 .components(Electrotine, 4, Silver, 1)
-                .cableProperties(GTValues.V[GTValues.HV], 2, 1)
+                .cableProperties(GTValues.V[HV], 2, 1)
                 .buildAndRegister();
 
         RadAway = new Material.Builder(GTCEu.id("rad_away"))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.common.data.materials;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty.GasTier;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.HazardProperty;
@@ -14,6 +13,7 @@ import com.gregtechceu.gtceu.common.data.GTMedicalConditions;
 
 import net.minecraft.world.item.enchantment.Enchantments;
 
+import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
@@ -116,8 +116,8 @@ public class SecondDegreeMaterials {
                 .color(0x666666).secondaryColor(0x1a120e).iconSet(METALLIC)
                 .appendFlags(EXT_METAL, GENERATE_FINE_WIRE, GENERATE_GEAR, GENERATE_FRAME)
                 .components(Nickel, 1, BlackBronze, 1, Steel, 3)
-                .cableProperties(GTValues.V[4], 3, 2)
-                .blastTemp(1200, GasTier.LOW)
+                .cableProperties(V[EV], 3, 2)
+                .blast(1200, GasTier.LOW)
                 .buildAndRegister();
 
         DamascusSteel = new Material.Builder(GTCEu.id("damascus_steel"))
@@ -130,7 +130,7 @@ public class SecondDegreeMaterials {
                         .attackSpeed(0.3F).enchantability(33)
                         .enchantment(Enchantments.MOB_LOOTING, 3)
                         .enchantment(Enchantments.BLOCK_FORTUNE, 3).build())
-                .blastTemp(1500, GasTier.LOW)
+                .blast(1500, GasTier.LOW)
                 .buildAndRegister();
 
         TungstenSteel = new Material.Builder(GTCEu.id("tungsten_steel"))
@@ -143,8 +143,10 @@ public class SecondDegreeMaterials {
                         .enchantability(14).build())
                 .rotorStats(160, 120, 4.0f, 2560)
                 .fluidPipeProperties(3587, 225, true)
-                .cableProperties(GTValues.V[5], 3, 2)
-                .blastTemp(3000, GasTier.MID, GTValues.VA[GTValues.EV], 1000)
+                .cableProperties(V[IV], 3, 2)
+                .blast(b -> b.temp(3000, GasTier.MID)
+                        .blastStats(VA[EV], 1000)
+                        .vacuumStats(VA[HV]))
                 .buildAndRegister();
 
         CobaltBrass = new Material.Builder(GTCEu.id("cobalt_brass"))
@@ -305,7 +307,7 @@ public class SecondDegreeMaterials {
                         .attackSpeed(-0.2F).enchantability(5).build())
                 .rotorStats(130, 115, 3.0f, 1920)
                 .fluidPipeProperties(2073, 50, true, true, false, false)
-                .blastTemp(1453, GasTier.LOW)
+                .blast(1453, GasTier.LOW)
                 .buildAndRegister();
 
         Potin = new Material.Builder(GTCEu.id("potin"))
@@ -342,8 +344,10 @@ public class SecondDegreeMaterials {
                 .toolStats(ToolProperty.Builder.of(40.0F, 12.0F, 3072, 5)
                         .attackSpeed(0.3F).enchantability(33).magnetic().build())
                 .rotorStats(190, 120, 5.0f, 5120)
-                .cableProperties(GTValues.V[8], 2, 4)
-                .blastTemp(7200, GasTier.HIGH, GTValues.VA[GTValues.LuV], 1000)
+                .cableProperties(V[UV], 2, 4)
+                .blast(b -> b.temp(7200, GasTier.HIGH)
+                        .blastStats(VA[LuV], 1000)
+                        .vacuumStats(VA[IV], 300))
                 .buildAndRegister();
 
         SulfuricNickelSolution = new Material.Builder(GTCEu.id("sulfuric_nickel_solution"))
@@ -490,7 +494,9 @@ public class SecondDegreeMaterials {
                 .appendFlags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE, GENERATE_SMALL_GEAR)
                 .components(Palladium, 3, Rhodium, 1)
                 .rotorStats(130, 155, 3.0f, 1024)
-                .blastTemp(4500, GasTier.HIGH, GTValues.VA[GTValues.IV], 1200)
+                .blast(b -> b.temp(4500, GasTier.HIGH)
+                        .blastStats(VA[IV], 1200)
+                        .vacuumStats(VA[EV], 300))
                 .buildAndRegister();
 
         Clay = new Material.Builder(GTCEu.id("clay"))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
@@ -218,11 +218,15 @@ public class MaterialRecipeHandler {
 
         // Add Vacuum Freezer recipe if required.
         if (ingotHot.doGenerateItem(material)) {
+            int vacuumEUt = property.getVacuumEUtOverride() != -1 ? property.getVacuumEUtOverride() : VA[MV];
+            int vacuumDuration = property.getVacuumDurationOverride() != -1 ? property.getVacuumDurationOverride() :
+                    (int) material.getMass() * 3;
             if (blastTemp < 5000) {
                 VACUUM_RECIPES.recipeBuilder("cool_hot_" + material.getName() + "_ingot")
                         .inputItems(ingotHot, material)
                         .outputItems(ingot, material)
-                        .duration((int) material.getMass() * 3)
+                        .duration(vacuumDuration)
+                        .EUt(vacuumEUt)
                         .save(provider);
             } else {
                 VACUUM_RECIPES.recipeBuilder("cool_hot_" + material.getName() + "_ingot")
@@ -230,7 +234,8 @@ public class MaterialRecipeHandler {
                         .inputFluids(Helium.getFluid(FluidStorageKeys.LIQUID, 500))
                         .outputItems(ingot, material)
                         .outputFluids(Helium.getFluid(250))
-                        .duration((int) material.getMass() * 3)
+                        .duration(vacuumDuration)
+                        .EUt(vacuumEUt)
                         .save(provider);
             }
         }


### PR DESCRIPTION
## What
Adds vacuum recipe overrides for lots of materials

## Implementation Details
adds a blast builder to the blast property, which allows for different vacuum freezer voltage and duration

## Outcome
more granularity in the vacuum freezer requirement for various gt materials

## Additional Information
hopefully shouldnt affect kube recipes

## Potential Compatibility Issues
nichrome was changed to ev gated, in parity to 1.12