### PR TITLE
Adds RS latch for advanced item and fluid detectors

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedFluidDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedFluidDetectorCover.java
@@ -22,6 +22,7 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
+import lombok.Setter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -48,7 +49,10 @@ public class AdvancedFluidDetectorCover extends FluidDetectorCover implements IU
 
     private static final int DEFAULT_MIN = 64;
     private static final int DEFAULT_MAX = 512;
-
+    @Persisted
+    @Getter
+    @Setter
+    private int outputAmount;
     @Persisted
     @Getter
     private int minValue, maxValue;
@@ -96,7 +100,7 @@ public class AdvancedFluidDetectorCover extends FluidDetectorCover implements IU
         }
 
         setRedstoneSignalOutput(
-                RedstoneUtil.computeRedstoneBetweenValues(storedFluid, maxValue, minValue, this.isInverted()));
+                this.outputAmount = RedstoneUtil.computeLatchedRedstoneBetweenValues(storedFluid, maxValue, minValue, isInverted(), this.outputAmount));
     }
 
     public void setMinValue(int minValue) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedFluidDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedFluidDetectorCover.java
@@ -22,7 +22,6 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
-import lombok.Setter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
@@ -30,6 +29,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -100,7 +100,8 @@ public class AdvancedFluidDetectorCover extends FluidDetectorCover implements IU
         }
 
         setRedstoneSignalOutput(
-                this.outputAmount = RedstoneUtil.computeLatchedRedstoneBetweenValues(storedFluid, maxValue, minValue, isInverted(), this.outputAmount));
+                this.outputAmount = RedstoneUtil.computeLatchedRedstoneBetweenValues(storedFluid, maxValue, minValue,
+                        isInverted(), this.outputAmount));
     }
 
     public void setMinValue(int minValue) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
@@ -21,7 +21,6 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
-import lombok.Setter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
@@ -29,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -97,7 +97,8 @@ public class AdvancedItemDetectorCover extends ItemDetectorCover implements IUIC
         }
 
         setRedstoneSignalOutput(
-            this.outputAmount =  RedstoneUtil.computeLatchedRedstoneBetweenValues(storedItems, maxValue, minValue, isInverted(),this.outputAmount));
+                this.outputAmount = RedstoneUtil.computeLatchedRedstoneBetweenValues(storedItems, maxValue, minValue,
+                        isInverted(), this.outputAmount));
     }
 
     public void setMinValue(int minValue) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
@@ -21,6 +21,7 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
+import lombok.Setter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
@@ -47,7 +48,10 @@ public class AdvancedItemDetectorCover extends ItemDetectorCover implements IUIC
 
     private static final int DEFAULT_MIN = 64;
     private static final int DEFAULT_MAX = 512;
-
+    @Persisted
+    @Getter
+    @Setter
+    private int outputAmount;
     @Persisted
     @Getter
     private int minValue, maxValue;
@@ -93,7 +97,7 @@ public class AdvancedItemDetectorCover extends ItemDetectorCover implements IUIC
         }
 
         setRedstoneSignalOutput(
-                RedstoneUtil.computeRedstoneBetweenValues(storedItems, maxValue, minValue, isInverted()));
+            this.outputAmount =  RedstoneUtil.computeLatchedRedstoneBetweenValues(storedItems, maxValue, minValue, isInverted(),this.outputAmount));
     }
 
     public void setMinValue(int minValue) {


### PR DESCRIPTION
currently the advanced item and fluid covers both used    RedstoneUtil.computeRedstoneBetweenValues when it should've been using the better  RedstoneUtil.computeLatchedRedstoneBetweenValues

fixes #2267