### PR TITLE
Fix Item pipes teleporting items

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/ItemPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/ItemPipeBlockEntity.java
@@ -182,6 +182,8 @@ public class ItemPipeBlockEntity extends PipeBlockEntity<ItemPipeType, ItemPipeP
 
     public IItemHandlerModifiable getHandler(@Nullable Direction side, boolean useCoverCapability) {
         ensureHandlersInitialized();
+        checkNetwork();
+        if (this.currentItemPipeNet.get() == null) return null;
 
         ItemNetHandler handler = getHandlers().getOrDefault(side, getDefaultHandler());
         if (!useCoverCapability || side == null) return handler;


### PR DESCRIPTION
## What
Force item pipe nets to reinitialize its network onNeighborChanged
Fixes #2420 

## Outcome
no more teleporting items in pipes