### PR TITLE
Fix Honeycomb Dupe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/RecyclingRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/RecyclingRecipes.java
@@ -251,7 +251,8 @@ public class RecyclingRecipes {
         } else if (prefix == TagPrefix.block) {
             if (ms != null && !ms.material().hasProperty(PropertyKey.GEM)) {
                 ItemStack output = ChemicalHelper.get(TagPrefix.ingot,
-                        ms.material().getProperty(PropertyKey.INGOT).getArcSmeltingInto(), 9);
+                        ms.material().getProperty(PropertyKey.INGOT).getArcSmeltingInto(),
+                        (int) (TagPrefix.block.getMaterialAmount(ms.material()) / GTValues.M));
                 ResourceLocation itemPath = BuiltInRegistries.ITEM.getKey(input.getItem());
                 GTRecipeBuilder builder = GTRecipeTypes.ARC_FURNACE_RECIPES.recipeBuilder("arc_" + itemPath.getPath())
                         .outputItems(output)


### PR DESCRIPTION
## What
Fixes random honeycomb dupe

## Implementation Details
Uses the actual material amount for decomp of material blocks in the arc furnace

## Outcome
no more 1->9 and 4->1 dupe bugs