### PR TITLE
Add Empty Hand Interaction for Covers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -295,7 +295,8 @@ public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
         }
 
         Set<GTToolType> types = ToolHelper.getToolTypes(itemStack);
-        if (machine != null && !types.isEmpty() && ToolHelper.canUse(itemStack)) {
+        if (machine != null && (!types.isEmpty() && ToolHelper.canUse(itemStack)) ||
+                (types.isEmpty() && player.isShiftKeyDown())) {
             var result = machine.onToolClick(types, itemStack, new UseOnContext(player, hand, hit));
             if (result.getSecond() == InteractionResult.CONSUME && player instanceof ServerPlayer serverPlayer) {
                 ToolHelper.playToolSound(result.getFirst(), serverPlayer);

--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -350,7 +350,7 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
         }
 
         Set<GTToolType> types = ToolHelper.getToolTypes(itemStack);
-        if (!types.isEmpty() && ToolHelper.canUse(itemStack)) {
+        if ((!types.isEmpty() && ToolHelper.canUse(itemStack)) || (types.isEmpty() && player.isShiftKeyDown())) {
             var result = pipeBlockEntity.onToolClick(types, itemStack, new UseOnContext(player, hand, hit));
             if (result.getSecond() == InteractionResult.CONSUME && player instanceof ServerPlayer serverPlayer) {
                 ToolHelper.playToolSound(result.getFirst(), serverPlayer);

--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -379,6 +379,11 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
         if (gridSide == null) gridSide = hitResult.getDirection();
 
         // Prioritize covers where they apply (Screwdriver, Soft Mallet)
+        if (toolTypes.isEmpty() && playerIn.isShiftKeyDown()) {
+            if (coverBehavior != null) {
+                return Pair.of(null, coverBehavior.onScrewdriverClick(playerIn, hand, hitResult));
+            }
+        }
         if (toolTypes.contains(GTToolType.SCREWDRIVER)) {
             if (coverBehavior != null) {
                 return Pair.of(GTToolType.SCREWDRIVER, coverBehavior.onScrewdriverClick(playerIn, hand, hitResult));

--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -10,7 +10,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.api.item.tool.IToolGridHighLight;
+import com.gregtechceu.gtceu.api.item.tool.IToolGridHighlight;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.pipenet.*;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
@@ -66,7 +66,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeType<NodeDataType>, NodeDataType>
                                      extends BlockEntity implements IPipeNode<PipeType, NodeDataType>, IEnhancedManaged,
-                                     IAsyncAutoSyncBlockEntity, IAutoPersistBlockEntity, IToolGridHighLight, IToolable {
+                                     IAsyncAutoSyncBlockEntity, IAutoPersistBlockEntity, IToolGridHighlight, IToolable {
 
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(PipeBlockEntity.class);
     @Getter

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/CoverBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/CoverBehavior.java
@@ -189,7 +189,7 @@ public abstract class CoverBehavior implements IEnhancedManaged, IToolGridHighLi
     public boolean shouldRenderGrid(Player player, BlockPos pos, BlockState state, ItemStack held,
                                     Set<GTToolType> toolTypes) {
         return toolTypes.contains(GTToolType.CROWBAR) ||
-                (toolTypes.contains(GTToolType.SCREWDRIVER) && this instanceof IUICover);
+                ((toolTypes.isEmpty() || toolTypes.contains(GTToolType.SCREWDRIVER)) && this instanceof IUICover);
     }
 
     @Override
@@ -198,7 +198,7 @@ public abstract class CoverBehavior implements IEnhancedManaged, IToolGridHighLi
         if (toolTypes.contains(GTToolType.CROWBAR)) {
             return GuiTextures.TOOL_REMOVE_COVER;
         }
-        if (toolTypes.contains(GTToolType.SCREWDRIVER) && this instanceof IUICover) {
+        if ((toolTypes.isEmpty() || toolTypes.contains(GTToolType.SCREWDRIVER)) && this instanceof IUICover) {
             return GuiTextures.TOOL_COVER_SETTINGS;
         }
         return null;

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/CoverBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/CoverBehavior.java
@@ -5,7 +5,7 @@ import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.factory.CoverUIFactory;
 import com.gregtechceu.gtceu.api.gui.fancy.IFancyConfigurator;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.api.item.tool.IToolGridHighLight;
+import com.gregtechceu.gtceu.api.item.tool.IToolGridHighlight;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
 import com.gregtechceu.gtceu.client.renderer.cover.ICoverRenderer;
 
@@ -44,7 +44,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public abstract class CoverBehavior implements IEnhancedManaged, IToolGridHighLight {
+public abstract class CoverBehavior implements IEnhancedManaged, IToolGridHighlight {
 
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(CoverBehavior.class);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/IToolGridHighlight.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/IToolGridHighlight.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * @author KilaBash
  * @date 2023/3/2
  */
-public interface IToolGridHighLight {
+public interface IToolGridHighlight {
 
     default boolean shouldRenderGrid(Player player, BlockPos pos, BlockState state, ItemStack held,
                                      Set<GTToolType> toolTypes) {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -240,7 +240,7 @@ public class ToolHelper {
     }
 
     public static void playToolSound(GTToolType toolType, ServerPlayer player) {
-        if (toolType.soundEntry != null) {
+        if (toolType != null && toolType.soundEntry != null) {
             toolType.soundEntry.playOnServer(player.level(), player.blockPosition());
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/IMachineBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/IMachineBlockEntity.java
@@ -1,7 +1,7 @@
 package com.gregtechceu.gtceu.api.machine;
 
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
-import com.gregtechceu.gtceu.api.item.tool.IToolGridHighLight;
+import com.gregtechceu.gtceu.api.item.tool.IToolGridHighlight;
 import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
 
 import com.lowdragmc.lowdraglib.syncdata.blockentity.IAsyncAutoSyncBlockEntity;
@@ -19,7 +19,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
  * <p/>
  * Also delivers most of the Information about TileEntities.
  */
-public interface IMachineBlockEntity extends IToolGridHighLight, IAsyncAutoSyncBlockEntity, IRPCBlockEntity,
+public interface IMachineBlockEntity extends IToolGridHighlight, IAsyncAutoSyncBlockEntity, IRPCBlockEntity,
                                      IAutoPersistBlockEntity {
 
     default BlockEntity self() {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -15,7 +15,7 @@ import com.gregtechceu.gtceu.api.data.RotationState;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.fancy.IFancyTooltip;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.api.item.tool.IToolGridHighLight;
+import com.gregtechceu.gtceu.api.item.tool.IToolGridHighlight;
 import com.gregtechceu.gtceu.api.machine.feature.*;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.trait.MachineTrait;
@@ -90,7 +90,7 @@ import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.getBehaviorsTag;
  */
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscription, IAppearance, IToolGridHighLight,
+public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscription, IAppearance, IToolGridHighlight,
                          IFancyTooltip, IPaintable, IRedstoneSignalMachine {
 
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(MetaMachine.class);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -323,6 +323,11 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
         if (gridSide == null) gridSide = hitResult.getDirection();
 
         // Prioritize covers where they apply (Screwdriver, Soft Mallet)
+        if (toolType.isEmpty() && playerIn.isShiftKeyDown()) {
+            if (coverBehavior != null) {
+                return Pair.of(null, coverBehavior.onScrewdriverClick(playerIn, hand, hitResult));
+            }
+        }
         if (toolType.contains(GTToolType.SCREWDRIVER)) {
             if (coverBehavior != null) {
                 return Pair.of(GTToolType.SCREWDRIVER, coverBehavior.onScrewdriverClick(playerIn, hand, hitResult));

--- a/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
@@ -4,7 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.client.EnvironmentalHazardClientHandler;
 import com.gregtechceu.gtceu.client.TooltipsHandler;
-import com.gregtechceu.gtceu.client.renderer.BlockHighLightRenderer;
+import com.gregtechceu.gtceu.client.renderer.BlockHighlightRenderer;
 import com.gregtechceu.gtceu.client.renderer.MultiblockInWorldPreviewRenderer;
 import com.gregtechceu.gtceu.client.util.TooltipHelper;
 import com.gregtechceu.gtceu.common.commands.GTClientCommands;
@@ -40,7 +40,7 @@ public class ForgeClientEventListener {
 
     @SubscribeEvent
     public static void onBlockHighlightEvent(RenderHighlightEvent.Block event) {
-        BlockHighLightRenderer.renderBlockHighLight(event.getPoseStack(), event.getCamera(), event.getTarget(),
+        BlockHighlightRenderer.renderBlockHighlight(event.getPoseStack(), event.getCamera(), event.getTarget(),
                 event.getMultiBufferSource(), event.getPartialTick());
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighLightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighLightRenderer.java
@@ -65,7 +65,7 @@ public class BlockHighLightRenderer {
             BlockEntity blockEntity = level.getBlockEntity(blockPos);
 
             // draw tool grid highlight
-            if (!toolType.isEmpty()) {
+            if ((!toolType.isEmpty()) || (held.isEmpty() && player.isShiftKeyDown())) {
                 IToolGridHighLight gridHighLight = null;
                 if (blockEntity instanceof IToolGridHighLight highLight) {
                     gridHighLight = highLight;

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighLightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighLightRenderer.java
@@ -6,7 +6,7 @@ import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.item.PipeBlockItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.api.item.tool.IToolGridHighLight;
+import com.gregtechceu.gtceu.api.item.tool.IToolGridHighlight;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.api.pipenet.IPipeType;
 import com.gregtechceu.gtceu.common.item.CoverPlaceBehavior;
@@ -66,15 +66,15 @@ public class BlockHighLightRenderer {
 
             // draw tool grid highlight
             if ((!toolType.isEmpty()) || (held.isEmpty() && player.isShiftKeyDown())) {
-                IToolGridHighLight gridHighLight = null;
-                if (blockEntity instanceof IToolGridHighLight highLight) {
+                IToolGridHighlight gridHighLight = null;
+                if (blockEntity instanceof IToolGridHighlight highLight) {
                     gridHighLight = highLight;
-                } else if (level.getBlockState(blockPos).getBlock() instanceof IToolGridHighLight highLight) {
+                } else if (level.getBlockState(blockPos).getBlock() instanceof IToolGridHighlight highLight) {
                     gridHighLight = highLight;
                 } else if (toolType.contains(GTToolType.WRENCH)) {
                     var behavior = CustomBlockRotations.getCustomRotation(level.getBlockState(blockPos).getBlock());
                     if (behavior != null && behavior.showGrid()) {
-                        gridHighLight = new IToolGridHighLight() {
+                        gridHighLight = new IToolGridHighlight() {
 
                             @Override
                             public ResourceTexture sideTips(Player player, BlockPos pos, BlockState state,
@@ -95,7 +95,7 @@ public class BlockHighLightRenderer {
                 if (gridHighLight.shouldRenderGrid(player, blockPos, state, held, toolType)) {
                     var buffer = multiBufferSource.getBuffer(RenderType.lines());
                     RenderSystem.lineWidth(3);
-                    final IToolGridHighLight finalGridHighLight = gridHighLight;
+                    final IToolGridHighlight finalGridHighLight = gridHighLight;
                     drawGridOverlays(poseStack, buffer, target,
                             side -> finalGridHighLight.sideTips(player, blockPos, state, toolType, side));
                 } else {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
@@ -47,12 +47,12 @@ import java.util.function.Function;
 /**
  * @author KilaBash
  * @date 2023/2/24
- * @implNote BlockHighLightRenderer
+ * @implNote BlockHighlightRenderer
  */
 @OnlyIn(Dist.CLIENT)
-public class BlockHighLightRenderer {
+public class BlockHighlightRenderer {
 
-    public static void renderBlockHighLight(PoseStack poseStack, Camera camera, BlockHitResult target,
+    public static void renderBlockHighlight(PoseStack poseStack, Camera camera, BlockHitResult target,
                                             MultiBufferSource multiBufferSource, float partialTick) {
         var mc = Minecraft.getInstance();
         var level = mc.level;
@@ -66,15 +66,15 @@ public class BlockHighLightRenderer {
 
             // draw tool grid highlight
             if ((!toolType.isEmpty()) || (held.isEmpty() && player.isShiftKeyDown())) {
-                IToolGridHighlight gridHighLight = null;
+                IToolGridHighlight gridHighlight = null;
                 if (blockEntity instanceof IToolGridHighlight highLight) {
-                    gridHighLight = highLight;
+                    gridHighlight = highLight;
                 } else if (level.getBlockState(blockPos).getBlock() instanceof IToolGridHighlight highLight) {
-                    gridHighLight = highLight;
+                    gridHighlight = highLight;
                 } else if (toolType.contains(GTToolType.WRENCH)) {
                     var behavior = CustomBlockRotations.getCustomRotation(level.getBlockState(blockPos).getBlock());
                     if (behavior != null && behavior.showGrid()) {
-                        gridHighLight = new IToolGridHighlight() {
+                        gridHighlight = new IToolGridHighlight() {
 
                             @Override
                             public ResourceTexture sideTips(Player player, BlockPos pos, BlockState state,
@@ -85,22 +85,22 @@ public class BlockHighLightRenderer {
                         };
                     }
                 }
-                if (gridHighLight == null) {
+                if (gridHighlight == null) {
                     return;
                 }
                 var state = level.getBlockState(blockPos);
                 Vec3 pos = camera.getPosition();
                 poseStack.pushPose();
                 poseStack.translate(-pos.x, -pos.y, -pos.z);
-                if (gridHighLight.shouldRenderGrid(player, blockPos, state, held, toolType)) {
+                if (gridHighlight.shouldRenderGrid(player, blockPos, state, held, toolType)) {
                     var buffer = multiBufferSource.getBuffer(RenderType.lines());
                     RenderSystem.lineWidth(3);
-                    final IToolGridHighlight finalGridHighLight = gridHighLight;
+                    final IToolGridHighlight finalGridHighlight = gridHighlight;
                     drawGridOverlays(poseStack, buffer, target,
-                            side -> finalGridHighLight.sideTips(player, blockPos, state, toolType, side));
+                            side -> finalGridHighlight.sideTips(player, blockPos, state, toolType, side));
                 } else {
                     var facing = target.getDirection();
-                    var texture = gridHighLight.sideTips(player, blockPos, state, toolType, facing);
+                    var texture = gridHighlight.sideTips(player, blockPos, state, toolType, facing);
                     if (texture != null) {
                         RenderSystem.disableDepthTest();
                         RenderSystem.enableBlend();

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
@@ -12,7 +12,6 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.transfer.item.ItemHandlerDelegate;
 import com.gregtechceu.gtceu.common.cover.data.FilterMode;
 import com.gregtechceu.gtceu.common.cover.data.ManualIOMode;
-import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
@@ -78,7 +77,7 @@ public class ItemFilterCover extends CoverBehavior implements IUICover {
 
     @Override
     public boolean canAttach() {
-        return GTTransferUtils.getItemHandler(coverHolder.getLevel(), coverHolder.getPos(), attachedSide).isPresent();
+        return coverHolder.getItemHandlerCap(attachedSide, false) != null;
     }
 
     @Override


### PR DESCRIPTION
## What
Allows for players to open covers with an empty hand

## Implementation Details
various checks for if the toolset is empty and player sneaking for opening covers

## Outcome
no longer a chore if you forget your screwdriver