### PR TITLE
Fix miscalculation of max parallel by output for non-64 stacked items

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
@@ -58,7 +58,8 @@ public class OverlayedItemHandler {
             ItemStack slotKey = this.slots[i].getItemStack();
             if (slotKey.isEmpty() || ItemStack.isSameItemSameTags(slotKey, stack)) {
                 // if the slot is not full
-                int canInsertUpTo = Math.min(this.slots[i].getSlotLimit() - this.slots[i].getCount(), stack.getMaxStackSize());
+                int canInsertUpTo = Math.min(this.slots[i].getSlotLimit() - this.slots[i].getCount(),
+                        stack.getMaxStackSize());
                 if (canInsertUpTo > 0) {
                     int insertedAmount = Math.min(canInsertUpTo, amountToInsert);
                     this.slots[i].setItemStack(stack.copy()); // this copy may not be need, needs further tests

--- a/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
@@ -56,9 +56,9 @@ public class OverlayedItemHandler {
             initSlot(i);
             // if it's the same item or there is no item in the slot
             ItemStack slotKey = this.slots[i].getItemStack();
-            if (slotKey.isEmpty() || ItemStackHashStrategy.comparingAllButCount().equals(slotKey, stack)) {
+            if (slotKey.isEmpty() || ItemStack.isSameItemSameTags(slotKey, stack)) {
                 // if the slot is not full
-                int canInsertUpTo = this.slots[i].getSlotLimit() - this.slots[i].getCount();
+                int canInsertUpTo = Math.min(this.slots[i].getSlotLimit() - this.slots[i].getCount(), stack.getMaxStackSize());
                 if (canInsertUpTo > 0) {
                     int insertedAmount = Math.min(canInsertUpTo, amountToInsert);
                     this.slots[i].setItemStack(stack.copy()); // this copy may not be need, needs further tests
@@ -139,7 +139,7 @@ public class OverlayedItemHandler {
         }
 
         public void setItemStack(@NotNull ItemStack itemStack) {
-            if (!ItemStackHashStrategy.comparingAllButCount().equals(this.itemStack, itemStack)) {
+            if (!ItemStack.isSameItemSameTags(this.itemStack, itemStack)) {
                 this.itemStack = itemStack;
                 this.slotLimit = Math.min(itemStack.getMaxStackSize(), slotLimit);
             }


### PR DESCRIPTION
## What
fixes edge case in OverlayedItemHandler when determining the amount you can insert into a slot

## Implementation Details
adds a maxstacksize check