### PR TITLE
Allow absolute-zero fluids

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/fluids/FluidBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/fluids/FluidBuilder.java
@@ -77,7 +77,7 @@ public class FluidBuilder {
      * @return this;
      */
     public @NotNull FluidBuilder temperature(int temperature) {
-        Preconditions.checkArgument(temperature > 0, "temperature must be > 0");
+        Preconditions.checkArgument(temperature >= 0, "temperature must be >= 0");
         this.temperature = temperature;
         return this;
     }


### PR DESCRIPTION
## What
Allows fluids with a temperature of absolute zero.

## Implementation Details
Now, fluids will be accepted with a temperature value of zero. (also changed rejection message)

## Additional Information
I thought this would be cool.

## Potential Compatibility Issues
"bUt AbSoLuTe ZeRo CaN't ExIsT"—neither can naquadah. shut up.