### PR TITLE
Fix Creative Energy dropdown to show MAX+ better

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeEnergyContainerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeEnergyContainerMachine.java
@@ -234,7 +234,7 @@ public class CreativeEnergyContainerMachine extends MetaMachine implements ILase
                         new GuiTextureGroup(ResourceBorderTexture.BUTTON_COMMON,
                                 new TextTexture("gtceu.creative.energy.source")))
                         .setPressed(source))
-                .widget(new SelectorWidget(7, 7, 30, 20, Arrays.stream(GTValues.VNF).toList(), -1)
+                .widget(new SelectorWidget(7, 7, 50, 20, Arrays.stream(GTValues.VNF).toList(), -1)
                         .setOnChanged(tier -> {
                             setTier = ArrayUtils.indexOf(GTValues.VNF, tier);
                             voltage = GTValues.VEX[setTier];


### PR DESCRIPTION
## What
Makes the Dropdown wider to show the whole text for Creative Energy Hatch's tier dropdown.

## Outcome
:reading:

## Additional Information
Previously
![java_VqzfUMNIGW](https://github.com/user-attachments/assets/0829f03f-c192-4822-966f-3a622c0f727f)

Now
![image](https://github.com/user-attachments/assets/d74bf2aa-3484-4dde-9dd6-bde5bbe4f33c)