### PR TITLE
Missing Decomp Recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.data.chemical;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.FluidProperty;
@@ -19,6 +20,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
@@ -29,6 +31,7 @@ import net.minecraftforge.registries.RegistryObject;
 
 import com.mojang.datafixers.util.Pair;
 import com.tterrag.registrate.util.entry.BlockEntry;
+import com.tterrag.registrate.util.entry.ItemEntry;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -68,6 +71,13 @@ public class ChemicalHelper {
     }
 
     public static ItemMaterialInfo getMaterialInfo(ItemLike item) {
+        if (item instanceof Block block) {
+            return ITEM_MATERIAL_INFO.get(block);
+        } else if (item instanceof BlockItem blockItem) {
+            return ITEM_MATERIAL_INFO.get(blockItem.getBlock());
+        } else if (item instanceof ItemEntry<?> entry) {
+            return ITEM_MATERIAL_INFO.get(entry.asItem());
+        }
         return ITEM_MATERIAL_INFO.get(item);
     }
 
@@ -158,7 +168,13 @@ public class ChemicalHelper {
             }
         }
         ItemMaterialInfo info = ITEM_MATERIAL_INFO.get(itemLike);
-        return info == null ? null : info.getMaterial().copy();
+        if (info == null)
+            return null;
+        if (info.getMaterial() == null) {
+            GTCEu.LOGGER.error("ItemMaterialInfo for {} is empty!", itemLike);
+            return null;
+        }
+        return info.getMaterial().copy();
     }
 
     @Nullable

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/MaterialInfoLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/MaterialInfoLoader.java
@@ -236,7 +236,10 @@ public class MaterialInfoLoader {
                 new ItemMaterialInfo(new MaterialStack(GTMaterials.Clay, M * 4)));
 
         ChemicalHelper.registerMaterialInfo(GTBlocks.CASING_PRIMITIVE_BRICKS.get(),
-                new ItemMaterialInfo(new MaterialStack(GTMaterials.Fireclay, M * 4)));
+                ConfigHolder.INSTANCE.recipes.harderBrickRecipes ?
+                        new ItemMaterialInfo(new MaterialStack(GTMaterials.Fireclay, M * 6),
+                                new MaterialStack(GTMaterials.Gypsum, M * 2)) :
+                        new ItemMaterialInfo(new MaterialStack(GTMaterials.Fireclay, M * 4)));
 
         if (ConfigHolder.INSTANCE.recipes.hardWoodRecipes) {
             ChemicalHelper.registerMaterialInfo(Items.ACACIA_DOOR, new ItemMaterialInfo(


### PR DESCRIPTION
## What
Fixes #256 
Adds finer item cast checking when retrieving material information about that item, for use in decomp recipes

## Implementation Details
Also added the extra brick and gypsum to hard firebrick recipes decomp

## Outcome
Recycling recipes for all machines now give back the correct amount of ingredients