### PR TITLE
Add explicit constructor to transfer covers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/FluidPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/FluidPipeBlockEntity.java
@@ -270,7 +270,7 @@ public class FluidPipeBlockEntity extends PipeBlockEntity<FluidPipeType, FluidPi
     private boolean checkForPumpCover(@Nullable CoverBehavior cover) {
         if (cover instanceof PumpCover coverPump) {
             int pipeThroughput = getNodeData().getThroughput() * 20;
-            if (coverPump.getCurrentMilliBucketsPerTick() > pipeThroughput) {
+            if (coverPump.getTransferRate() > pipeThroughput) {
                 coverPump.setTransferRate(pipeThroughput);
             }
             return coverPump.getManualIOMode() == ManualIOMode.DISABLED;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -42,6 +42,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 
+import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenCustomHashMap;
@@ -66,6 +67,10 @@ public class ConveyorCover extends CoverBehavior implements IUICover, IControlla
 
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(ConveyorCover.class,
             CoverBehavior.MANAGED_FIELD_HOLDER);
+
+    // 8 32 128 512 1024
+    public static final Int2IntFunction CONVEYOR_SCALING = tier -> 2 * (int) Math.pow(4, Math.min(tier, GTValues.LuV));
+
     public final int tier;
     public final int maxItemTransferRate;
     @Persisted
@@ -96,10 +101,11 @@ public class ConveyorCover extends CoverBehavior implements IUICover, IControlla
     protected final FilterHandler<ItemStack, ItemFilter> filterHandler;
     protected final ConditionalSubscriptionHandler subscriptionHandler;
 
-    public ConveyorCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier) {
+    public ConveyorCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier,
+                         int maxTransferRate) {
         super(definition, coverHolder, attachedSide);
         this.tier = tier;
-        this.maxItemTransferRate = 2 * (int) Math.pow(4, Math.min(tier, GTValues.LuV)); // 8 32 128 512 1024
+        this.maxItemTransferRate = maxTransferRate;
         this.transferRate = maxItemTransferRate;
         this.itemsLeftToTransferLastSecond = transferRate;
         this.io = IO.OUT;
@@ -110,6 +116,10 @@ public class ConveyorCover extends CoverBehavior implements IUICover, IControlla
                 .onFilterLoaded(f -> configureFilter())
                 .onFilterUpdated(f -> configureFilter())
                 .onFilterRemoved(f -> configureFilter());
+    }
+
+    public ConveyorCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier) {
+        this(definition, coverHolder, attachedSide, tier, CONVEYOR_SCALING.applyAsInt(tier));
     }
 
     protected boolean isSubscriptionActive() {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/RobotArmCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/RobotArmCover.java
@@ -28,8 +28,8 @@ import java.util.Map;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
-@MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class RobotArmCover extends ConveyorCover {
 
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(RobotArmCover.class,
@@ -47,10 +47,14 @@ public class RobotArmCover extends ConveyorCover {
 
     private IntInputWidget stackSizeInput;
 
-    public RobotArmCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier) {
-        super(definition, coverHolder, attachedSide, tier);
-
+    public RobotArmCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier,
+                         int maxTransferRate) {
+        super(definition, coverHolder, attachedSide, tier, maxTransferRate);
         setTransferMode(TransferMode.TRANSFER_ANY);
+    }
+
+    public RobotArmCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier) {
+        this(definition, coverHolder, attachedSide, tier, CONVEYOR_SCALING.applyAsInt(tier));
     }
 
     @Override


### PR DESCRIPTION
## What
This PR adds a constructor to the 4 transfer covers with the max transfer rate explicitly defined as an argument, i.e.,
`(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide, int tier, int maxTransferRate)`


## Implementation Details

The current scaling functions that we use have been pulled out as a static member and used in the previous constructor s.t. any existing cover definitions are not affected.

## Outcome
This allows Addon devs to define their own transfer covers with whatever maximum transfer rate they want.

## Additional details
I also cleaned up/renamed some of the fields to be less egregious (i.e. the use of `millibuckets` everywhere) and made the classes more mirrored.