### PR TITLE
Fix build output directory

### DIFF
--- a/gradle/scripts/jars.gradle
+++ b/gradle/scripts/jars.gradle
@@ -16,6 +16,7 @@ tasks.register('sourcesJar', Jar) {
 }
 
 jar.archiveClassifier = "dev"
+reobfJar.archiveClassifier = ""
 
 base {
     archivesName = "${project.name}-${libs.versions.minecraft.get()}"

--- a/gradle/scripts/jars.gradle
+++ b/gradle/scripts/jars.gradle
@@ -15,12 +15,15 @@ tasks.register('sourcesJar', Jar) {
     archiveClassifier = "sources"
 }
 
+jar.archiveClassifier = "dev"
+
 base {
     archivesName = "${project.name}-${libs.versions.minecraft.get()}"
 }
 
 afterEvaluate {
     tasks.withType(org.gradle.jvm.tasks.Jar).configureEach {
+        destinationDirectory = file('build/libs/')
         manifest.attributes([
                 'MixinConfigs': 'gtceu.mixins.json',
                 'Specification-Title': project.name,


### PR DESCRIPTION
## What
Moves all output jars back to `/build/libs` with correct names, as the default locations (and naming) were changed by MDG-Legacy
| Before | After |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/1423fc40-cbd5-4ec7-bc79-d0d4bf9dc073) | ![image](https://github.com/user-attachments/assets/b4a99540-305a-47d3-92b0-4e8efcb6f604) |