### PR TITLE
Fix crash when dedicated server is being stopped

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
@@ -15,6 +15,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.*;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.event.server.ServerStoppedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -66,5 +67,10 @@ public class ForgeClientEventListener {
     @SubscribeEvent
     public static void registerClientCommand(RegisterClientCommandsEvent event) {
         GTClientCommands.register(event.getDispatcher(), event.getBuildContext());
+    }
+
+    @SubscribeEvent
+    public static void serverStopped(ServerStoppedEvent event) {
+        ClientCacheManager.clearCaches();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -280,7 +280,6 @@ public class ForgeCommonEventListener {
 
     @SubscribeEvent
     public static void serverStopped(ServerStoppedEvent event) {
-        ClientCacheManager.clearCaches();
         ServerCache.instance.clear();
     }
 


### PR DESCRIPTION
## What
Yet another server loading client class issue.

## Implementation Details
Split `ServerStoppedEvent` into two, where one is only for integrated server.
