### PR TITLE
Add ability for Quantum Storages to hold more than INT_MAX

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/TankWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/TankWidget.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.gui.widget;
 
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.fluids.GTFluid;
 import com.gregtechceu.gtceu.api.transfer.fluid.CycleFluidHandler;
 import com.gregtechceu.gtceu.api.transfer.fluid.TagOrCycleFluidHandler;
@@ -376,14 +377,14 @@ public class TankWidget extends Widget implements IRecipeIngredientSlot, IConfig
         var stack = currentJEIRenderedIngredient != null ? currentJEIRenderedIngredient : lastFluidInTank;
         if (stack != null && !stack.isEmpty()) {
             tooltips.add(stack.getDisplayName());
-            if (!isPhantom) {
+            if (!isPhantom && showAmount) {
                 tooltips.add(
                         Component.translatable("ldlib.fluid.amount", stack.getAmount(), lastTankCapacity)
                                 .append(" mB"));
             }
-            if (stack.getFluid() instanceof GTFluid gtFluid)
-                TooltipsHandler.appendFluidTooltips(gtFluid, stack.getAmount(), tooltips::add, null);
-            else {
+            if(ChemicalHelper.getMaterial(stack.getFluid()) != null) {
+                TooltipsHandler.appendFluidTooltips(stack.getFluid(), stack.getAmount(), tooltips::add, null);
+            } else {
                 tooltips.add(Component.translatable("ldlib.fluid.temperature",
                         stack.getFluid().getFluidType().getTemperature(stack)));
                 tooltips.add(Component.translatable(stack.getFluid().getFluidType().isLighterThanAir() ?
@@ -391,7 +392,7 @@ public class TankWidget extends Widget implements IRecipeIngredientSlot, IConfig
             }
         } else {
             tooltips.add(Component.translatable("ldlib.fluid.empty"));
-            if (!isPhantom) {
+            if (!isPhantom && showAmount) {
                 tooltips.add(Component.translatable("ldlib.fluid.amount", 0, lastTankCapacity).append(" mB"));
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/TankWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/TankWidget.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.api.gui.widget;
 
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
-import com.gregtechceu.gtceu.api.fluids.GTFluid;
 import com.gregtechceu.gtceu.api.transfer.fluid.CycleFluidHandler;
 import com.gregtechceu.gtceu.api.transfer.fluid.TagOrCycleFluidHandler;
 import com.gregtechceu.gtceu.client.TooltipsHandler;
@@ -382,7 +381,7 @@ public class TankWidget extends Widget implements IRecipeIngredientSlot, IConfig
                         Component.translatable("ldlib.fluid.amount", stack.getAmount(), lastTankCapacity)
                                 .append(" mB"));
             }
-            if(ChemicalHelper.getMaterial(stack.getFluid()) != null) {
+            if (ChemicalHelper.getMaterial(stack.getFluid()) != null) {
                 TooltipsHandler.appendFluidTooltips(stack.getFluid(), stack.getAmount(), tooltips::add, null);
             } else {
                 tooltips.add(Component.translatable("ldlib.fluid.temperature",

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -136,22 +136,14 @@ public class Content {
             graphics.pose().pushPose();
             graphics.pose().translate(0, 0, 400);
             graphics.pose().scale(0.5f, 0.5f, 1);
-            double amount = ingredient.getAmount();
-            String s;
-            if (amount >= 1_000_000_000) {
-                amount /= 1_000_000_000;
-                s = FormattingUtil.DECIMAL_FORMAT_1F.format((float) amount) + "MB";
-            } else if (amount >= 1_000_000) {
-                amount /= 1_000_000;
-                s = FormattingUtil.DECIMAL_FORMAT_1F.format((float) amount) + "KB";
-            } else if (amount >= 1000) {
-                amount /= 1000;
-                s = FormattingUtil.DECIMAL_FORMAT_1F.format((float) amount) + "B";
-            } else {
-                s = (int) amount + "mB";
-            }
+            int amount = ingredient.getAmount();
             Font fontRenderer = Minecraft.getInstance().font;
-            graphics.drawString(fontRenderer, s, (int) ((x + (width / 3f)) * 2 - fontRenderer.width(s) + 21),
+            String s = FormattingUtil.formatBuckets(amount);
+            if (fontRenderer.width(s) > 32)
+                s = FormattingUtil.formatNumberReadable(amount, true, FormattingUtil.DECIMAL_FORMAT_1F, "B");
+            if (fontRenderer.width(s) > 32)
+                s = FormattingUtil.formatNumberReadable(amount, true, FormattingUtil.DECIMAL_FORMAT_0F, "B");
+            graphics.drawString(fontRenderer, s, (int) ((x + (width / 3f)) * 2 - fontRenderer.width(s) + 22),
                     (int) ((y + (height / 3f) + 6) * 2), 0xFFFFFF, true);
             graphics.pose().popPose();
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/transfer/fluid/CustomFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/transfer/fluid/CustomFluidTank.java
@@ -46,7 +46,12 @@ public class CustomFluidTank extends FluidTank
 
     @Override
     public void setFluidInTank(int tank, FluidStack stack) {
-        this.setFluid(stack);
+        setFluid(stack);
+    }
+
+    @Override
+    public void setFluid(FluidStack stack) {
+        super.setFluid(stack);
         this.onContentsChanged();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumChestRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumChestRenderer.java
@@ -66,7 +66,7 @@ public class QuantumChestRenderer extends TieredHullMachineRenderer {
             poseStack.translate(-0.5D, -0.5D, -0.5D);
 
             ItemStack itemStack = ItemStack.of(stack.getOrCreateTagElement("stored"));
-            int storedAmount = stack.getOrCreateTag().getInt("storedAmount");
+            long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
             float tick = Minecraft.getInstance().level.getGameTime() + Minecraft.getInstance().getFrameTime();
             // Don't need to handle locked items here since they don't get saved to the item
             renderChest(poseStack, buffer, Direction.NORTH, itemStack, storedAmount, tick, ItemStack.EMPTY,
@@ -93,7 +93,7 @@ public class QuantumChestRenderer extends TieredHullMachineRenderer {
 
     @OnlyIn(Dist.CLIENT)
     public void renderChest(PoseStack poseStack, MultiBufferSource buffer, Direction frontFacing, ItemStack stored,
-                            int storedAmount,
+                            long storedAmount,
                             float tick, ItemStack locked, boolean isCreative) {
         ItemStack itemStack = !stored.isEmpty() ? stored : locked;
         if (itemStack.isEmpty()) return;

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumChestRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumChestRenderer.java
@@ -6,11 +6,11 @@ import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.common.machine.storage.CreativeChestMachine;
 import com.gregtechceu.gtceu.common.machine.storage.QuantumChestMachine;
 import com.gregtechceu.gtceu.core.mixins.GuiGraphicsAccessor;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import com.lowdragmc.lowdraglib.client.utils.RenderUtils;
 import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
 import com.lowdragmc.lowdraglib.gui.texture.TransformTexture;
-import com.lowdragmc.lowdraglib.gui.util.TextFormattingUtil;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -127,7 +127,7 @@ public class QuantumChestRenderer extends TieredHullMachineRenderer {
         if (isCreative) {
             text = new TextTexture("∞").setDropShadow(false).scale(3.0f);
         } else {
-            var amount = stored.isEmpty() ? "*" : TextFormattingUtil.formatLongToCompactString(storedAmount, 4);
+            var amount = stored.isEmpty() ? "*" : FormattingUtil.formatNumberReadable(storedAmount, false);
             text = new TextTexture(amount).setDropShadow(false);
         }
         text.draw(GuiGraphicsAccessor.create(Minecraft.getInstance(), poseStack,

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumChestRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumChestRenderer.java
@@ -87,7 +87,7 @@ public class QuantumChestRenderer extends TieredHullMachineRenderer {
             var frontFacing = machine.getFrontFacing();
             float tick = level.getGameTime() + partialTicks;
             renderChest(poseStack, buffer, frontFacing, machine.getStored(), machine.getStoredAmount(), tick,
-                    machine.getLockedItem().getStackInSlot(0), machine instanceof CreativeChestMachine);
+                    machine.getLockedItem(), machine instanceof CreativeChestMachine);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
@@ -67,9 +67,11 @@ public class QuantumTankRenderer extends TieredHullMachineRenderer {
             model.getTransforms().getTransform(transformType).apply(leftHand, poseStack);
             poseStack.translate(-0.5D, -0.5D, -0.5D);
 
-            FluidStack tank = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
+            FluidStack stored = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
+            long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
+            if(storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
             // Don't need to handle locked fluids here since they don't get saved to the item
-            renderTank(poseStack, buffer, Direction.NORTH, tank, FluidStack.EMPTY, stack.is(CREATIVE_FLUID_ITEM));
+            renderTank(poseStack, buffer, Direction.NORTH, stored, storedAmount, FluidStack.EMPTY, stack.is(CREATIVE_FLUID_ITEM));
 
             poseStack.popPose();
         }
@@ -82,14 +84,14 @@ public class QuantumTankRenderer extends TieredHullMachineRenderer {
                        int combinedLight, int combinedOverlay) {
         if (blockEntity instanceof IMachineBlockEntity machineBlockEntity &&
                 machineBlockEntity.getMetaMachine() instanceof QuantumTankMachine machine) {
-            renderTank(poseStack, buffer, machine.getFrontFacing(), machine.getStored(),
-                    machine.getCache().getLockedFluid().getFluid(), machine instanceof CreativeTankMachine);
+            renderTank(poseStack, buffer, machine.getFrontFacing(), machine.getStored(), machine.getStoredAmount(),
+                    machine.getLockedFluid(), machine instanceof CreativeTankMachine);
         }
     }
 
     @OnlyIn(Dist.CLIENT)
     public void renderTank(PoseStack poseStack, MultiBufferSource buffer, Direction frontFacing, FluidStack stored,
-                           FluidStack locked, boolean isCreative) {
+                           long storedAmount, FluidStack locked, boolean isCreative) {
         FluidStack fluid = !stored.isEmpty() ? stored : locked;
         if (fluid.isEmpty()) return;
 
@@ -121,7 +123,7 @@ public class QuantumTankRenderer extends TieredHullMachineRenderer {
             text = new TextTexture("∞").setDropShadow(false).scale(3.0f);
         } else {
             var amount = stored.isEmpty() ? "*" :
-                    TextFormattingUtil.formatLongToCompactString(fluid.getAmount(), 4);
+                    TextFormattingUtil.formatLongToCompactStringBuckets(storedAmount, 4);
             text = new TextTexture(amount).setDropShadow(false);
         }
         text.draw(GuiGraphicsAccessor.create(Minecraft.getInstance(), poseStack,

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
@@ -69,9 +69,10 @@ public class QuantumTankRenderer extends TieredHullMachineRenderer {
 
             FluidStack stored = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
             long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
-            if(storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
+            if (storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
             // Don't need to handle locked fluids here since they don't get saved to the item
-            renderTank(poseStack, buffer, Direction.NORTH, stored, storedAmount, FluidStack.EMPTY, stack.is(CREATIVE_FLUID_ITEM));
+            renderTank(poseStack, buffer, Direction.NORTH, stored, storedAmount, FluidStack.EMPTY,
+                    stack.is(CREATIVE_FLUID_ITEM));
 
             poseStack.popPose();
         }

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/QuantumTankRenderer.java
@@ -6,12 +6,12 @@ import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.common.machine.storage.CreativeTankMachine;
 import com.gregtechceu.gtceu.common.machine.storage.QuantumTankMachine;
 import com.gregtechceu.gtceu.core.mixins.GuiGraphicsAccessor;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import com.lowdragmc.lowdraglib.client.utils.RenderBufferUtils;
 import com.lowdragmc.lowdraglib.client.utils.RenderUtils;
 import com.lowdragmc.lowdraglib.gui.texture.TextTexture;
 import com.lowdragmc.lowdraglib.gui.texture.TransformTexture;
-import com.lowdragmc.lowdraglib.gui.util.TextFormattingUtil;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -123,8 +123,7 @@ public class QuantumTankRenderer extends TieredHullMachineRenderer {
         if (isCreative) {
             text = new TextTexture("∞").setDropShadow(false).scale(3.0f);
         } else {
-            var amount = stored.isEmpty() ? "*" :
-                    TextFormattingUtil.formatLongToCompactStringBuckets(storedAmount, 4);
+            var amount = stored.isEmpty() ? "*" : FormattingUtil.formatNumberReadable(storedAmount, true);
             text = new TextTexture(amount).setDropShadow(false);
         }
         text.draw(GuiGraphicsAccessor.create(Minecraft.getInstance(), poseStack,

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -585,22 +585,23 @@ public class GTMachines {
                     .register(),
             LV, MV, HV);
 
-    public static final Component CREATIVE_TOOLTIPS = Component.translatable("gtceu.creative_tooltip.1")
-            .append(Component.translatable("gtceu.creative_tooltip.2")
-                    .withStyle(style -> style.withColor(TooltipHelper.RAINBOW_SLOW.getCurrent())))
-            .append(Component.translatable("gtceu.creative_tooltip.3"));
+    public static final BiConsumer<ItemStack, List<Component>> CREATIVE_TOOLTIPS = (stack, list) -> list.add(1,
+            Component.translatable("gtceu.creative_tooltip.1")
+                    .append(Component.translatable("gtceu.creative_tooltip.2")
+                            .withStyle(style -> style.withColor(TooltipHelper.RAINBOW_SLOW.getCurrent())))
+                    .append(Component.translatable("gtceu.creative_tooltip.3")));
 
     public static final MachineDefinition CREATIVE_ENERGY = REGISTRATE
             .machine("creative_energy", CreativeEnergyContainerMachine::new)
             .rotationState(RotationState.NONE)
-            .tooltips(CREATIVE_TOOLTIPS)
+            .tooltipBuilder(CREATIVE_TOOLTIPS)
             .compassNodeSelf()
             .register();
 
     public static final MachineDefinition CREATIVE_COMPUTATION_PROVIDER = REGISTRATE
             .machine("creative_computation_provider", CreativeComputationProviderMachine::new)
             .rotationState(RotationState.NONE)
-            .tooltips(CREATIVE_TOOLTIPS)
+            .tooltipBuilder(CREATIVE_TOOLTIPS)
             .compassNodeSelf()
             .register();
 
@@ -608,6 +609,7 @@ public class GTMachines {
             .machine("creative_tank", CreativeTankMachine::new)
             .rotationState(RotationState.ALL)
             .tooltipBuilder((stack, list) -> {
+                CREATIVE_TOOLTIPS.accept(stack, list);
                 if (stack.hasTag()) {
                     FluidStack f = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
                     int perCycle = stack.getOrCreateTag().getInt("mBPerCycle");
@@ -615,7 +617,6 @@ public class GTMachines {
                             FormattingUtil.formatNumbers(perCycle)));
                 }
             })
-            .tooltips(CREATIVE_TOOLTIPS)
             .renderer(() -> new QuantumTankRenderer(MAX, GTCEu.id("block/machine/creative_tank")))
             .hasTESR(true)
             .compassNodeSelf()
@@ -624,6 +625,7 @@ public class GTMachines {
             .machine("creative_chest", CreativeChestMachine::new)
             .rotationState(RotationState.ALL)
             .tooltipBuilder((stack, list) -> {
+                CREATIVE_TOOLTIPS.accept(stack, list);
                 if (stack.hasTag()) {
                     ItemStack i = ItemStack.of(stack.getOrCreateTagElement("stored"));
                     int perCycle = stack.getOrCreateTag().getInt("itemsPerCycle");
@@ -631,7 +633,6 @@ public class GTMachines {
                             FormattingUtil.formatNumbers(perCycle)));
                 }
             })
-            .tooltips(CREATIVE_TOOLTIPS)
             .renderer(() -> new QuantumChestRenderer(MAX, GTCEu.id("block/machine/creative_chest")))
             .hasTESR(true)
             .compassNodeSelf()
@@ -681,7 +682,8 @@ public class GTMachines {
 
     public static BiConsumer<ItemStack, List<Component>> TANK_TOOLTIPS = (stack, list) -> {
         if (stack.hasTag()) {
-            FluidStack stored = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
+            String key = stack.getTag().contains("stored") ? "stored" : "Fluid";
+            FluidStack stored = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement(key));
             long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
             if (storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
             list.add(1, Component.translatable("gtceu.universal.tooltip.fluid_stored", stored.getDisplayName(),
@@ -2743,7 +2745,7 @@ public class GTMachines {
                     TANK_TOOLTIPS.accept(stack, list);
                     if (material.hasProperty(PropertyKey.FLUID_PIPE)) {
                         FluidPipeProperties pipeprops = material.getProperty(PropertyKey.FLUID_PIPE);
-                        pipeprops.appendTooltips(list, true, true);
+                        pipeprops.appendTooltips(list, false, true);
                     }
                 })
                 .tooltips(Component.translatable("gtceu.machine.quantum_tank.tooltip"),

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -604,14 +604,18 @@ public class GTMachines {
             .compassNodeSelf()
             .register();
 
-    public static final MachineDefinition CREATIVE_FLUID = REGISTRATE.machine("creative_tank", CreativeTankMachine::new)
+    public static final MachineDefinition CREATIVE_FLUID = REGISTRATE
+            .machine("creative_tank", CreativeTankMachine::new)
             .rotationState(RotationState.ALL)
-            .tooltips(CREATIVE_TOOLTIPS)
             .tooltipBuilder((stack, list) -> {
                 if (stack.hasTag()) {
-                    ItemStack itemStack = ItemStack.of(stack.getOrCreateTagElement("stored"));
+                    FluidStack f = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
+                    int perCycle = stack.getOrCreateTag().getInt("mBPerCycle");
+                    list.add(1, Component.translatable("gtceu.universal.tooltip.fluid_stored", f.getDisplayName(),
+                            FormattingUtil.formatNumbers(perCycle)));
                 }
             })
+            .tooltips(CREATIVE_TOOLTIPS)
             .renderer(() -> new QuantumTankRenderer(MAX, GTCEu.id("block/machine/creative_tank")))
             .hasTESR(true)
             .compassNodeSelf()
@@ -619,6 +623,14 @@ public class GTMachines {
     public static final MachineDefinition CREATIVE_ITEM = REGISTRATE
             .machine("creative_chest", CreativeChestMachine::new)
             .rotationState(RotationState.ALL)
+            .tooltipBuilder((stack, list) -> {
+                if (stack.hasTag()) {
+                    ItemStack i = ItemStack.of(stack.getOrCreateTagElement("stored"));
+                    int perCycle = stack.getOrCreateTag().getInt("itemsPerCycle");
+                    list.add(1, Component.translatable("gtceu.universal.tooltip.item_stored", i.getHoverName(),
+                            FormattingUtil.formatNumbers(perCycle)));
+                }
+            })
             .tooltips(CREATIVE_TOOLTIPS)
             .renderer(() -> new QuantumChestRenderer(MAX, GTCEu.id("block/machine/creative_chest")))
             .hasTESR(true)
@@ -666,25 +678,6 @@ public class GTMachines {
                     .compassNode("super_chest")
                     .register(),
             HIGH_TIERS);
-
-    public static BiConsumer<ItemStack, List<Component>> createTankTooltips(String nbtName,
-                                                                            @Nullable Material material) {
-        return (stack, list) -> {
-            if (stack.hasTag()) {
-                FluidStack tank = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement(nbtName));
-                list.add(1, Component.translatable("gtceu.universal.tooltip.fluid_stored", tank.getDisplayName(),
-                        FormattingUtil.formatNumbers(tank.getAmount())));
-            }
-
-            var item = stack.getItem();
-            if (item instanceof DrumMachineItem drumItem && material != null) {
-                if (material.hasProperty(PropertyKey.FLUID_PIPE)) {
-                    FluidPipeProperties pipeprops = material.getProperty(PropertyKey.FLUID_PIPE);
-                    pipeprops.appendTooltips(list, true, true);
-                }
-            }
-        };
-    }
 
     public static BiConsumer<ItemStack, List<Component>> TANK_TOOLTIPS = (stack, list) -> {
         if (stack.hasTag()) {
@@ -2746,7 +2739,13 @@ public class GTMachines {
                 .rotationState(RotationState.NONE)
                 .renderer(
                         () -> new MachineRenderer(GTCEu.id("block/machine/" + (wooden ? "wooden" : "metal") + "_drum")))
-                .tooltipBuilder(createTankTooltips("Fluid", material))
+                .tooltipBuilder((stack, list) -> {
+                    TANK_TOOLTIPS.accept(stack, list);
+                    if (material.hasProperty(PropertyKey.FLUID_PIPE)) {
+                        FluidPipeProperties pipeprops = material.getProperty(PropertyKey.FLUID_PIPE);
+                        pipeprops.appendTooltips(list, true, true);
+                    }
+                })
                 .tooltips(Component.translatable("gtceu.machine.quantum_tank.tooltip"),
                         Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity",
                                 FormattingUtil.formatNumbers(capacity)))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -631,17 +631,16 @@ public class GTMachines {
     public static BiConsumer<ItemStack, List<Component>> CHEST_TOOLTIPS = (stack, list) -> {
         if (stack.hasTag()) {
             ItemStack itemStack = ItemStack.of(stack.getOrCreateTagElement("stored"));
-            int storedAmount = stack.getOrCreateTag().getInt("storedAmount");
+            long storedAmount = stack.getOrCreateTag().getInt("storedAmount");
             list.add(1, Component.translatable("gtceu.universal.tooltip.item_stored", itemStack.getHoverName(),
                     FormattingUtil.formatNumbers(storedAmount)));
         }
     };
 
     public static final MachineDefinition[] SUPER_CHEST = registerTieredMachines("super_chest",
-            (holder, tier) -> new QuantumChestMachine(holder, tier,
-                    (int) Math.min(4000000L * (long) Math.pow(2, tier - 1), Integer.MAX_VALUE)),
+            (holder, tier) -> new QuantumChestMachine(holder, tier, 4_000_000 * (long) Math.pow(2, tier - 1)),
             (tier, builder) -> builder
-                    .langValue("Super Chest " + LVT[tier + 1 - LOW_TIERS[0]])
+                    .langValue("Super Chest " + LVT[tier])
                     .blockProp(BlockBehaviour.Properties::dynamicShape)
                     .rotationState(RotationState.ALL)
                     .renderer(() -> new QuantumChestRenderer(tier))
@@ -649,26 +648,23 @@ public class GTMachines {
                     .tooltipBuilder(CHEST_TOOLTIPS)
                     .tooltips(Component.translatable("gtceu.machine.quantum_chest.tooltip"),
                             Component.translatable("gtceu.universal.tooltip.item_storage_total",
-                                    FormattingUtil.formatNumbers(4000000L * (long) Math.pow(2, tier - 1))))
+                                    FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
                     .compassNode("super_chest")
                     .register(),
             LOW_TIERS);
 
     public static final MachineDefinition[] QUANTUM_CHEST = registerTieredMachines("quantum_chest",
             (holder, tier) -> new QuantumChestMachine(holder, tier,
-                    tier == GTValues.UHV ? Integer.MAX_VALUE :
-                            (int) Math.min(4000000L * (long) Math.pow(2, tier - 1), Integer.MAX_VALUE)),
+                    tier == MAX ? Long.MAX_VALUE : 4_000_000 * (long) Math.pow(2, tier - 1)),
             (tier, builder) -> builder
-                    .langValue("Quantum Chest " + LVT[tier + 1 - LOW_TIERS[0]])
+                    .langValue("Quantum Chest " + LVT[tier])
                     .blockProp(BlockBehaviour.Properties::dynamicShape)
                     .rotationState(RotationState.ALL)
                     .renderer(() -> new QuantumChestRenderer(tier))
                     .hasTESR(true)
                     .tooltipBuilder(CHEST_TOOLTIPS)
                     .tooltips(Component.translatable("gtceu.machine.quantum_chest.tooltip"),
-                            Component.translatable("gtceu.universal.tooltip.item_storage_total",
-                                    /* tier == GTValues.UHV ? Integer.MAX_VALUE : */ FormattingUtil
-                                            .formatNumbers(4000000L * (long) Math.pow(2, tier - 1))))
+                            Component.translatable("gtceu.universal.tooltip.item_storage_total", FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
                     .compassNode("super_chest")
                     .register(),
             HIGH_TIERS);
@@ -692,38 +688,43 @@ public class GTMachines {
         };
     }
 
+    public static BiConsumer<ItemStack, List<Component>> TANK_TOOLTIPS = (stack, list) -> {
+        if (stack.hasTag()) {
+            FluidStack stored = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
+            long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
+            if(storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
+            list.add(1, Component.translatable("gtceu.universal.tooltip.fluid_stored", stored.getDisplayName(),
+                    FormattingUtil.formatNumbers(storedAmount)));
+        }
+    };
+
     public static final MachineDefinition[] SUPER_TANK = registerTieredMachines("super_tank",
-            (holder, tier) -> new QuantumTankMachine(holder, tier,
-                    4000 * FluidType.BUCKET_VOLUME * (int) Math.pow(2, tier - 1)),
+            (holder, tier) -> new QuantumTankMachine(holder, tier, 4000 * FluidType.BUCKET_VOLUME * (long) Math.pow(2, tier - 1)),
             (tier, builder) -> builder
-                    .langValue("Super Tank " + LVT[tier + 1 - LOW_TIERS[0]])
+                    .langValue("Super Tank " + LVT[tier])
                     .blockProp(BlockBehaviour.Properties::dynamicShape)
                     .rotationState(RotationState.ALL)
                     .renderer(() -> new QuantumTankRenderer(tier))
                     .hasTESR(true)
-                    .tooltipBuilder(createTankTooltips("stored", null))
+                    .tooltipBuilder(TANK_TOOLTIPS)
                     .tooltips(Component.translatable("gtceu.machine.quantum_tank.tooltip"),
                             Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity",
-                                    FormattingUtil.formatNumbers(4000000L * (long) Math.pow(2, tier - 1))))
+                                    FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
                     .compassNode("super_tank")
                     .register(),
             LOW_TIERS);
 
     public static final MachineDefinition[] QUANTUM_TANK = registerTieredMachines("quantum_tank",
-            (holder, tier) -> new QuantumTankMachine(holder, tier,
-                    tier == GTValues.UHV ? Integer.MAX_VALUE :
-                            4000 * FluidType.BUCKET_VOLUME * (int) Math.pow(2, tier - 1)),
+            (holder, tier) -> new QuantumTankMachine(holder, tier, 4000 * FluidType.BUCKET_VOLUME * (long) Math.pow(2, tier - 1)),
             (tier, builder) -> builder
-                    .langValue("Quantum Tank " + LVT[tier + 1 - LOW_TIERS[0]])
+                    .langValue("Quantum Tank " + LVT[tier])
                     .blockProp(BlockBehaviour.Properties::dynamicShape)
                     .rotationState(RotationState.ALL)
                     .renderer(() -> new QuantumTankRenderer(tier))
                     .hasTESR(true)
-                    .tooltipBuilder(createTankTooltips("stored", null))
+                    .tooltipBuilder(TANK_TOOLTIPS)
                     .tooltips(Component.translatable("gtceu.machine.quantum_tank.tooltip"),
-                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity",
-                                    /* tier == GTValues.UHV ? Integer.MAX_VALUE : */ FormattingUtil
-                                            .formatNumbers(4000000L * (long) Math.pow(2, tier - 1))))
+                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity", FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
                     .compassNode("super_tank")
                     .register(),
             HIGH_TIERS);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -585,36 +585,33 @@ public class GTMachines {
                     .register(),
             LV, MV, HV);
 
-    public static final BiConsumer<ItemStack, List<Component>> CREATIVE_TOOLTIPS = (stack, components) -> components
-            .add(Component.translatable("gtceu.creative_tooltip.1")
-                    .append(Component.translatable("gtceu.creative_tooltip.2")
-                            .withStyle(style -> style.withColor(TooltipHelper.RAINBOW_SLOW.getCurrent())))
-                    .append(Component.translatable("gtceu.creative_tooltip.3")));
-
-    public static BiConsumer<ItemStack, List<Component>> createCreativeTooltips(boolean share) {
-        return (stack, list) -> {
-            CREATIVE_TOOLTIPS.accept(stack, list);
-            list.add(Component.translatable("gtceu.universal.%s".formatted(share ? "enabled" : "disabled")));
-        };
-    }
+    public static final Component CREATIVE_TOOLTIPS = Component.translatable("gtceu.creative_tooltip.1")
+            .append(Component.translatable("gtceu.creative_tooltip.2")
+                    .withStyle(style -> style.withColor(TooltipHelper.RAINBOW_SLOW.getCurrent())))
+            .append(Component.translatable("gtceu.creative_tooltip.3"));
 
     public static final MachineDefinition CREATIVE_ENERGY = REGISTRATE
             .machine("creative_energy", CreativeEnergyContainerMachine::new)
             .rotationState(RotationState.NONE)
-            .tooltipBuilder(CREATIVE_TOOLTIPS)
+            .tooltips(CREATIVE_TOOLTIPS)
             .compassNodeSelf()
             .register();
 
     public static final MachineDefinition CREATIVE_COMPUTATION_PROVIDER = REGISTRATE
             .machine("creative_computation_provider", CreativeComputationProviderMachine::new)
             .rotationState(RotationState.NONE)
-            .tooltipBuilder(CREATIVE_TOOLTIPS)
+            .tooltips(CREATIVE_TOOLTIPS)
             .compassNodeSelf()
             .register();
 
     public static final MachineDefinition CREATIVE_FLUID = REGISTRATE.machine("creative_tank", CreativeTankMachine::new)
             .rotationState(RotationState.ALL)
-            .tooltipBuilder(CREATIVE_TOOLTIPS)
+            .tooltips(CREATIVE_TOOLTIPS)
+            .tooltipBuilder((stack, list) -> {
+                if (stack.hasTag()) {
+                    ItemStack itemStack = ItemStack.of(stack.getOrCreateTagElement("stored"));
+                }
+            })
             .renderer(() -> new QuantumTankRenderer(MAX, GTCEu.id("block/machine/creative_tank")))
             .hasTESR(true)
             .compassNodeSelf()
@@ -622,7 +619,7 @@ public class GTMachines {
     public static final MachineDefinition CREATIVE_ITEM = REGISTRATE
             .machine("creative_chest", CreativeChestMachine::new)
             .rotationState(RotationState.ALL)
-            .tooltipBuilder(CREATIVE_TOOLTIPS)
+            .tooltips(CREATIVE_TOOLTIPS)
             .renderer(() -> new QuantumChestRenderer(MAX, GTCEu.id("block/machine/creative_chest")))
             .hasTESR(true)
             .compassNodeSelf()
@@ -631,7 +628,7 @@ public class GTMachines {
     public static BiConsumer<ItemStack, List<Component>> CHEST_TOOLTIPS = (stack, list) -> {
         if (stack.hasTag()) {
             ItemStack itemStack = ItemStack.of(stack.getOrCreateTagElement("stored"));
-            long storedAmount = stack.getOrCreateTag().getInt("storedAmount");
+            long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
             list.add(1, Component.translatable("gtceu.universal.tooltip.item_stored", itemStack.getHoverName(),
                     FormattingUtil.formatNumbers(storedAmount)));
         }
@@ -664,7 +661,8 @@ public class GTMachines {
                     .hasTESR(true)
                     .tooltipBuilder(CHEST_TOOLTIPS)
                     .tooltips(Component.translatable("gtceu.machine.quantum_chest.tooltip"),
-                            Component.translatable("gtceu.universal.tooltip.item_storage_total", FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
+                            Component.translatable("gtceu.universal.tooltip.item_storage_total",
+                                    FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
                     .compassNode("super_chest")
                     .register(),
             HIGH_TIERS);
@@ -692,14 +690,15 @@ public class GTMachines {
         if (stack.hasTag()) {
             FluidStack stored = FluidStack.loadFluidStackFromNBT(stack.getOrCreateTagElement("stored"));
             long storedAmount = stack.getOrCreateTag().getLong("storedAmount");
-            if(storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
+            if (storedAmount == 0 && !stored.isEmpty()) storedAmount = stored.getAmount();
             list.add(1, Component.translatable("gtceu.universal.tooltip.fluid_stored", stored.getDisplayName(),
                     FormattingUtil.formatNumbers(storedAmount)));
         }
     };
 
     public static final MachineDefinition[] SUPER_TANK = registerTieredMachines("super_tank",
-            (holder, tier) -> new QuantumTankMachine(holder, tier, 4000 * FluidType.BUCKET_VOLUME * (long) Math.pow(2, tier - 1)),
+            (holder, tier) -> new QuantumTankMachine(holder, tier,
+                    4000 * FluidType.BUCKET_VOLUME * (long) Math.pow(2, tier - 1)),
             (tier, builder) -> builder
                     .langValue("Super Tank " + LVT[tier])
                     .blockProp(BlockBehaviour.Properties::dynamicShape)
@@ -715,7 +714,8 @@ public class GTMachines {
             LOW_TIERS);
 
     public static final MachineDefinition[] QUANTUM_TANK = registerTieredMachines("quantum_tank",
-            (holder, tier) -> new QuantumTankMachine(holder, tier, 4000 * FluidType.BUCKET_VOLUME * (long) Math.pow(2, tier - 1)),
+            (holder, tier) -> new QuantumTankMachine(holder, tier,
+                    4000 * FluidType.BUCKET_VOLUME * (long) Math.pow(2, tier - 1)),
             (tier, builder) -> builder
                     .langValue("Quantum Tank " + LVT[tier])
                     .blockProp(BlockBehaviour.Properties::dynamicShape)
@@ -724,7 +724,8 @@ public class GTMachines {
                     .hasTESR(true)
                     .tooltipBuilder(TANK_TOOLTIPS)
                     .tooltips(Component.translatable("gtceu.machine.quantum_tank.tooltip"),
-                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity", FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
+                            Component.translatable("gtceu.universal.tooltip.fluid_storage_capacity",
+                                    FormattingUtil.formatNumbers(4_000_000 * (long) Math.pow(2, tier - 1))))
                     .compassNode("super_tank")
                     .register(),
             HIGH_TIERS);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -672,7 +672,7 @@ public class GTRecipeTypes {
             .setSound(GTSoundEntries.ARC)
             .setOffsetVoltageText(true)
             .addDataInfo(data -> LocalizationUtils.format("gtceu.recipe.eu_to_start",
-                    FormattingUtil.formatCompactNumbers(data.getLong("eu_to_start")),
+                    FormattingUtil.formatNumberReadable2F(data.getLong("eu_to_start"), false),
                     FusionReactorMachine.getFusionTier(data.getLong("eu_to_start"))));
 
     public static final GTRecipeType DUMMY_RECIPES = register("dummy", DUMMY)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTResearchMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTResearchMachines.java
@@ -49,7 +49,7 @@ import java.util.function.Function;
 import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.api.pattern.Predicates.*;
 import static com.gregtechceu.gtceu.common.data.GTBlocks.*;
-import static com.gregtechceu.gtceu.common.data.GTMachines.createCreativeTooltips;
+import static com.gregtechceu.gtceu.common.data.GTMachines.CREATIVE_TOOLTIPS;
 import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
 
 @SuppressWarnings("unused")
@@ -352,8 +352,9 @@ public class GTResearchMachines {
             .tier(MAX)
             .rotationState(RotationState.ALL)
             .abilities(PartAbility.DATA_ACCESS)
-            .tooltips(Component.translatable("gtceu.machine.data_access_hatch.tooltip.0"))
-            .tooltipBuilder(createCreativeTooltips(true))
+            .tooltips(Component.translatable("gtceu.machine.data_access_hatch.tooltip.0"),
+                    CREATIVE_TOOLTIPS,
+                    Component.translatable("gtceu.universal.enabled"))
             .overlayTieredHullRenderer("data_access_hatch_creative")
             .register();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTResearchMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTResearchMachines.java
@@ -352,9 +352,11 @@ public class GTResearchMachines {
             .tier(MAX)
             .rotationState(RotationState.ALL)
             .abilities(PartAbility.DATA_ACCESS)
-            .tooltips(Component.translatable("gtceu.machine.data_access_hatch.tooltip.0"),
-                    CREATIVE_TOOLTIPS,
-                    Component.translatable("gtceu.universal.enabled"))
+            .tooltipBuilder((s, list) -> {
+                CREATIVE_TOOLTIPS.accept(s, list);
+                list.add(1, Component.translatable("gtceu.machine.data_access_hatch.tooltip.0"));
+            })
+            .tooltips(Component.translatable("gtceu.universal.enabled"))
             .overlayTieredHullRenderer("data_access_hatch_creative")
             .register();
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
@@ -150,7 +150,7 @@ public class CreativeChestMachine extends QuantumChestMachine {
 
         @Override
         public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-            if (!stored.isEmpty()) return ItemStack.EMPTY;
+            if (!stored.isEmpty() && ItemStack.isSameItemSameTags(stored, stack)) return ItemStack.EMPTY;
             return stack;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
@@ -14,6 +14,7 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.DropSaved;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
+import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -27,6 +28,10 @@ import net.minecraftforge.items.ItemHandlerHelper;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class CreativeChestMachine extends QuantumChestMachine {
 
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(CreativeChestMachine.class,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.items.ItemHandlerHelper;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 public class CreativeChestMachine extends QuantumChestMachine {
@@ -31,9 +32,11 @@ public class CreativeChestMachine extends QuantumChestMachine {
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(CreativeChestMachine.class,
             QuantumChestMachine.MANAGED_FIELD_HOLDER);
 
+    @Getter
     @Persisted
     @DropSaved
     private int itemsPerCycle = 1;
+    @Getter
     @Persisted
     @DropSaved
     private int ticksPerCycle = 1;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
@@ -1,13 +1,10 @@
 package com.gregtechceu.gtceu.common.machine.storage;
 
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.widget.PhantomSlotWidget;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
-import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceBorderTexture;
@@ -46,36 +43,35 @@ public class CreativeChestMachine extends QuantumChestMachine {
     }
 
     @Override
-    protected NotifiableItemStackHandler createCacheItemHandler(Object... args) {
-        return new InfiniteStackHandler(this);
+    protected ItemCache createCacheItemHandler(Object... args) {
+        return new InfiniteCache(this);
     }
 
     protected void checkAutoOutput() {
         if (getOffsetTimer() % ticksPerCycle == 0) {
             if (isAutoOutputItems() && getOutputFacingItems() != null) {
-                updateItemTick();
+                cache.exportToNearby(getOutputFacingItems());
             }
             updateAutoOutputSubscription();
         }
     }
 
-    public void updateItemTick() {
-        ItemStack stack = cache.getStackInSlot(0).copyWithCount(itemsPerCycle);
-        this.stored = stack; // For rendering purposes
-        if (ticksPerCycle == 0 || getOffsetTimer() % ticksPerCycle != 0) return;
-        if (getLevel().isClientSide || !isWorkingEnabled() || stack.isEmpty()) return;
-
-        GTTransferUtils.getAdjacentItemHandler(getLevel(), getPos(), getOutputFacingItems()).ifPresent(adj -> {
-            var remainder = ItemHandlerHelper.insertItemStacked(adj, stack, true);
-            if (remainder.getCount() < itemsPerCycle) {
-                ItemHandlerHelper.insertItemStacked(adj, stack, false);
-            }
-        });
+    private InteractionResult updateStored(ItemStack item) {
+        stored = item.copyWithCount(1);
+        onItemChanged();
+        return InteractionResult.SUCCESS;
     }
 
-    private void updateStored(ItemStack item) {
-        cache.setStackInSlot(0, item.copyWithCount(1));
-        stored = cache.getStackInSlot(0);
+    private void setTicksPerCycle(String value) {
+        if (value.isEmpty()) return;
+        ticksPerCycle = Integer.parseInt(value);
+        onItemChanged();
+    }
+
+    private void setItemsPerCycle(String value) {
+        if (value.isEmpty()) return;
+        itemsPerCycle = Integer.parseInt(value);
+        onItemChanged();
     }
 
     @Override
@@ -85,8 +81,7 @@ public class CreativeChestMachine extends QuantumChestMachine {
         if (hit.getDirection() == getFrontFacing() && !isRemote()) {
             // Clear item if empty hand + shift-rclick
             if (heldItem.isEmpty() && player.isCrouching() && !stored.isEmpty()) {
-                updateStored(ItemStack.EMPTY);
-                return InteractionResult.SUCCESS;
+                return updateStored(ItemStack.EMPTY);
             }
 
             // If held item can stack with stored item, delete held item
@@ -94,8 +89,7 @@ public class CreativeChestMachine extends QuantumChestMachine {
                 player.setItemInHand(hand, ItemStack.EMPTY);
                 return InteractionResult.SUCCESS;
             } else if (!heldItem.isEmpty()) { // If held item is different than stored item, update stored item
-                updateStored(heldItem);
-                return InteractionResult.SUCCESS;
+                return updateStored(heldItem);
             }
         }
         return InteractionResult.PASS;
@@ -111,21 +105,15 @@ public class CreativeChestMachine extends QuantumChestMachine {
                 .setChangeListener(this::markDirty));
         group.addWidget(new LabelWidget(7, 9, "gtceu.creative.chest.item"));
         group.addWidget(new ImageWidget(7, 48, 154, 14, GuiTextures.DISPLAY));
-        group.addWidget(new TextFieldWidget(9, 50, 152, 10, () -> String.valueOf(itemsPerCycle), value -> {
-            if (!value.isEmpty()) {
-                itemsPerCycle = Integer.parseInt(value);
-            }
-        }).setMaxStringLength(11).setNumbersOnly(1, Integer.MAX_VALUE));
+        group.addWidget(new TextFieldWidget(9, 50, 152, 10, () -> String.valueOf(itemsPerCycle), this::setItemsPerCycle)
+                .setMaxStringLength(11)
+                .setNumbersOnly(1, Integer.MAX_VALUE));
         group.addWidget(new LabelWidget(7, 28, "gtceu.creative.chest.ipc"));
-
         group.addWidget(new ImageWidget(7, 85, 154, 14, GuiTextures.DISPLAY));
-        group.addWidget(new TextFieldWidget(9, 87, 152, 10, () -> String.valueOf(ticksPerCycle), value -> {
-            if (!value.isEmpty()) {
-                ticksPerCycle = Integer.parseInt(value);
-            }
-        }).setMaxStringLength(11).setNumbersOnly(1, Integer.MAX_VALUE));
+        group.addWidget(new TextFieldWidget(9, 87, 152, 10, () -> String.valueOf(ticksPerCycle), this::setTicksPerCycle)
+                .setMaxStringLength(11)
+                .setNumbersOnly(1, Integer.MAX_VALUE));
         group.addWidget(new LabelWidget(7, 65, "gtceu.creative.chest.tpc"));
-
         group.addWidget(new SwitchWidget(7, 101, 162, 20, (clickData, value) -> setWorkingEnabled(value))
                 .setTexture(
                         new GuiTextureGroup(ResourceBorderTexture.BUTTON_COMMON,
@@ -142,10 +130,20 @@ public class CreativeChestMachine extends QuantumChestMachine {
         return MANAGED_FIELD_HOLDER;
     }
 
-    private class InfiniteStackHandler extends NotifiableItemStackHandler {
+    private class InfiniteCache extends ItemCache {
 
-        public InfiniteStackHandler(MetaMachine holder) {
-            super(holder, 1, IO.BOTH, IO.BOTH);
+        public InfiniteCache(MetaMachine holder) {
+            super(holder);
+        }
+
+        @Override
+        public @NotNull ItemStack getStackInSlot(int slot) {
+            return stored;
+        }
+
+        @Override
+        public void setStackInSlot(int index, ItemStack stack) {
+            updateStored(stack);
         }
 
         @Override
@@ -156,8 +154,13 @@ public class CreativeChestMachine extends QuantumChestMachine {
 
         @Override
         public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
-            if (!stored.isEmpty()) return stored.copyWithCount(amount);
+            if (!stored.isEmpty()) return stored.copyWithCount(itemsPerCycle);
             return ItemStack.EMPTY;
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+            return true;
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
@@ -27,6 +27,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.items.ItemHandlerHelper;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 public class CreativeTankMachine extends QuantumTankMachine {
@@ -34,15 +35,17 @@ public class CreativeTankMachine extends QuantumTankMachine {
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(CreativeTankMachine.class,
             QuantumTankMachine.MANAGED_FIELD_HOLDER);
 
+    @Getter
     @Persisted
     @DropSaved
     private int mBPerCycle = 1000;
+    @Getter
     @Persisted
     @DropSaved
     private int ticksPerCycle = 1;
 
     public CreativeTankMachine(IMachineBlockEntity holder) {
-        super(holder, GTValues.MAX, -1);
+        super(holder, GTValues.MAX, 1);
     }
 
     protected FluidCache createCacheFluidHandler(Object... args) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
@@ -1,12 +1,10 @@
 package com.gregtechceu.gtceu.common.machine.storage;
 
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.widget.PhantomFluidWidget;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
 import com.gregtechceu.gtceu.api.transfer.fluid.CustomFluidTank;
 
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
@@ -26,9 +24,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.FluidUtil;
-import net.minecraftforge.fluids.capability.IFluidHandler.FluidAction;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +36,7 @@ public class CreativeTankMachine extends QuantumTankMachine {
 
     @Persisted
     @DropSaved
-    private int mBPerCycle = 1;
+    private int mBPerCycle = 1000;
     @Persisted
     @DropSaved
     private int ticksPerCycle = 1;
@@ -49,8 +45,8 @@ public class CreativeTankMachine extends QuantumTankMachine {
         super(holder, GTValues.MAX, -1);
     }
 
-    protected NotifiableFluidTank createCacheFluidHandler(Object... args) {
-        return new InfiniteTank(this);
+    protected FluidCache createCacheFluidHandler(Object... args) {
+        return new InfiniteCache(this);
     }
 
     protected void checkAutoOutput() {
@@ -63,8 +59,21 @@ public class CreativeTankMachine extends QuantumTankMachine {
     }
 
     private InteractionResult updateStored(FluidStack fluid) {
-        cache.setFluidInTank(0, new FluidStack(fluid, 1000));
+        stored = new FluidStack(fluid, 1000);
+        onFluidChanged();
         return InteractionResult.SUCCESS;
+    }
+
+    private void setTicksPerCycle(String value) {
+        if (value.isEmpty()) return;
+        ticksPerCycle = Integer.parseInt(value);
+        onFluidChanged();
+    }
+
+    private void setmBPerCycle(String value) {
+        if (value.isEmpty()) return;
+        mBPerCycle = Integer.parseInt(value);
+        onFluidChanged();
     }
 
     @Override
@@ -112,26 +121,20 @@ public class CreativeTankMachine extends QuantumTankMachine {
     @Override
     public WidgetGroup createUIWidget() {
         var group = new WidgetGroup(0, 0, 176, 131);
-        group.addWidget(new PhantomFluidWidget(cache, 0, 36, 6, 18, 18,
-                this::getStored, this::updateStored)
-                .setShowAmount(false).setBackground(GuiTextures.FLUID_SLOT));
+        group.addWidget(new PhantomFluidWidget(cache, 0, 36, 6, 18, 18, this::getStored, this::updateStored)
+                .setShowAmount(false)
+                .setBackground(GuiTextures.FLUID_SLOT));
         group.addWidget(new LabelWidget(7, 9, "gtceu.creative.tank.fluid"));
         group.addWidget(new ImageWidget(7, 45, 154, 14, GuiTextures.DISPLAY));
-        group.addWidget(new TextFieldWidget(9, 47, 152, 10, () -> String.valueOf(mBPerCycle), value -> {
-            if (!value.isEmpty()) {
-                mBPerCycle = Integer.parseInt(value);
-            }
-        }).setMaxStringLength(11).setNumbersOnly(1, Integer.MAX_VALUE));
+        group.addWidget(new TextFieldWidget(9, 47, 152, 10, () -> String.valueOf(mBPerCycle), this::setmBPerCycle)
+                .setMaxStringLength(11)
+                .setNumbersOnly(1, Integer.MAX_VALUE));
         group.addWidget(new LabelWidget(7, 28, "gtceu.creative.tank.mbpc"));
-
         group.addWidget(new ImageWidget(7, 82, 154, 14, GuiTextures.DISPLAY));
-        group.addWidget(new TextFieldWidget(9, 84, 152, 10, () -> String.valueOf(ticksPerCycle), value -> {
-            if (!value.isEmpty()) {
-                ticksPerCycle = Integer.parseInt(value);
-            }
-        }).setMaxStringLength(11).setNumbersOnly(1, Integer.MAX_VALUE));
+        group.addWidget(new TextFieldWidget(9, 84, 152, 10, () -> String.valueOf(ticksPerCycle), this::setTicksPerCycle)
+                .setMaxStringLength(11)
+                .setNumbersOnly(1, Integer.MAX_VALUE));
         group.addWidget(new LabelWidget(7, 65, "gtceu.creative.tank.tpc"));
-
         group.addWidget(new SwitchWidget(7, 101, 162, 20, (clickData, value) -> setWorkingEnabled(value))
                 .setTexture(
                         new GuiTextureGroup(ResourceBorderTexture.BUTTON_COMMON,
@@ -148,10 +151,15 @@ public class CreativeTankMachine extends QuantumTankMachine {
         return MANAGED_FIELD_HOLDER;
     }
 
-    private class InfiniteTank extends NotifiableFluidTank {
+    private class InfiniteCache extends FluidCache {
 
-        public InfiniteTank(MetaMachine holder) {
-            super(holder, 1, FluidType.BUCKET_VOLUME, IO.BOTH, IO.BOTH);
+        public InfiniteCache(MetaMachine holder) {
+            super(holder);
+        }
+
+        @Override
+        public @NotNull FluidStack getFluidInTank(int tank) {
+            return stored;
         }
 
         @Override
@@ -170,6 +178,11 @@ public class CreativeTankMachine extends QuantumTankMachine {
         public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
             if (!stored.isEmpty() && stored.isFluidEqual(resource)) return new FluidStack(resource, mBPerCycle);
             return FluidStack.EMPTY;
+        }
+
+        @Override
+        public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
+            return true;
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
@@ -64,7 +64,6 @@ public class CreativeTankMachine extends QuantumTankMachine {
 
     private InteractionResult updateStored(FluidStack fluid) {
         cache.setFluidInTank(0, new FluidStack(fluid, 1000));
-        stored = cache.getFluidInTank(0);
         return InteractionResult.SUCCESS;
     }
 
@@ -89,8 +88,7 @@ public class CreativeTankMachine extends QuantumTankMachine {
             }
 
             // Need to make a fake source to fully fill held-item since our cache only allows mbPerTick extraction
-            CustomFluidTank source = new CustomFluidTank(
-                    new FluidStack(stored.getFluid(), Integer.MAX_VALUE, stored.getTag()));
+            CustomFluidTank source = new CustomFluidTank(new FluidStack(stored, Integer.MAX_VALUE));
             ItemStack result = FluidUtil.tryFillContainer(heldItem, source, Integer.MAX_VALUE, player, true)
                     .getResult();
             if (!result.isEmpty() && heldItem.getCount() > 1) {
@@ -114,7 +112,7 @@ public class CreativeTankMachine extends QuantumTankMachine {
     @Override
     public WidgetGroup createUIWidget() {
         var group = new WidgetGroup(0, 0, 176, 131);
-        group.addWidget(new PhantomFluidWidget(this.cache.getStorages()[0], 0, 36, 6, 18, 18,
+        group.addWidget(new PhantomFluidWidget(cache, 0, 36, 6, 18, 18,
                 this::getStored, this::updateStored)
                 .setShowAmount(false).setBackground(GuiTextures.FLUID_SLOT));
         group.addWidget(new LabelWidget(7, 9, "gtceu.creative.tank.fluid"));
@@ -158,7 +156,7 @@ public class CreativeTankMachine extends QuantumTankMachine {
 
         @Override
         public int fill(FluidStack resource, FluidAction action) {
-            if (!stored.isEmpty()) return resource.getAmount();
+            if (!stored.isEmpty() && stored.isFluidEqual(resource)) return resource.getAmount();
             return 0;
         }
 
@@ -172,6 +170,11 @@ public class CreativeTankMachine extends QuantumTankMachine {
         public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
             if (!stored.isEmpty() && stored.isFluidEqual(resource)) return new FluidStack(resource, mBPerCycle);
             return FluidStack.EMPTY;
+        }
+
+        @Override
+        public int getTankCapacity(int tank) {
+            return 1000;
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -108,7 +108,6 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
     @Nullable
     protected TickableSubscription autoOutputSubs;
-    private final Predicate<ItemStack> storeFilter = s -> true;
 
     public QuantumChestMachine(IMachineBlockEntity holder, int tier, long maxAmount, Object... args) {
         super(holder, tier);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -17,6 +17,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
+import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
 import com.lowdragmc.lowdraglib.gui.editor.Icons;
@@ -89,12 +90,12 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     @Persisted
     protected boolean allowInputFromOutputSideItems;
     @Getter
-    private final int maxStoredItems;
+    private final long maxStoredItems;
     @Getter
     @Persisted
     @DescSynced
     @DropSaved
-    protected int storedAmount = 0;
+    protected long storedAmount = 0;
     @Getter
     @Persisted
     @DescSynced
@@ -118,7 +119,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     @Getter
     private final CustomItemStackHandler lockedItem;
 
-    public QuantumChestMachine(IMachineBlockEntity holder, int tier, int maxStoredItems, Object... args) {
+    public QuantumChestMachine(IMachineBlockEntity holder, int tier, long maxStoredItems, Object... args) {
         super(holder, tier);
         this.outputFacingItems = getFrontFacing().getOpposite();
         this.maxStoredItems = maxStoredItems;
@@ -335,36 +336,21 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
     public Widget createUIWidget() {
         var group = new WidgetGroup(0, 0, 109, 63);
-        var importItems = new CustomItemStackHandler();
-        importItems.setFilter(itemStack -> cache.insertItem(0, itemStack, true).getCount() != itemStack.getCount());
-        importItems.setOnContentsChanged(() -> {
-            var item = importItems.getStackInSlot(0).copy();
-            if (!item.isEmpty()) {
-                importItems.setStackInSlot(0, ItemStack.EMPTY);
-                importItems.onContentsChanged(0);
-                cache.insertItem(0, item.copy(), false);
-            }
-        });
-        var current = cache.getStackInSlot(0).copy();
-        if (!current.isEmpty()) {
-            current.setCount(Math.min(current.getCount(), current.getItem().getMaxStackSize()));
-        }
+        var importItems = createImportItems();
         group.addWidget(new ImageWidget(4, 4, 81, 55, GuiTextures.DISPLAY))
                 .addWidget(new LabelWidget(8, 8, "gtceu.machine.quantum_chest.items_stored"))
                 .addWidget(new LabelWidget(8, 18, () -> storedAmount + "").setTextColor(-1).setDropShadow(true))
                 .addWidget(new SlotWidget(importItems, 0, 87, 5, false, true)
                         .setBackgroundTexture(new GuiTextureGroup(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY)))
                 .addWidget(new SlotWidget(cache, 0, 87, 23, false, false)
-                        .setItemHook(itemStack -> itemStack
-                                .copyWithCount(Math.min(storedAmount, itemStack.getItem().getMaxStackSize(itemStack))))
+                        .setItemHook(stack -> stack.copyWithCount((int) Math.min(storedAmount, stack.getMaxStackSize())))
                         .setBackgroundTexture(GuiTextures.SLOT))
                 .addWidget(new ButtonWidget(87, 42, 18, 18,
                         new GuiTextureGroup(ResourceBorderTexture.BUTTON_COMMON, Icons.DOWN.scale(0.7f)), cd -> {
                             if (!cd.isRemote) {
-                                var stored = cache.getStackInSlot(0);
                                 if (!stored.isEmpty()) {
                                     var extracted = cache.extractItem(0,
-                                            Math.min(storedAmount, stored.getItem().getMaxStackSize(stored)), false);
+                                            (int) Math.min(storedAmount, stored.getMaxStackSize()), false);
                                     if (!group.getGui().entityPlayer.addItem(extracted)) {
                                         Block.popResource(group.getGui().entityPlayer.level(),
                                                 group.getGui().entityPlayer.getOnPos(), extracted);
@@ -389,6 +375,20 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
                         .setTooltipText("gtceu.gui.item_voiding_partial.tooltip"));
         group.setBackground(GuiTextures.BACKGROUND_INVERSE);
         return group;
+    }
+
+    private @NotNull CustomItemStackHandler createImportItems() {
+        var importItems = new CustomItemStackHandler();
+        importItems.setFilter(itemStack -> cache.insertItem(0, itemStack, true).getCount() != itemStack.getCount());
+        importItems.setOnContentsChanged(() -> {
+            var item = importItems.getStackInSlot(0).copy();
+            if (!item.isEmpty()) {
+                importItems.setStackInSlot(0, ItemStack.EMPTY);
+                importItems.onContentsChanged(0);
+                cache.insertItem(0, item.copy(), false);
+            }
+        });
+        return importItems;
     }
 
     //////////////////////////////////////
@@ -425,13 +425,13 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
         @Override
         public @NotNull ItemStack getStackInSlot(int slot) {
-            return inner().copyWithCount(storedAmount);
+            return inner().copyWithCount(GTMath.saturatedCast(storedAmount));
         }
 
         @Override
         public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-            int free = isVoiding ? Integer.MAX_VALUE : maxStoredItems - storedAmount;
-            int canStore = 0;
+            long free = isVoiding ? Long.MAX_VALUE : maxStoredItems - storedAmount;
+            long canStore = 0;
             if ((inner().isEmpty() || ItemHandlerHelper.canItemStacksStack(inner(), stack)) &&
                     storage.getFilter().test(stack)) {
                 canStore = Math.min(stack.getCount(), free);
@@ -439,24 +439,24 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
             if (!simulate && canStore > 0) {
                 if (inner().isEmpty()) setStackInSlot(0, stack.copyWithCount(1));
                 storedAmount = Math.min(maxStoredItems, storedAmount + canStore);
-                storage.onContentsChanged(0);
+                onContentsChanged();
             }
             if (canStore == stack.getCount()) return ItemStack.EMPTY;
-            return stack.copyWithCount(stack.getCount() - canStore);
+            return stack.copyWithCount((int) (stack.getCount() - canStore));
         }
 
         @Override
         public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
             var stored = inner().copy();
             if (stored.isEmpty()) return ItemStack.EMPTY;
-            int toExtract = Math.min(storedAmount, amount);
+            long toExtract = Math.min(storedAmount, amount);
             if (!simulate && toExtract > 0) {
                 storedAmount -= toExtract;
                 if (storedAmount == 0) setStackInSlot(0, ItemStack.EMPTY);
-                storage.onContentsChanged(0);
+                onContentsChanged();
             }
             if (toExtract == 0) return ItemStack.EMPTY;
-            return stored.copyWithCount(toExtract);
+            return stored.copyWithCount((int) toExtract);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -17,6 +17,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
 import com.gregtechceu.gtceu.api.machine.trait.MachineTrait;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
@@ -107,6 +108,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
     @Nullable
     protected TickableSubscription autoOutputSubs;
+    private final Predicate<ItemStack> storeFilter = s -> true;
 
     public QuantumChestMachine(IMachineBlockEntity holder, int tier, long maxAmount, Object... args) {
         super(holder, tier);
@@ -149,11 +151,16 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     }
 
     @Override
+    public boolean saveBreak() {
+        return !stored.isEmpty();
+    }
+
+    @Override
     public void saveCustomPersistedData(@NotNull CompoundTag tag, boolean forDrop) {
         super.saveCustomPersistedData(tag, forDrop);
         if (!forDrop) tag.put("lockedItem", lockedItem.serializeNBT());
-        if (!stored.isEmpty()) tag.put("stored", stored.serializeNBT());
-        if (storedAmount > 0) tag.putLong("storedAmount", storedAmount);
+        tag.put("stored", stored.serializeNBT());
+        tag.putLong("storedAmount", storedAmount);
     }
 
     @Override
@@ -333,12 +340,13 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
         var importItems = createImportItems();
         group.addWidget(new ImageWidget(4, 4, 81, 55, GuiTextures.DISPLAY))
                 .addWidget(new LabelWidget(8, 8, "gtceu.machine.quantum_chest.items_stored"))
-                .addWidget(new LabelWidget(8, 18, () -> storedAmount + "").setTextColor(-1).setDropShadow(true))
+                .addWidget(new LabelWidget(8, 18, () -> FormattingUtil.formatNumbers(storedAmount))
+                        .setTextColor(-1)
+                        .setDropShadow(true))
                 .addWidget(new SlotWidget(importItems, 0, 87, 5, false, true)
                         .setBackgroundTexture(new GuiTextureGroup(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY)))
                 .addWidget(new SlotWidget(cache, 0, 87, 23, false, false)
-                        .setItemHook(
-                                stack -> stack.copyWithCount((int) Math.min(storedAmount, stack.getMaxStackSize())))
+                        .setItemHook(s -> s.copyWithCount((int) Math.min(storedAmount, s.getMaxStackSize())))
                         .setBackgroundTexture(GuiTextures.SLOT))
                 .addWidget(new ButtonWidget(87, 42, 18, 18,
                         new GuiTextureGroup(ResourceBorderTexture.BUTTON_COMMON, Icons.DOWN.scale(0.7f)), cd -> {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -44,6 +44,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
@@ -236,23 +237,31 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     public InteractionResult onUse(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand,
                                    BlockHitResult hit) {
         if (hit.getDirection() == getFrontFacing() && !isRemote()) {
+            // Check to see if the hit is within the glass frame of the chest
+            var aabb = new AABB(hit.getBlockPos()).deflate(0.12);
+            var hitVector = hit.getLocation().relative(getFrontFacing(), -0.5);
+            if (!aabb.contains(hitVector)) return InteractionResult.PASS;
+
             var held = player.getMainHandItem();
-            if (!held.isEmpty() && (cache.insertItem(0, held, true).getCount() != held.getCount())) { // push
+            if (!held.isEmpty() && cache.canInsert(held)) { // push
                 var remaining = cache.insertItem(0, held, false);
                 player.setItemInHand(InteractionHand.MAIN_HAND, remaining);
                 return InteractionResult.SUCCESS;
-            } else if (System.currentTimeMillis() -
-                    INTERACTION_LOGGER.getOrDefault(player.getUUID(), System.currentTimeMillis()) < 300) {
-                        for (var stack : player.getInventory().items) {
-                            if (!stack.isEmpty() && (cache.insertItem(0, stack, true).getCount() != stack.getCount())) {
-                                stack.setCount(cache.insertItem(0, stack, false).getCount());
-                            }
-                        }
+            } else if (isDoubleHit(player.getUUID())) {
+                for (var stack : player.getInventory().items) {
+                    if (!stack.isEmpty() && cache.canInsert(stack)) {
+                        stack.setCount(cache.insertItem(0, stack, false).getCount());
                     }
+                }
+            }
             INTERACTION_LOGGER.put(player.getUUID(), System.currentTimeMillis());
             return InteractionResult.SUCCESS;
         }
         return InteractionResult.PASS;
+    }
+
+    private static boolean isDoubleHit(UUID uuid) {
+        return (System.currentTimeMillis() - INTERACTION_LOGGER.getOrDefault(uuid, System.currentTimeMillis())) < 300;
     }
 
     @Override
@@ -260,8 +269,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
         if (direction == getFrontFacing() && !isRemote()) {
             if (player.getItemInHand(hand).is(GTToolType.WRENCH.itemTags.get(0))) return false;
             if (!stored.isEmpty()) { // pull
-                var drained = cache.extractItem(0, player.isShiftKeyDown() ? stored.getItem().getMaxStackSize() : 1,
-                        false);
+                var drained = cache.extractItem(0, player.isShiftKeyDown() ? stored.getMaxStackSize() : 1, false);
                 if (!drained.isEmpty()) {
                     if (!player.addItem(drained)) {
                         Block.popResourceFromFace(world, getPos(), getFrontFacing(), drained);
@@ -381,7 +389,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
     private @NotNull CustomItemStackHandler createImportItems() {
         var importItems = new CustomItemStackHandler();
-        importItems.setFilter(itemStack -> cache.insertItem(0, itemStack, true).getCount() != itemStack.getCount());
+        importItems.setFilter(cache::canInsert);
         importItems.setOnContentsChanged(() -> {
             var item = importItems.getStackInSlot(0).copy();
             if (!item.isEmpty()) {
@@ -488,6 +496,10 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
                 GTTransferUtils.getAdjacentItemHandler(level, pos, facing)
                         .ifPresent(adj -> GTTransferUtils.transferItemsFiltered(this, adj, filter));
             }
+        }
+
+        public boolean canInsert(ItemStack stack) {
+            return filter.test(stack) && (insertItem(0, stack, true).getCount() != stack.getCount());
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -15,7 +15,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputItem;
 import com.gregtechceu.gtceu.api.machine.feature.IDropSaveMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+import com.gregtechceu.gtceu.api.machine.trait.MachineTrait;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
@@ -25,15 +25,14 @@ import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceBorderTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
 import com.lowdragmc.lowdraglib.gui.widget.*;
-import com.lowdragmc.lowdraglib.syncdata.ISubscription;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
-import com.lowdragmc.lowdraglib.syncdata.annotation.DropSaved;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.annotation.RequireRerender;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
@@ -45,6 +44,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
@@ -56,6 +56,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -89,40 +90,28 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     @Setter
     @Persisted
     protected boolean allowInputFromOutputSideItems;
-    @Getter
-    private final long maxStoredItems;
-    @Getter
     @Persisted
-    @DescSynced
-    @DropSaved
-    protected long storedAmount = 0;
-    @Getter
-    @Persisted
-    @DescSynced
-    @DropSaved
-    @NotNull
-    protected ItemStack stored = ItemStack.EMPTY;
-    @Persisted
-    @DropSaved
-    @Getter
-    protected final NotifiableItemStackHandler cache;
-    @Nullable
-    protected TickableSubscription autoOutputSubs;
-    @Nullable
-    protected ISubscription exportItemSubs;
-    @Persisted
-    @Getter
-    @Setter
     private boolean isVoiding;
-    @Persisted
+
+    private final long maxAmount;
+    protected final ItemCache cache;
     @DescSynced
-    @Getter
     private final CustomItemStackHandler lockedItem;
 
-    public QuantumChestMachine(IMachineBlockEntity holder, int tier, long maxStoredItems, Object... args) {
+    @Getter
+    @DescSynced
+    protected ItemStack stored = ItemStack.EMPTY;
+    @Getter
+    @DescSynced
+    protected long storedAmount = 0;
+
+    @Nullable
+    protected TickableSubscription autoOutputSubs;
+
+    public QuantumChestMachine(IMachineBlockEntity holder, int tier, long maxAmount, Object... args) {
         super(holder, tier);
         this.outputFacingItems = getFrontFacing().getOpposite();
-        this.maxStoredItems = maxStoredItems;
+        this.maxAmount = maxAmount;
         this.cache = createCacheItemHandler(args);
         this.lockedItem = new CustomItemStackHandler();
     }
@@ -136,40 +125,43 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
         return MANAGED_FIELD_HOLDER;
     }
 
-    protected NotifiableItemStackHandler createCacheItemHandler(Object... args) {
-        return new CustomCache(this).setFilter(itemStack -> !isLocked() ||
-                ItemHandlerHelper.canItemStacksStack(lockedItem.getStackInSlot(0), itemStack));
+    protected ItemCache createCacheItemHandler(Object... args) {
+        return new ItemCache(this);
     }
 
     @Override
     public void onLoad() {
         super.onLoad();
-        this.stored = cache.storage.getStackInSlot(0);
         if (getLevel() instanceof ServerLevel serverLevel) {
             serverLevel.getServer().tell(new TickTask(0, this::updateAutoOutputSubscription));
         }
-        exportItemSubs = cache.addChangedListener(this::onItemChanged);
     }
 
-    private void onItemChanged() {
+    protected void onItemChanged() {
         if (!isRemote()) {
-            this.stored = cache.storage.getStackInSlot(0);
             updateAutoOutputSubscription();
-        }
-    }
-
-    @Override
-    public void onUnload() {
-        super.onUnload();
-        if (exportItemSubs != null) {
-            exportItemSubs.unsubscribe();
-            exportItemSubs = null;
         }
     }
 
     @Override
     public boolean savePickClone() {
         return false;
+    }
+
+    @Override
+    public void saveCustomPersistedData(@NotNull CompoundTag tag, boolean forDrop) {
+        super.saveCustomPersistedData(tag, forDrop);
+        if (!forDrop) tag.put("lockedItem", lockedItem.serializeNBT());
+        if (!stored.isEmpty()) tag.put("stored", stored.serializeNBT());
+        if (storedAmount > 0) tag.putLong("storedAmount", storedAmount);
+    }
+
+    @Override
+    public void loadCustomPersistedData(@NotNull CompoundTag tag) {
+        super.loadCustomPersistedData(tag);
+        lockedItem.deserializeNBT(tag.getCompound("lockedItem"));
+        stored = ItemStack.of(tag.getCompound("stored"));
+        storedAmount = tag.getLong("storedAmount");
     }
 
     //////////////////////////////////////
@@ -206,7 +198,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
     protected void updateAutoOutputSubscription() {
         var outputFacing = getOutputFacingItems();
-        if ((isAutoOutputItems() && !cache.isEmpty()) && outputFacing != null &&
+        if ((isAutoOutputItems() && !stored.isEmpty()) && outputFacing != null &&
                 GTTransferUtils.hasAdjacentItemHandler(getLevel(), getPos(), outputFacing)) {
             autoOutputSubs = subscribeServerTick(autoOutputSubs, this::checkAutoOutput);
         } else if (autoOutputSubs != null) {
@@ -321,13 +313,15 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
 
     protected void setLocked(boolean locked) {
         if (!stored.isEmpty() && locked) {
-            var copied = stored.copy();
-            copied.setCount(1);
+            var copied = stored.copyWithCount(1);
             lockedItem.setStackInSlot(0, copied);
         } else if (!locked) {
             lockedItem.setStackInSlot(0, ItemStack.EMPTY);
         }
-        lockedItem.onContentsChanged(0);
+    }
+
+    public ItemStack getLockedItem() {
+        return lockedItem.getStackInSlot(0);
     }
 
     //////////////////////////////////////
@@ -343,7 +337,8 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
                 .addWidget(new SlotWidget(importItems, 0, 87, 5, false, true)
                         .setBackgroundTexture(new GuiTextureGroup(GuiTextures.SLOT, GuiTextures.IN_SLOT_OVERLAY)))
                 .addWidget(new SlotWidget(cache, 0, 87, 23, false, false)
-                        .setItemHook(stack -> stack.copyWithCount((int) Math.min(storedAmount, stack.getMaxStackSize())))
+                        .setItemHook(
+                                stack -> stack.copyWithCount((int) Math.min(storedAmount, stack.getMaxStackSize())))
                         .setBackgroundTexture(GuiTextures.SLOT))
                 .addWidget(new ButtonWidget(87, 42, 18, 18,
                         new GuiTextureGroup(ResourceBorderTexture.BUTTON_COMMON, Icons.DOWN.scale(0.7f)), cd -> {
@@ -370,7 +365,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
                         .setShouldUseBaseBackground()
                         .setTooltipText("gtceu.gui.item_lock.tooltip"))
                 .addWidget(new ToggleButtonWidget(40, 41, 18, 18,
-                        GuiTextures.BUTTON_VOID, this::isVoiding, this::setVoiding)
+                        GuiTextures.BUTTON_VOID, () -> isVoiding, (b) -> isVoiding = b)
                         .setShouldUseBaseBackground()
                         .setTooltipText("gtceu.gui.item_voiding_partial.tooltip"));
         group.setBackground(GuiTextures.BACKGROUND_INVERSE);
@@ -413,50 +408,84 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
         return super.sideTips(player, pos, state, toolTypes, side);
     }
 
-    private class CustomCache extends NotifiableItemStackHandler {
+    protected class ItemCache extends MachineTrait implements IItemHandlerModifiable {
 
-        public CustomCache(MetaMachine holder) {
-            super(holder, 1, IO.BOTH, IO.BOTH);
+        private final Predicate<ItemStack> filter = i -> !isLocked() ||
+                ItemStack.isSameItemSameTags(i, getLockedItem());
+
+        public ItemCache(MetaMachine holder) {
+            super(holder);
         }
 
-        private ItemStack inner() {
-            return storage.getStackInSlot(0);
+        @Override
+        public void setStackInSlot(int index, ItemStack stack) {
+            stored = stack.copyWithCount(1);
+            storedAmount = stack.getCount();
+            onItemChanged();
         }
 
         @Override
         public @NotNull ItemStack getStackInSlot(int slot) {
-            return inner().copyWithCount(GTMath.saturatedCast(storedAmount));
+            return stored.copyWithCount(GTMath.saturatedCast(storedAmount));
         }
 
         @Override
         public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-            long free = isVoiding ? Long.MAX_VALUE : maxStoredItems - storedAmount;
+            long free = isVoiding ? Long.MAX_VALUE : maxAmount - storedAmount;
             long canStore = 0;
-            if ((inner().isEmpty() || ItemHandlerHelper.canItemStacksStack(inner(), stack)) &&
-                    storage.getFilter().test(stack)) {
+            if ((stored.isEmpty() || ItemHandlerHelper.canItemStacksStack(stored, stack)) && filter.test(stack)) {
                 canStore = Math.min(stack.getCount(), free);
             }
             if (!simulate && canStore > 0) {
-                if (inner().isEmpty()) setStackInSlot(0, stack.copyWithCount(1));
-                storedAmount = Math.min(maxStoredItems, storedAmount + canStore);
-                onContentsChanged();
+                if (stored.isEmpty()) stored = stack.copyWithCount(1);
+                storedAmount = Math.min(maxAmount, storedAmount + canStore);
+                onItemChanged();
             }
-            if (canStore == stack.getCount()) return ItemStack.EMPTY;
             return stack.copyWithCount((int) (stack.getCount() - canStore));
         }
 
         @Override
         public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
-            var stored = inner().copy();
             if (stored.isEmpty()) return ItemStack.EMPTY;
             long toExtract = Math.min(storedAmount, amount);
+            var copy = stored.copyWithCount((int) toExtract);
             if (!simulate && toExtract > 0) {
                 storedAmount -= toExtract;
-                if (storedAmount == 0) setStackInSlot(0, ItemStack.EMPTY);
-                onContentsChanged();
+                if (storedAmount == 0) stored = ItemStack.EMPTY;
+                onItemChanged();
             }
-            if (toExtract == 0) return ItemStack.EMPTY;
-            return stored.copyWithCount((int) toExtract);
+            return copy;
+        }
+
+        @Override
+        public int getSlotLimit(int slot) {
+            return GTMath.saturatedCast(maxAmount);
+        }
+
+        @Override
+        public int getSlots() {
+            return 1;
+        }
+
+        @Override
+        public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+            return filter.test(stack);
+        }
+
+        public void exportToNearby(@NotNull Direction... facings) {
+            if (stored.isEmpty()) return;
+            var level = getMachine().getLevel();
+            var pos = getMachine().getPos();
+            for (Direction facing : facings) {
+                var filter = getMachine().getItemCapFilter(facing, IO.OUT);
+                GTTransferUtils.getAdjacentItemHandler(level, pos, facing)
+                        .ifPresent(adj -> GTTransferUtils.transferItemsFiltered(this, adj, filter));
+            }
+        }
+
+        @Override
+        public ManagedFieldHolder getFieldHolder() {
+            return MANAGED_FIELD_HOLDER;
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -15,7 +15,8 @@ import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputFluid;
 import com.gregtechceu.gtceu.api.machine.feature.IDropSaveMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
+import com.gregtechceu.gtceu.api.machine.trait.MachineTrait;
+import com.gregtechceu.gtceu.api.transfer.fluid.CustomFluidTank;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
@@ -25,15 +26,14 @@ import com.lowdragmc.lowdraglib.gui.widget.ImageWidget;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
-import com.lowdragmc.lowdraglib.syncdata.ISubscription;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
-import com.lowdragmc.lowdraglib.syncdata.annotation.DropSaved;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.annotation.RequireRerender;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
@@ -46,6 +46,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
 import lombok.Getter;
@@ -54,6 +55,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
+import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -79,36 +81,30 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     @Setter
     @Persisted
     protected boolean allowInputFromOutputSideFluids;
-    @Getter
-    private final long maxStoredFluids;
-    @Getter
     @Persisted
-    @DescSynced
-    @DropSaved
-    protected long storedAmount = 0;
-    @Getter
-    @Persisted
-    @DropSaved
-    protected final NotifiableFluidTank cache;
-    @Nullable
-    protected TickableSubscription autoOutputSubs;
-    @Nullable
-    protected ISubscription exportFluidSubs;
-    @Persisted
-    @DescSynced
-    @Getter
-    @DropSaved
-    protected FluidStack stored = FluidStack.EMPTY;
-    @Persisted
-    @Getter
-    @Setter
     private boolean isVoiding;
 
-    public QuantumTankMachine(IMachineBlockEntity holder, int tier, long maxStoredFluids, Object... args) {
+    private final long maxAmount;
+    protected final FluidCache cache;
+    @DescSynced
+    private final CustomFluidTank lockedFluid;
+
+    @Getter
+    @DescSynced
+    protected FluidStack stored = FluidStack.EMPTY;
+    @Getter
+    @DescSynced
+    protected long storedAmount = 0;
+
+    @Nullable
+    protected TickableSubscription autoOutputSubs;
+
+    public QuantumTankMachine(IMachineBlockEntity holder, int tier, long maxAmount, Object... args) {
         super(holder, tier);
         this.outputFacingFluids = getFrontFacing().getOpposite();
-        this.maxStoredFluids = maxStoredFluids;
+        this.maxAmount = maxAmount;
         this.cache = createCacheFluidHandler(args);
+        this.lockedFluid = new CustomFluidTank(1000);
     }
 
     //////////////////////////////////////
@@ -120,42 +116,49 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
         return MANAGED_FIELD_HOLDER;
     }
 
-    protected NotifiableFluidTank createCacheFluidHandler(Object... args) {
-        return new CustomCache(this);
+    protected FluidCache createCacheFluidHandler(Object... args) {
+        return new FluidCache(this);
     }
 
     @Override
     public void onLoad() {
         super.onLoad();
-        if(!stored.isEmpty()) cache.setFluidInTank(0, stored);
-        else stored = cache.getFluidInTank(0);
-
-        if(storedAmount == 0) storedAmount = stored.getAmount();
         if (getLevel() instanceof ServerLevel serverLevel) {
             serverLevel.getServer().tell(new TickTask(0, this::updateAutoOutputSubscription));
         }
-        exportFluidSubs = cache.addChangedListener(this::onFluidChanged);
     }
 
-    private void onFluidChanged() {
+    protected void onFluidChanged() {
         if (!isRemote()) {
-            this.stored = cache.getFluidInTank(0);
             updateAutoOutputSubscription();
-        }
-    }
-
-    @Override
-    public void onUnload() {
-        super.onUnload();
-        if (exportFluidSubs != null) {
-            exportFluidSubs.unsubscribe();
-            exportFluidSubs = null;
         }
     }
 
     @Override
     public boolean savePickClone() {
         return false;
+    }
+
+    @Override
+    public void saveCustomPersistedData(@NotNull CompoundTag tag, boolean forDrop) {
+        super.saveCustomPersistedData(tag, forDrop);
+        if (!forDrop) tag.put("lockedFluid", lockedFluid.writeToNBT(new CompoundTag()));
+        if (!stored.isEmpty()) tag.put("stored", stored.writeToNBT(new CompoundTag()));
+        if (storedAmount > 0) tag.putLong("storedAmount", storedAmount);
+    }
+
+    @Override
+    public void loadCustomPersistedData(@NotNull CompoundTag tag) {
+        super.loadCustomPersistedData(tag);
+
+        var from = tag.contains("cache") ? tag.getCompound("cache") : tag;
+        this.lockedFluid.readFromNBT(from.getCompound("lockedFluid"));
+
+        var stored = FluidStack.loadFluidStackFromNBT(tag.getCompound("stored"));
+        this.stored = new FluidStack(stored, 1000);
+
+        if (!tag.contains("storedAmount")) this.storedAmount = stored.getAmount();
+        else this.storedAmount = tag.getLong("storedAmount");
     }
 
     //////////////////////////////////////
@@ -192,7 +195,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
 
     protected void updateAutoOutputSubscription() {
         var outputFacing = getOutputFacingFluids();
-        if ((isAutoOutputFluids() && !cache.isEmpty()) && outputFacing != null &&
+        if ((isAutoOutputFluids() && !stored.isEmpty()) && outputFacing != null &&
                 GTTransferUtils.hasAdjacentFluidHandler(getLevel(), getPos(), outputFacing)) {
             autoOutputSubs = subscribeServerTick(autoOutputSubs, this::checkAutoOutput);
         } else if (autoOutputSubs != null) {
@@ -272,28 +275,26 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     }
 
     public boolean isLocked() {
-        return cache.isLocked();
+        return !lockedFluid.isEmpty();
     }
 
     protected void setLocked(boolean locked) {
         if (!stored.isEmpty() && locked) {
             var copied = new FluidStack(stored, 1000);
-            cache.setLocked(true, copied);
+            lockedFluid.setFluid(copied);
         } else if (!locked) {
-            cache.setLocked(false);
+            lockedFluid.setFluid(FluidStack.EMPTY);
         }
     }
 
     protected void setLocked(FluidStack fluid) {
         if (fluid.isEmpty()) setLocked(false);
-        else if (stored.isEmpty()) {
-            cache.setLocked(false);
-            cache.setLocked(true, fluid);
-        } else if (stored.isFluidEqual(fluid)) setLocked(true);
+        else if (stored.isEmpty()) lockedFluid.setFluid(fluid);
+        else if (stored.isFluidEqual(fluid)) setLocked(true);
     }
 
     public FluidStack getLockedFluid() {
-        return cache.getLockedFluid().getFluid();
+        return lockedFluid.getFluid();
     }
 
     //////////////////////////////////////
@@ -309,7 +310,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
                 .addWidget(new TankWidget(cache, 0, 68, 23, true, true)
                         .setShowAmount(false)
                         .setBackground(GuiTextures.FLUID_SLOT))
-                .addWidget(new PhantomFluidWidget(cache.getLockedFluid(), 0, 68, 41, 18, 18,
+                .addWidget(new PhantomFluidWidget(lockedFluid, 0, 68, 41, 18, 18,
                         this::getLockedFluid, this::setLocked)
                         .setShowAmount(false)
                         .setBackground(ColorPattern.T_GRAY.rectTexture()))
@@ -322,7 +323,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
                         .setShouldUseBaseBackground()
                         .setTooltipText("gtceu.gui.fluid_lock.tooltip"))
                 .addWidget(new ToggleButtonWidget(40, 41, 18, 18,
-                        GuiTextures.BUTTON_VOID, this::isVoiding, this::setVoiding)
+                        GuiTextures.BUTTON_VOID, () -> isVoiding, (b) -> isVoiding = b)
                         .setShouldUseBaseBackground()
                         .setTooltipText("gtceu.gui.fluid_voiding_partial.tooltip"));
         group.setBackground(GuiTextures.BACKGROUND_INVERSE);
@@ -351,54 +352,82 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
         return super.sideTips(player, pos, state, toolTypes, side);
     }
 
-    private class CustomCache extends NotifiableFluidTank {
-        public CustomCache(MetaMachine holder) { super(holder, 1, 1000, IO.BOTH); }
+    protected class FluidCache extends MachineTrait implements IFluidHandler {
 
-        private FluidStack inner() { return storages[0].getFluid(); }
+        private final Predicate<FluidStack> filter = f -> !isLocked() || getLockedFluid().isFluidEqual(f);
 
-        @Override
-        public int getTankCapacity(int tank) {
-            return GTMath.saturatedCast(maxStoredFluids);
+        public FluidCache(MetaMachine holder) {
+            super(holder);
         }
 
         @Override
         public @NotNull FluidStack getFluidInTank(int tank) {
-            return new FluidStack(inner(), GTMath.saturatedCast(storedAmount));
+            return new FluidStack(stored, GTMath.saturatedCast(storedAmount));
         }
 
         @Override
         public int fill(FluidStack resource, FluidAction action) {
-            long free = isVoiding ? Long.MAX_VALUE : maxStoredFluids - storedAmount;
+            long free = isVoiding ? Long.MAX_VALUE : maxAmount - storedAmount;
             long canFill = 0;
-            if((inner().isEmpty() || inner().isFluidEqual(resource)) && filter.test(resource)) {
+            if ((stored.isEmpty() || stored.isFluidEqual(resource)) && filter.test(resource)) {
                 canFill = Math.min(resource.getAmount(), free);
             }
-            if(action.execute() && canFill > 0) {
-                if(inner().isEmpty()) setFluidInTank(0, new FluidStack(resource, 1000));
-                storedAmount = Math.min(maxStoredFluids, storedAmount + canFill);
-                onContentsChanged();
+            if (action.execute() && canFill > 0) {
+                if (stored.isEmpty()) stored = new FluidStack(resource, 1000);
+                storedAmount = Math.min(maxAmount, storedAmount + canFill);
+                onFluidChanged();
             }
             return (int) canFill;
         }
 
         @Override
         public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
-            var stored = inner().copy();
-            if(stored.isEmpty()) return FluidStack.EMPTY;
+            if (stored.isEmpty()) return FluidStack.EMPTY;
             long toDrain = Math.min(storedAmount, maxDrain);
-            if(action.execute() && toDrain > 0) {
+            var copy = new FluidStack(stored, (int) toDrain);
+            if (action.execute() && toDrain > 0) {
                 storedAmount -= toDrain;
-                if(storedAmount == 0) setFluidInTank(0, FluidStack.EMPTY);
-                onContentsChanged();
+                if (storedAmount == 0) stored = FluidStack.EMPTY;
+                onFluidChanged();
             }
-            if(toDrain == 0) return FluidStack.EMPTY;
-            return new FluidStack(stored, (int) toDrain);
+            return copy.isEmpty() ? FluidStack.EMPTY : copy;
         }
 
         @Override
         public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
-            if(!resource.isFluidEqual(inner())) return FluidStack.EMPTY;
+            if (!resource.isFluidEqual(stored)) return FluidStack.EMPTY;
             return drain(resource.getAmount(), action);
+        }
+
+        @Override
+        public int getTankCapacity(int tank) {
+            return GTMath.saturatedCast(maxAmount);
+        }
+
+        @Override
+        public int getTanks() {
+            return 1;
+        }
+
+        @Override
+        public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
+            return filter.test(stack);
+        }
+
+        public void exportToNearby(@NotNull Direction... facings) {
+            if (stored.isEmpty()) return;
+            var level = getMachine().getLevel();
+            var pos = getMachine().getPos();
+            for (Direction facing : facings) {
+                var filter = getMachine().getFluidCapFilter(facing, IO.OUT);
+                GTTransferUtils.getAdjacentFluidHandler(level, pos, facing)
+                        .ifPresent(adj -> GTTransferUtils.transferFluidsFiltered(this, adj, filter));
+            }
+        }
+
+        @Override
+        public ManagedFieldHolder getFieldHolder() {
+            return MANAGED_FIELD_HOLDER;
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -17,6 +17,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
 import com.gregtechceu.gtceu.api.machine.trait.MachineTrait;
 import com.gregtechceu.gtceu.api.transfer.fluid.CustomFluidTank;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
@@ -84,6 +85,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     @Persisted
     private boolean isVoiding;
 
+    @Getter
     private final long maxAmount;
     protected final FluidCache cache;
     @DescSynced
@@ -140,11 +142,16 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     }
 
     @Override
+    public boolean saveBreak() {
+        return !stored.isEmpty();
+    }
+
+    @Override
     public void saveCustomPersistedData(@NotNull CompoundTag tag, boolean forDrop) {
         super.saveCustomPersistedData(tag, forDrop);
         if (!forDrop) tag.put("lockedFluid", lockedFluid.writeToNBT(new CompoundTag()));
-        if (!stored.isEmpty()) tag.put("stored", stored.writeToNBT(new CompoundTag()));
-        if (storedAmount > 0) tag.putLong("storedAmount", storedAmount);
+        tag.put("stored", stored.writeToNBT(new CompoundTag()));
+        tag.putLong("storedAmount", storedAmount);
     }
 
     @Override
@@ -159,6 +166,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
 
         if (!tag.contains("storedAmount")) this.storedAmount = stored.getAmount();
         else this.storedAmount = tag.getLong("storedAmount");
+        if (storedAmount == 0 && !stored.isEmpty()) this.storedAmount = stored.getAmount();
     }
 
     //////////////////////////////////////
@@ -304,7 +312,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
         var group = new WidgetGroup(0, 0, 90, 63);
         group.addWidget(new ImageWidget(4, 4, 82, 55, GuiTextures.DISPLAY))
                 .addWidget(new LabelWidget(8, 8, "gtceu.gui.fluid_amount"))
-                .addWidget(new LabelWidget(8, 18, () -> String.valueOf(storedAmount))
+                .addWidget(new LabelWidget(8, 18, () -> FormattingUtil.formatBuckets(storedAmount))
                         .setTextColor(-1)
                         .setDropShadow(false))
                 .addWidget(new TankWidget(cache, 0, 68, 23, true, true)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -16,6 +16,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IDropSaveMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IFancyUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
+import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
 import com.lowdragmc.lowdraglib.gui.editor.ColorPattern;
@@ -49,6 +50,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
@@ -78,7 +80,12 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     @Persisted
     protected boolean allowInputFromOutputSideFluids;
     @Getter
-    private final int maxStoredFluids;
+    private final long maxStoredFluids;
+    @Getter
+    @Persisted
+    @DescSynced
+    @DropSaved
+    protected long storedAmount = 0;
     @Getter
     @Persisted
     @DropSaved
@@ -97,7 +104,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     @Setter
     private boolean isVoiding;
 
-    public QuantumTankMachine(IMachineBlockEntity holder, int tier, int maxStoredFluids, Object... args) {
+    public QuantumTankMachine(IMachineBlockEntity holder, int tier, long maxStoredFluids, Object... args) {
         super(holder, tier);
         this.outputFacingFluids = getFrontFacing().getOpposite();
         this.maxStoredFluids = maxStoredFluids;
@@ -114,29 +121,16 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
     }
 
     protected NotifiableFluidTank createCacheFluidHandler(Object... args) {
-        return new NotifiableFluidTank(this, 1, maxStoredFluids, IO.BOTH) {
-
-            @Override
-            public int fill(FluidStack resource, FluidAction action) {
-                return handleVoiding(super.fill(resource, action), resource);
-            }
-
-            private int handleVoiding(int filled, FluidStack resource) {
-                if (filled < resource.getAmount() && isVoiding && isFluidValid(0, resource)) {
-                    if (stored.isEmpty() || stored.isFluidEqual(resource)) {
-                        return resource.getAmount();
-                    }
-                }
-
-                return filled;
-            }
-        };
+        return new CustomCache(this);
     }
 
     @Override
     public void onLoad() {
         super.onLoad();
-        this.stored = cache.getFluidInTank(0);
+        if(!stored.isEmpty()) cache.setFluidInTank(0, stored);
+        else stored = cache.getFluidInTank(0);
+
+        if(storedAmount == 0) storedAmount = stored.getAmount();
         if (getLevel() instanceof ServerLevel serverLevel) {
             serverLevel.getServer().tell(new TickTask(0, this::updateAutoOutputSubscription));
         }
@@ -283,8 +277,7 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
 
     protected void setLocked(boolean locked) {
         if (!stored.isEmpty() && locked) {
-            var copied = stored.copy();
-            copied.setAmount(cache.getLockedFluid().getCapacity());
+            var copied = new FluidStack(stored, 1000);
             cache.setLocked(true, copied);
         } else if (!locked) {
             cache.setLocked(false);
@@ -299,6 +292,10 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
         } else if (stored.isFluidEqual(fluid)) setLocked(true);
     }
 
+    public FluidStack getLockedFluid() {
+        return cache.getLockedFluid().getFluid();
+    }
+
     //////////////////////////////////////
     // *********** GUI ***********//
     //////////////////////////////////////
@@ -306,13 +303,14 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
         var group = new WidgetGroup(0, 0, 90, 63);
         group.addWidget(new ImageWidget(4, 4, 82, 55, GuiTextures.DISPLAY))
                 .addWidget(new LabelWidget(8, 8, "gtceu.gui.fluid_amount"))
-                .addWidget(new LabelWidget(8, 18,
-                        () -> String.valueOf(cache.getFluidInTank(0).getAmount()))
-                        .setTextColor(-1).setDropShadow(false))
-                .addWidget(new TankWidget(cache.getStorages()[0], 68, 23, true, true)
+                .addWidget(new LabelWidget(8, 18, () -> String.valueOf(storedAmount))
+                        .setTextColor(-1)
+                        .setDropShadow(false))
+                .addWidget(new TankWidget(cache, 0, 68, 23, true, true)
+                        .setShowAmount(false)
                         .setBackground(GuiTextures.FLUID_SLOT))
                 .addWidget(new PhantomFluidWidget(cache.getLockedFluid(), 0, 68, 41, 18, 18,
-                        () -> cache.getLockedFluid().getFluid(), this::setLocked)
+                        this::getLockedFluid, this::setLocked)
                         .setShowAmount(false)
                         .setBackground(ColorPattern.T_GRAY.rectTexture()))
                 .addWidget(new ToggleButtonWidget(4, 41, 18, 18,
@@ -351,5 +349,56 @@ public class QuantumTankMachine extends TieredMachine implements IAutoOutputFlui
             if (side == getFrontFacing()) return null;
         }
         return super.sideTips(player, pos, state, toolTypes, side);
+    }
+
+    private class CustomCache extends NotifiableFluidTank {
+        public CustomCache(MetaMachine holder) { super(holder, 1, 1000, IO.BOTH); }
+
+        private FluidStack inner() { return storages[0].getFluid(); }
+
+        @Override
+        public int getTankCapacity(int tank) {
+            return GTMath.saturatedCast(maxStoredFluids);
+        }
+
+        @Override
+        public @NotNull FluidStack getFluidInTank(int tank) {
+            return new FluidStack(inner(), GTMath.saturatedCast(storedAmount));
+        }
+
+        @Override
+        public int fill(FluidStack resource, FluidAction action) {
+            long free = isVoiding ? Long.MAX_VALUE : maxStoredFluids - storedAmount;
+            long canFill = 0;
+            if((inner().isEmpty() || inner().isFluidEqual(resource)) && filter.test(resource)) {
+                canFill = Math.min(resource.getAmount(), free);
+            }
+            if(action.execute() && canFill > 0) {
+                if(inner().isEmpty()) setFluidInTank(0, new FluidStack(resource, 1000));
+                storedAmount = Math.min(maxStoredFluids, storedAmount + canFill);
+                onContentsChanged();
+            }
+            return (int) canFill;
+        }
+
+        @Override
+        public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
+            var stored = inner().copy();
+            if(stored.isEmpty()) return FluidStack.EMPTY;
+            long toDrain = Math.min(storedAmount, maxDrain);
+            if(action.execute() && toDrain > 0) {
+                storedAmount -= toDrain;
+                if(storedAmount == 0) setFluidInTank(0, FluidStack.EMPTY);
+                onContentsChanged();
+            }
+            if(toDrain == 0) return FluidStack.EMPTY;
+            return new FluidStack(stored, (int) toDrain);
+        }
+
+        @Override
+        public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
+            if(!resource.isFluidEqual(inner())) return FluidStack.EMPTY;
+            return drain(resource.getAmount(), action);
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.integration.jade;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.common.blockentity.FluidPipeBlockEntity;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.integration.jade.provider.*;
@@ -46,6 +47,8 @@ public class GTJadePlugin implements IWailaPlugin {
             registration.registerBlockDataProvider(new MEPatternBufferProvider(), BlockEntity.class);
         }
 
+        registration.registerItemStorage(GTItemStorageProvider.INSTANCE, MetaMachineBlockEntity.class);
+        registration.registerFluidStorage(GTFluidStorageProvider.INSTANCE, MetaMachineBlockEntity.class);
         registration.registerFluidStorage(FluidPipeStorageProvider.INSTANCE, FluidPipeBlockEntity.class);
     }
 
@@ -73,6 +76,8 @@ public class GTJadePlugin implements IWailaPlugin {
             registration.registerBlockComponent(new MEPatternBufferProvider(), Block.class);
         }
 
+        registration.registerItemStorageClient(GTItemStorageProvider.INSTANCE);
+        registration.registerFluidStorageClient(GTFluidStorageProvider.INSTANCE);
         registration.registerFluidStorageClient(FluidPipeStorageProvider.INSTANCE);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/GTFluidStorageProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/GTFluidStorageProvider.java
@@ -1,0 +1,89 @@
+package com.gregtechceu.gtceu.integration.jade.provider;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.common.machine.storage.CreativeTankMachine;
+import com.gregtechceu.gtceu.common.machine.storage.QuantumTankMachine;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+import org.jetbrains.annotations.Nullable;
+import snownee.jade.addon.universal.FluidStorageProvider;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.fluid.JadeFluidObject;
+import snownee.jade.api.ui.IElementHelper;
+import snownee.jade.api.view.ClientViewGroup;
+import snownee.jade.api.view.FluidView;
+import snownee.jade.api.view.IClientExtensionProvider;
+import snownee.jade.api.view.IServerExtensionProvider;
+import snownee.jade.api.view.ViewGroup;
+import snownee.jade.util.FluidTextHelper;
+
+import java.util.List;
+
+/**
+ * Custom FluidView info provider for any machines that require it
+ * Currently: Quantum Tanks
+ * Defaults to Jade's normal FluidView provider
+ */
+public enum GTFluidStorageProvider implements IServerExtensionProvider<MetaMachineBlockEntity, CompoundTag>,
+        IClientExtensionProvider<CompoundTag, FluidView> {
+
+    INSTANCE;
+
+    @Override
+    public ResourceLocation getUid() {
+        return GTCEu.id("custom_fluid_storage");
+    }
+
+    @Override
+    public List<ClientViewGroup<FluidView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<CompoundTag>> groups) {
+        return ClientViewGroup.map(groups, GTFluidStorageProvider::readFluid, null);
+    }
+
+    @Override
+    public @Nullable List<ViewGroup<CompoundTag>> getGroups(ServerPlayer serverPlayer, ServerLevel serverLevel,
+                                                            MetaMachineBlockEntity mmbe, boolean b) {
+        if (mmbe.getMetaMachine() instanceof QuantumTankMachine qtm) {
+            CompoundTag tag = new CompoundTag();
+            tag.putBoolean("special", true);
+            FluidStack stored = qtm.getStored();
+            tag.putString("fluid", BuiltInRegistries.FLUID.getKey(stored.getFluid()).toString());
+            long amount = qtm.getStoredAmount();
+            if (qtm instanceof CreativeTankMachine ctm) {
+                amount = (long) Math.ceil(1d * ctm.getMBPerCycle() / ctm.getTicksPerCycle());
+            }
+            tag.putLong("amount", amount);
+            tag.putLong("capacity", qtm.getMaxAmount());
+            if (stored.hasTag()) tag.put("tag", stored.getTag());
+            return List.of(new ViewGroup<>(List.of(tag)));
+        }
+
+        return FluidStorageProvider.INSTANCE.getGroups(serverPlayer, serverLevel, mmbe, b);
+    }
+
+    // FluidView#readDefault can't handle amount > INT_MAX
+    private static FluidView readFluid(CompoundTag tag) {
+        if (!tag.contains("special")) return FluidView.readDefault(tag);
+        long capacity = tag.getLong("capacity");
+        if (capacity <= 0) return null;
+
+        Fluid fluid = BuiltInRegistries.FLUID.get(new ResourceLocation(tag.getString("fluid")));
+        CompoundTag nbt = tag.contains("nbt") ? tag.getCompound("nbt") : null;
+        long amount = tag.getLong("amount");
+        JadeFluidObject fluidObject = JadeFluidObject.of(fluid, 1000, nbt);
+        FluidView fluidView = new FluidView(IElementHelper.get().fluid(fluidObject));
+        fluidView.fluidName = fluid.getFluidType().getDescription();
+        fluidView.current = FluidTextHelper.getUnicodeMillibuckets(amount, true);
+        fluidView.max = FluidTextHelper.getUnicodeMillibuckets(capacity, true);
+        fluidView.ratio = (float) ((double) amount / capacity);
+
+        return fluidView;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/GTItemStorageProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/GTItemStorageProvider.java
@@ -1,0 +1,63 @@
+package com.gregtechceu.gtceu.integration.jade.provider;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.common.machine.storage.CreativeChestMachine;
+import com.gregtechceu.gtceu.common.machine.storage.QuantumChestMachine;
+import com.gregtechceu.gtceu.utils.GTMath;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+import org.jetbrains.annotations.Nullable;
+import snownee.jade.addon.universal.ItemStorageProvider;
+import snownee.jade.api.Accessor;
+import snownee.jade.api.view.ClientViewGroup;
+import snownee.jade.api.view.IClientExtensionProvider;
+import snownee.jade.api.view.IServerExtensionProvider;
+import snownee.jade.api.view.ItemView;
+import snownee.jade.api.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom ItemStack provider for any machines that require it
+ * Currently: Quantum Chests
+ * Defaults to Jade's normal ItemStack provider
+ */
+public enum GTItemStorageProvider implements IServerExtensionProvider<MetaMachineBlockEntity, ItemStack>,
+        IClientExtensionProvider<ItemStack, ItemView> {
+
+    INSTANCE;
+
+    @Override
+    public ResourceLocation getUid() {
+        return GTCEu.id("custom_item_storage");
+    }
+
+    @Override
+    public List<ClientViewGroup<ItemView>> getClientGroups(Accessor<?> accessor, List<ViewGroup<ItemStack>> list) {
+        return ItemStorageProvider.INSTANCE.getClientGroups(accessor, list);
+    }
+
+    @Override
+    public @Nullable List<ViewGroup<ItemStack>> getGroups(ServerPlayer serverPlayer, ServerLevel serverLevel,
+                                                          MetaMachineBlockEntity mmbe, boolean b) {
+        if (mmbe.getMetaMachine() instanceof QuantumChestMachine qcm) {
+            ItemStack stored = qcm.getStored();
+            long amount = qcm.getStoredAmount();
+            if (qcm instanceof CreativeChestMachine ccm) {
+                amount = (long) Math.ceil(1d * ccm.getItemsPerCycle() / ccm.getTicksPerCycle());
+            }
+            List<ItemStack> list = new ArrayList<>();
+            for (int stack : GTMath.split(amount)) {
+                list.add(stored.copyWithCount(stack));
+            }
+            return list.isEmpty() ? List.of() : List.of(new ViewGroup<>(list));
+        }
+        return ItemStorageProvider.INSTANCE.getGroups(serverPlayer, serverLevel, mmbe, b);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/WorkableBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/WorkableBlockProvider.java
@@ -55,23 +55,8 @@ public class WorkableBlockProvider extends CapabilityBlockProvider<IWorkable> {
 
         // show as total computation instead
         if (capData.getBoolean("Research")) {
-            String current, max;
-            if (currentProgress >= 1e6) {
-                current = FormattingUtil.DECIMAL_FORMAT_1F.format(currentProgress / 1e6) + "M";
-            } else if (currentProgress >= 1e3) {
-                current = FormattingUtil.DECIMAL_FORMAT_1F.format(currentProgress / 1e3) + "K";
-            } else {
-                current = String.valueOf(currentProgress);
-            }
-
-            if (maxProgress >= 1e6) {
-                max = FormattingUtil.DECIMAL_FORMAT_1F.format(maxProgress / 1e6) + "M";
-            } else if (maxProgress >= 1e3) {
-                max = FormattingUtil.DECIMAL_FORMAT_1F.format(maxProgress / 1e3) + "K";
-            } else {
-                max = String.valueOf(maxProgress);
-            }
-
+            String current = FormattingUtil.formatNumberReadable(currentProgress);
+            String max = FormattingUtil.formatNumberReadable(maxProgress);
             text = Component.translatable("gtceu.jade.progress_computation", current, max);
 
             tooltip.add(


### PR DESCRIPTION
## What
This PR adds the ability for the Quantum Storages to hold more than INT_MAX items or mB. This is done by tracking the stored amount separately from the stored item or fluid. 

## Implementation Details
The following details apply to the Tanks as well.

The stored item is now saved as an `ItemStack` field with count 1. All item manipulations are based on this field.
For the locked item slot, a `CustomItemStackHandler` field is necessary for the `PhantomSlotWidget`.

In order to achieve interoperability with Forge's item capability system, the Quantum Chests now have the nested `ItemCache` class, which is an implementation of `IItemHandler`, rather than directly extending the `NotifiableItemStackHandler` class. It also extends the `MachineTrait` class so that it will be accounted for by `MetaMachine#getItemHandlerCap`. The `ItemCache` properly accounts for the long->int conversion when necessary and properly exposes its contents to the outside.

Due to *issues*, the data for the locked item, the stored item, and the stored amount are persisted without the `@Persisted` or `@DropSaved` annotations. A tag will not be saved on break if the stored item is empty.

## Additional Details
ItemStorage and FluidStorage providers for Jade have been created to properly handle the `long` nature of the Quantums. They will act like normal for other MMBEs. 

Quantum Chests will now check to see the BlockHitResult lands within the bounds of the front glass to count as an interaction.

A new set of `FormattingUtil` methods have been created that will compact numbers into engineering notation using SI prefixes. This has been inserted into a few places throughout the codebase.
Some tooltips in GTMachines have also been cleaned up.