### PR TITLE
Stone recipe tweaks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/StoneTypeEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/StoneTypeEntry.java
@@ -224,7 +224,8 @@ public class StoneTypeEntry {
 
         public StoneTypeEntry build() {
             return new StoneTypeEntry(modid, stoneName,
-                    stone, polishedStone, smeltStone, chiselStone, crackedStone, slab, stair, button, wall, pressurePlate,
+                    stone, polishedStone, smeltStone, chiselStone, crackedStone, slab, stair, button, wall,
+                    pressurePlate,
                     material, materialAmount,
                     addStoneOreDict, addPolishedStoneOreDict, addSlabOreDict, addStairOreDict,
                     addButtonOreDict, addWallOreDict, addPressurePlateOreDict,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/StoneTypeEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/StoneTypeEntry.java
@@ -23,6 +23,8 @@ public class StoneTypeEntry {
     @Nullable
     public final Item chiselStone;
     @Nullable
+    public final Item crackedStone;
+    @Nullable
     public final Item slab;
     @Nullable
     public final Item stair;
@@ -45,6 +47,7 @@ public class StoneTypeEntry {
     public final boolean addPolishedStoneUnificationInfo;
     public final boolean addSmeltStoneUnificationInfo;
     public final boolean addChiselStoneUnificationInfo;
+    public final boolean addCrackedStoneUnificationInfo;
     public final boolean addSlabUnificationInfo;
     public final boolean addStairUnificationInfo;
     public final boolean addButtonUnificationInfo;
@@ -54,7 +57,7 @@ public class StoneTypeEntry {
     private StoneTypeEntry(@NotNull String modid, @NotNull String stoneName,
                            @Nullable Item stone, @Nullable Item polishedStone,
                            @Nullable Item smeltStone, @Nullable Item chiselStone,
-                           @Nullable Item slab,
+                           @Nullable Item crackedStone, @Nullable Item slab,
                            @Nullable Item stair, @Nullable Item button,
                            @Nullable Item wall, @Nullable Item pressurePlate,
                            @Nullable Material material, long materialAmount,
@@ -64,7 +67,7 @@ public class StoneTypeEntry {
                            boolean addWallOreDict, boolean addPressurePlateOreDict,
                            boolean addStoneUnificationInfo, boolean addPolishedStoneUnificationInfo,
                            boolean addSmeltStoneUnificationInfo, boolean addChiselStoneUnificationInfo,
-                           boolean addSlabUnificationInfo,
+                           boolean addCrackedStoneUnificationInfo, boolean addSlabUnificationInfo,
                            boolean addStairUnificationInfo, boolean addButtonUnificationInfo,
                            boolean addWallUnificationInfo, boolean addPressurePlateUnificationInfo) {
         this.modid = modid;
@@ -73,6 +76,7 @@ public class StoneTypeEntry {
         this.polishedStone = polishedStone;
         this.smeltStone = smeltStone;
         this.chiselStone = chiselStone;
+        this.crackedStone = crackedStone;
         this.slab = slab;
         this.stair = stair;
         this.button = button;
@@ -90,6 +94,7 @@ public class StoneTypeEntry {
         this.addStoneUnificationInfo = addStoneUnificationInfo;
         this.addPolishedStoneUnificationInfo = addPolishedStoneUnificationInfo;
         this.addChiselStoneUnificationInfo = addChiselStoneUnificationInfo;
+        this.addCrackedStoneUnificationInfo = addCrackedStoneUnificationInfo;
         this.addSmeltStoneUnificationInfo = addSmeltStoneUnificationInfo;
         this.addSlabUnificationInfo = addSlabUnificationInfo;
         this.addStairUnificationInfo = addStairUnificationInfo;
@@ -106,6 +111,7 @@ public class StoneTypeEntry {
         public Item polishedStone = null;
         public Item smeltStone = null;
         public Item chiselStone = null;
+        public Item crackedStone = null;
         public Item slab = null;
         public Item stair = null;
         public Item button = null;
@@ -125,6 +131,7 @@ public class StoneTypeEntry {
         public boolean addPolishedStoneUnificationInfo = false;
         public boolean addSmeltStoneUnificationInfo = false;
         public boolean addChiselStoneUnificationInfo = false;
+        public boolean addCrackedStoneUnificationInfo = false;
         public boolean addSlabUnificationInfo = false;
         public boolean addStairUnificationInfo = false;
         public boolean addButtonUnificationInfo = false;
@@ -153,6 +160,11 @@ public class StoneTypeEntry {
 
         public Builder chiselStone(@NotNull Item chiselStone) {
             this.chiselStone = chiselStone;
+            return this;
+        }
+
+        public Builder crackedStone(@NotNull Item crackedStone) {
+            this.crackedStone = crackedStone;
             return this;
         }
 
@@ -212,12 +224,12 @@ public class StoneTypeEntry {
 
         public StoneTypeEntry build() {
             return new StoneTypeEntry(modid, stoneName,
-                    stone, polishedStone, smeltStone, chiselStone, slab, stair, button, wall, pressurePlate,
+                    stone, polishedStone, smeltStone, chiselStone, crackedStone, slab, stair, button, wall, pressurePlate,
                     material, materialAmount,
                     addStoneOreDict, addPolishedStoneOreDict, addSlabOreDict, addStairOreDict,
                     addButtonOreDict, addWallOreDict, addPressurePlateOreDict,
                     addStoneUnificationInfo, addPolishedStoneUnificationInfo, addSmeltStoneUnificationInfo,
-                    addChiselStoneUnificationInfo, addSlabUnificationInfo,
+                    addChiselStoneUnificationInfo, addCrackedStoneUnificationInfo, addSlabUnificationInfo,
                     addStairUnificationInfo, addButtonUnificationInfo,
                     addWallUnificationInfo, addPressurePlateUnificationInfo);
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -168,7 +168,8 @@ public class VanillaRecipeHelper {
 
     public static void addSmeltingRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName, Item input,
                                          Item output, float experience) {
-        addSmeltingRecipe(provider, GTCEu.id(regName), input.getDefaultInstance(), output.getDefaultInstance(), experience);
+        addSmeltingRecipe(provider, GTCEu.id(regName), input.getDefaultInstance(), output.getDefaultInstance(),
+                experience);
     }
 
     public static void addSmeltingRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName, ItemStack input,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -161,6 +161,11 @@ public class VanillaRecipeHelper {
         addSmeltingRecipe(provider, GTCEu.id(regName), input, output, 0.0f);
     }
 
+    public static void addSmeltingRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName, Item input,
+                                         Item output) {
+        addSmeltingRecipe(provider, GTCEu.id(regName), input.getDefaultInstance(), output.getDefaultInstance(), 0.0f);
+    }
+
     public static void addSmeltingRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName, ItemStack input,
                                          ItemStack output, float experience) {
         addSmeltingRecipe(provider, GTCEu.id(regName), input, output, experience);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -166,6 +166,11 @@ public class VanillaRecipeHelper {
         addSmeltingRecipe(provider, GTCEu.id(regName), input.getDefaultInstance(), output.getDefaultInstance(), 0.0f);
     }
 
+    public static void addSmeltingRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName, Item input,
+                                         Item output, float experience) {
+        addSmeltingRecipe(provider, GTCEu.id(regName), input.getDefaultInstance(), output.getDefaultInstance(), experience);
+    }
+
     public static void addSmeltingRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName, ItemStack input,
                                          ItemStack output, float experience) {
         addSmeltingRecipe(provider, GTCEu.id(regName), input, output, experience);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -163,6 +163,7 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:light_weighted_pressure_plate"));
         registry.accept(new ResourceLocation("minecraft:stone_button"));
         registry.accept(new ResourceLocation("minecraft:polished_blackstone_button"));
+        registry.accept(new ResourceLocation("minecraft:calibrated_sculk_sensor"));
     }
 
     private static void hardToolArmorRecipes(Consumer<ResourceLocation> registry) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -397,9 +397,11 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:waxed_exposed_cut_copper"));
         registry.accept(new ResourceLocation("minecraft:waxed_weathered_cut_copper"));
         registry.accept(new ResourceLocation("minecraft:waxed_oxidized_cut_copper"));
-        // registry.accept(new ResourceLocation("minecraft:end_crystal"));
+        registry.accept(new ResourceLocation("minecraft:end_crystal"));
         registry.accept(new ResourceLocation("minecraft:end_rod"));
         registry.accept(new ResourceLocation("minecraft:mud_bricks"));
+        registry.accept(new ResourceLocation("minecraft:mossy_stone_bricks_from_vine"));
+        registry.accept(new ResourceLocation("minecraft:mossy_stone_bricks_from_moss_block"));
 
         // Carpet replacement
         for (DyeColor color : DyeColor.values()) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeRemoval.java
@@ -356,7 +356,6 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:polished_diorite"));
         registry.accept(new ResourceLocation("minecraft:polished_granite"));
         registry.accept(new ResourceLocation("minecraft:coarse_dirt"));
-        registry.accept(new ResourceLocation("minecraft:smooth_sandstone"));
         registry.accept(new ResourceLocation("minecraft:chiseled_sandstone"));
         registry.accept(new ResourceLocation("minecraft:chiseled_quartz_block"));
         registry.accept(new ResourceLocation("minecraft:stone_bricks"));
@@ -366,7 +365,6 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:red_nether_bricks"));
         registry.accept(new ResourceLocation("minecraft:red_sandstone"));
         registry.accept(new ResourceLocation("minecraft:chiseled_red_sandstone"));
-        registry.accept(new ResourceLocation("minecraft:smooth_red_sandstone"));
         registry.accept(new ResourceLocation("minecraft:bookshelf"));
         registry.accept(new ResourceLocation("minecraft:quartz_pillar"));
         registry.accept(new ResourceLocation("minecraft:sea_lantern"));
@@ -403,6 +401,7 @@ public class RecipeRemoval {
         registry.accept(new ResourceLocation("minecraft:mud_bricks"));
         registry.accept(new ResourceLocation("minecraft:mossy_stone_bricks_from_vine"));
         registry.accept(new ResourceLocation("minecraft:mossy_stone_bricks_from_moss_block"));
+        registry.accept(new ResourceLocation("minecraft:packed_mud"));
 
         // Carpet replacement
         for (DyeColor color : DyeColor.values()) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -1299,11 +1299,19 @@ public class MachineRecipeLoader {
                                            List<ItemStack> mossStack) {
         for (int i = 0; i < regularStack.size(); i++) {
             ResourceLocation mossId = BuiltInRegistries.ITEM.getKey(mossStack.get(i).getItem());
-            CHEMICAL_BATH_RECIPES.recipeBuilder("bath_" + mossId.getPath())
+            MIXER_RECIPES.recipeBuilder(mossId.getPath() + "_from_moss_block")
                     .inputItems(regularStack.get(i))
-                    .inputFluids(Water.getFluid(100))
+                    .inputItems(new ItemStack(Blocks.MOSS_BLOCK))
+                    .inputFluids(Water.getFluid(250))
                     .outputItems(mossStack.get(i))
-                    .duration(50).EUt(16).save(provider);
+                    .duration(40).EUt(1).save(provider);
+
+            MIXER_RECIPES.recipeBuilder(mossId.getPath() + "_from_vine")
+                    .inputItems(regularStack.get(i))
+                    .inputItems(new ItemStack(Blocks.VINE))
+                    .inputFluids(Water.getFluid(250))
+                    .outputItems(mossStack.get(i))
+                    .duration(40).EUt(1).save(provider);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -524,14 +524,15 @@ public class StoneMachineRecipes {
     }
 
     public static void registerStoneTypeRecipes(Consumer<FinishedRecipe> provider, @NotNull StoneTypeEntry entry) {
-        if(entry.stone == null) {
+        if (entry.stone == null) {
             GTCEu.LOGGER.error("could not find stone form of StoneTypeEntry, id: {}", entry.stoneName);
             return;
         }
 
-        if(entry.polishedStone != null) {
-            if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_polish_hammer", new ItemStack(entry.polishedStone),
+        if (entry.polishedStone != null) {
+            if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_polish_hammer",
+                        new ItemStack(entry.polishedStone),
                         "hSS", " SS",
                         'S', entry.stone);
             }
@@ -545,9 +546,10 @@ public class StoneMachineRecipes {
                     .save(provider);
         }
 
-        if(entry.crackedStone != null) {
-            if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_hammer", new ItemStack(entry.crackedStone),
+        if (entry.crackedStone != null) {
+            if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_hammer",
+                        new ItemStack(entry.crackedStone),
                         "h", "S",
                         'S', entry.stone);
             }
@@ -558,13 +560,15 @@ public class StoneMachineRecipes {
                     .duration(12).EUt(4).save(provider);
         }
 
-        if(entry.smeltStone != null) {
-            VanillaRecipeHelper.addSmeltingRecipe(provider, "smelt_" + entry.stoneName + "_into_" + entry.smeltStone, entry.stone, entry.smeltStone, 0.1f);
+        if (entry.smeltStone != null) {
+            VanillaRecipeHelper.addSmeltingRecipe(provider, "smelt_" + entry.stoneName + "_into_" + entry.smeltStone,
+                    entry.stone, entry.smeltStone, 0.1f);
         }
 
-        if(entry.slab != null) {
-            if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_slab_saw", new ItemStack(entry.slab), "sS",
+        if (entry.slab != null) {
+            if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_slab_saw", new ItemStack(entry.slab),
+                        "sS",
                         'S', entry.stone);
             }
 
@@ -575,9 +579,10 @@ public class StoneMachineRecipes {
                     .EUt(8)
                     .save(provider);
 
-            if(entry.chiselStone != null) {
-                if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-                    VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_polished_hammer", new ItemStack(entry.chiselStone),
+            if (entry.chiselStone != null) {
+                if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                    VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_polished_hammer",
+                            new ItemStack(entry.chiselStone),
                             "mSd", " S", " S",
                             'S', entry.slab);
                 }
@@ -590,14 +595,13 @@ public class StoneMachineRecipes {
             }
         }
 
-
-        if(entry.button != null) {
-            if(ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.pressurePlate != null) {
+        if (entry.button != null) {
+            if (ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.pressurePlate != null) {
                 VanillaRecipeHelper.addShapedRecipe(provider, "stone_button", new ItemStack(entry.button, 6), "sP",
                         'P', entry.pressurePlate);
             }
 
-            if(entry.slab != null) {
+            if (entry.slab != null) {
                 GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("cut_" + entry.stoneName + "slab_into_button")
                         .inputItems(entry.slab)
                         .outputItems(entry.button, 3)
@@ -615,15 +619,14 @@ public class StoneMachineRecipes {
             }
         }
 
-        if(entry.pressurePlate != null) {
+        if (entry.pressurePlate != null) {
 
-            if(ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.slab != null) {
+            if (ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.slab != null) {
                 VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_pressure_plate",
                         new ItemStack(entry.pressurePlate, 2), "ShS", "LCL", "SdS",
                         'S', new UnificationEntry(TagPrefix.screw, GTMaterials.Iron),
                         'L', entry.slab,
                         'C', new UnificationEntry(TagPrefix.spring, GTMaterials.Iron));
-
 
                 ASSEMBLER_RECIPES.recipeBuilder(entry.stoneName + "_pressure_plate")
                         .inputItems(TagPrefix.spring, GTMaterials.Iron)
@@ -632,16 +635,15 @@ public class StoneMachineRecipes {
                         .duration(100)
                         .EUt(VA[ULV])
                         .save(provider);
-            }
-            else if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-
+            } else if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
 
             }
         }
 
         if (entry.stair != null) {
-            if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_stair_saw", new ItemStack(entry.stair, 3),
+            if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_stair_saw",
+                        new ItemStack(entry.stair, 3),
                         "Ss ", "SS ", "SSS",
                         'S', entry.stone);
             }
@@ -656,8 +658,9 @@ public class StoneMachineRecipes {
         }
 
         if (entry.wall != null) {
-            if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
-                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_wall_saw", new ItemStack(entry.wall, 2),
+            if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_wall_saw",
+                        new ItemStack(entry.wall, 2),
                         "sS", " S", " S",
                         'S', entry.stone);
             }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -9,7 +9,6 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
-import com.gregtechceu.gtceu.common.data.GTRecipeCategories;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.StoneTypeEntry;
@@ -18,7 +17,6 @@ import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.block.Blocks;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -62,7 +60,7 @@ public class StoneMachineRecipes {
                             .build(),
                     new StoneTypeEntry.Builder(mcModID, "stone_brick")
                             .stone(Items.STONE_BRICKS)
-                            .smeltStone(Items.CRACKED_STONE_BRICKS)
+                            .crackedStone(Items.CRACKED_STONE_BRICKS)
                             .chiselStone(Items.CHISELED_STONE_BRICKS)
                             .slab(Items.STONE_BRICK_SLAB)
                             .stair(Items.STONE_BRICK_STAIRS)
@@ -204,6 +202,7 @@ public class StoneMachineRecipes {
                             .stone(Items.POLISHED_BLACKSTONE)
                             .polishedStone(Items.POLISHED_BLACKSTONE_BRICKS)
                             .chiselStone(Items.CHISELED_POLISHED_BLACKSTONE)
+                            .crackedStone(Items.CRACKED_POLISHED_BLACKSTONE_BRICKS)
                             .slab(Items.POLISHED_BLACKSTONE_SLAB)
                             .stair(Items.POLISHED_BLACKSTONE_STAIRS)
                             .wall(Items.POLISHED_BLACKSTONE_WALL)
@@ -213,7 +212,6 @@ public class StoneMachineRecipes {
                             .build(),
                     new StoneTypeEntry.Builder(mcModID, "polished_blackstone_brick")
                             .stone(Items.POLISHED_BLACKSTONE_BRICKS)
-                            .smeltStone(Items.CRACKED_POLISHED_BLACKSTONE_BRICKS)
                             .slab(Items.POLISHED_BLACKSTONE_BRICK_SLAB)
                             .stair(Items.POLISHED_BLACKSTONE_BRICK_STAIRS)
                             .button(Items.POLISHED_BLACKSTONE_BUTTON)
@@ -237,9 +235,9 @@ public class StoneMachineRecipes {
                             .material(GTMaterials.Clay) // maybe?
                             .registerAllUnificationInfo()
                             .build(),
-                    new StoneTypeEntry.Builder(mcModID, "nether_brick")
+                    new StoneTypeEntry.Builder(mcModID, "nether_bricks")
                             .stone(Items.NETHER_BRICKS)
-                            .smeltStone(Items.CRACKED_NETHER_BRICKS)
+                            .crackedStone(Items.CRACKED_NETHER_BRICKS)
                             .chiselStone(Items.CHISELED_NETHER_BRICKS)
                             .slab(Items.NETHER_BRICK_SLAB)
                             .stair(Items.NETHER_BRICK_STAIRS)
@@ -392,9 +390,10 @@ public class StoneMachineRecipes {
                             .material(GTMaterials.Deepslate)
                             .registerAllUnificationInfo()
                             .build(),
-                    new StoneTypeEntry.Builder(mcModID, "deepslate_brick")
+                    new StoneTypeEntry.Builder(mcModID, "deepslate_bricks")
                             .stone(Items.DEEPSLATE_BRICKS)
-                            .smeltStone(Items.CRACKED_DEEPSLATE_BRICKS)
+                            .polishedStone(Items.DEEPSLATE_TILES)
+                            .crackedStone(Items.CRACKED_DEEPSLATE_BRICKS)
                             .slab(Items.DEEPSLATE_BRICK_SLAB)
                             .stair(Items.DEEPSLATE_BRICK_STAIRS)
                             .wall(Items.DEEPSLATE_BRICK_WALL)
@@ -403,7 +402,7 @@ public class StoneMachineRecipes {
                             .build(),
                     new StoneTypeEntry.Builder(mcModID, "deepslate_tile")
                             .stone(Items.DEEPSLATE_TILES)
-                            .smeltStone(Items.CRACKED_DEEPSLATE_TILES)
+                            .crackedStone(Items.CRACKED_DEEPSLATE_TILES)
                             .slab(Items.DEEPSLATE_TILE_SLAB)
                             .stair(Items.DEEPSLATE_TILE_STAIRS)
                             .wall(Items.DEEPSLATE_TILE_WALL)
@@ -470,6 +469,16 @@ public class StoneMachineRecipes {
             }
         }
 
+        if (entry.material != null && entry.crackedStone != null) {
+            if (entry.addStoneOreDict) {
+                ChemicalHelper.registerUnificationItems(TagPrefix.block, entry.material, entry.crackedStone);
+            }
+            if (entry.addCrackedStoneUnificationInfo) {
+                ChemicalHelper.registerMaterialInfo(entry.crackedStone,
+                        new ItemMaterialInfo(new MaterialStack(entry.material, entry.materialAmount)));
+            }
+        }
+
         if (entry.material != null && entry.slab != null) {
             if (entry.addSlabOreDict) {
                 ChemicalHelper.registerUnificationItems(TagPrefix.slab, entry.material, entry.slab);
@@ -529,6 +538,7 @@ public class StoneMachineRecipes {
                         "hSS", " SS",
                         'S', entry.stone);
             }
+
             GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("assemble_" + entry.stoneName + "_into_polished")
                     .inputItems(entry.stone, 4)
                     .circuitMeta(4)
@@ -536,6 +546,23 @@ public class StoneMachineRecipes {
                     .duration(160)
                     .EUt(1)
                     .save(provider);
+        }
+
+        if(entry.crackedStone != null) {
+            if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
+                VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_hammer", new ItemStack(entry.crackedStone),
+                        "h", "S",
+                        'S', entry.stone);
+            }
+
+            GTRecipeTypes.FORGE_HAMMER_RECIPES.recipeBuilder("hammer_" + entry.stoneName + "_into_cracked")
+                    .inputItems(entry.stone)
+                    .outputItems(entry.crackedStone)
+                    .duration(12).EUt(4).save(provider);
+        }
+
+        if(entry.smeltStone != null) {
+            VanillaRecipeHelper.addSmeltingRecipe(provider, "smelt_" + entry.stoneName + "_into_" + entry.smeltStone, entry.stone, entry.smeltStone);
         }
 
         if(entry.slab != null) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -44,7 +44,6 @@ public class StoneMachineRecipes {
                             .stone(Items.STONE)
                             .crackedStone(Items.COBBLESTONE)
                             .polishedStone(Items.STONE_BRICKS)
-                            .smeltStone(Items.SMOOTH_STONE)
                             .slab(Items.STONE_SLAB)
                             .stair(Items.STONE_STAIRS)
                             .button(Items.STONE_BUTTON)
@@ -119,7 +118,6 @@ public class StoneMachineRecipes {
                     new StoneTypeEntry.Builder(mcModID, "sandstone")
                             .stone(Items.SANDSTONE)
                             .polishedStone(Items.CUT_SANDSTONE)
-                            .smeltStone(Items.SMOOTH_SANDSTONE)
                             .chiselStone(Items.CHISELED_SANDSTONE)
                             .slab(Items.SANDSTONE_SLAB)
                             .stair(Items.SANDSTONE_STAIRS)
@@ -143,7 +141,6 @@ public class StoneMachineRecipes {
                     new StoneTypeEntry.Builder(mcModID, "red_sandstone")
                             .stone(Items.RED_SANDSTONE)
                             .polishedStone(Items.CUT_RED_SANDSTONE)
-                            .smeltStone(Items.SMOOTH_RED_SANDSTONE)
                             .chiselStone(Items.CHISELED_RED_SANDSTONE)
                             .slab(Items.RED_SANDSTONE_SLAB)
                             .stair(Items.RED_SANDSTONE_STAIRS)
@@ -166,7 +163,6 @@ public class StoneMachineRecipes {
                             .build(),
                     new StoneTypeEntry.Builder(mcModID, "cobblestone")
                             .stone(Items.COBBLESTONE)
-                            .smeltStone(Items.STONE)
                             .slab(Items.COBBLESTONE_SLAB)
                             .stair(Items.COBBLESTONE_STAIRS)
                             .wall(Items.COBBLESTONE_WALL)
@@ -256,7 +252,6 @@ public class StoneMachineRecipes {
                     new StoneTypeEntry.Builder(mcModID, "quartz")
                             .stone(Items.QUARTZ_BLOCK)
                             .polishedStone(Items.QUARTZ_BRICKS)
-                            .smeltStone(Items.SMOOTH_QUARTZ)
                             .chiselStone(Items.CHISELED_QUARTZ_BLOCK)
                             .slab(Items.QUARTZ_SLAB)
                             .stair(Items.QUARTZ_STAIRS)
@@ -370,10 +365,13 @@ public class StoneMachineRecipes {
                             .material(GTMaterials.Wood)
                             .registerAllUnificationInfo()
                             .build(),
+                    new StoneTypeEntry.Builder(mcModID, "deepslate")
+                            .stone(Items.DEEPSLATE)
+                            .crackedStone(Items.COBBLED_DEEPSLATE)
+                            .build(),
                     new StoneTypeEntry.Builder(mcModID, "cobbled_deepslate")
                             .stone(Items.COBBLED_DEEPSLATE)
                             .polishedStone(Items.POLISHED_DEEPSLATE)
-                            .smeltStone(Items.DEEPSLATE)
                             .chiselStone(Items.CHISELED_DEEPSLATE)
                             .slab(Items.COBBLED_DEEPSLATE_SLAB)
                             .stair(Items.COBBLED_DEEPSLATE_STAIRS)
@@ -412,7 +410,6 @@ public class StoneMachineRecipes {
                     new StoneTypeEntry.Builder(mcModID, "basalt")
                             .stone(Items.BASALT)
                             .polishedStone(Items.POLISHED_BASALT)
-                            .smeltStone(Items.SMOOTH_BASALT)
                             .material(GTMaterials.Basalt)
                             .registerAllUnificationInfo()
                             .build()
@@ -540,10 +537,10 @@ public class StoneMachineRecipes {
             }
 
             GTRecipeTypes.ASSEMBLER_RECIPES.recipeBuilder("assemble_" + entry.stoneName + "_into_polished")
-                    .inputItems(entry.stone, 4)
+                    .inputItems(entry.stone)
                     .circuitMeta(4)
-                    .outputItems(entry.polishedStone, 4)
-                    .duration(160)
+                    .outputItems(entry.polishedStone)
+                    .duration(80)
                     .EUt(1)
                     .save(provider);
         }
@@ -562,7 +559,7 @@ public class StoneMachineRecipes {
         }
 
         if(entry.smeltStone != null) {
-            VanillaRecipeHelper.addSmeltingRecipe(provider, "smelt_" + entry.stoneName + "_into_" + entry.smeltStone, entry.stone, entry.smeltStone);
+            VanillaRecipeHelper.addSmeltingRecipe(provider, "smelt_" + entry.stoneName + "_into_" + entry.smeltStone, entry.stone, entry.smeltStone, 0.1f);
         }
 
         if(entry.slab != null) {
@@ -587,7 +584,7 @@ public class StoneMachineRecipes {
                 GTRecipeTypes.FORMING_PRESS_RECIPES.recipeBuilder("form_" + entry.stoneName + "_slab_into_pillar")
                         .inputItems(entry.slab, 2)
                         .outputItems(entry.chiselStone)
-                        .duration(160)
+                        .duration(80)
                         .EUt(8)
                         .save(provider);
             }
@@ -653,7 +650,7 @@ public class StoneMachineRecipes {
                     .inputItems(entry.stone, 3)
                     .circuitMeta(7)
                     .outputItems(entry.stair, 4)
-                    .duration(160)
+                    .duration(80)
                     .EUt(8)
                     .save(provider);
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -44,6 +44,7 @@ public class StoneMachineRecipes {
             return DEFAULT_ENTRIES = Arrays.asList(
                     new StoneTypeEntry.Builder(mcModID, "stone")
                             .stone(Items.STONE)
+                            .crackedStone(Items.COBBLESTONE)
                             .polishedStone(Items.STONE_BRICKS)
                             .smeltStone(Items.SMOOTH_STONE)
                             .slab(Items.STONE_SLAB)
@@ -335,8 +336,9 @@ public class StoneMachineRecipes {
                             // .material() // TODO purpur material?
                             .registerAllUnificationInfo()
                             .build(),
-                    new StoneTypeEntry.Builder(mcModID, "end_stone_brick")
-                            .stone(Items.END_STONE_BRICKS)
+                    new StoneTypeEntry.Builder(mcModID, "end_stone")
+                            .stone(Items.END_STONE)
+                            .polishedStone(Items.END_STONE_BRICKS)
                             .slab(Items.END_STONE_BRICK_SLAB)
                             .stair(Items.END_STONE_BRICK_STAIRS)
                             .wall(Items.END_STONE_BRICK_WALL)
@@ -383,6 +385,7 @@ public class StoneMachineRecipes {
                             .build(),
                     new StoneTypeEntry.Builder(mcModID, "polished_deepslate")
                             .stone(Items.POLISHED_DEEPSLATE)
+                            .polishedStone(Items.DEEPSLATE_BRICKS)
                             .slab(Items.POLISHED_DEEPSLATE_SLAB)
                             .stair(Items.POLISHED_DEEPSLATE_STAIRS)
                             .wall(Items.POLISHED_DEEPSLATE_WALL)
@@ -531,7 +534,7 @@ public class StoneMachineRecipes {
                     .circuitMeta(4)
                     .outputItems(entry.polishedStone, 4)
                     .duration(160)
-                    .EUt(8)
+                    .EUt(1)
                     .save(provider);
         }
 
@@ -551,7 +554,7 @@ public class StoneMachineRecipes {
             if(entry.chiselStone != null) {
                 if(ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
                     VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_polished_hammer", new ItemStack(entry.chiselStone),
-                            "mS", " S", " S",
+                            "mSd", " S", " S",
                             'S', entry.slab);
                 }
                 GTRecipeTypes.FORMING_PRESS_RECIPES.recipeBuilder("form_" + entry.stoneName + "_slab_into_pillar")

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -53,14 +53,13 @@ public class VanillaStandardRecipes {
                 .outputItems(new ItemStack(Blocks.STONE))
                 .save(provider);
 
-        // todo autogenerate 2x2 recipes?
         COMPRESSOR_RECIPES.recipeBuilder("sandstone").duration(300).EUt(2)
-                .inputItems(new ItemStack(Blocks.SAND, 4))
+                .inputItems(new ItemStack(Blocks.SAND, 2))
                 .outputItems(new ItemStack(Blocks.SANDSTONE))
                 .save(provider);
 
         COMPRESSOR_RECIPES.recipeBuilder("red_sandstone").duration(300).EUt(2)
-                .inputItems(new ItemStack(Blocks.RED_SAND))
+                .inputItems(new ItemStack(Blocks.RED_SAND), 2)
                 .outputItems(new ItemStack(Blocks.RED_SANDSTONE))
                 .save(provider);
 
@@ -1197,6 +1196,18 @@ public class VanillaStandardRecipes {
                 .inputItems(new ItemStack(Items.DIORITE))
                 .inputItems(new ItemStack(Items.COBBLESTONE))
                 .outputItems(new ItemStack(Items.ANDESITE, 2))
+                .duration(80).EUt(4).save(provider);
+
+        ASSEMBLER_RECIPES.recipeBuilder("assemble_block_of_quartz_into_quartz_pillar")
+                .inputItems(new ItemStack(Items.QUARTZ_BLOCK))
+                .circuitMeta(5)
+                .outputItems(new ItemStack(Items.QUARTZ_PILLAR))
+                .duration(80).EUt(1).save(provider);
+
+        MIXER_RECIPES.recipeBuilder("packed_mud")
+                .inputItems(new ItemStack(Items.MUD))
+                .inputItems(new ItemStack(Items.WHEAT))
+                .outputItems(new ItemStack(Items.PACKED_MUD))
                 .duration(80).EUt(4).save(provider);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -270,23 +270,6 @@ public class VanillaStandardRecipes {
      * Adds smashing related recipes for vanilla blocks and items
      */
     private static void smashingRecipes(Consumer<FinishedRecipe> provider) {
-        VanillaRecipeHelper.addShapedRecipe(provider, "cobblestone_hammer", new ItemStack(Blocks.COBBLESTONE), "h", "C",
-                'C', new ItemStack(Blocks.STONE));
-        VanillaRecipeHelper.addShapedRecipe(provider, "cobbled_deepslate_hammer",
-                new ItemStack(Blocks.COBBLED_DEEPSLATE), "h", "C", 'C', new ItemStack(Blocks.DEEPSLATE));
-
-        FORGE_HAMMER_RECIPES.recipeBuilder("stone_to_cobblestone")
-                .inputItems(new ItemStack(Blocks.STONE))
-                .outputItems(new ItemStack(Blocks.COBBLESTONE))
-                .EUt(16).duration(10)
-                .save(provider);
-
-        FORGE_HAMMER_RECIPES.recipeBuilder("deepslate_to_cobbled_deepslate")
-                .inputItems(new ItemStack(Blocks.DEEPSLATE))
-                .outputItems(new ItemStack(Blocks.COBBLED_DEEPSLATE))
-                .EUt(16).duration(10)
-                .save(provider);
-
         FORGE_HAMMER_RECIPES.recipeBuilder("cobblestone_to_gravel")
                 .inputItems(ItemTags.STONE_CRAFTING_MATERIALS)
                 .outputItems(new ItemStack(Blocks.GRAVEL))
@@ -335,11 +318,6 @@ public class VanillaStandardRecipes {
         FORGE_HAMMER_RECIPES.recipeBuilder("chiseled_red_sandstone_to_red_sand")
                 .inputItems(new ItemStack(Blocks.CHISELED_RED_SANDSTONE))
                 .outputItems(new ItemStack(Blocks.RED_SAND))
-                .EUt(2).duration(400).save(provider);
-
-        FORGE_HAMMER_RECIPES.recipeBuilder("cracked_stone_bricks")
-                .inputItems(new ItemStack(Blocks.STONE_BRICKS))
-                .outputItems(new ItemStack(Blocks.CRACKED_STONE_BRICKS))
                 .EUt(2).duration(400).save(provider);
 
         VanillaRecipeHelper.addShapelessRecipe(provider, "clay_block_to_dust", ChemicalHelper.get(dust, Clay), 'm',
@@ -870,7 +848,7 @@ public class VanillaStandardRecipes {
                 .circuitMeta(7)
                 .duration(700).EUt(4).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("iron_nars")
+        ASSEMBLER_RECIPES.recipeBuilder("iron_bars")
                 .inputItems(rod, Iron, 3)
                 .outputItems(new ItemStack(Blocks.IRON_BARS, 4))
                 .circuitMeta(3)
@@ -988,27 +966,31 @@ public class VanillaStandardRecipes {
                 .outputItems(new ItemStack(Blocks.WHITE_WOOL))
                 .duration(100).EUt(4).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("mossy_cobblestone_from_vine")
+        MIXER_RECIPES.recipeBuilder("mossy_cobblestone_from_vine")
                 .inputItems(new ItemStack(Blocks.COBBLESTONE))
                 .inputItems(new ItemStack(Blocks.VINE))
+                .inputFluids(Water.getFluid(250))
                 .outputItems(new ItemStack(Blocks.MOSSY_COBBLESTONE))
                 .duration(40).EUt(1).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("mossy_cobblestone_from_moss_block")
+        MIXER_RECIPES.recipeBuilder("mossy_cobblestone_from_moss_block")
                 .inputItems(new ItemStack(Blocks.COBBLESTONE))
                 .inputItems(new ItemStack(Blocks.MOSS_BLOCK))
+                .inputFluids(Water.getFluid(250))
                 .outputItems(new ItemStack(Blocks.MOSSY_COBBLESTONE))
                 .duration(40).EUt(1).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("mossy_stone_bricks_from_vine")
+        MIXER_RECIPES.recipeBuilder("mossy_stone_bricks_from_vine")
                 .inputItems(new ItemStack(Blocks.STONE_BRICKS))
                 .inputItems(new ItemStack(Blocks.VINE))
+                .inputFluids(Water.getFluid(250))
                 .outputItems(new ItemStack(Blocks.MOSSY_STONE_BRICKS))
                 .duration(40).EUt(1).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("mossy_stone_bricks_from_moss_block")
+        MIXER_RECIPES.recipeBuilder("mossy_stone_bricks_from_moss_block")
                 .inputItems(new ItemStack(Blocks.STONE_BRICKS))
                 .inputItems(new ItemStack(Blocks.MOSS_BLOCK))
+                .inputFluids(Water.getFluid(250))
                 .outputItems(new ItemStack(Blocks.MOSSY_STONE_BRICKS))
                 .duration(40).EUt(1).save(provider);
 
@@ -1033,9 +1015,9 @@ public class VanillaStandardRecipes {
                 .inputItems(new ItemStack(Items.POPPED_CHORUS_FRUIT)).inputItems(new ItemStack(Items.BLAZE_ROD))
                 .outputItems(new ItemStack(Blocks.END_ROD, 4)).save(provider);
 
-        ASSEMBLER_RECIPES.recipeBuilder("purple_shulker_box").duration(100).EUt(VA[ULV])
+        ASSEMBLER_RECIPES.recipeBuilder("shulker_box").duration(100).EUt(VA[ULV])
                 .inputItems(Tags.Items.CHESTS_WOODEN).inputItems(new ItemStack(Items.SHULKER_SHELL, 2))
-                .outputItems(new ItemStack(Blocks.PURPLE_SHULKER_BOX)).save(provider);
+                .outputItems(new ItemStack(Blocks.SHULKER_BOX)).save(provider);
 
         ASSEMBLER_RECIPES.recipeBuilder("painting").duration(100).EUt(4).circuitMeta(1).inputItems(ItemTags.WOOL)
                 .inputItems(new ItemStack(Items.STICK, 8)).outputItems(new ItemStack(Items.PAINTING)).save(provider);
@@ -1200,6 +1182,22 @@ public class VanillaStandardRecipes {
                 .inputItems(new ItemStack(Items.NAUTILUS_SHELL, 8))
                 .outputItems(new ItemStack(Blocks.CONDUIT))
                 .duration(200).EUt(16).save(provider);
+
+        ALLOY_SMELTER_RECIPES.recipeBuilder("granite")
+                .inputItems(new ItemStack(Items.DIORITE))
+                .inputItems(new ItemStack(Items.QUARTZ))
+                .outputItems(new ItemStack(Items.GRANITE))
+                .duration(80).EUt(4).save(provider);
+        ALLOY_SMELTER_RECIPES.recipeBuilder("diorite")
+                .inputItems(new ItemStack(Items.COBBLESTONE, 2))
+                .inputItems(new ItemStack(Items.QUARTZ, 2))
+                .outputItems(new ItemStack(Items.DIORITE, 2))
+                .duration(80).EUt(4).save(provider);
+        ALLOY_SMELTER_RECIPES.recipeBuilder("andesite")
+                .inputItems(new ItemStack(Items.DIORITE))
+                .inputItems(new ItemStack(Items.COBBLESTONE))
+                .outputItems(new ItemStack(Items.ANDESITE, 2))
+                .duration(80).EUt(4).save(provider);
     }
 
     /**
@@ -1352,7 +1350,7 @@ public class VanillaStandardRecipes {
                 .save(provider);
 
         CHEMICAL_BATH_RECIPES.recipeBuilder("dark_prismarine")
-                .inputItems(new ItemStack(Items.PRISMARINE_SHARD, 8))
+                .inputItems(new ItemStack(Items.PRISMARINE_SHARD, 4))
                 .inputFluids(DyeBlack.getFluid(L))
                 .outputItems(new ItemStack(Blocks.DARK_PRISMARINE))
                 .duration(20).EUt(VA[ULV]).save(provider);


### PR DESCRIPTION
## What
Misc recipe fixes for stone building blocks

To-do:
- [ ] GT stone types
- [x] Quartz pillar
- [x] Packed mud
- [x] Sandstone
- [x] Red sandstone
- [x] Smooth sandstones
- [ ] Components for Blackstone, Purpur, Prismarine

## Implementation Details
Smelting recipe for cracked bricks has been removed to keep parity with cracked stone bricks. Lmk if I should revert this

Also added cracked stone option for StoneTypeEntry, implemented smeltStone recipe, added new methods for smelting recipe helper