### PR TITLE
Rework and refactor Chance Logic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -332,7 +332,7 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
                                 @NotNull GTRecipeType recipeType,
                                 @UnknownNullability("null when content == null") GTRecipe recipe,
                                 @Nullable Content content,
-                                @Nullable Object storage, int tier, int minTier) {
+                                @Nullable Object storage, int recipeTier, int chanceTier) {
         if (widget instanceof TankWidget tank) {
             if (storage instanceof TagOrCycleFluidHandler fluidHandler) {
                 tank.setFluidTank(fluidHandler, index);
@@ -343,8 +343,8 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
             tank.setAllowClickFilled(!isXEI);
             tank.setAllowClickDrained(!isXEI && io.support(IO.IN));
             if (content != null) {
-                float chance = (float) recipeType.getChanceFunction().getBoostedChance(content, minTier, tier) /
-                        content.maxChance;
+                float chance = (float) recipeType.getChanceFunction()
+                        .getBoostedChance(content, recipeTier, chanceTier) / content.maxChance;
                 tank.setXEIChance(chance);
                 tank.setOnAddedTooltips((w, tooltips) -> {
                     FluidIngredient ingredient = FluidRecipeCapability.CAP.of(content.content);
@@ -357,12 +357,15 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
                     }
 
                     GTRecipeWidget.setConsumedChance(content,
-                            recipe.getChanceLogicForCapability(this, io, isTickSlot(index, io, recipe)), tooltips, tier,
-                            minTier, recipeType.getChanceFunction());
+                            recipe.getChanceLogicForCapability(this, io, isTickSlot(index, io, recipe)),
+                            tooltips, recipeTier, chanceTier, recipeType.getChanceFunction());
                     if (isTickSlot(index, io, recipe)) {
                         tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
                     }
                 });
+                if (io == IO.IN && (content.chance == 0)) {
+                    tank.setIngredientIO(IngredientIO.CATALYST);
+                }
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeCapabilityHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeCapabilityHolder.java
@@ -13,12 +13,4 @@ public interface IRecipeCapabilityHolder {
 
     @NotNull
     Table<IO, RecipeCapability<?>, List<IRecipeHandler<?>>> getCapabilitiesProxy();
-
-    /**
-     * get Tier for chance boost.
-     * if -1, all chanced outputs are voided.
-     */
-    default int getChanceTier() {
-        return 0;
-    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -499,7 +499,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                                 @NotNull GTRecipeType recipeType,
                                 @UnknownNullability("null when content == null") GTRecipe recipe,
                                 @Nullable Content content,
-                                @Nullable Object storage, int tier, int minTier) {
+                                @Nullable Object storage, int recipeTier, int chanceTier) {
         if (widget instanceof SlotWidget slot) {
             if (storage instanceof IItemHandlerModifiable items) {
                 if (index >= 0 && index < items.getSlots()) {
@@ -533,13 +533,13 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                 }
             }
             if (content != null) {
-                float chance = (float) recipeType.getChanceFunction().getBoostedChance(content, minTier, tier) /
-                        content.maxChance;
+                float chance = (float) recipeType.getChanceFunction()
+                        .getBoostedChance(content, recipeTier, chanceTier) / content.maxChance;
                 slot.setXEIChance(chance);
                 slot.setOnAddedTooltips((w, tooltips) -> {
                     GTRecipeWidget.setConsumedChance(content,
-                            recipe.getChanceLogicForCapability(this, io, isTickSlot(index, io, recipe)), tooltips, tier,
-                            minTier, recipeType.getChanceFunction());
+                            recipe.getChanceLogicForCapability(this, io, isTickSlot(index, io, recipe)),
+                            tooltips, recipeTier, chanceTier, recipeType.getChanceFunction());
                     //@formatter:off
                     if (this.of(content.content) instanceof IntProviderIngredient ingredient) {
                         IntProvider countProvider = ingredient.getCountProvider();

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
@@ -192,12 +192,7 @@ public abstract class RecipeCapability<T> {
                                 @NotNull GTRecipeType recipeType,
                                 @Nullable("null when content == null") GTRecipe recipe,
                                 @Nullable Content content,
-                                @Nullable Object storage, int tier, int minTier) {}
-
-    // TODO
-    public double calculateAmount(List<T> left) {
-        return 1;
-    }
+                                @Nullable Object storage, int recipeTier, int chanceTier) {}
 
     /**
      * Create a cache map for chanced outputs

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -22,17 +22,6 @@ import org.jetbrains.annotations.Nullable;
 public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFeature, IWorkable, ICleanroomReceiver,
                                      IVoidable {
 
-    @Override
-    default int getChanceTier() {
-        if (self() instanceof IOverclockMachine ocMachine) {
-            return ocMachine.getOverclockTier();
-        } else if (self() instanceof ITieredMachine tieredMachine) {
-            return tieredMachine.getTier();
-        }
-
-        return self().getDefinition().getTier();
-    }
-
     /**
      * RecipeType held
      */

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -331,10 +331,12 @@ public class MultiblockDisplayText {
             return this;
         }
 
-        public Builder addOutputLines(GTRecipe recipe, int chanceTier) {
+        public Builder addOutputLines(GTRecipe recipe) {
             if (!isStructureFormed || !isActive)
                 return this;
             if (recipe != null) {
+                int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
+                int chanceTier = recipeTier + recipe.ocLevel;
                 var function = recipe.getType().getChanceFunction();
                 double maxDurationSec = (double) recipe.duration / 20.0;
                 var itemOutputs = recipe.getOutputContents(ItemRecipeCapability.CAP);
@@ -346,8 +348,7 @@ public class MultiblockDisplayText {
                     double countD = count;
                     if (item.chance < item.maxChance) {
                         countD = countD * recipe.parallels *
-                                function.getBoostedChance(item, RecipeHelper.getPreOCRecipeEuTier(recipe), chanceTier) /
-                                item.maxChance;
+                                function.getBoostedChance(item, recipeTier, chanceTier) / item.maxChance;
                         count = countD < 1 ? 1 : (int) Math.round(countD);
                     }
                     if (count < maxDurationSec) {
@@ -365,8 +366,8 @@ public class MultiblockDisplayText {
                     int amount = stack.getAmount();
                     double amountD = amount;
                     if (fluid.chance < fluid.maxChance) {
-                        amountD = amountD * recipe.parallels * function.getBoostedChance(fluid,
-                                RecipeHelper.getPreOCRecipeEuTier(recipe), chanceTier) / fluid.maxChance;
+                        amountD = amountD * recipe.parallels *
+                                function.getBoostedChance(fluid, recipeTier, chanceTier) / fluid.maxChance;
                         amount = amountD < 1 ? 1 : (int) Math.round(amountD);
                     }
                     if (amount < maxDurationSec) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -100,7 +100,7 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
                 .addWorkingStatusLine()
                 .addProgressLine(recipeLogic.getProgress(), recipeLogic.getMaxProgress(),
                         recipeLogic.getProgressPercent())
-                .addOutputLines(recipeLogic.getLastRecipe(), this.getChanceTier());
+                .addOutputLines(recipeLogic.getLastRecipe());
         getDefinition().getAdditionalDisplay().accept(this, textList);
         IDisplayUIMachine.super.addDisplayText(textList);
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -63,7 +63,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     public CompoundTag data;
     public int duration;
     public int parallels = 1;
-    public int ocTier = 0;
+    public int ocLevel = 0;
     public GTRecipeCategory recipeCategory = null;
     @Getter
     public boolean isFuel;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -62,7 +62,7 @@ public class RecipeHelper {
         long EUt = getInputEUt(recipe);
         if (EUt == 0) EUt = getOutputEUt(recipe);
         if (recipe.parallels > 1) EUt /= recipe.parallels;
-        EUt >>= (recipe.ocTier * 2);
+        EUt >>= (recipe.ocLevel * 2);
         return GTUtil.getTierByVoltage(EUt);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -111,12 +111,10 @@ class RecipeRunner {
         // Only roll if there's anything to roll for
         if (!chancedContents.isEmpty()) {
             int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-            int holderTier = holder.getChanceTier();
+            int chanceTier = recipeTier + recipe.ocLevel;
             var cache = this.chanceCaches.get(cap);
-            chancedContents = logic.roll(chancedContents, function, recipeTier, holderTier, cache, recipe.parallels,
-                    cap);
+            chancedContents = logic.roll(chancedContents, function, recipeTier, chanceTier, cache, recipe.parallels);
 
-            if (chancedContents == null) return;
             for (Content cont : chancedContents) {
                 if (cont.slotName == null) {
                     this.content.content.add(cont.content);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/boost/ChanceBoostFunction.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/boost/ChanceBoostFunction.java
@@ -15,8 +15,8 @@ public interface ChanceBoostFunction {
     /**
      * Chance boosting function based on the number of performed overclocks
      */
-    ChanceBoostFunction OVERCLOCK = (entry, recipeTier, machineTier) -> {
-        int tierDiff = machineTier - recipeTier;
+    ChanceBoostFunction OVERCLOCK = (entry, recipeTier, chanceTier) -> {
+        int tierDiff = chanceTier - recipeTier;
         if (tierDiff <= 0) return entry.chance; // equal or invalid tiers do not boost at all
         if (recipeTier == GTValues.ULV) tierDiff--; // LV does not boost over ULV
         return GTMath.clamp(entry.chance + (entry.tierChanceBoost * tierDiff), 0, entry.maxChance);
@@ -25,13 +25,13 @@ public interface ChanceBoostFunction {
     /**
      * Chance boosting function which performs no boosting
      */
-    ChanceBoostFunction NONE = (entry, recipeTier, machineTier) -> entry.chance;
+    ChanceBoostFunction NONE = (entry, recipeTier, chanceTier) -> entry.chance;
 
     /**
-     * @param entry       the amount to boost by
-     * @param recipeTier  the base tier of the recipe
-     * @param machineTier the tier the recipe is run at
+     * @param entry      the amount to boost by
+     * @param recipeTier the base tier of the recipe
+     * @param chanceTier the tier the recipe is run at
      * @return the boosted chance
      */
-    int getBoostedChance(@NotNull Content entry, int recipeTier, int machineTier);
+    int getBoostedChance(@NotNull Content entry, int recipeTier, int chanceTier);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -2,10 +2,8 @@ package com.gregtechceu.gtceu.api.recipe.chance.logic;
 
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
-import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 
 import net.minecraft.network.chat.Component;
@@ -18,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -35,38 +34,33 @@ public abstract class ChanceLogic {
     public static final ChanceLogic OR = new ChanceLogic("or") {
 
         @Override
-        public @Nullable @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                                   @NotNull ChanceBoostFunction boostFunction,
-                                                                   int baseTier, int machineTier,
-                                                                   @Nullable Object2IntMap<?> cache, int times,
-                                                                   RecipeCapability<?> cap) {
+        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction,
+                                                         int recipeTier, int chanceTier,
+                                                         @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
             for (Content entry : chancedEntries) {
-                int newChance = getChance(entry, boostFunction, baseTier, machineTier);
                 int maxChance = entry.maxChance;
 
-                // Chanced outputs are deterministic
+                // OR Chanced outputs are deterministic
                 // If a large batch is being done we can calculate how many we expect to get.
                 // Add the guaranteed part of that to the list, then roll for the remaining chanced part.
+                int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                 int totalChance = times * newChance;
                 int guaranteed = totalChance / maxChance;
-                if (guaranteed > 0) builder.add(entry.copyExplicit(cap, ContentModifier.multiplier(guaranteed)));
-                newChance = totalChance - (guaranteed * maxChance);
+                if (guaranteed > 0) builder.addAll(Collections.nCopies(guaranteed, entry));
+                newChance = totalChance % maxChance;
 
                 int cached = getCachedChance(entry, cache);
                 int chance = newChance + cached;
-                if (passesChance(chance, maxChance)) {
-                    do {
-                        builder.add(entry);
-                        chance -= maxChance;
-                        newChance -= maxChance;
-                    } while (passesChance(chance, maxChance));
+                while (passesChance(chance, maxChance)) {
+                    builder.add(entry);
+                    chance -= maxChance;
+                    newChance -= maxChance;
                 }
                 updateCachedChance(entry.content, cache, newChance / 2 + cached);
             }
-
-            List<Content> list = builder.build();
-            return list.isEmpty() ? null : list;
+            return builder.build();
         }
 
         @Override
@@ -86,18 +80,16 @@ public abstract class ChanceLogic {
     public static final ChanceLogic AND = new ChanceLogic("and") {
 
         @Override
-        public @Nullable @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                                   @NotNull ChanceBoostFunction boostFunction,
-                                                                   int baseTier, int machineTier,
-                                                                   @Nullable Object2IntMap<?> cache, int times,
-                                                                   RecipeCapability<?> cap) {
+        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction,
+                                                         int recipeTier, int chanceTier,
+                                                         @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
             for (int i = 0; i < times; ++i) {
                 boolean failed = false;
                 for (Content entry : chancedEntries) {
+                    int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                     int cached = getCachedChance(entry, cache);
-
-                    int newChance = getChance(entry, boostFunction, baseTier, machineTier);
                     int chance = newChance + cached;
                     if (!passesChance(chance, entry.maxChance)) failed = true;
                     updateCachedChance(entry.content, cache, newChance / 2 + cached);
@@ -105,8 +97,7 @@ public abstract class ChanceLogic {
                 }
                 if (!failed) builder.addAll(chancedEntries);
             }
-            List<Content> list = builder.build();
-            return list.isEmpty() ? null : list;
+            return builder.build();
         }
 
         @Override
@@ -126,18 +117,16 @@ public abstract class ChanceLogic {
     public static final ChanceLogic XOR = new ChanceLogic("xor") {
 
         @Override
-        public @Nullable @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                                   @NotNull ChanceBoostFunction boostFunction,
-                                                                   int baseTier, int machineTier,
-                                                                   @Nullable Object2IntMap<?> cache, int times,
-                                                                   RecipeCapability<?> cap) {
+        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction,
+                                                         int recipeTier, int chanceTier,
+                                                         @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
             for (int i = 0; i < times; ++i) {
                 Content selected = null;
                 for (Content entry : chancedEntries) {
+                    int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                     int cached = getCachedChance(entry, cache);
-
-                    int newChance = getChance(entry, boostFunction, baseTier, machineTier);
                     int chance = newChance + cached;
                     if (passesChance(chance, entry.maxChance)) selected = entry;
                     updateCachedChance(entry.content, cache, newChance / 2 + cached);
@@ -145,8 +134,7 @@ public abstract class ChanceLogic {
                 }
                 if (selected != null) builder.add(selected);
             }
-            List<Content> list = builder.build();
-            return list.isEmpty() ? null : list;
+            return builder.build();
         }
 
         @Override
@@ -166,12 +154,11 @@ public abstract class ChanceLogic {
     public static final ChanceLogic NONE = new ChanceLogic("none") {
 
         @Override
-        public @Nullable @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                                   @NotNull ChanceBoostFunction boostFunction,
-                                                                   int baseTier, int machineTier,
-                                                                   @Nullable Object2IntMap<?> cache, int times,
-                                                                   RecipeCapability<?> cap) {
-            return null;
+        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction,
+                                                         int recipeTier, int chanceTier,
+                                                         @Nullable Object2IntMap<?> cache, int times) {
+            return Collections.emptyList();
         }
 
         @Override
@@ -192,13 +179,13 @@ public abstract class ChanceLogic {
     /**
      * @param entry         the entry to get the complete chance for
      * @param boostFunction the function boosting the entry's chance
-     * @param baseTier      the base tier of the recipe
-     * @param machineTier   the tier the recipe is run at
+     * @param recipeTier    the base tier of the recipe
+     * @param chanceTier    the tier the recipe is run at
      * @return the total chance for the entry
      */
-    static int getChance(@NotNull Content entry, @NotNull ChanceBoostFunction boostFunction, int baseTier,
-                         int machineTier) {
-        return boostFunction.getBoostedChance(entry, baseTier, machineTier);
+    static int getChance(@NotNull Content entry, @NotNull ChanceBoostFunction boostFunction, int recipeTier,
+                         int chanceTier) {
+        return boostFunction.getBoostedChance(entry, recipeTier, chanceTier);
     }
 
     /**
@@ -245,35 +232,33 @@ public abstract class ChanceLogic {
      *
      * @param chancedEntries the list of entries to roll
      * @param boostFunction  the function to boost the entries' chances
-     * @param baseTier       the base tier of the recipe
-     * @param machineTier    the tier the recipe is run at
+     * @param recipeTier     the base tier of the recipe
+     * @param chanceTier     the tier the recipe is run at
      * @param cache          the cache of previously rolled chances, can be null
-     * @param cap
-     * @return a list of the produced outputs, or null if failed
+     * @param times          the number of times to roll
+     * @return a list of the produced outputs, empty if roll fails
      */
-    public abstract @Nullable @Unmodifiable List<@NotNull Content> roll(
-                                                                        @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                                        @NotNull ChanceBoostFunction boostFunction,
-                                                                        int baseTier, int machineTier,
-                                                                        @Nullable Object2IntMap<?> cache, int times,
-                                                                        RecipeCapability<?> cap);
+    public abstract @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                              @NotNull ChanceBoostFunction boostFunction,
+                                                              int recipeTier,
+                                                              int chanceTier, @Nullable Object2IntMap<?> cache,
+                                                              int times);
 
     /**
      * Roll the chance and attempt to produce the output
      *
      * @param chancedEntries the list of entries to roll
      * @param boostFunction  the function to boost the entries' chances
-     * @param baseTier       the base tier of the recipe
-     * @param machineTier    the tier the recipe is run at
+     * @param recipeTier     the base tier of the recipe
+     * @param chanceTier     the tier the recipe is run at
+     * @param times          the number of times to roll
      * @return a list of the produced outputs
      */
-    @Nullable
     @Unmodifiable
-    public List<@NotNull Content> roll(
-                                       @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                       @NotNull ChanceBoostFunction boostFunction,
-                                       int baseTier, int machineTier, int times, RecipeCapability<?> cap) {
-        return roll(chancedEntries, boostFunction, baseTier, machineTier, null, times, cap);
+    public List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                       @NotNull ChanceBoostFunction boostFunction, int recipeTier, int chanceTier,
+                                       int times) {
+        return roll(chancedEntries, boostFunction, recipeTier, chanceTier, null, times);
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -94,7 +94,7 @@ public abstract class ChanceLogic {
                     if (passesChance(chance, entry.maxChance)) newChance -= entry.maxChance;
                     else failed = true;
                     updateCachedChance(entry.content, cache, newChance / 2 + cached);
-                    if(failed) break;
+                    if (failed) break;
                 }
                 if (!failed) builder.addAll(chancedEntries);
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -91,9 +91,10 @@ public abstract class ChanceLogic {
                     int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                     int cached = getCachedChance(entry, cache);
                     int chance = newChance + cached;
-                    if (!passesChance(chance, entry.maxChance)) failed = true;
+                    if (passesChance(chance, entry.maxChance)) newChance -= entry.maxChance;
+                    else failed = true;
                     updateCachedChance(entry.content, cache, newChance / 2 + cached);
-                    if (failed) break;
+                    if(failed) break;
                 }
                 if (!failed) builder.addAll(chancedEntries);
             }
@@ -128,7 +129,10 @@ public abstract class ChanceLogic {
                     int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                     int cached = getCachedChance(entry, cache);
                     int chance = newChance + cached;
-                    if (passesChance(chance, entry.maxChance)) selected = entry;
+                    if (passesChance(chance, entry.maxChance)) {
+                        selected = entry;
+                        newChance -= entry.maxChance;
+                    }
                     updateCachedChance(entry.content, cache, newChance / 2 + cached);
                     if (selected != null) break;
                 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/RecipeModifierList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/RecipeModifierList.java
@@ -56,7 +56,7 @@ public class RecipeModifierList implements RecipeModifier {
                 modifiedRecipe = ParallelLogic.applyParallel(machine, modifiedRecipe, result.getParallel(), false)
                         .getFirst();
             }
-            modifiedRecipe.ocTier = result.getOcLevel();
+            modifiedRecipe.ocLevel = result.getOcLevel();
         }
         result.reset();
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1176,7 +1176,7 @@ public class GTRecipeBuilder {
         if (recipeType != null) {
             if (recipeCategory == null) {
                 GTCEu.LOGGER.error("Recipes must have a category", new IllegalArgumentException());
-            } else if (recipeCategory.getRecipeType() != this.recipeType) {
+            } else if (recipeCategory != GTRecipeCategory.EMPTY && recipeCategory.getRecipeType() != recipeType) {
                 GTCEu.LOGGER.error("Cannot apply Category with incompatible RecipeType",
                         new IllegalArgumentException());
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTOreByProduct.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTOreByProduct.java
@@ -299,7 +299,7 @@ public class GTOreByProduct {
             float chance = 100 * (float) entry.chance / entry.maxChance;
             float boost = entry.tierChanceBoost / 100.0f;
             tooltips.add(FormattingUtil.formatPercentage2Places("gtceu.gui.content.chance_base", chance));
-            tooltips.add(FormattingUtil.formatPercentage2Places("gtceu.gui.content.chance_tier_boost", boost));
+            tooltips.add(FormattingUtil.formatPercentage2Places("gtceu.gui.content.chance_tier_boost_plus", boost));
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/GTRecipeWidget.java
@@ -38,7 +38,6 @@ import net.minecraft.util.Mth;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-import lombok.Getter;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
@@ -64,11 +63,8 @@ public class GTRecipeWidget extends WidgetGroup {
     private final int xOffset;
     private final GTRecipe recipe;
     private final List<LabelWidget> recipeParaTexts = new ArrayList<>();
-    @Getter
     private final int minTier;
-    @Getter
     private int tier;
-    @Getter
     private int yOffset;
     private LabelWidget voltageTextWidget;
 
@@ -180,7 +176,7 @@ public class GTRecipeWidget extends WidgetGroup {
                     voltageTextWidget.getSizeWidth(), voltageTextWidget.getSizeHeight(),
                     cd -> setRecipeOC(cd.button, cd.isShiftClick))
                     .setHoverTooltips(
-                            Component.translatable("gtceu.oc.tooltip.0", GTValues.VNF[getMinTier()]),
+                            Component.translatable("gtceu.oc.tooltip.0", GTValues.VNF[minTier]),
                             Component.translatable("gtceu.oc.tooltip.1"),
                             Component.translatable("gtceu.oc.tooltip.2"),
                             Component.translatable("gtceu.oc.tooltip.3"),
@@ -265,7 +261,7 @@ public class GTRecipeWidget extends WidgetGroup {
         long inputEUt = RecipeHelper.getInputEUt(recipe);
         int duration = recipe.duration;
         String tierText = GTValues.VNF[tier];
-        if (tier > getMinTier() && inputEUt != 0) {
+        if (tier > minTier && inputEUt != 0) {
             OCParams p = new OCParams();
             OCResult r = new OCResult();
             RecipeHelper.performOverclocking(logic, recipe, inputEUt, GTValues.V[tier], p, r);
@@ -283,10 +279,10 @@ public class GTRecipeWidget extends WidgetGroup {
         updateScreen();
     }
 
-    public static void setConsumedChance(Content content, ChanceLogic logic, List<Component> tooltips, int tier,
-                                         int minTier, ChanceBoostFunction function) {
+    public static void setConsumedChance(Content content, ChanceLogic logic, List<Component> tooltips, int recipeTier,
+                                         int chanceTier, ChanceBoostFunction function) {
         if (content.chance < ChanceLogic.getMaxChancedValue()) {
-            int boostedChance = function.getBoostedChance(content, minTier, tier);
+            int boostedChance = function.getBoostedChance(content, recipeTier, chanceTier);
             if (boostedChance == 0) {
                 tooltips.add(Component.translatable("gtceu.gui.content.chance_nc"));
             } else {
@@ -320,11 +316,11 @@ public class GTRecipeWidget extends WidgetGroup {
     }
 
     private void setTier(int tier) {
-        this.tier = Mth.clamp(tier, getMinTier(), GTValues.MAX);
+        this.tier = Mth.clamp(tier, minTier, GTValues.MAX);
     }
 
     private void setTierToMin() {
-        setTier(getMinTier());
+        setTier(minTier);
     }
 
     public void collectStorage(Table<IO, RecipeCapability<?>, Object> extraTable,
@@ -392,10 +388,9 @@ public class GTRecipeWidget extends WidgetGroup {
                             if (index >= 0 && index < contents.size()) {
                                 var content = contents.get(index);
                                 cap.applyWidgetInfo(widget, index, true, io, null, recipe.getType(), recipe, content,
-                                        null, tier, getMinTier());
-                                widget.setOverlay(
-                                        content.createOverlay(index >= nonTickCount, getMinTier(), tier,
-                                                recipe.getType().getChanceFunction()));
+                                        null, minTier, tier);
+                                widget.setOverlay(content.createOverlay(index >= nonTickCount, minTier, tier,
+                                        recipe.getType().getChanceFunction()));
                             }
                         });
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -403,6 +403,9 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                 if (gtRecipe.getValue(GTRecipeSchema.IS_FUEL) != null) {
                     builder.isFuel = gtRecipe.getValue(GTRecipeSchema.IS_FUEL);
                 }
+                if(gtRecipe.getValue(GTRecipeSchema.CATEGORY) != null) {
+                    builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES.get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
+                }
                 builder.researchRecipeEntries().addAll(gtRecipe.researchRecipeEntries());
 
                 if (gtRecipe.getValue(GTRecipeSchema.ALL_INPUTS) != null) {
@@ -440,6 +443,19 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                                                     .getSecond().write(gtRecipe, content)))
                                     .toList()))
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                }
+
+                if(gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS) != null) {
+                    builder.inputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS));
+                }
+                if(gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS) != null) {
+                    builder.outputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS));
+                }
+                if(gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS) != null) {
+                    builder.tickInputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS));
+                }
+                if(gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS) != null) {
+                    builder.tickOutputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS));
                 }
 
                 builder.save(builtRecipe -> recipesByName.put(builtRecipe.getId(),

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -403,8 +403,9 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                 if (gtRecipe.getValue(GTRecipeSchema.IS_FUEL) != null) {
                     builder.isFuel = gtRecipe.getValue(GTRecipeSchema.IS_FUEL);
                 }
-                if(gtRecipe.getValue(GTRecipeSchema.CATEGORY) != null) {
-                    builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES.get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
+                if (gtRecipe.getValue(GTRecipeSchema.CATEGORY) != null) {
+                    builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES
+                            .get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
                 }
                 builder.researchRecipeEntries().addAll(gtRecipe.researchRecipeEntries());
 
@@ -445,16 +446,16 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
                 }
 
-                if(gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS) != null) {
+                if (gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS) != null) {
                     builder.inputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS));
                 }
-                if(gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS) != null) {
+                if (gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS) != null) {
                     builder.outputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS));
                 }
-                if(gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS) != null) {
+                if (gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS) != null) {
                     builder.tickInputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS));
                 }
-                if(gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS) != null) {
+                if (gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS) != null) {
                     builder.tickOutputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS));
                 }
 


### PR DESCRIPTION
## What
This PR refactors chance and chance-related parts of the code base. 
One major change is that chance boosts are now dependent on the `ocLevel` (formerly `ocTier`) of the recipe being run, rather than the overclock tier of the machine running the recipe. For instance, an IV-tier multiblock running 4 recipes in parallel at EV will now only boost their chance up to EV rather than all the way to IV.

This change has been reflected throughout the code base, where the boost tier is now referred to as `chanceTier` rather than `machineTier` in relevant places.

## Implementation Details
`IRecipeCapabilityHolder#getChanceTier()` and its implementations have been removed.
Whenever a chance tier is required for a recipe, it is calculated by taking the base recipe tier and adding the OC level to it
`ChanceLogic#roll` now returns an empty list, rather than null, if all rolls fail.
`AND` and `XOR` have been fixed (again)
`GTRecipeWidget#getMinTier()` has been removed for brevity as `minTier` is a private final field that can be directly accessed.

## Additional Information
The KJS plugin has been updated to actually allow different chance logics to be used in recipes. Also the category.
Fixes #2455 