### PR TITLE
Fixed ULV -> LV Showing a boosted chance for byproducts

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.recipe.content;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -154,7 +154,8 @@ public class Content {
         graphics.pose().translate(0, 0, 400);
         graphics.pose().scale(0.5f, 0.5f, 1);
         float chance = 100 *
-                (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= GTValues.LV ? tier - 1 : tier))), maxChance) /
+                (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= GTValues.LV ? tier - 1 : tier))),
+                        maxChance) /
                 maxChance;
         String percent = FormattingUtil.formatPercent(chance);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -153,7 +153,9 @@ public class Content {
         graphics.pose().pushPose();
         graphics.pose().translate(0, 0, 400);
         graphics.pose().scale(0.5f, 0.5f, 1);
-        float chance = 100 * (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= 1 ? tier - 1 : tier))), maxChance) / maxChance;
+        float chance = 100 *
+                (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= 1 ? tier - 1 : tier))), maxChance) /
+                maxChance;
         String percent = FormattingUtil.formatPercent(chance);
 
         String s = chance == 0 ? LocalizationUtils.format("gtceu.gui.content.chance_0_short") :

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -154,7 +154,7 @@ public class Content {
         graphics.pose().translate(0, 0, 400);
         graphics.pose().scale(0.5f, 0.5f, 1);
         float chance = 100 *
-                (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= 1 ? tier - 1 : tier))), maxChance) /
+                (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= GTValues.LV ? tier - 1 : tier))), maxChance) /
                 maxChance;
         String percent = FormattingUtil.formatPercent(chance);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -153,7 +153,7 @@ public class Content {
         graphics.pose().pushPose();
         graphics.pose().translate(0, 0, 400);
         graphics.pose().scale(0.5f, 0.5f, 1);
-        float chance = 100 * (float) Math.min((this.chance + (this.tierChanceBoost * tier)), maxChance) / maxChance;
+        float chance = 100 * (float) Math.min((this.chance + (this.tierChanceBoost * (tier >= 1 ? tier - 1 : tier))), maxChance) / maxChance;
         String percent = FormattingUtil.formatPercent(chance);
 
         String s = chance == 0 ? LocalizationUtils.format("gtceu.gui.content.chance_0_short") :

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -289,7 +289,7 @@ public class GTRecipeWidget extends WidgetGroup {
                 float chanceFloat = 100 * (float) content.chance / content.maxChance;
                 float chanceAtTierFloat = Math
                         .min(chanceFloat + (100.0f * ((float) content.tierChanceBoost / (float) content.maxChance)) *
-                                Math.max(0, (tier >= 1 ? tier - 1 : tier) - minTier), 100.0f);
+                                Math.max(0, (tier >= GTValues.LV ? tier - 1 : tier) - minTier), 100.0f);
                 if (logic != ChanceLogic.NONE && logic != ChanceLogic.OR) {
                     tooltips.add(Component.translatable("gtceu.gui.content.chance_1_logic",
                             FormattingUtil.formatNumber2Places(chanceFloat), logic.getTranslation())

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -289,7 +289,7 @@ public class GTRecipeWidget extends WidgetGroup {
                 float chanceFloat = 100 * (float) content.chance / content.maxChance;
                 float chanceAtTierFloat = Math
                         .min(chanceFloat + (100.0f * ((float) content.tierChanceBoost / (float) content.maxChance)) *
-                                Math.max(0, tier - minTier), 100.0f);
+                                Math.max(0, (tier >= 1 ? tier - 1 : tier) - minTier), 100.0f);
                 if (logic != ChanceLogic.NONE && logic != ChanceLogic.OR) {
                     tooltips.add(Component.translatable("gtceu.gui.content.chance_1_logic",
                             FormattingUtil.formatNumber2Places(chanceFloat), logic.getTranslation())


### PR DESCRIPTION
## What
Fixes recipe viewers & tooltips showing boosted chance on outputs when going from ULV -> LV