### PR TITLE
Fix sign & chain recipe conflicts

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -172,6 +172,7 @@ public class RecipeAddition {
         ASSEMBLER_RECIPES.recipeBuilder("chain_iron")
                 .inputItems(ring, Iron, 3)
                 .outputItems(new ItemStack(Items.CHAIN, 2))
+                .circuitMeta(1)
                 .duration(40).EUt(10).save(provider);
 
         VanillaRecipeHelper.addShapedRecipe(provider, "chain_wrought_iron", new ItemStack(Items.CHAIN, 2), " R ",
@@ -181,6 +182,7 @@ public class RecipeAddition {
         ASSEMBLER_RECIPES.recipeBuilder("chain_wrought_iron")
                 .inputItems(ring, WroughtIron, 3)
                 .outputItems(new ItemStack(Items.CHAIN, 3))
+                .circuitMeta(1)
                 .duration(40).EUt(10).save(provider);
 
         VanillaRecipeHelper.addShapedRecipe(provider, "chain_steel", new ItemStack(Items.CHAIN, 3), " R ",
@@ -190,6 +192,7 @@ public class RecipeAddition {
         ASSEMBLER_RECIPES.recipeBuilder("chain_steel")
                 .inputItems(ring, Steel, 3)
                 .outputItems(new ItemStack(Items.CHAIN, 6))
+                .circuitMeta(1)
                 .duration(40).EUt(10).save(provider);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -564,7 +564,7 @@ public class WoodMachineRecipes {
                         .inputItems(new ItemStack(entry.planks), 6)
                         .inputItems(entry.getStick())
                         .outputItems(new ItemStack(entry.sign), 3)
-                        .circuitMeta(3)
+                        .circuitMeta(4)
                         .duration(100).EUt(4).save(provider);
             }
 


### PR DESCRIPTION
## What
Fixes wrong circuit number being applied to normal sign assembler recipes and gives a circuit number to chains, which stops it 'conflicting' with inductors.

## Outcome
Normal sign recipes work again in the assembler, & log stops complaining about trapdoor & chain conflicts.