### PR TITLE
FTB Teams Optional NPE Fix

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/owner/FTBOwner.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/owner/FTBOwner.java
@@ -28,7 +28,7 @@ public final class FTBOwner implements IMachineOwner {
 
     @Override
     public void save(CompoundTag tag) {
-        if(team != null)
+        if (team != null)
             tag.putUUID("teamUUID", team.getTeamId());
         tag.putUUID("playerUUID", playerUUID);
     }
@@ -36,10 +36,10 @@ public final class FTBOwner implements IMachineOwner {
     @Override
     public void load(CompoundTag tag) {
         try {
-            if(tag.contains("teamUUID"))
+            if (tag.contains("teamUUID"))
                 this.team = FTBTeamsAPIImpl.INSTANCE.getManager().getTeamByID(tag.getUUID("teamUUID")).orElse(null);
             else this.team = null;
-        } catch(NullPointerException e) {
+        } catch (NullPointerException e) {
             this.team = null;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/owner/FTBOwner.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/owner/FTBOwner.java
@@ -28,13 +28,21 @@ public final class FTBOwner implements IMachineOwner {
 
     @Override
     public void save(CompoundTag tag) {
-        tag.putUUID("teamUUID", team.getTeamId());
+        if(team != null)
+            tag.putUUID("teamUUID", team.getTeamId());
         tag.putUUID("playerUUID", playerUUID);
     }
 
     @Override
     public void load(CompoundTag tag) {
-        this.team = FTBTeamsAPIImpl.INSTANCE.getManager().getTeamByID(tag.getUUID("teamUUID")).orElse(null);
+        try {
+            if(tag.contains("teamUUID"))
+                this.team = FTBTeamsAPIImpl.INSTANCE.getManager().getTeamByID(tag.getUUID("teamUUID")).orElse(null);
+            else this.team = null;
+        } catch(NullPointerException e) {
+            this.team = null;
+        }
+
         this.playerUUID = tag.getUUID("playerUUID");
     }
 


### PR DESCRIPTION
## What
Fixes an issue regarding ftb teams not null checking teams before trying to return by uuid

## Implementation Details
try catch and null checking for saving/loading team uuid

## Outcome
no more crash when you delete a team and try to access a machine