### PR TITLE
Change LuV item naming convention in code

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -821,7 +821,7 @@ public class GTItems {
             .onRegister(modelPredicate(GTCEu.id("battery"), ElectricStats::getStoredPredicate))
             .onRegister(attach(ElectricStats.createRechargeableBattery(40_960_000L, GTValues.IV)))
             .tag(CustomTags.IV_BATTERIES).register();
-    public static ItemEntry<ComponentItem> BATTERY_LUV_VANADIUM = REGISTRATE
+    public static ItemEntry<ComponentItem> BATTERY_LuV_VANADIUM = REGISTRATE
             .item("luv_vanadium_battery", ComponentItem::create)
             .lang("Large Vanadium Battery")
             .model(overrideModel(GTCEu.id("battery"), 8))
@@ -1165,7 +1165,7 @@ public class GTItems {
             .onRegister(compassNodeExist(GTCompassSections.COMPONENTS, "fluid_regulator"))
             .tag(CustomTags.FLUID_REGULATORS)
             .register();
-    public static ItemEntry<ComponentItem> FLUID_REGULATOR_LUV = REGISTRATE
+    public static ItemEntry<ComponentItem> FLUID_REGULATOR_LuV = REGISTRATE
             .item("luv_fluid_regulator", ComponentItem::create)
             .lang("LuV Fluid Regulator")
             .onRegister(attach(new CoverPlaceBehavior(GTCovers.FLUID_REGULATORS[5])))
@@ -1430,7 +1430,7 @@ public class GTItems {
             .onRegister(compassNodeExist(GTCompassSections.COMPONENTS, "piston"))
             .tag(CustomTags.ELECTRIC_PISTONS)
             .register();
-    public static ItemEntry<Item> ELECTRIC_PISTON_LUV = REGISTRATE.item("luv_electric_piston", Item::new)
+    public static ItemEntry<Item> ELECTRIC_PISTON_LuV = REGISTRATE.item("luv_electric_piston", Item::new)
             .lang("LuV Electric Piston")
             .onRegister(compassNodeExist(GTCompassSections.COMPONENTS, "piston"))
             .tag(CustomTags.ELECTRIC_PISTONS)
@@ -2030,7 +2030,7 @@ public class GTItems {
     public static ItemEntry<Item> NANO_COMPUTER_IV = REGISTRATE.item("nano_processor_computer", Item::new)
             .lang("Nanoprocessor Supercomputer").tag(CustomTags.IV_CIRCUITS)
             .onRegister(compassNode(GTCompassSections.CIRCUITS)).register();
-    public static ItemEntry<Item> NANO_MAINFRAME_LUV = REGISTRATE.item("nano_processor_mainframe", Item::new)
+    public static ItemEntry<Item> NANO_MAINFRAME_LuV = REGISTRATE.item("nano_processor_mainframe", Item::new)
             .lang("Nanoprocessor Mainframe").tag(CustomTags.LuV_CIRCUITS)
             .onRegister(compassNode(GTCompassSections.CIRCUITS)).register();
 
@@ -2041,7 +2041,7 @@ public class GTItems {
     public static ItemEntry<Item> QUANTUM_ASSEMBLY_IV = REGISTRATE.item("quantum_processor_assembly", Item::new)
             .lang("Quantum Processor Assembly").tag(CustomTags.IV_CIRCUITS)
             .onRegister(compassNode(GTCompassSections.CIRCUITS)).register();
-    public static ItemEntry<Item> QUANTUM_COMPUTER_LUV = REGISTRATE.item("quantum_processor_computer", Item::new)
+    public static ItemEntry<Item> QUANTUM_COMPUTER_LuV = REGISTRATE.item("quantum_processor_computer", Item::new)
             .lang("Quantum Processor Supercomputer").tag(CustomTags.LuV_CIRCUITS)
             .onRegister(compassNode(GTCompassSections.CIRCUITS)).register();
     public static ItemEntry<Item> QUANTUM_MAINFRAME_ZPM = REGISTRATE.item("quantum_processor_mainframe", Item::new)
@@ -2052,7 +2052,7 @@ public class GTItems {
     public static ItemEntry<Item> CRYSTAL_PROCESSOR_IV = REGISTRATE.item("crystal_processor", Item::new)
             .lang("Crystal Processor").tag(CustomTags.IV_CIRCUITS).onRegister(compassNode(GTCompassSections.CIRCUITS))
             .register();
-    public static ItemEntry<Item> CRYSTAL_ASSEMBLY_LUV = REGISTRATE.item("crystal_processor_assembly", Item::new)
+    public static ItemEntry<Item> CRYSTAL_ASSEMBLY_LuV = REGISTRATE.item("crystal_processor_assembly", Item::new)
             .lang("Crystal Processor Assembly").tag(CustomTags.LuV_CIRCUITS)
             .onRegister(compassNode(GTCompassSections.CIRCUITS)).register();
     public static ItemEntry<Item> CRYSTAL_COMPUTER_ZPM = REGISTRATE.item("crystal_processor_computer", Item::new)
@@ -2063,7 +2063,7 @@ public class GTItems {
             .onRegister(compassNode(GTCompassSections.CIRCUITS)).register();
 
     // T7: Wetware
-    public static ItemEntry<Item> WETWARE_PROCESSOR_LUV = REGISTRATE.item("wetware_processor", Item::new)
+    public static ItemEntry<Item> WETWARE_PROCESSOR_LuV = REGISTRATE.item("wetware_processor", Item::new)
             .lang("Wetware Processor").tag(CustomTags.LuV_CIRCUITS).onRegister(compassNode(GTCompassSections.CIRCUITS))
             .register();
     public static ItemEntry<Item> WETWARE_PROCESSOR_ASSEMBLY_ZPM = REGISTRATE
@@ -2318,7 +2318,7 @@ public class GTItems {
                         GTValues.VNF[GTValues.IV]));
             }))).onRegister(attach(new CoverPlaceBehavior(GTCovers.SOLAR_PANEL[5])))
             .onRegister(compassNodeExist(GTCompassSections.COVERS, "solar_panel", GTCompassNodes.COVER)).register();
-    public static ItemEntry<ComponentItem> COVER_SOLAR_PANEL_LUV = REGISTRATE
+    public static ItemEntry<ComponentItem> COVER_SOLAR_PANEL_LuV = REGISTRATE
             .item("luv_solar_panel", ComponentItem::create).lang("Ludicrous Voltage Solar Panel")
             .onRegister(attach(new TooltipBehavior(lines -> {
                 lines.addAll(LangHandler.getMultiLang("metaitem.cover.solar.panel.tooltip"));
@@ -2473,7 +2473,7 @@ public class GTItems {
                             ProspectorMode.FLUID,
                             ConfigHolder.INSTANCE.machines.doBedrockOres ? ProspectorMode.BEDROCK_ORE : null)))
             .register();
-    public static ItemEntry<ComponentItem> PROSPECTOR_LUV = REGISTRATE.item("prospector.luv", ComponentItem::create)
+    public static ItemEntry<ComponentItem> PROSPECTOR_LuV = REGISTRATE.item("prospector.luv", ComponentItem::create)
             .lang("Super Prospector (LuV)")
             .properties(p -> p.stacksTo(1))
             .onRegister(compassNodeExist(GTCompassSections.ITEMS, "prospector"))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/CraftingComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/CraftingComponent.java
@@ -622,7 +622,7 @@ public class CraftingComponent {
                 { 3, GTItems.ELECTRIC_PISTON_HV.asStack() },
                 { 4, GTItems.ELECTRIC_PISTON_EV.asStack() },
                 { 5, GTItems.ELECTRIC_PISTON_IV.asStack() },
-                { 6, GTItems.ELECTRIC_PISTON_LUV.asStack() },
+                { 6, GTItems.ELECTRIC_PISTON_LuV.asStack() },
                 { 7, GTItems.ELECTRIC_PISTON_ZPM.asStack() },
                 { 8, GTItems.ELECTRIC_PISTON_UV.asStack() },
                 { FALLBACK, GTItems.ELECTRIC_PISTON_UV.asStack() },

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
@@ -95,7 +95,7 @@ public class ToolRecipeHandler {
         batteryItems.put(GTValues.EV, ImmutableList.of(GTItems.BATTERY_EV_VANADIUM, GTItems.LAPOTRON_CRYSTAL));
         batteryItems.put(GTValues.IV, ImmutableList.of(GTItems.BATTERY_IV_VANADIUM, GTItems.ENERGY_LAPOTRONIC_ORB));
         batteryItems.put(GTValues.LuV,
-                ImmutableList.of(GTItems.BATTERY_LUV_VANADIUM, GTItems.ENERGY_LAPOTRONIC_ORB_CLUSTER));
+                ImmutableList.of(GTItems.BATTERY_LuV_VANADIUM, GTItems.ENERGY_LAPOTRONIC_ORB_CLUSTER));
         batteryItems.put(GTValues.ZPM, ImmutableList.of(GTItems.BATTERY_ZPM_NAQUADRIA, GTItems.ENERGY_MODULE));
         batteryItems.put(GTValues.UV, ImmutableList.of(GTItems.BATTERY_UV_NAQUADRIA, GTItems.ENERGY_CLUSTER));
 
@@ -583,7 +583,7 @@ public class ToolRecipeHandler {
         for (ItemEntry<? extends Item> batteryItem : batteryItems.get(LuV)) {
             VanillaRecipeHelper.addShapedEnergyTransferRecipe(provider, true, false, true,
                     "prospector_luv_" + batteryItem.getId().getPath(),
-                    Ingredient.of(batteryItem), GTItems.PROSPECTOR_LUV.asStack(),
+                    Ingredient.of(batteryItem), GTItems.PROSPECTOR_LuV.asStack(),
                     "EPS", "CDC", "PBP",
                     'E', GTItems.EMITTER_LuV.asStack(),
                     'P', new UnificationEntry(plate, GTMaterials.RhodiumPlatedPalladium),

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/BatteryRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/BatteryRecipes.java
@@ -201,7 +201,7 @@ public class BatteryRecipes {
         CANNER_RECIPES.recipeBuilder("vanadium_battery_luv")
                 .inputItems(BATTERY_HULL_LARGE_VANADIUM)
                 .inputItems(dust, Vanadium, 16)
-                .outputItems(BATTERY_LUV_VANADIUM)
+                .outputItems(BATTERY_LuV_VANADIUM)
                 .duration(200).EUt(VA[EV]).save(provider);
 
         // ZPM
@@ -243,7 +243,7 @@ public class BatteryRecipes {
                 .outputItems(BATTERY_HULL_SMALL_VANADIUM).save(provider);
         EXTRACTOR_RECIPES.recipeBuilder("unpackage_iv_vanadium_battery").inputItems(BATTERY_IV_VANADIUM)
                 .outputItems(BATTERY_HULL_MEDIUM_VANADIUM).save(provider);
-        EXTRACTOR_RECIPES.recipeBuilder("unpackage_luv_vanadium_battery").inputItems(BATTERY_LUV_VANADIUM)
+        EXTRACTOR_RECIPES.recipeBuilder("unpackage_luv_vanadium_battery").inputItems(BATTERY_LuV_VANADIUM)
                 .outputItems(BATTERY_HULL_LARGE_VANADIUM).save(provider);
 
         EXTRACTOR_RECIPES.recipeBuilder("unpackage_zpm_naquadria_battery").inputItems(BATTERY_ZPM_NAQUADRIA)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CircuitRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CircuitRecipes.java
@@ -1277,7 +1277,7 @@ public class CircuitRecipes {
                 .inputItems(SMD_CAPACITOR, 32)
                 .inputItems(RANDOM_ACCESS_MEMORY, 16)
                 .inputItems(wireGtSingle, AnnealedCopper, 32)
-                .outputItems(NANO_MAINFRAME_LUV)
+                .outputItems(NANO_MAINFRAME_LuV)
                 .solderMultiplier(4)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
@@ -1289,7 +1289,7 @@ public class CircuitRecipes {
                 .inputItems(ADVANCED_SMD_CAPACITOR, 8)
                 .inputItems(RANDOM_ACCESS_MEMORY, 16)
                 .inputItems(wireGtSingle, AnnealedCopper, 32)
-                .outputItems(NANO_MAINFRAME_LUV)
+                .outputItems(NANO_MAINFRAME_LuV)
                 .solderMultiplier(4)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
@@ -1362,7 +1362,7 @@ public class CircuitRecipes {
                 .inputItems(NOR_MEMORY_CHIP, 4)
                 .inputItems(RANDOM_ACCESS_MEMORY, 16)
                 .inputItems(wireFine, Platinum, 32)
-                .outputItems(QUANTUM_COMPUTER_LUV)
+                .outputItems(QUANTUM_COMPUTER_LuV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
@@ -1374,7 +1374,7 @@ public class CircuitRecipes {
                 .inputItems(NOR_MEMORY_CHIP, 4)
                 .inputItems(RANDOM_ACCESS_MEMORY, 16)
                 .inputItems(wireFine, Platinum, 32)
-                .outputItems(QUANTUM_COMPUTER_LUV)
+                .outputItems(QUANTUM_COMPUTER_LuV)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
@@ -1382,7 +1382,7 @@ public class CircuitRecipes {
         // ZPM
         CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder("quantum_mainframe_zpm").EUt(VA[IV]).duration(800)
                 .inputItems(frameGt, HSSG, 2)
-                .inputItems(QUANTUM_COMPUTER_LUV, 2)
+                .inputItems(QUANTUM_COMPUTER_LuV, 2)
                 .inputItems(SMD_INDUCTOR, 24)
                 .inputItems(SMD_CAPACITOR, 48)
                 .inputItems(RANDOM_ACCESS_MEMORY, 24)
@@ -1394,7 +1394,7 @@ public class CircuitRecipes {
 
         CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder("quantum_mainframe_zpm_asmd").EUt(VA[IV]).duration(400)
                 .inputItems(frameGt, HSSG, 2)
-                .inputItems(QUANTUM_COMPUTER_LUV, 2)
+                .inputItems(QUANTUM_COMPUTER_LuV, 2)
                 .inputItems(ADVANCED_SMD_INDUCTOR, 6)
                 .inputItems(ADVANCED_SMD_CAPACITOR, 12)
                 .inputItems(RANDOM_ACCESS_MEMORY, 24)
@@ -1436,7 +1436,7 @@ public class CircuitRecipes {
                 .inputItems(ADVANCED_SMD_CAPACITOR, 8)
                 .inputItems(RANDOM_ACCESS_MEMORY, 24)
                 .inputItems(wireFine, NiobiumTitanium, 16)
-                .outputItems(CRYSTAL_ASSEMBLY_LUV, 2)
+                .outputItems(CRYSTAL_ASSEMBLY_LuV, 2)
                 .solderMultiplier(2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
@@ -1444,7 +1444,7 @@ public class CircuitRecipes {
         // ZPM
         CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder("crystal_computer_zpm").EUt(9600).duration(400)
                 .inputItems(ELITE_CIRCUIT_BOARD)
-                .inputItems(CRYSTAL_ASSEMBLY_LUV, 2)
+                .inputItems(CRYSTAL_ASSEMBLY_LuV, 2)
                 .inputItems(RANDOM_ACCESS_MEMORY, 4)
                 .inputItems(NOR_MEMORY_CHIP, 32)
                 .inputItems(NAND_MEMORY_CHIP, 64)
@@ -1494,7 +1494,7 @@ public class CircuitRecipes {
                 .inputItems(ADVANCED_SMD_CAPACITOR, 8)
                 .inputItems(ADVANCED_SMD_TRANSISTOR, 8)
                 .inputItems(wireFine, YttriumBariumCuprate, 8)
-                .outputItems(WETWARE_PROCESSOR_LUV, outputAmount)
+                .outputItems(WETWARE_PROCESSOR_LuV, outputAmount)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
 
@@ -1504,14 +1504,14 @@ public class CircuitRecipes {
                 .inputItems(HIGHLY_ADVANCED_SOC)
                 .inputItems(wireFine, YttriumBariumCuprate, 8)
                 .inputItems(bolt, Naquadah, 8)
-                .outputItems(WETWARE_PROCESSOR_LUV, outputAmount * 2)
+                .outputItems(WETWARE_PROCESSOR_LuV, outputAmount * 2)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .save(provider);
 
         // ZPM
         CIRCUIT_ASSEMBLER_RECIPES.recipeBuilder("wetware_processor_assembly_zpm").EUt(38400).duration(400)
                 .inputItems(WETWARE_CIRCUIT_BOARD)
-                .inputItems(WETWARE_PROCESSOR_LUV, 2)
+                .inputItems(WETWARE_PROCESSOR_LuV, 2)
                 .inputItems(ADVANCED_SMD_INDUCTOR, 6)
                 .inputItems(ADVANCED_SMD_CAPACITOR, 12)
                 .inputItems(RANDOM_ACCESS_MEMORY, 24)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/ComponentRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/ComponentRecipes.java
@@ -461,7 +461,7 @@ public class ComponentRecipes {
                 .inputItems(ELECTRIC_PUMP_LuV)
                 .inputItems(CustomTags.LuV_CIRCUITS, 2)
                 .circuitMeta(1)
-                .outputItems(FLUID_REGULATOR_LUV)
+                .outputItems(FLUID_REGULATOR_LuV)
                 .EUt(VA[LuV])
                 .duration(150)
                 .save(provider);
@@ -601,7 +601,7 @@ public class ComponentRecipes {
                 .inputItems(cableGtSingle, NiobiumTitanium, 2)
                 .inputFluids(SolderingAlloy.getFluid(L))
                 .inputFluids(Lubricant.getFluid(250))
-                .outputItems(ELECTRIC_PISTON_LUV)
+                .outputItems(ELECTRIC_PISTON_LuV)
                 .scannerResearch(b -> b
                         .researchStack(ELECTRIC_PISTON_IV.asStack())
                         .duration(900)
@@ -621,7 +621,7 @@ public class ComponentRecipes {
                 .inputFluids(Lubricant.getFluid(500))
                 .outputItems(ELECTRIC_PISTON_ZPM)
                 .scannerResearch(b -> b
-                        .researchStack(ELECTRIC_PISTON_LUV.asStack())
+                        .researchStack(ELECTRIC_PISTON_LuV.asStack())
                         .duration(1200)
                         .EUt(VA[IV]))
                 .duration(600).EUt(24000).save(provider);
@@ -713,7 +713,7 @@ public class ComponentRecipes {
                 .inputItems(gear, HSSS)
                 .inputItems(gearSmall, HSSS, 3)
                 .inputItems(ELECTRIC_MOTOR_LuV, 2)
-                .inputItems(ELECTRIC_PISTON_LUV)
+                .inputItems(ELECTRIC_PISTON_LuV)
                 .inputItems(CustomTags.LuV_CIRCUITS)
                 .inputItems(CustomTags.IV_CIRCUITS, 2)
                 .inputItems(CustomTags.EV_CIRCUITS, 4)

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockFluidEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockFluidEmiCategory.java
@@ -28,7 +28,7 @@ public class GTBedrockFluidEmiCategory extends EmiRecipeCategory {
 
     public static void registerWorkStations(EmiRegistry registry) {
         registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_HV.asStack()));
-        registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LUV.asStack()));
+        registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LuV.asStack()));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockOreEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTBedrockOreEmiCategory.java
@@ -31,7 +31,7 @@ public class GTBedrockOreEmiCategory extends EmiRecipeCategory {
 
     public static void registerWorkStations(EmiRegistry registry) {
         registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_HV.asStack()));
-        registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LUV.asStack()));
+        registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LuV.asStack()));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTOreVeinEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/orevein/GTOreVeinEmiCategory.java
@@ -29,7 +29,7 @@ public class GTOreVeinEmiCategory extends EmiRecipeCategory {
     public static void registerWorkStations(EmiRegistry registry) {
         registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LV.asStack()));
         registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_HV.asStack()));
-        registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LUV.asStack()));
+        registry.addWorkstation(CATEGORY, EmiStack.of(GTItems.PROSPECTOR_LuV.asStack()));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTBedrockFluidInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTBedrockFluidInfoCategory.java
@@ -40,7 +40,7 @@ public class GTBedrockFluidInfoCategory extends ModularUIRecipeCategory<GTBedroc
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(GTItems.PROSPECTOR_HV.asStack(), RECIPE_TYPE);
-        registration.addRecipeCatalyst(GTItems.PROSPECTOR_LUV.asStack(), RECIPE_TYPE);
+        registration.addRecipeCatalyst(GTItems.PROSPECTOR_LuV.asStack(), RECIPE_TYPE);
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTBedrockOreInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTBedrockOreInfoCategory.java
@@ -43,7 +43,7 @@ public class GTBedrockOreInfoCategory extends ModularUIRecipeCategory<GTBedrockO
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(GTItems.PROSPECTOR_HV.asStack(), RECIPE_TYPE);
-        registration.addRecipeCatalyst(GTItems.PROSPECTOR_LUV.asStack(), RECIPE_TYPE);
+        registration.addRecipeCatalyst(GTItems.PROSPECTOR_LuV.asStack(), RECIPE_TYPE);
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTOreVeinInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/orevein/GTOreVeinInfoCategory.java
@@ -53,7 +53,7 @@ public class GTOreVeinInfoCategory extends ModularUIRecipeCategory<GTOreVeinInfo
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(GTItems.PROSPECTOR_LV.asStack(), RECIPE_TYPE);
         registration.addRecipeCatalyst(GTItems.PROSPECTOR_HV.asStack(), RECIPE_TYPE);
-        registration.addRecipeCatalyst(GTItems.PROSPECTOR_LUV.asStack(), RECIPE_TYPE);
+        registration.addRecipeCatalyst(GTItems.PROSPECTOR_LuV.asStack(), RECIPE_TYPE);
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTBedrockFluidDisplayCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTBedrockFluidDisplayCategory.java
@@ -68,6 +68,6 @@ public class GTBedrockFluidDisplayCategory extends ModularUIDisplayCategory<GTBe
         registry.addWorkstations(GTBedrockFluidDisplayCategory.CATEGORY,
                 EntryStacks.of(GTItems.PROSPECTOR_HV.asStack()));
         registry.addWorkstations(GTBedrockFluidDisplayCategory.CATEGORY,
-                EntryStacks.of(GTItems.PROSPECTOR_LUV.asStack()));
+                EntryStacks.of(GTItems.PROSPECTOR_LuV.asStack()));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTBedrockOreDisplayCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTBedrockOreDisplayCategory.java
@@ -68,6 +68,6 @@ public class GTBedrockOreDisplayCategory extends ModularUIDisplayCategory<GTBedr
         registry.addWorkstations(GTBedrockOreDisplayCategory.CATEGORY,
                 EntryStacks.of(GTItems.PROSPECTOR_HV.asStack()));
         registry.addWorkstations(GTBedrockOreDisplayCategory.CATEGORY,
-                EntryStacks.of(GTItems.PROSPECTOR_LUV.asStack()));
+                EntryStacks.of(GTItems.PROSPECTOR_LuV.asStack()));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTOreVeinDisplayCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/orevein/GTOreVeinDisplayCategory.java
@@ -67,6 +67,6 @@ public class GTOreVeinDisplayCategory extends ModularUIDisplayCategory<GTOreVein
     public static void registerWorkstations(CategoryRegistry registry) {
         registry.addWorkstations(GTOreVeinDisplayCategory.CATEGORY, EntryStacks.of(GTItems.PROSPECTOR_LV.asStack()));
         registry.addWorkstations(GTOreVeinDisplayCategory.CATEGORY, EntryStacks.of(GTItems.PROSPECTOR_HV.asStack()));
-        registry.addWorkstations(GTOreVeinDisplayCategory.CATEGORY, EntryStacks.of(GTItems.PROSPECTOR_LUV.asStack()));
+        registry.addWorkstations(GTOreVeinDisplayCategory.CATEGORY, EntryStacks.of(GTItems.PROSPECTOR_LuV.asStack()));
     }
 }

--- a/src/main/resources/assets/gtceu/compass/pages/en_us/components/electric_motor.xml
+++ b/src/main/resources/assets/gtceu/compass/pages/en_us/components/electric_motor.xml
@@ -75,7 +75,7 @@
    <style color="0xafff00" hover-info="click link" link="gtceu:links" underlined="true">Home button</style>
    . at
    <style color="0xafff00" hover-info="click link" link="gtceu:links" underlined="true">assembly line</style>
-   Assembling LUV ~ UV grade 
+   Assembling LuV ~ UV grade
  in
    <style color="0xafff00" hover-info="click link" link="gtceu:links" underlined="true">
  Invar - Invar

--- a/src/main/resources/assets/gtceu/compass/pages/zh_cn/components/electric_motor.xml
+++ b/src/main/resources/assets/gtceu/compass/pages/zh_cn/components/electric_motor.xml
@@ -70,7 +70,7 @@
    <style color="0xafff00" hover-info="click link" lang="zh-cn" link="gtceu:links" pwt="true" underlined="true">能量单元</style>
    。在
    <style color="0xafff00" hover-info="click link" lang="zh-cn" link="gtceu:links" pwt="true" underlined="true">装配线</style>
-   中组装 LUV ~ UV 级的
+   中组装 LuV ~ UV 级的
    <style color="0xafff00" hover-info="click link" lang="zh-cn" link="gtceu:links" pwt="true" underlined="true">发射器</style>
    和
    <style color="0xafff00" hover-info="click link" lang="zh-cn" link="gtceu:links" pwt="true" underlined="true">传感器</style>
@@ -85,7 +85,7 @@
    <style color="0xafff00" hover-info="click link" lang="zh-cn" link="gtceu:links" pwt="true" underlined="true">电弧炉</style>
    或
    <style color="0xafff00" hover-info="click link" lang="zh-cn" link="gtceu:links" pwt="true" underlined="true">研磨机</style>
-   中回收，得到大部分合成原料；而 LUV 及以上电压等级的电动马达无法被拆解。
+   中回收，得到大部分合成原料；而 LuV 及以上电压等级的电动马达无法被拆解。
    <br/>
   </style>
   <br/>


### PR DESCRIPTION
## What
makes all luv things use LuV as the formatting

## Implementation Details
ctrl shift r, replace

## Outcome
no more LUV