### PR TITLE
add equality to ore veins to hopefully avoid crashes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/BiomeWeightModifier.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/BiomeWeightModifier.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.biome.Biome;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -32,5 +33,20 @@ public class BiomeWeightModifier implements Function<Holder<Biome>, Integer> {
     @Override
     public Integer apply(Holder<Biome> biome) {
         return biomes.get().contains(biome) ? addedWeight : 0;
+    }
+
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof BiomeWeightModifier that)) return false;
+
+        return addedWeight == that.addedWeight && biomes.get().equals(that.biomes.get());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(biomes.get());
+        result = 31 * result + addedWeight;
+        return result;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTLayerPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTLayerPattern.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -47,6 +48,19 @@ public class GTLayerPattern {
                 return layer;
         }
         return null;
+    }
+
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof GTLayerPattern that)) return false;
+
+        return layers.equals(that.layers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(layers);
     }
 
     public static Builder builder(RuleTest... rules) {
@@ -107,6 +121,25 @@ public class GTLayerPattern {
             if (targets.size() == 1)
                 return targets.get(0);
             return targets.get(random.nextInt(targets.size()));
+        }
+
+        @Override
+        public final boolean equals(Object object) {
+            if (this == object) return true;
+            if (!(object instanceof Layer layer)) return false;
+
+            return minSize == layer.minSize && maxSize == layer.maxSize &&
+                    weight == layer.weight &&
+                    targets.equals(layer.targets);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = targets.hashCode();
+            result = 31 * result + minSize;
+            result = 31 * result + maxSize;
+            result = 31 * result + weight;
+            return result;
         }
 
         public static class Builder {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTLayerPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTLayerPattern.java
@@ -60,7 +60,7 @@ public class GTLayerPattern {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(layers);
+        return layers.hashCode();
     }
 
     public static Builder builder(RuleTest... rules) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTOreDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTOreDefinition.java
@@ -356,9 +356,9 @@ public class GTOreDefinition {
         result = 31 * result + range.hashCode();
         result = 31 * result + Float.hashCode(discardChanceOnAirExposure);
         if (biomes != null) {
-            result = 31 * result + Objects.hashCode(biomes);
+            result = 31 * result + Objects.hashCode(biomes.get());
         } else {
-            result = 313 * result;
+            result *= 31;
         }
         result = 31 * result + Objects.hashCode(biomeWeightModifier);
         result = 31 * result + veinGenerator.hashCode();

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTOreDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTOreDefinition.java
@@ -324,6 +324,48 @@ public class GTOreDefinition {
         return generator;
     }
 
+    /**
+     * equality check. crashes when not in a world because of the biome list.
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+
+        GTOreDefinition that = (GTOreDefinition) object;
+        return Float.compare(density, that.density) == 0 &&
+                weight == that.weight &&
+                Float.compare(discardChanceOnAirExposure, that.discardChanceOnAirExposure) == 0 &&
+                clusterSize.equals(that.clusterSize) &&
+                layer.equals(that.layer) &&
+                dimensionFilter.equals(that.dimensionFilter) &&
+                // this line makes this equality check crash when not in a world
+                (biomes == null ? that.biomes == null : biomes.get().equals(that.biomes.get())) &&
+                Objects.equals(biomeWeightModifier, that.biomeWeightModifier) &&
+                veinGenerator.equals(that.veinGenerator) &&
+                indicatorGenerators.equals(that.indicatorGenerators);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = clusterSize.hashCode();
+        result = 31 * result + Float.hashCode(density);
+        result = 31 * result + weight;
+        result = 31 * result + layer.hashCode();
+        result = 31 * result + dimensionFilter.hashCode();
+        result = 31 * result + range.hashCode();
+        result = 31 * result + Float.hashCode(discardChanceOnAirExposure);
+        if (biomes != null) {
+            result = 31 * result + Objects.hashCode(biomes);
+        } else {
+            result = 313 * result;
+        }
+        result = 31 * result + Objects.hashCode(biomeWeightModifier);
+        result = 31 * result + veinGenerator.hashCode();
+        result = 31 * result + indicatorGenerators.hashCode();
+        return result;
+    }
+
     private static class InferredProperties {
 
         public Pair<Integer, Integer> heightRange = null;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/IndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/IndicatorGenerator.java
@@ -69,5 +69,9 @@ public abstract class IndicatorGenerator {
 
     public abstract Codec<? extends IndicatorGenerator> codec();
 
+    public abstract boolean equals(Object that);
+
+    public abstract int hashCode();
+
     public abstract int getSearchRadiusModifier(int veinRadius);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/VeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/VeinGenerator.java
@@ -102,4 +102,8 @@ public abstract class VeinGenerator {
     }
 
     public abstract Codec<? extends VeinGenerator> codec();
+
+    public abstract boolean equals(Object that);
+
+    public abstract int hashCode();
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/NoopIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/NoopIndicatorGenerator.java
@@ -49,4 +49,14 @@ public class NoopIndicatorGenerator extends IndicatorGenerator {
     public Codec<? extends IndicatorGenerator> codec() {
         return CODEC;
     }
+
+    @Override
+    public boolean equals(Object that) {
+        return this == that;
+    }
+
+    @Override
+    public int hashCode() {
+        return -1;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -185,6 +185,26 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
         return CODEC;
     }
 
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof SurfaceIndicatorGenerator that)) return false;
+
+        return block.equals(that.block) &&
+                radius.equals(that.radius) &&
+                density.equals(that.density) &&
+                placement == that.placement;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = block.hashCode();
+        result = 31 * result + radius.hashCode();
+        result = 31 * result + density.hashCode();
+        result = 31 * result + placement.hashCode();
+        return result;
+    }
+
     @AllArgsConstructor
     public enum IndicatorPlacement implements StringRepresentable {
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/ClassicVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/ClassicVeinGenerator.java
@@ -207,6 +207,36 @@ public class ClassicVeinGenerator extends VeinGenerator {
         return CODEC;
     }
 
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof ClassicVeinGenerator that)) return false;
+
+        return yRadius == that.yRadius &&
+                sporadicDivisor == that.sporadicDivisor &&
+                startPrimary == that.startPrimary &&
+                startBetween == that.startBetween &&
+                primary.equals(that.primary) &&
+                secondary.equals(that.secondary) &&
+                between.equals(that.between) &&
+                sporadic.equals(that.sporadic) &&
+                Arrays.equals(rules, that.rules);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = primary.hashCode();
+        result = 31 * result + secondary.hashCode();
+        result = 31 * result + between.hashCode();
+        result = 31 * result + sporadic.hashCode();
+        result = 31 * result + yRadius;
+        result = 31 * result + sporadicDivisor;
+        result = 31 * result + startPrimary;
+        result = 31 * result + startBetween;
+        result = 31 * result + Arrays.hashCode(rules);
+        return result;
+    }
+
     public ClassicVeinGenerator primary(Consumer<Layer.Builder> builder) {
         Layer.Builder layerBuilder = new Layer.Builder(
                 rules != null ? rules : new RuleTest[] { AlwaysTrueTest.INSTANCE });
@@ -283,6 +313,21 @@ public class ClassicVeinGenerator extends VeinGenerator {
 
         public Layer copy() {
             return new Layer(this.target.mapBoth(ArrayList::new, Function.identity()), layers);
+        }
+
+        @Override
+        public final boolean equals(Object object) {
+            if (this == object) return true;
+            if (!(object instanceof Layer layer)) return false;
+
+            return layers == layer.layers && target.equals(layer.target);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = target.hashCode();
+            result = 31 * result + layers;
+            return result;
         }
 
         public static class Builder {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/CuboidVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/CuboidVeinGenerator.java
@@ -305,6 +305,29 @@ public class CuboidVeinGenerator extends VeinGenerator {
         return CODEC;
     }
 
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof CuboidVeinGenerator that)) return false;
+
+        return minY == that.minY && maxY == that.maxY &&
+                top.equals(that.top) &&
+                middle.equals(that.middle) &&
+                bottom.equals(that.bottom) &&
+                spread.equals(that.spread);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = top.hashCode();
+        result = 31 * result + middle.hashCode();
+        result = 31 * result + bottom.hashCode();
+        result = 31 * result + spread.hashCode();
+        result = 31 * result + minY;
+        result = 31 * result + maxY;
+        return result;
+    }
+
     public CuboidVeinGenerator top(Consumer<ClassicVeinGenerator.Layer.Builder> builder) {
         ClassicVeinGenerator.Layer.Builder layerBuilder = new ClassicVeinGenerator.Layer.Builder(
                 AlwaysTrueTest.INSTANCE);

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/DikeVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/DikeVeinGenerator.java
@@ -168,6 +168,22 @@ public class DikeVeinGenerator extends VeinGenerator {
         return CODEC;
     }
 
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof DikeVeinGenerator that)) return false;
+
+        return minYLevel == that.minYLevel && maxYLevel == that.maxYLevel && blocks.equals(that.blocks);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = blocks.hashCode();
+        result = 31 * result + minYLevel;
+        result = 31 * result + maxYLevel;
+        return result;
+    }
+
     public DikeVeinGenerator withBlock(Material block, int weight, int minY, int maxY) {
         return this.withBlock(new DikeBlockDefinition(block, weight, minY, maxY));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/GeodeVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/GeodeVeinGenerator.java
@@ -318,6 +318,43 @@ public class GeodeVeinGenerator extends VeinGenerator {
         return CODEC;
     }
 
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof GeodeVeinGenerator that)) return false;
+
+        return Double.compare(usePotentialPlacementsChance, that.usePotentialPlacementsChance) == 0 &&
+                Double.compare(useAlternateLayer0Chance, that.useAlternateLayer0Chance) == 0 &&
+                placementsRequireLayer0Alternate == that.placementsRequireLayer0Alternate &&
+                minGenOffset == that.minGenOffset && maxGenOffset == that.maxGenOffset &&
+                Double.compare(noiseMultiplier, that.noiseMultiplier) == 0 &&
+                invalidBlocksThreshold == that.invalidBlocksThreshold &&
+                geodeBlockSettings.equals(that.geodeBlockSettings) &&
+                geodeLayerSettings.equals(that.geodeLayerSettings) &&
+                geodeCrackSettings.equals(that.geodeCrackSettings) &&
+                outerWallDistance.equals(that.outerWallDistance) &&
+                distributionPoints.equals(that.distributionPoints) &&
+                pointOffset.equals(that.pointOffset);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = geodeBlockSettings.hashCode();
+        result = 31 * result + geodeLayerSettings.hashCode();
+        result = 31 * result + geodeCrackSettings.hashCode();
+        result = 31 * result + Double.hashCode(usePotentialPlacementsChance);
+        result = 31 * result + Double.hashCode(useAlternateLayer0Chance);
+        result = 31 * result + Boolean.hashCode(placementsRequireLayer0Alternate);
+        result = 31 * result + outerWallDistance.hashCode();
+        result = 31 * result + distributionPoints.hashCode();
+        result = 31 * result + pointOffset.hashCode();
+        result = 31 * result + minGenOffset;
+        result = 31 * result + maxGenOffset;
+        result = 31 * result + Double.hashCode(noiseMultiplier);
+        result = 31 * result + invalidBlocksThreshold;
+        return result;
+    }
+
     public record GeodeBlockSettings(Either<BlockStateProvider, Material> fillingProvider,
                                      Either<BlockStateProvider, Material> innerLayerProvider,
                                      Either<BlockStateProvider, Material> alternateInnerLayerProvider,

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
@@ -234,4 +234,17 @@ public class LayeredVeinGenerator extends VeinGenerator {
     public Codec<? extends VeinGenerator> codec() {
         return CODEC;
     }
+
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof LayeredVeinGenerator that)) return false;
+
+        return getLayerPatterns().equals(that.getLayerPatterns());
+    }
+
+    @Override
+    public int hashCode() {
+        return getLayerPatterns().hashCode();
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/NoopVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/NoopVeinGenerator.java
@@ -46,4 +46,14 @@ public class NoopVeinGenerator extends VeinGenerator {
     public Codec<? extends VeinGenerator> codec() {
         return CODEC;
     }
+
+    @Override
+    public boolean equals(Object that) {
+        return this == that;
+    }
+
+    @Override
+    public int hashCode() {
+        return -1;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/StandardVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/StandardVeinGenerator.java
@@ -30,10 +30,7 @@ import com.tterrag.registrate.util.nullness.NonNullSupplier;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.apache.commons.lang3.mutable.MutableInt;
 
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -137,6 +134,19 @@ public class StandardVeinGenerator extends VeinGenerator {
     @Override
     public Codec<? extends VeinGenerator> codec() {
         return CODEC;
+    }
+
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof StandardVeinGenerator that)) return false;
+
+        return blocks.equals(that.blocks);
+    }
+
+    @Override
+    public int hashCode() {
+        return blocks.hashCode();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/VeinedVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/VeinedVeinGenerator.java
@@ -288,6 +288,41 @@ public class VeinedVeinGenerator extends VeinGenerator {
         return CODEC;
     }
 
+    @Override
+    public final boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof VeinedVeinGenerator that)) return false;
+
+        return minYLevel == that.minYLevel && maxYLevel == that.maxYLevel &&
+                Float.compare(veininessThreshold, that.veininessThreshold) == 0 &&
+                edgeRoundoffBegin == that.edgeRoundoffBegin &&
+                Double.compare(maxEdgeRoundoff, that.maxEdgeRoundoff) == 0 &&
+                Float.compare(minRichness, that.minRichness) == 0 &&
+                Float.compare(maxRichness, that.maxRichness) == 0 &&
+                Float.compare(maxRichnessThreshold, that.maxRichnessThreshold) == 0 &&
+                Float.compare(rareBlockChance, that.rareBlockChance) == 0 &&
+                oreBlocks.equals(that.oreBlocks) &&
+                rareBlocks.equals(that.rareBlocks) &&
+                fillerBlock == that.fillerBlock;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = oreBlocks.hashCode();
+        result = 31 * result + rareBlocks.hashCode();
+        result = 31 * result + fillerBlock.hashCode();
+        result = 31 * result + minYLevel;
+        result = 31 * result + maxYLevel;
+        result = 31 * result + Float.hashCode(veininessThreshold);
+        result = 31 * result + edgeRoundoffBegin;
+        result = 31 * result + Double.hashCode(maxEdgeRoundoff);
+        result = 31 * result + Float.hashCode(minRichness);
+        result = 31 * result + Float.hashCode(maxRichness);
+        result = 31 * result + Float.hashCode(maxRichnessThreshold);
+        result = 31 * result + Float.hashCode(rareBlockChance);
+        return result;
+    }
+
     public VeinedVeinGenerator oreBlock(Material block, int weight) {
         return this.oreBlock(new VeinBlockDefinition(block, weight));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/GeneratedVeinMetadata.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/GeneratedVeinMetadata.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Accessors(fluent = true)
@@ -103,7 +104,7 @@ public final class GeneratedVeinMetadata {
         if (this == object) return true;
         if (!(object instanceof GeneratedVeinMetadata that)) return false;
 
-        return id.equals(that.id) && originChunk.equals(that.originChunk) && center.equals(that.center) &&
+        return Objects.equals(id, that.id) && originChunk.equals(that.originChunk) && center.equals(that.center) &&
                 definition.equals(that.definition);
     }
 


### PR DESCRIPTION
## What
this PR aims to stop crashes caused by just running /reload and the vein registry getting different values. I don't know if it works yet, someone will have to test.

## Implementation Details
Added an implementation of equals() and hashCode() to veins, indicators

## Outcome
no more crash (hopefully)