### PR TITLE
Refactor multiblock fluid renderer code

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeChemicalBathRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeChemicalBathRenderer.java
@@ -58,7 +58,10 @@ public class LargeChemicalBathRenderer extends WorkableCasingMachineRenderer {
         if (blockEntity instanceof MetaMachineBlockEntity mm) {
             if (mm.metaMachine instanceof LargeChemicalBathMachine lcb) {
                 var lastRecipe = lcb.recipeLogic.getLastRecipe();
-                if (lastRecipe != null && (lcb.getOffsetTimer() % 20 == 0 || lastRecipe.id != cachedRecipe)) {
+                if (lastRecipe == null) {
+                    cachedRecipe = null;
+                    cachedFluid = null;
+                } else if (lcb.getOffsetTimer() % 20 == 0 || lastRecipe.id != cachedRecipe) {
                     cachedRecipe = lastRecipe.id;
                     if (lcb.isActive()) {
                         cachedFluid = RenderUtil.getRecipeFluidToRender(lastRecipe);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeMixerRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeMixerRenderer.java
@@ -58,7 +58,10 @@ public class LargeMixerRenderer extends WorkableCasingMachineRenderer {
         if (blockEntity instanceof MetaMachineBlockEntity mm) {
             if (mm.metaMachine instanceof LargeMixerMachine lm) {
                 var lastRecipe = lm.recipeLogic.getLastRecipe();
-                if (lastRecipe != null && (lm.getOffsetTimer() % 20 == 0 || lastRecipe.id != cachedRecipe)) {
+                if (lastRecipe == null) {
+                    cachedRecipe = null;
+                    cachedFluid = null;
+                } else if (lm.getOffsetTimer() % 20 == 0 || lastRecipe.id != cachedRecipe) {
                     cachedRecipe = lastRecipe.id;
                     if (lm.isActive()) {
                         cachedFluid = RenderUtil.getRecipeFluidToRender(lastRecipe);


### PR DESCRIPTION
## What
Adds `lastRecipe` nullity check that resets the cached data, hopefully should solve the problem of fluids not clearing up after a recipe completion sometimes.