### PR TITLE
Change Jade to show Steam usage

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
@@ -47,7 +47,7 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
     public int maxParallels = ConfigHolder.INSTANCE.machines.steamMultiParallelAmount;
 
     // if in millibuckets, this is 0.5, Meaning 2mb of steam -> 1 EU
-    private static final double CONVERSION_RATE = 0.5D;
+    public static final double CONVERSION_RATE = 0.5D;
 
     public SteamParallelMultiblockMachine(IMachineBlockEntity holder, Object... args) {
         this(holder, ConfigHolder.INSTANCE.machines.steamMultiParallelAmount, args);

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MEPatternBufferProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MEPatternBufferProvider.java
@@ -12,6 +12,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -41,7 +42,7 @@ public class MEPatternBufferProvider implements IBlockComponentProvider, IServer
                     CompoundTag itemTag = itemTags.getCompound(i);
                     Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemTag.getString("item")));
                     long count = itemTag.getLong("count");
-                    if (item != null) {
+                    if (item != null && !item.equals(Items.AIR)) {
                         iTooltip.add(item.getDescription()
                                 .copy()
                                 .withStyle(ChatFormatting.GOLD)

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MEPatternBufferProxyProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MEPatternBufferProxyProvider.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -45,7 +46,7 @@ public class MEPatternBufferProxyProvider implements IBlockComponentProvider, IS
                     CompoundTag itemTag = itemTags.getCompound(i);
                     Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemTag.getString("item")));
                     long count = itemTag.getLong("count");
-                    if (item != null) {
+                    if (item != null && !item.equals(Items.AIR)) {
                         iTooltip.add(item.getDescription()
                                 .copy()
                                 .withStyle(ChatFormatting.GOLD)


### PR DESCRIPTION
## What
This PR changes the Jade RecipeLogicProvider to now show the steam usage rather than a false EU/t value for steam machines and multiblocks.

Also, small fix with Jade showing `Air * 0` in empty pattern buffers

## Outcome
People will stop misunderstanding steam usage

## Additional Information
![image](https://github.com/user-attachments/assets/9b303b2f-e7f6-4db8-9bdf-9ad90ab33e08)
