### PR TITLE
Fix Multiblocks not staying suspended on unform/reform

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -148,7 +148,8 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
         isActive = false;
         fuelTime = 0;
         lastFailedMatches = null;
-        status = Status.IDLE;
+        if (status != Status.SUSPEND)
+            status = Status.IDLE;
         ocResult.reset();
         updateTickSubscription();
     }


### PR DESCRIPTION
## What
Makes sure machines stay suspended after forming/unforming if you suspended with a mallet
Fixes #2365 

## Implementation Details
checks if the machine is already suspended in resetting the recipe logic

## Outcome
Don't have to take all the items out after unforming to keep machines off after forming