### PR TITLE
removed unused overclock divisor config

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2335,7 +2335,6 @@
   "config.gtceu.option.oreVeinGridSize": "ǝzıSpıɹ⅁uıǝΛǝɹo",
   "config.gtceu.option.oreVeinRandomOffset": "ʇǝsɟɟOɯopuɐᴚuıǝΛǝɹo",
   "config.gtceu.option.oreVeins": "suıǝΛǝɹo",
-  "config.gtceu.option.overclockDivisor": "ɹosıʌıᗡʞɔoןɔɹǝʌo",
   "config.gtceu.option.ownerOPBypass": "ssɐdʎᗺԀOɹǝuʍo",
   "config.gtceu.option.prospectorEnergyUseMultiplier": "ɹǝıןdıʇןnWǝs∩ʎbɹǝuƎɹoʇɔǝdsoɹd",
   "config.gtceu.option.recipeProgressLowEnergy": "ʎbɹǝuƎʍoꞀssǝɹboɹԀǝdıɔǝɹ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2335,7 +2335,6 @@
   "config.gtceu.option.oreVeinGridSize": "oreVeinGridSize",
   "config.gtceu.option.oreVeinRandomOffset": "oreVeinRandomOffset",
   "config.gtceu.option.oreVeins": "oreVeins",
-  "config.gtceu.option.overclockDivisor": "overclockDivisor",
   "config.gtceu.option.ownerOPBypass": "ownerOPBypass",
   "config.gtceu.option.prospectorEnergyUseMultiplier": "prospectorEnergyUseMultiplier",
   "config.gtceu.option.recipeProgressLowEnergy": "recipeProgressLowEnergy",

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/OverclockingLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/OverclockingLogic.java
@@ -2,7 +2,6 @@ package com.gregtechceu.gtceu.api.recipe;
 
 import com.gregtechceu.gtceu.api.recipe.logic.OCParams;
 import com.gregtechceu.gtceu.api.recipe.logic.OCResult;
-import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import lombok.Getter;
@@ -30,8 +29,8 @@ public class OverclockingLogic {
 
     public static final double STD_VOLTAGE_FACTOR = 4.0;
     public static final double PERFECT_HALF_VOLTAGE_FACTOR = 2.0;
-    public static final double STD_DURATION_FACTOR = 1 / ConfigHolder.INSTANCE.machines.overclockDivisor;
-    public static final double STD_DURATION_FACTOR_INV = ConfigHolder.INSTANCE.machines.overclockDivisor;
+    public static final double STD_DURATION_FACTOR = 0.5;
+    public static final double STD_DURATION_FACTOR_INV = 2.0;
     public static final double PERFECT_DURATION_FACTOR = 0.25;
     public static final double PERFECT_DURATION_FACTOR_INV = 4.0;
     public static final double PERFECT_HALF_DURATION_FACTOR = 0.5;

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -423,11 +423,6 @@ public class ConfigHolder {
                 "Default: false" })
         public boolean harmlessActiveTransformers = false;
         @Configurable
-        @Configurable.Comment({ "Divisor for Recipe Duration per Overclock.", "Default: 2.0" })
-        @Configurable.DecimalRange(min = 2.0, max = 3.0)
-        @Configurable.Gui.NumberFormat("0.0#")
-        public double overclockDivisor = 2.0;
-        @Configurable
         @Configurable.Comment({ "Whether to play machine sounds while machines are active.", "Default: true" })
         public boolean machineSounds = true;
         @Configurable

--- a/src/main/resources/assets/gtceu/lang/ja_jp.json
+++ b/src/main/resources/assets/gtceu/lang/ja_jp.json
@@ -2265,7 +2265,6 @@
     "config.gtceu.option.oreVeinGridSize": "鉱脈グリッドサイズ",
     "config.gtceu.option.oreVeinRandomOffset": "鉱脈ランダムオフセット",
     "config.gtceu.option.oreVeins": "鉱脈",
-    "config.gtceu.option.overclockDivisor": "オーバークロック除算器",
     "config.gtceu.option.platformToEuRatio": "プラットフォームとEUの比率",
     "config.gtceu.option.prospectorEnergyUseMultiplier": "プロスペクター エネルギー使用乗数",
     "config.gtceu.option.recipeProgressLowEnergy": "レシピ プログレス 低エネルギー",

--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -1822,7 +1822,6 @@
     "config.gtceu.option.oreVeinGridSize": "oreVeinGridSize",
     "config.gtceu.option.oreVeinRandomOffset": "oreVeinRandomOffset",
     "config.gtceu.option.oreVeins": "oreVeins",
-    "config.gtceu.option.overclockDivisor": "overclockDivisor",
     "config.gtceu.option.platformToEuRatio": "platformToEuRatio",
     "config.gtceu.option.recipeProgressLowEnergy": "recipeProgressLowEnergy",
     "config.gtceu.option.recipes": "recipes",

--- a/src/main/resources/assets/gtceu/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceu/lang/zh_cn.json
@@ -2325,7 +2325,6 @@
     "config.gtceu.option.oreVeinGridSize":"矿脉网格大小",
     "config.gtceu.option.oreVeinRandomOffset":"矿脉随机偏移",
     "config.gtceu.option.oreVeins":"矿脉",
-    "config.gtceu.option.overclockDivisor":"超频除数",
     "config.gtceu.option.platformToEuRatio":"GTEU与加载器原生能量之间的转化率（转换器）",
     "config.gtceu.option.prospectorEnergyUseMultiplier":"探矿仪能源消耗乘数",
     "config.gtceu.option.recipeProgressLowEnergy":"跳电时，机器进度将",

--- a/src/main/resources/assets/gtceu/lang/zh_tw.json
+++ b/src/main/resources/assets/gtceu/lang/zh_tw.json
@@ -2325,7 +2325,6 @@
     "config.gtceu.option.oreVeinGridSize":"礦脈網格大小",
     "config.gtceu.option.oreVeinRandomOffset":"礦脈隨機偏移",
     "config.gtceu.option.oreVeins":"礦脈",
-    "config.gtceu.option.overclockDivisor":"超頻除數",
     "config.gtceu.option.platformToEuRatio":"GTEU與載入器原生能量之間的轉化率（轉換器）",
     "config.gtceu.option.prospectorEnergyUseMultiplier":"探礦儀能源消耗倍率",
     "config.gtceu.option.recipeProgressLowEnergy":"跳電時，機器進度將",


### PR DESCRIPTION
## What
hard codes overclock divisor to 2.0 instead of leaving it as a config