### PR TITLE
Fix Coke Oven Hatch gaps

### DIFF
--- a/src/main/resources/assets/gtceu/models/block/machine/part/coke_oven_hatch.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/part/coke_oven_hatch.json
@@ -8,8 +8,8 @@
 	},
 	"elements": [
 		{
-			"from": [0.001, 0.001, 0.001],
-			"to": [15.999, 15.999, 15.999],
+			"from": [0, 0, 0],
+			"to": [16, 16, 16],
 			"faces": {
 				"north": {"texture": "#1", "cullface": "north"},
 				"east": {"texture": "#1", "cullface": "east"},
@@ -20,8 +20,8 @@
 			}
 		},
 		{
-			"from": [-0.002, -0.002, -0.002],
-			"to": [16.002, 16.002, -0.002],
+			"from": [0, 0, 0],
+			"to": [16, 16, 0],
 			"faces": {
 				"north": {"texture": "#2", "cullface": "north"}
 			}


### PR DESCRIPTION
## What
it should be accepted so there isnt gaps between blocks bc the model is wrong

## Implementation Details
i just changed some values, it doesnt even cause any z fighting or anything theres no issue

## Outcome
i chaged some values so theres no gaps between blocks

## Additional Information
![image](https://github.com/user-attachments/assets/1a2fc223-b13e-4ead-869d-b246ab6480ed)
![image](https://github.com/user-attachments/assets/9fd14ac2-8231-4125-b413-153171397632)
no longer any gaps