### PR TITLE
Fix recipe fluid stack output crashing top users

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/top/TheOneProbePlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/TheOneProbePlugin.java
@@ -1,12 +1,37 @@
 package com.gregtechceu.gtceu.integration.top;
 
+import com.gregtechceu.gtceu.integration.top.element.FluidStackElement;
+import com.gregtechceu.gtceu.integration.top.element.FluidStyle;
 import com.gregtechceu.gtceu.integration.top.provider.*;
 
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.fluids.FluidStack;
+
+import mcjty.theoneprobe.api.IElement;
+import mcjty.theoneprobe.api.IElementFactory;
 import mcjty.theoneprobe.api.ITheOneProbe;
 
 public class TheOneProbePlugin {
 
     public static void init(ITheOneProbe oneProbe) {
+        oneProbe.registerElementFactory(new IElementFactory() {
+
+            private ResourceLocation id = null;
+
+            @Override
+            public IElement createElement(FriendlyByteBuf friendlyByteBuf) {
+                return new FluidStackElement(friendlyByteBuf);
+            }
+
+            @Override
+            public ResourceLocation getId() {
+                if (id == null)
+                    id = new FluidStackElement(FluidStack.EMPTY, new FluidStyle()).getID();
+                return id;
+            }
+        });
+
         oneProbe.registerProvider(new ElectricContainerInfoProvider());
         // oneProbe.registerProvider(new FuelableInfoProvider());
         oneProbe.registerProvider(new WorkableInfoProvider());


### PR DESCRIPTION
## What
Prevents players from crashing if they look at a machine who's current recipe outputs a fluid stack while top is active.

## Implementation Details
Registers the fluid stack element properly.

## Additionally
fixes #2411 