### PR TITLE
Adds the ability to get prospection data when you break a surface rock.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/block/SurfaceRockBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/SurfaceRockBlock.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
@@ -64,6 +65,19 @@ public class SurfaceRockBlock extends Block {
         if (Platform.isClient()) {
             SurfaceRockRenderer.create(this);
         }
+    }
+
+    @Override
+    public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest,
+                                       FluidState fluid) {
+        if (!level.isClientSide) {
+            ServerCache.instance.prospectSurfaceRockMaterial(
+                    level.dimension(),
+                    this.material,
+                    pos,
+                    (ServerPlayer) player);
+        }
+        return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
     }
 
     @Override


### PR DESCRIPTION
## What
Allows the player to get prospection data when they break a surface rock, not just from right clicking anymore

## Implementation Details
copy paste the use method to onDestroyedByPlayer

## Outcome
you can use either right or left click now