### PR TITLE
Fix empty crates and drums not stacking with new ones

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CrateMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CrateMachine.java
@@ -140,6 +140,11 @@ public class CrateMachine extends MetaMachine implements IUIMachine, IMachineLif
     }
 
     @Override
+    public boolean saveBreak() {
+        return isTaped;
+    }
+
+    @Override
     public void onMachineRemoved() {
         if (!isTaped) clearInventory(inventory.storage);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
@@ -208,6 +208,11 @@ public class DrumMachine extends MetaMachine implements IAutoOutputFluid, IDropS
     }
 
     @Override
+    public boolean saveBreak() {
+        return !stored.isEmpty();
+    }
+
+    @Override
     protected InteractionResult onScrewdriverClick(Player playerIn, InteractionHand hand, Direction gridSide,
                                                    BlockHitResult hitResult) {
         if (!isRemote()) {


### PR DESCRIPTION
## What
Solves the issue with crates where they'd save an empty tag causing them not to stack with new crates.
Solves the issue with drums where they'd save a tag with an empty fluidstack causing them not to stack with new drums.

## Implementation Details
Just added a check for crates to see if they're taped and for drums if they're not empty before saving the tag.

## Outcome
They stack correctly when broken and still save their data otherwise.

## Also
Fixes #2310 