### PR TITLE
Fix pattern encoding for multiblock preview in EMI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
@@ -1,5 +1,7 @@
 package com.gregtechceu.gtceu.integration.emi.recipe;
 
+import com.gregtechceu.gtceu.integration.emi.multipage.MultiblockInfoEmiRecipe;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.inventory.Slot;

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
@@ -37,7 +37,7 @@ public class Ae2PatternTerminalHandler<T extends PatternEncodingTermMenu> implem
 
     @Override
     public boolean supportsRecipe(EmiRecipe recipe) {
-        return recipe instanceof GTEmiRecipe | recipe instanceof MultiblockInfoEmiRecipe;
+        return recipe instanceof GTEmiRecipe || recipe instanceof MultiblockInfoEmiRecipe;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/Ae2PatternTerminalHandler.java
@@ -37,7 +37,7 @@ public class Ae2PatternTerminalHandler<T extends PatternEncodingTermMenu> implem
 
     @Override
     public boolean supportsRecipe(EmiRecipe recipe) {
-        return recipe instanceof GTEmiRecipe;
+        return recipe instanceof GTEmiRecipe | recipe instanceof MultiblockInfoEmiRecipe;
     }
 
     @Override


### PR DESCRIPTION
## What
Allows for encoding multiblocks into a processing pattern

## Implementation Details
simply checks for instanceof `MultiblockInfoEmiRecipe` in `supportsRecipe`

## Outcome
Fixes: #2463