### PR TITLE
Make large miners mine upside down

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -1960,7 +1960,7 @@ public class GTMachines {
                             .where('F', frames(LargeMinerMachine.getMaterial(tier)))
                             .where('#', any())
                             .build())
-                    .allowExtendedFacing(false)
+                    .allowExtendedFacing(true)
                     .renderer(() -> new LargeMinerRenderer(
                             MinerRenderer.MATERIALS_TO_CASING_MODELS.get(LargeMinerMachine.getMaterial(tier)),
                             GTCEu.id("block/multiblock/large_miner")))

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/LargeMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/LargeMinerMachine.java
@@ -121,7 +121,14 @@ public class LargeMinerMachine extends WorkableElectricMultiblockMachine
     @Override
     public void onStructureFormed() {
         super.onStructureFormed();
+        Direction opposite = this.getUpwardsFacing().getOpposite();
+        getRecipeLogic().setDir(opposite == Direction.NORTH ? Direction.UP : Direction.DOWN);
         initializeAbilities();
+    }
+
+    @Override
+    public boolean checkPattern() {
+        return super.checkPattern() && (this.getUpwardsFacing() == Direction.NORTH || this.getUpwardsFacing() == Direction.SOUTH);
     }
 
     private void initializeAbilities() {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/LargeMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/LargeMinerMachine.java
@@ -128,7 +128,8 @@ public class LargeMinerMachine extends WorkableElectricMultiblockMachine
 
     @Override
     public boolean checkPattern() {
-        return super.checkPattern() && (this.getUpwardsFacing() == Direction.NORTH || this.getUpwardsFacing() == Direction.SOUTH);
+        return super.checkPattern() &&
+                (this.getUpwardsFacing() == Direction.NORTH || this.getUpwardsFacing() == Direction.SOUTH);
     }
 
     private void initializeAbilities() {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.core.Direction;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -69,20 +70,34 @@ public class LargeMinerLogic extends MinerLogic {
         if (!isChunkMode) {
             super.initPos(pos, currentRadius);
         } else {
+            Direction dir = super.getDir();
             ServerLevel world = (ServerLevel) this.getMachine().getLevel();
             ChunkAccess origin = world.getChunk(pos);
             ChunkPos startPos = (world.getChunk(origin.getPos().x - currentRadius / CHUNK_LENGTH,
                     origin.getPos().z - currentRadius / CHUNK_LENGTH)).getPos();
             x = startPos.getMinBlockX();
-            y = pos.getY() - 1;
+            if (dir == Direction.UP) {
+                y = pos.getY() + 1;
+            } else {
+                y = pos.getY() - 1;
+            }
             z = startPos.getMinBlockZ();
             startX = startPos.getMinBlockX();
             startY = pos.getY();
             startZ = startPos.getMinBlockZ();
             mineX = startPos.getMinBlockX();
-            mineY = pos.getY() - 1;
+            if (dir == Direction.UP) {
+                mineY = pos.getY() + 1;
+            } else {
+                mineY = pos.getY() - 1;
+            }
             mineZ = startPos.getMinBlockZ();
-            pipeY = pos.getY() - 1;
+            startY = pos.getY();
+            if (dir == Direction.UP) {
+                pipeY = pos.getY() + 1;
+            } else {
+                pipeY = pos.getY() - 1;
+            }
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
@@ -8,6 +8,7 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
@@ -20,7 +21,6 @@ import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.functions.ApplyBonusCount;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
-import net.minecraft.core.Direction;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
@@ -92,7 +92,6 @@ public class LargeMinerLogic extends MinerLogic {
                 mineY = pos.getY() - 1;
             }
             mineZ = startPos.getMinBlockZ();
-            startY = pos.getY();
             if (dir == Direction.UP) {
                 pipeY = pos.getY() + 1;
             } else {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.misc.IgnoreEnergyRecipeHandler;
 import com.gregtechceu.gtceu.api.misc.ItemRecipeHandler;
@@ -103,6 +104,8 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     @Getter
     private int minBuildHeight = Integer.MAX_VALUE;
     @Getter
+    private int maxBuildHeight = Integer.MAX_VALUE;
+    @Getter
     @Persisted
     private int pipeLength = 0;
     @Getter
@@ -118,6 +121,8 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     private final Table<IO, RecipeCapability<?>, List<IRecipeHandler<?>>> capabilitiesProxy;
     private final ItemRecipeHandler inputItemHandler, outputItemHandler;
     private final IgnoreEnergyRecipeHandler inputEnergyHandler;
+    @Setter
+    private Direction dir = Direction.DOWN;
 
     /**
      * Creates the general logic for all in-world ore block miners
@@ -201,10 +206,14 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
             }
 
             // drill a hole beneath the miner and extend the pipe downwards by one
-            if (mineY < pipeY) {
+            if ((dir == Direction.DOWN && mineY < pipeY) || (dir == Direction.UP && mineY > pipeY)) {
                 BlockPos miningPos = getMiningPos();
                 serverLevel.destroyBlock(new BlockPos(miningPos.getX(), pipeY, miningPos.getZ()), false);
-                --pipeY;
+                if (dir == Direction.UP) {
+                    ++pipeY;
+                } else {
+                    --pipeY;
+                }
                 incrementPipeLength();
             }
 
@@ -428,14 +437,26 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     public void initPos(@NotNull BlockPos pos, int currentRadius) {
         x = pos.getX() - currentRadius;
         z = pos.getZ() - currentRadius;
-        y = pos.getY() - 1;
+        if (dir == Direction.UP) {
+            y = pos.getY() + 1;
+        } else {
+            y = pos.getY() - 1;
+        }
         startX = pos.getX() - currentRadius;
         startZ = pos.getZ() - currentRadius;
         startY = pos.getY();
-        pipeY = pos.getY() - 1;
+        if (dir == Direction.UP) {
+            pipeY = pos.getY() + 1;
+        } else {
+            pipeY = pos.getY() - 1;
+        }
         mineX = pos.getX() - currentRadius;
         mineZ = pos.getZ() - currentRadius;
-        mineY = pos.getY() - 1;
+        if (dir == Direction.UP) {
+            mineY = pos.getY() + 1;
+        } else {
+            mineY = pos.getY() - 1;
+        }
         onRemove();
     }
 
@@ -485,10 +506,13 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         if (this.minBuildHeight == Integer.MAX_VALUE)
             this.minBuildHeight = this.getMachine().getLevel().getMinBuildHeight();
 
+        if (this.maxBuildHeight == Integer.MAX_VALUE)
+            this.maxBuildHeight = this.getMachine().getLevel().getMaxBuildHeight();
+
         // keep getting blocks until the target amount is reached
         while (calculated < calcAmount) {
             // moving down the y-axis
-            if (y > minBuildHeight) {
+            if (y > minBuildHeight && y < maxBuildHeight) {
                 // moving across the z-axis
                 if (z <= startZ + currentRadius * 2) {
                     // check every block along the x-axis
@@ -510,7 +534,11 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
                 } else {
                     // reset z and move to the next y layer
                     z = startZ;
-                    --y;
+                    if (dir == Direction.DOWN) {
+                        --y;
+                    } else {
+                        ++y;
+                    }
                 }
             } else
                 return blocks;
@@ -560,7 +588,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     private void incrementPipeLength() {
         this.pipeLength++;
         if (getMachine().getLevel() instanceof ServerLevel serverLevel) {
-            var pos = getMiningPos().relative(Direction.DOWN, this.pipeLength);
+            var pos = getMiningPos().relative(dir, this.pipeLength);
             serverLevel.setBlockAndUpdate(pos, GTBlocks.MINER_PIPE.getDefaultState());
         }
     }
@@ -575,10 +603,10 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     public void onRemove() {
         pipeLength = 0;
         if (getMachine().getLevel() instanceof ServerLevel serverLevel) {
-            var pos = getMiningPos().relative(Direction.DOWN);
+            var pos = getMiningPos().relative(dir);
             while (serverLevel.getBlockState(pos).is(GTBlocks.MINER_PIPE.get())) {
                 serverLevel.removeBlock(pos, false);
-                pos = pos.relative(Direction.DOWN);
+                pos = pos.relative(dir);
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -6,7 +6,6 @@ import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.misc.IgnoreEnergyRecipeHandler;
 import com.gregtechceu.gtceu.api.misc.ItemRecipeHandler;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -534,10 +534,10 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
                 } else {
                     // reset z and move to the next y layer
                     z = startZ;
-                    if (dir == Direction.DOWN) {
-                        --y;
-                    } else {
+                    if (dir == Direction.UP) {
                         ++y;
+                    } else {
+                        --y;
                     }
                 }
             } else

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -122,6 +122,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     private final ItemRecipeHandler inputItemHandler, outputItemHandler;
     private final IgnoreEnergyRecipeHandler inputEnergyHandler;
     @Setter
+    @Getter
     private Direction dir = Direction.DOWN;
 
     /**


### PR DESCRIPTION
## What
Allows rotating Large miner controller blocks and adds logic changes to allow them to mine "below" them. This is useful for getting nether ores that are above where the player may be

## Additional Information
![image](https://github.com/user-attachments/assets/df8616db-b0cb-439c-ad8e-258d65cd233f)

