### PR TITLE
Add waypoint creation in the prospector

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -54,6 +54,7 @@
   "behavior.portable_scanner.workable_production": "Ɐ %s ʇɐ ʇ/∩Ǝ %s :sǝɔnpoɹԀ ʎןqɐqoɹԀ",
   "behavior.portable_scanner.workable_progress": "s %s / s %s :ssǝɹboɹԀ",
   "behavior.portable_scanner.workable_stored_energy": "∩Ǝ %s / ∩Ǝ %s :ʎbɹǝuƎ pǝɹoʇS",
+  "behavior.prospector.added_waypoint": "¡%s pǝɯɐu ʇuıodʎɐʍ pǝʇɐǝɹƆ",
   "behavior.prospector.not_enough_energy": "¡ʎbɹǝuƎ ɥbnouƎ ʇoN",
   "behavior.toggle_energy_consumer.tooltip": "ǝpoɯ ǝןbboʇ oʇ ǝs∩",
   "behaviour.boor.by": "%s ʎq",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -54,6 +54,7 @@
   "behavior.portable_scanner.workable_production": "Probably Produces: %s EU/t at %s A",
   "behavior.portable_scanner.workable_progress": "Progress: %s s / %s s",
   "behavior.portable_scanner.workable_stored_energy": "Stored Energy: %s EU / %s EU",
+  "behavior.prospector.added_waypoint": "Created waypoint named %s!",
   "behavior.prospector.not_enough_energy": "Not Enough Energy!",
   "behavior.toggle_energy_consumer.tooltip": "Use to toggle mode",
   "behaviour.boor.by": "by %s",

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
@@ -6,9 +6,10 @@ import com.gregtechceu.gtceu.api.gui.misc.ProspectorMode;
 import com.gregtechceu.gtceu.api.gui.texture.ProspectingTexture;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.common.item.ProspectorScannerBehavior;
+import com.gregtechceu.gtceu.integration.map.WaypointManager;
 import com.gregtechceu.gtceu.integration.map.cache.client.GTClientCache;
 import com.gregtechceu.gtceu.integration.map.cache.server.ServerCache;
-
+import com.gregtechceu.gtceu.integration.map.layer.builtin.OreRenderLayer;
 import com.lowdragmc.lowdraglib.gui.editor.ColorPattern;
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
@@ -17,11 +18,14 @@ import com.lowdragmc.lowdraglib.gui.widget.*;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -249,6 +253,76 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        var clickedItem = getClickedVein(mouseX, mouseY);
+        if (clickedItem == null) {
+            return super.mouseClicked(mouseX, mouseY, button);
+        }
+        WaypointManager.setWaypoint(new ChunkPos(clickedItem.position).toString(),
+                clickedItem.name,
+                clickedItem.color,
+                gui.entityPlayer.level().dimension(),
+                clickedItem.position.getX(), clickedItem.position.getY(), clickedItem.position.getZ());
+        gui.entityPlayer.displayClientMessage(Component.translatable("behavior.prospector.added_waypoint", clickedItem.name), true);
+        playButtonClickSound();
+        return true;
+    }
+
+    private WaypointItem getClickedVein(double mouseX, double mouseY) {
+        var position = getPosition();
+        var size = getSize();
+        var x = position.x + 3;
+        var y = position.y + (size.getHeight() - texture.getImageHeight()) / 2 - 1;
+
+        int cX = (int) (mouseX - x) / 16;
+        int cZ = (int) (mouseY - y) / 16;
+        int offsetX = Math.abs((int) (mouseX - x) % 16);
+        int offsetZ = Math.abs((int) (mouseY - y) % 16);
+        int xDiff = cX - (chunkRadius - 1);
+        int zDiff = cZ - (chunkRadius - 1);
+
+        int xPos = ((gui.entityPlayer.chunkPosition().x + xDiff) << 4) + offsetX;
+        int zPos = ((gui.entityPlayer.chunkPosition().z + zDiff) << 4) + offsetZ;
+
+        var blockPos = new BlockPos(xPos, gui.entityPlayer.level().getHeight(Heightmap.Types.WORLD_SURFACE, xPos, zPos), zPos);
+        if (cX < 0 || cZ < 0 || cX >= chunkRadius * 2 - 1 || cZ >= chunkRadius * 2 - 1) {
+            return null;
+        }
+
+        // If the ores are filtered use its name
+        if (!texture.getSelected().equals(ProspectingTexture.SELECTED_ALL)) {
+            for (var item : items) {
+                if (!texture.getSelected().equals(mode.getUniqueID(item))) continue;
+                var name = Component.translatable(mode.getDescriptionId(item)).getString();
+                var color = mode.getItemColor(item);
+                return new WaypointItem(blockPos, name, color);
+            }
+        }
+
+        // If the cursor is over an ore use its name
+        var hoveredItem = texture.data[cX * mode.cellSize + offsetX][cZ * mode.cellSize + offsetZ];
+        if (hoveredItem != null && hoveredItem.length != 0) {
+            var name = Component.translatable(mode.getDescriptionId(hoveredItem[0])).getString();
+            var color = mode.getItemColor(hoveredItem[0]);
+            return new WaypointItem(blockPos, name, color);
+        }
+
+        // If all else fails see if there's a nearby vein and use the vein's name
+        var vein = GTClientCache.instance.getNearbyVeins(gui.entityPlayer.level().dimension(), blockPos, 32);
+        if (!vein.isEmpty()) {
+            vein.sort((o1, o2) -> (int) (o1.center().distToCenterSqr(xPos, o1.center().getY(), zPos) - o2.center().distToCenterSqr(xPos, o2.center().getY(), zPos)));
+            var name = OreRenderLayer.getName(vein.get(0)).getString();
+            var materials = vein.get(0).definition().veinGenerator().getAllMaterials();
+            var mostCommonItem = materials.get(materials.size() - 1);
+            var color = mostCommonItem.getMaterialRGB();
+            return new WaypointItem(blockPos, name, color);
+        }
+
+        return new WaypointItem(blockPos, "Depleted Vein", 0x990000);
+    }
+
+    @Override
     public String resultDisplay(Object value) {
         return mode.getDescriptionId(value);
     }
@@ -280,5 +354,8 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
                 }
             }
         }
+    }
+
+    private record WaypointItem(BlockPos position, String name, int color) {
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
@@ -10,6 +10,7 @@ import com.gregtechceu.gtceu.integration.map.WaypointManager;
 import com.gregtechceu.gtceu.integration.map.cache.client.GTClientCache;
 import com.gregtechceu.gtceu.integration.map.cache.server.ServerCache;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.OreRenderLayer;
+
 import com.lowdragmc.lowdraglib.gui.editor.ColorPattern;
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
@@ -264,7 +265,8 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
                 clickedItem.color,
                 gui.entityPlayer.level().dimension(),
                 clickedItem.position.getX(), clickedItem.position.getY(), clickedItem.position.getZ());
-        gui.entityPlayer.displayClientMessage(Component.translatable("behavior.prospector.added_waypoint", clickedItem.name), true);
+        gui.entityPlayer.displayClientMessage(
+                Component.translatable("behavior.prospector.added_waypoint", clickedItem.name), true);
         playButtonClickSound();
         return true;
     }
@@ -285,7 +287,8 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
         int xPos = ((gui.entityPlayer.chunkPosition().x + xDiff) << 4) + offsetX;
         int zPos = ((gui.entityPlayer.chunkPosition().z + zDiff) << 4) + offsetZ;
 
-        var blockPos = new BlockPos(xPos, gui.entityPlayer.level().getHeight(Heightmap.Types.WORLD_SURFACE, xPos, zPos), zPos);
+        var blockPos = new BlockPos(xPos, gui.entityPlayer.level().getHeight(Heightmap.Types.WORLD_SURFACE, xPos, zPos),
+                zPos);
         if (cX < 0 || cZ < 0 || cX >= chunkRadius * 2 - 1 || cZ >= chunkRadius * 2 - 1) {
             return null;
         }
@@ -311,7 +314,8 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
         // If all else fails see if there's a nearby vein and use the vein's name
         var vein = GTClientCache.instance.getNearbyVeins(gui.entityPlayer.level().dimension(), blockPos, 32);
         if (!vein.isEmpty()) {
-            vein.sort((o1, o2) -> (int) (o1.center().distToCenterSqr(xPos, o1.center().getY(), zPos) - o2.center().distToCenterSqr(xPos, o2.center().getY(), zPos)));
+            vein.sort((o1, o2) -> (int) (o1.center().distToCenterSqr(xPos, o1.center().getY(), zPos) -
+                    o2.center().distToCenterSqr(xPos, o2.center().getY(), zPos)));
             var name = OreRenderLayer.getName(vein.get(0)).getString();
             var materials = vein.get(0).definition().veinGenerator().getAllMaterials();
             var mostCommonItem = materials.get(materials.size() - 1);
@@ -356,6 +360,5 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
         }
     }
 
-    private record WaypointItem(BlockPos position, String name, int color) {
-    }
+    private record WaypointItem(BlockPos position, String name, int color) {}
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -747,6 +747,7 @@ public class LangHandler {
         provider.add("metaitem.prospector.tooltip.radius", "Scans range in a %s Chunk Radius");
         provider.add("metaitem.prospector.tooltip.modes", "Available Modes:");
         provider.add("behavior.prospector.not_enough_energy", "Not Enough Energy!");
+        provider.add("behavior.prospector.added_waypoint", "Created waypoint named %s!");
         provider.add("metaitem.tricorder_scanner.tooltip", "Tricorder");
         provider.add("metaitem.debug_scanner.tooltip", "Tricorder");
         provider.add("behavior.portable_scanner.bedrock_fluid.amount", "Fluid In Deposit: %s %s - %s%%");


### PR DESCRIPTION
## What
Adds the ability to click to set a waypoint as described in #1821. The issue was closed because the ability to see the veins was implemented on the map but not actual waypoints that show in world if the player clicks inside the prospector.

## Additional Information
Xaero waypoints seem to be somewhat broken in that they don't show up in it's waypoint manager and can't be deleted. This is an issue with the waypoint integration so I didn't fix it in this PR. 
Also this implementation isn't the exact same as the 1.12 version. I added logic to get the exact clicked ore instead of just using the tooltip's name.