### PR TITLE
remove generic from `IMaterialProperty`

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -491,15 +491,15 @@ public class Material implements Comparable<Material> {
         return new MaterialStack(this, amount);
     }
 
-    public <T extends IMaterialProperty<T>> boolean hasProperty(PropertyKey<T> key) {
+    public <T extends IMaterialProperty> boolean hasProperty(PropertyKey<T> key) {
         return getProperty(key) != null;
     }
 
-    public <T extends IMaterialProperty<T>> T getProperty(PropertyKey<T> key) {
+    public <T extends IMaterialProperty> T getProperty(PropertyKey<T> key) {
         return properties.getProperty(key);
     }
 
-    public <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, IMaterialProperty<T> property) {
+    public <T extends IMaterialProperty> void setProperty(PropertyKey<T> key, IMaterialProperty property) {
         if (!GTCEuAPI.materialManager.canModifyMaterials()) {
             throw new IllegalStateException("Cannot add properties to a Material when registry is frozen!");
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/AlloyBlastProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/AlloyBlastProperty.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
 
-public class AlloyBlastProperty implements IMaterialProperty<AlloyBlastProperty> {
+public class AlloyBlastProperty implements IMaterialProperty {
 
     /**
      * Internal material fluid field

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/BlastProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/BlastProperty.java
@@ -3,7 +3,7 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 import lombok.Getter;
 import lombok.Setter;
 
-public class BlastProperty implements IMaterialProperty<BlastProperty> {
+public class BlastProperty implements IMaterialProperty {
 
     /**
      * Blast Furnace Temperature of this Material.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/DustProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/DustProperty.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
 import lombok.Getter;
 
-public class DustProperty implements IMaterialProperty<DustProperty> {
+public class DustProperty implements IMaterialProperty {
 
     /**
      * Tool level needed to harvest block of this Material.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/FluidPipeProperties.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/FluidPipeProperties.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.UnmodifiableView;
 import java.util.Collection;
 import java.util.Objects;
 
-public class FluidPipeProperties implements IMaterialProperty<FluidPipeProperties>, IPropertyFluidFilter {
+public class FluidPipeProperties implements IMaterialProperty, IPropertyFluidFilter {
 
     /**
      * The maximum number of channels any fluid pipe can have

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/FluidProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/FluidProperty.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Supplier;
 
 @NoArgsConstructor
-public class FluidProperty implements IMaterialProperty<FluidProperty>, FluidStorage {
+public class FluidProperty implements IMaterialProperty, FluidStorage {
 
     private final FluidStorageImpl storage = new FluidStorageImpl();
     @Getter

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/GemProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/GemProperty.java
@@ -1,6 +1,6 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
-public class GemProperty implements IMaterialProperty<GemProperty> {
+public class GemProperty implements IMaterialProperty {
 
     @Override
     public void verifyProperty(MaterialProperties properties) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/HazardProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/HazardProperty.java
@@ -33,7 +33,7 @@ import java.util.*;
  * @date 2024/2/12
  * @implNote HazardProperty
  */
-public class HazardProperty implements IMaterialProperty<HazardProperty> {
+public class HazardProperty implements IMaterialProperty {
 
     public final MedicalCondition condition;
     public final HazardTrigger hazardTrigger;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/IMaterialProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/IMaterialProperty.java
@@ -1,7 +1,7 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
 @FunctionalInterface
-public interface IMaterialProperty<T> {
+public interface IMaterialProperty {
 
     void verifyProperty(MaterialProperties properties);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/IngotProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/IngotProperty.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
-public class IngotProperty implements IMaterialProperty<IngotProperty> {
+public class IngotProperty implements IMaterialProperty {
 
     /**
      * Specifies a material into which this material parts turn when heated

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/ItemPipeProperties.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/ItemPipeProperties.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
 import java.util.Objects;
 
-public class ItemPipeProperties implements IMaterialProperty<ItemPipeProperties> {
+public class ItemPipeProperties implements IMaterialProperty {
 
     /**
      * Items will try to take the path with the lowest priority

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/MaterialProperties.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/MaterialProperties.java
@@ -18,7 +18,7 @@ public class MaterialProperties {
         baseTypes.add(baseTypeKey);
     }
 
-    private final Map<PropertyKey<? extends IMaterialProperty<?>>, IMaterialProperty<?>> propertyMap;
+    private final Map<PropertyKey<? extends IMaterialProperty>, IMaterialProperty> propertyMap;
     private Material material;
 
     public MaterialProperties() {
@@ -29,15 +29,15 @@ public class MaterialProperties {
         return propertyMap.isEmpty();
     }
 
-    public <T extends IMaterialProperty<T>> T getProperty(PropertyKey<T> key) {
+    public <T extends IMaterialProperty> T getProperty(PropertyKey<T> key) {
         return key.cast(propertyMap.get(key));
     }
 
-    public <T extends IMaterialProperty<T>> boolean hasProperty(PropertyKey<T> key) {
+    public <T extends IMaterialProperty> boolean hasProperty(PropertyKey<T> key) {
         return propertyMap.get(key) != null;
     }
 
-    public <T extends IMaterialProperty<T>> void setProperty(PropertyKey<T> key, IMaterialProperty<T> value) {
+    public <T extends IMaterialProperty> void setProperty(PropertyKey<T> key, IMaterialProperty value) {
         if (value == null) throw new IllegalArgumentException("Material Property must not be null!");
         if (hasProperty(key))
             throw new IllegalArgumentException("Material Property " + key.toString() + " already registered!");
@@ -45,7 +45,7 @@ public class MaterialProperties {
         propertyMap.remove(PropertyKey.EMPTY);
     }
 
-    public <T extends IMaterialProperty<T>> void removeProperty(PropertyKey<T> property) {
+    public <T extends IMaterialProperty> void removeProperty(PropertyKey<T> property) {
         if (!hasProperty(property))
             throw new IllegalArgumentException("Material Property " + property.toString() + " not present!");
         propertyMap.remove(property);
@@ -53,7 +53,7 @@ public class MaterialProperties {
             propertyMap.put(PropertyKey.EMPTY, PropertyKey.EMPTY.constructDefault());
     }
 
-    public <T extends IMaterialProperty<T>> void ensureSet(PropertyKey<T> key, boolean verify) {
+    public <T extends IMaterialProperty> void ensureSet(PropertyKey<T> key, boolean verify) {
         if (!hasProperty(key)) {
             propertyMap.put(key, key.constructDefault());
             propertyMap.remove(PropertyKey.EMPTY);
@@ -61,12 +61,12 @@ public class MaterialProperties {
         }
     }
 
-    public <T extends IMaterialProperty<T>> void ensureSet(PropertyKey<T> key) {
+    public <T extends IMaterialProperty> void ensureSet(PropertyKey<T> key) {
         ensureSet(key, false);
     }
 
     public void verify() {
-        List<IMaterialProperty<?>> oldList;
+        List<IMaterialProperty> oldList;
         do {
             oldList = new ArrayList<>(propertyMap.values());
             oldList.forEach(p -> p.verifyProperty(this));

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/OreProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/OreProperty.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class OreProperty implements IMaterialProperty<OreProperty> {
+public class OreProperty implements IMaterialProperty {
 
     /**
      * List of Ore byproducts.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/PolymerProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/PolymerProperty.java
@@ -2,7 +2,7 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
 
-public class PolymerProperty implements IMaterialProperty<PolymerProperty> {
+public class PolymerProperty implements IMaterialProperty {
 
     @Override
     public void verifyProperty(MaterialProperties properties) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/PropertyKey.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/PropertyKey.java
@@ -1,6 +1,6 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
-public class PropertyKey<T extends IMaterialProperty<T>> {
+public class PropertyKey<T extends IMaterialProperty> {
 
     public static final PropertyKey<BlastProperty> BLAST = new PropertyKey<>("blast", BlastProperty.class);
     public static final PropertyKey<AlloyBlastProperty> ALLOY_BLAST = new PropertyKey<>("blast_alloy",
@@ -45,7 +45,7 @@ public class PropertyKey<T extends IMaterialProperty<T>> {
         }
     }
 
-    public T cast(IMaterialProperty<?> property) {
+    public T cast(IMaterialProperty property) {
         return this.type.cast(property);
     }
 
@@ -67,7 +67,7 @@ public class PropertyKey<T extends IMaterialProperty<T>> {
         return key;
     }
 
-    private static class EmptyProperty implements IMaterialProperty<EmptyProperty> {
+    private static class EmptyProperty implements IMaterialProperty {
 
         @Override
         public void verifyProperty(MaterialProperties properties) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/RotorProperty.java
@@ -3,7 +3,7 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
-public class RotorProperty implements IMaterialProperty<RotorProperty> {
+public class RotorProperty implements IMaterialProperty {
 
     /**
      * Power of rotors made from this Material.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/ToolProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/ToolProperty.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 
 import static com.gregtechceu.gtceu.api.item.tool.GTToolType.*;
 
-public class ToolProperty implements IMaterialProperty<ToolProperty> {
+public class ToolProperty implements IMaterialProperty {
 
     /**
      * Harvest speed of tools made from this Material.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/WireProperties.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/WireProperties.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags.GENERATE_FOIL;
 
-public class WireProperties implements IMaterialProperty<WireProperties> {
+public class WireProperties implements IMaterialProperty {
 
     private long voltage;
     private int amperage;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/WoodProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/WoodProperty.java
@@ -1,6 +1,6 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
-public class WoodProperty implements IMaterialProperty<WoodProperty> {
+public class WoodProperty implements IMaterialProperty {
 
     @Override
     public void verifyProperty(MaterialProperties properties) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -1081,12 +1081,12 @@ public class TagPrefix {
     }
 
     @FunctionalInterface
-    public interface MaterialRecipeHandler<T extends IMaterialProperty<T>> {
+    public interface MaterialRecipeHandler<T extends IMaterialProperty> {
 
         void accept(TagPrefix prefix, Material material, T property, Consumer<FinishedRecipe> provider);
     }
 
-    public <T extends IMaterialProperty<T>> void executeHandler(Consumer<FinishedRecipe> provider,
+    public <T extends IMaterialProperty> void executeHandler(Consumer<FinishedRecipe> provider,
                                                                 PropertyKey<T> propertyKey,
                                                                 MaterialRecipeHandler<T> handler) {
         for (Material material : GTCEuAPI.materialManager.getRegisteredMaterials()) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -1087,8 +1087,8 @@ public class TagPrefix {
     }
 
     public <T extends IMaterialProperty> void executeHandler(Consumer<FinishedRecipe> provider,
-                                                                PropertyKey<T> propertyKey,
-                                                                MaterialRecipeHandler<T> handler) {
+                                                             PropertyKey<T> propertyKey,
+                                                             MaterialRecipeHandler<T> handler) {
         for (Material material : GTCEuAPI.materialManager.getRegisteredMaterials()) {
             if (material.hasProperty(propertyKey) && !material.hasFlag(MaterialFlags.NO_UNIFICATION) &&
                     !ChemicalHelper.get(this, material).isEmpty()) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PipeRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PipeRecipeHandler.java
@@ -77,7 +77,7 @@ public class PipeRecipeHandler {
                 'P', new UnificationEntry(unrestrictive, material), 'R', ChemicalHelper.get(ring, Iron));
     }
 
-    private static void processPipeTiny(TagPrefix pipePrefix, Material material, IMaterialProperty<?> property,
+    private static void processPipeTiny(TagPrefix pipePrefix, Material material, IMaterialProperty property,
                                         Consumer<FinishedRecipe> provider) {
         if (material.hasProperty(PropertyKey.WOOD)) return;
         ItemStack pipeStack = ChemicalHelper.get(pipePrefix, material);
@@ -104,7 +104,7 @@ public class PipeRecipeHandler {
         }
     }
 
-    private static void processPipeSmall(TagPrefix pipePrefix, Material material, IMaterialProperty<?> property,
+    private static void processPipeSmall(TagPrefix pipePrefix, Material material, IMaterialProperty property,
                                          Consumer<FinishedRecipe> provider) {
         if (material.hasProperty(PropertyKey.WOOD)) return;
         ItemStack pipeStack = ChemicalHelper.get(pipePrefix, material);
@@ -131,7 +131,7 @@ public class PipeRecipeHandler {
         }
     }
 
-    private static void processPipeNormal(TagPrefix pipePrefix, Material material, IMaterialProperty<?> property,
+    private static void processPipeNormal(TagPrefix pipePrefix, Material material, IMaterialProperty property,
                                           Consumer<FinishedRecipe> provider) {
         if (material.hasProperty(PropertyKey.WOOD)) return;
         ItemStack pipeStack = ChemicalHelper.get(pipePrefix, material);
@@ -158,7 +158,7 @@ public class PipeRecipeHandler {
         }
     }
 
-    private static void processPipeLarge(TagPrefix pipePrefix, Material material, IMaterialProperty<?> property,
+    private static void processPipeLarge(TagPrefix pipePrefix, Material material, IMaterialProperty property,
                                          Consumer<FinishedRecipe> provider) {
         if (material.hasProperty(PropertyKey.WOOD)) return;
         ItemStack pipeStack = ChemicalHelper.get(pipePrefix, material);
@@ -185,7 +185,7 @@ public class PipeRecipeHandler {
         }
     }
 
-    private static void processPipeHuge(TagPrefix pipePrefix, Material material, IMaterialProperty<?> property,
+    private static void processPipeHuge(TagPrefix pipePrefix, Material material, IMaterialProperty property,
                                         Consumer<FinishedRecipe> provider) {
         if (material.hasProperty(PropertyKey.WOOD)) return;
         ItemStack pipeStack = ChemicalHelper.get(pipePrefix, material);


### PR DESCRIPTION
For some reason, `IMaterialProperty` has a generic property. The only use seems to recursively store…itself? I dunno. `T` wasn't even used at all in the interface.