### PR TITLE
Workflow Separation

### DIFF
--- a/.github/json/config-1.21.json
+++ b/.github/json/config-1.21.json
@@ -14,8 +14,18 @@
     }
   ],
   "sort": "ASC",
-  "template": "## Version [#{{TO_TAG}}](#{{RELEASE_DIFF}})\n#{{CHANGELOG}} ",
+  "template": "## Version [v#{{VERSION}}](#{{RELEASE_DIFF}})\n#{{CHANGELOG}} ",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "custom_placeholders": [
+    {
+      "name": "VERSION",
+      "source": "TO_TAG",
+      "transformer": {
+        "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+        "target": "$1"
+      }
+    }
+  ],
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],
   "tag_resolver": {

--- a/.github/json/config-1.21.json
+++ b/.github/json/config-1.21.json
@@ -21,7 +21,7 @@
   "tag_resolver": {
     "method": "semver",
     "filter": {
-      "pattern": "^(?!v?[0-9\\.]+(-1\\.21)?$).+$",
+      "pattern": "^(?!v?[0-9\\.]+(-1\\.21)$).+$",
       "flags": "gu"
     },
     "transformer": {

--- a/.github/json/config-1.21.json
+++ b/.github/json/config-1.21.json
@@ -21,7 +21,7 @@
   "tag_resolver": {
     "method": "semver",
     "filter": {
-      "pattern": "^(?!v?[0-9\\.]+(-1\\.20\\.1)?$).+$",
+      "pattern": "^(?!v?[0-9\\.]+(-1\\.21)?$).+$",
       "flags": "gu"
     },
     "transformer": {
@@ -31,5 +31,5 @@
   },
   "max_pull_requests": 1000,
   "max_back_track_time_days": 90,
-  "base_branches": ["1.20.1"]
+  "base_branches": ["1.21"]
 }

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -19,5 +19,5 @@
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],
   "max_pull_requests": 1000,
-  "max_back_track_time_days": 90
+  "max_back_track_time_days": 30
 }

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -14,8 +14,9 @@
     }
   ],
   "sort": "ASC",
-  "template": "## What's Changed\n#{{CHANGELOG}}",
+  "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "empty_template": "",
   "ignore_labels": ["ignore changelog"],
   "max_pull_requests": 1000,
   "max_back_track_time_days": 90

--- a/.github/json/config.json
+++ b/.github/json/config.json
@@ -14,8 +14,18 @@
     }
   ],
   "sort": "ASC",
-  "template": "## Version [#{{TO_TAG}}](#{{RELEASE_DIFF}})\n#{{CHANGELOG}} ",
+  "template": "## Version [v#{{VERSION}}](#{{RELEASE_DIFF}})\n#{{CHANGELOG}} ",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "custom_placeholders": [
+    {
+      "name": "VERSION",
+      "source": "TO_TAG",
+      "transformer": {
+        "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+        "target": "$1"
+      }
+    }
+  ],
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],
   "tag_resolver": {

--- a/.github/json/config.json
+++ b/.github/json/config.json
@@ -21,12 +21,12 @@
   "tag_resolver": {
     "method": "semver",
     "filter": {
-      "pattern": "^(?!v?(1\\.20\\.1-)?[0-9\\.]+$).+$",
+      "pattern": "^(?!v?[0-9\\.]+(-1\\.20\\.1)?$).+$",
       "flags": "gu"
     },
     "transformer": {
-      "pattern": "v?([0-9\\.]+-)?([0-9\\.]+)",
-      "target": "$2"
+      "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+      "target": "$1"
     }
   },
   "max_pull_requests": 1000,

--- a/.github/workflows/manage-pr-labels.yml
+++ b/.github/workflows/manage-pr-labels.yml
@@ -1,10 +1,12 @@
 # Manages labels on PRs before allowing merging
 name: Pull Request Labels
 
-# Checks for label once PR has been reviewed
+# Checks for label once PR has been reviewed or label is applied
 on:
   pull_request_review:
     types: [submitted]
+  pull_request:
+    types: [labeled]
 
 concurrency:
   group: pr-labels-${{ github.head_ref }}

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -21,10 +21,10 @@ jobs:
       pull-requests: read
     steps:
       - name: Read Tag
+        id: tag
         run: |
-          echo ${{ github.ref_name }}
-          echo ${{ contains(github.ref_name, '1.20.1') }}
-          echo ${{ contains(github.ref_name, '1.21') }}
+          [[ "${{ contains(github.ref_name, '1.21') }}" = "true" ]] && O="-1.21" || O=""
+          echo "O=$O" >> $GITHUB_OUTPUT
       - name: Get Config
         uses: actions/checkout@v4
         with:
@@ -36,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         uses: mikepenz/release-changelog-builder-action@v5
         with:
-          configuration: ./.github/json/config.json
+          configuration: './.github/json/config${{ steps.tag.outputs.O }}.json'
           toTag: ${{ github.ref }}
           ignorePreReleases: true
           fetchViaCommits: true

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -7,10 +7,6 @@ on:
 # TODO: Make it so you can publish releases for each mc-ver individually
 
 jobs:
-#  versioning:
-#    name: Get Version to Publish
-#    runs-on: ubuntu-latest
-#    steps:
   meta:
     name: Metadata
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -14,11 +14,6 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - name: Read Tag
-        id: tag
-        run: |
-          [[ "${{ contains(github.ref_name, '1.21') }}" = "true" ]] && O="-1.21" || O=""
-          echo "O=$O" >> $GITHUB_OUTPUT
       - name: Get Config
         uses: actions/checkout@v4
         with:
@@ -28,9 +23,10 @@ jobs:
         id: changelog
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          CONFIG: ${{ contains(github.ref_name, '1.21') && '-1.21' || '' }}
         uses: mikepenz/release-changelog-builder-action@v5
         with:
-          configuration: './.github/json/config${{ steps.tag.outputs.O }}.json'
+          configuration: './.github/json/config${{ env.CONFIG }}.json'
           ignorePreReleases: true
           fetchViaCommits: true
           failOnError: true

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -7,18 +7,28 @@ on:
 # TODO: Make it so you can publish releases for each mc-ver individually
 
 jobs:
+#  versioning:
+#    name: Get Version to Publish
+#    runs-on: ubuntu-latest
+#    steps:
   meta:
     name: Metadata
     runs-on: ubuntu-latest
     outputs:
       CHANGELOG: ${{ steps.changelog.outputs.changelog }}
-      TWENTY: ${{ contains(github.event.release.tag, '1.20.1') && 'twenty' || '' }}
-      TWENTYONE: ${{ contains(github.event.release.tag, '1.21') && 'twentyone' || '' }}
-      BOTH: ${{ (!contains(github.event.release.tag, '1.20.1') && !contains(github.event.release.tag, '1.21')) && 'both' || '' }}
+      TWENTY: ${{ contains(github.ref_name, '1.20.1') }}
+      TWENTYONE: ${{ contains(github.ref_name, '1.21') }}
     permissions:
       contents: write
       pull-requests: read
     steps:
+      - name: Read Tag
+        run: |
+          echo ${{ github.event.release.tag }}
+          echo ${{ github.ref }}
+          echo ${{ github.ref_name }}
+          echo ${{ contains(github.ref_name, '1.20.1') }}
+          echo ${{ contains(github.ref_name, '1.21') }}
       - name: Get Config
         uses: actions/checkout@v4
         with:
@@ -31,20 +41,15 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ./.github/json/config.json
-          toTag: ${{ github.event.release.tag }}
+          toTag: ${{ github.ref }}
           ignorePreReleases: true
           fetchViaCommits: true
           failOnError: true
-      - name: debug
-        run: |
-          echo ${{ contains(github.event.release.tag, '1.20.1') }}
-          echo ${{ contains(github.event.release.tag, '1.21') }}
-          echo ${{ (!contains(github.event.release.tag, '1.20.1') && !contains(github.event.release.tag, '1.21')) }}
 
   publish-20:
     name: 1.20.1
     needs: [ meta ]
-    if: ${{ needs.meta.outputs.TWENTY || needs.meta.outputs.BOTH }}
+    if: ${{ needs.meta.outputs.TWENTY || !needs.meta.outputs.TWENTYONE }}
     secrets: inherit
     uses: ./.github/workflows/publish.yml
     with:
@@ -57,7 +62,7 @@ jobs:
   publish-21:
     name: 1.21.1
     needs: [ meta ]
-    if: ${{ needs.meta.outputs.TWENTYONE || needs.meta.outputs.BOTH }}
+    if: ${{ needs.meta.outputs.TWENTYONE || !needs.meta.outputs.TWENTY }}
     secrets: inherit
     uses: ./.github/workflows/publish.yml
     with:

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       CHANGELOG: ${{ steps.changelog.outputs.changelog }}
-      TWENTY: ${{ contains(github.event.release.tag, '1.20.1') }}
-      TWENTYONE: ${{ contains(github.event.release.tag, '1.21') }}
-      BOTH: ${{ !contains(github.event.release.tag, '1.20.1') && !contains(github.event.release.tag, '1.21') }}
+      TWENTY: ${{ contains(github.event.release.tag, '1.20.1') && 'twenty' || '' }}
+      TWENTYONE: ${{ contains(github.event.release.tag, '1.21') && 'twentyone' || '' }}
+      BOTH: ${{ (!contains(github.event.release.tag, '1.20.1') && !contains(github.event.release.tag, '1.21')) && 'both' || '' }}
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -4,8 +4,6 @@ on:
   release:
     types: [released]
 
-# TODO: Make it so you can publish releases for each mc-ver individually
-
 jobs:
   meta:
     name: Metadata

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -35,6 +35,11 @@ jobs:
           ignorePreReleases: true
           fetchViaCommits: true
           failOnError: true
+      - name: debug
+        run: |
+          echo ${{ contains(github.event.release.tag, '1.20.1') }}
+          echo ${{ contains(github.event.release.tag, '1.21') }}
+          echo ${{ (!contains(github.event.release.tag, '1.20.1') && !contains(github.event.release.tag, '1.21')) }}
 
   publish-20:
     name: 1.20.1

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -37,7 +37,6 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: './.github/json/config${{ steps.tag.outputs.O }}.json'
-          toTag: ${{ github.ref }}
           ignorePreReleases: true
           fetchViaCommits: true
           failOnError: true

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+      TWENTY: ${{ contains(github.event.release.tag, '1.20.1') }}
+      TWENTYONE: ${{ contains(github.event.release.tag, '1.21') }}
+      BOTH: ${{ !contains(github.event.release.tag, '1.20.1') && !contains(github.event.release.tag, '1.21') }}
     permissions:
       contents: write
       pull-requests: read
@@ -36,6 +39,7 @@ jobs:
   publish-20:
     name: 1.20.1
     needs: [ meta ]
+    if: ${{ needs.meta.outputs.TWENTY || needs.meta.outputs.BOTH }}
     secrets: inherit
     uses: ./.github/workflows/publish.yml
     with:
@@ -48,6 +52,7 @@ jobs:
   publish-21:
     name: 1.21.1
     needs: [ meta ]
+    if: ${{ needs.meta.outputs.TWENTYONE || needs.meta.outputs.BOTH }}
     secrets: inherit
     uses: ./.github/workflows/publish.yml
     with:

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -16,16 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       CHANGELOG: ${{ steps.changelog.outputs.changelog }}
-      TWENTY: ${{ contains(github.ref_name, '1.20.1') }}
-      TWENTYONE: ${{ contains(github.ref_name, '1.21') }}
     permissions:
       contents: write
       pull-requests: read
     steps:
       - name: Read Tag
         run: |
-          echo ${{ github.event.release.tag }}
-          echo ${{ github.ref }}
           echo ${{ github.ref_name }}
           echo ${{ contains(github.ref_name, '1.20.1') }}
           echo ${{ contains(github.ref_name, '1.21') }}
@@ -49,7 +45,7 @@ jobs:
   publish-20:
     name: 1.20.1
     needs: [ meta ]
-    if: ${{ needs.meta.outputs.TWENTY || !needs.meta.outputs.TWENTYONE }}
+    if: ${{ contains(github.ref_name, '1.20.1') || !contains(github.ref_name, '1.21') }}
     secrets: inherit
     uses: ./.github/workflows/publish.yml
     with:
@@ -62,7 +58,7 @@ jobs:
   publish-21:
     name: 1.21.1
     needs: [ meta ]
-    if: ${{ needs.meta.outputs.TWENTYONE || !needs.meta.outputs.TWENTY }}
+    if: ${{ contains(github.ref_name, '1.21') || !contains(github.ref_name, '1.20.1') }}
     secrets: inherit
     uses: ./.github/workflows/publish.yml
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,8 +76,8 @@ jobs:
           files: ./*.jar
           fail_on_unmatched_files: true
 
-  publish-cf-modrinth:
-    name: Publish Mod
+  publish-modrinth:
+    name: Publish to Modrinth
     needs: build
     if: ${{ !inputs.simulate }}
     runs-on: ubuntu-latest
@@ -93,10 +93,42 @@ jobs:
           MC_VERSION: ${{ inputs.branch == '1.21' && '1.21.1' || '1.20.1' }}
           LOADER: ${{ inputs.branch == '1.21' && 'neoforge' || 'forge' }}
           JAVA: ${{ inputs.branch == '1.21' && '21' || '17' }}
+          VERSION_TYPE: ${{ inputs.branch == '1.21' && 'alpha' || 'beta' }}
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
           modrinth-id: 7tG215v7
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          files: |
+            ./gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar
+            ./!(gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)
+          name: 'GregTechCEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
+          version: 'mc${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
+          version-type: ${{ env.VERSION_TYPE }}
+          changelog: ${{ inputs.release-body }}
+          loaders: ${{ env.LOADER }}
+          java: ${{ env.JAVA }}
+          fail-mode: fail
+
+  publish-cf:
+    name: Publish to CF
+    needs: build
+    if: ${{ !inputs.simulate }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ inputs.branch }}
+      - name: Publish Mod
+        env:
+          MC_VERSION: ${{ inputs.branch == '1.21' && '1.21.1' || '1.20.1' }}
+          LOADER: ${{ inputs.branch == '1.21' && 'neoforge' || 'forge' }}
+          JAVA: ${{ inputs.branch == '1.21' && '21' || '17' }}
+          VERSION_TYPE: ${{ inputs.branch == '1.21' && 'alpha' || 'beta' }}
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
           curseforge-id: 890405
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           files: |
@@ -104,7 +136,7 @@ jobs:
             ./!(gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)
           name: 'GregTechCEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
           version: 'mc${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
-          version-type: beta
+          version-type: ${{ env.VERSION_TYPE }}
           changelog: ${{ inputs.release-body }}
           loaders: ${{ env.LOADER }}
           java: ${{ env.JAVA }}
@@ -113,7 +145,7 @@ jobs:
   # After successful release, PR version bump and changelog
   bump-version-and-changelog:
     name: Bump Version and Build Changelog
-    needs: [ build, upload-release-artifacts, publish-cf-modrinth ]
+    needs: [ build, upload-release-artifacts, publish-modrinth, publish-cf]
     if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What
Changes publish workflows to allow for separate releases for 1.20.1 and 1.21
Release tag can be in three formats:
`v1.5.0` - which will publish *both* branches
`v1.5.0-1.20.1` - which will publish the 1.20.1 branch
`v1.5.0-1.21` - which will publish the 1.21 branch

Also, the job for publishing to CF and Modrinth has been split into two so that if one platform fails, it can be retried without bothering the other.
Also 1.21 is now being published as `alpha` while 1.20.1 is still `beta`