### PR TITLE
Separate Autogenerated Material Blocks & Items from Declared Blocks & Items

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -15,8 +15,8 @@ import com.gregtechceu.gtceu.api.pipenet.LevelPipeNet;
 import com.gregtechceu.gtceu.api.pipenet.PipeNet;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.client.renderer.block.PipeBlockRenderer;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.item.CoverPlaceBehavior;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
@@ -372,7 +372,7 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
             return;
         }
         if (pipeNode.getFrameMaterial() != null) {
-            BlockState frameState = GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
+            BlockState frameState = GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
                     .getDefaultState();
             frameState.getBlock().entityInside(frameState, level, pos, entity);
         }
@@ -467,7 +467,7 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
         List<ItemStack> drops = new ArrayList<>(super.getDrops(state, builder));
         if (tileEntity instanceof IPipeNode<?, ?> pipeTile) {
             if (pipeTile.getFrameMaterial() != null) {
-                drops.addAll(GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeTile.getFrameMaterial())
+                drops.addAll(GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeTile.getFrameMaterial())
                         .getDefaultState().getDrops(builder));
             }
             for (Direction direction : GTUtil.DIRECTIONS) {

--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -13,7 +13,7 @@ import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.item.tool.IToolGridHighlight;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.pipenet.*;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.datafixers.TagFixer;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -412,7 +412,7 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
             } else {
                 if (frameMaterial != null) {
                     Block.popResource(getLevel(), getPipePos(),
-                            GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, frameMaterial).asStack());
+                            GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, frameMaterial).asStack());
                     frameMaterial = null;
                     playerIn.swing(hand);
                     return Pair.of(GTToolType.CROWBAR, InteractionResult.CONSUME);

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
@@ -10,7 +10,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.tag.TagUtil;
 import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKey;
-import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.data.recipe.misc.WoodMachineRecipes;
 import com.gregtechceu.gtceu.data.tags.TagsHandler;
 import com.gregtechceu.gtceu.utils.SupplierMemoizer;
@@ -396,7 +396,7 @@ public class ChemicalHelper {
                 }
             });
         }
-        GTItems.toUnify.forEach(ChemicalHelper::registerUnificationItems);
+        GTMaterialItems.toUnify.forEach(ChemicalHelper::registerUnificationItems);
         WoodMachineRecipes.registerUnificationInfo();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -13,9 +13,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.properties.IMaterialProp
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
-import com.gregtechceu.gtceu.common.data.GTItems;
-import com.gregtechceu.gtceu.common.data.GTMaterials;
+import com.gregtechceu.gtceu.common.data.*;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 import com.gregtechceu.gtceu.integration.xei.widgets.GTOreByProduct;
@@ -595,7 +593,7 @@ public class TagPrefix {
 
     // made of 4 Ingots.
     public static final TagPrefix toolHeadBuzzSaw = new TagPrefix("buzzSawBlade")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Buzzsaw Blade")
             .materialAmount(GTValues.M * 4)
             .maxStackSize(16)
@@ -607,7 +605,7 @@ public class TagPrefix {
 
     // made of 1 Ingots.
     public static final TagPrefix toolHeadScrewdriver = new TagPrefix("screwdriverTip")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Screwdriver Tip")
             .materialAmount(GTValues.M)
             .maxStackSize(16)
@@ -619,7 +617,7 @@ public class TagPrefix {
 
     // made of 4 Ingots.
     public static final TagPrefix toolHeadDrill = new TagPrefix("drillHead")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Drill Head")
             .materialAmount(GTValues.M * 4)
             .maxStackSize(16)
@@ -631,7 +629,7 @@ public class TagPrefix {
 
     // made of 2 Ingots.
     public static final TagPrefix toolHeadChainsaw = new TagPrefix("chainsawHead")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Chainsaw Head")
             .materialAmount(GTValues.M * 2)
             .maxStackSize(16)
@@ -643,7 +641,7 @@ public class TagPrefix {
 
     // made of 4 Ingots.
     public static final TagPrefix toolHeadWrench = new TagPrefix("wrenchTip")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Wrench Tip")
             .materialAmount(GTValues.M * 4)
             .maxStackSize(16)
@@ -654,7 +652,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.WRENCH_LV)));
 
     public static final TagPrefix toolHeadWireCutter = new TagPrefix("wireCutterHead")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Wire Cutter Head")
             .materialAmount(GTValues.M * 4)
             .maxStackSize(16)
@@ -666,7 +664,7 @@ public class TagPrefix {
 
     // made of 5 Ingots.
     public static final TagPrefix turbineBlade = new TagPrefix("turbineBlade")
-            .itemTable(() -> GTItems.MATERIAL_ITEMS)
+            .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Turbine Blade")
             .materialAmount(GTValues.M * 10)
             .materialIconType(MaterialIconType.turbineBlade)
@@ -729,98 +727,98 @@ public class TagPrefix {
 
     // Pipes
     public static final TagPrefix pipeTinyFluid = new TagPrefix("pipeTinyFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Tiny %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Tiny %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M / 2)
             .unificationEnabled(true);
     public static final TagPrefix pipeSmallFluid = new TagPrefix("pipeSmallFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Small %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Small %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M).unificationEnabled(true);
     public static final TagPrefix pipeNormalFluid = new TagPrefix("pipeNormalFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Normal %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Normal %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 3)
             .unificationEnabled(true);
     public static final TagPrefix pipeLargeFluid = new TagPrefix("pipeLargeFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Large %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Large %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 6)
             .unificationEnabled(true);
     public static final TagPrefix pipeHugeFluid = new TagPrefix("pipeHugeFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Huge %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Huge %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 12)
             .unificationEnabled(true);
 
     public static final TagPrefix pipeQuadrupleFluid = new TagPrefix("pipeQuadrupleFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Quadruple %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Quadruple %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 4)
             .unificationEnabled(true);
     public static final TagPrefix pipeNonupleFluid = new TagPrefix("pipeNonupleFluid")
-            .itemTable(() -> GTBlocks.FLUID_PIPE_BLOCKS).langValue("Nonuple %s Fluid Pipe")
+            .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS).langValue("Nonuple %s Fluid Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 9)
             .unificationEnabled(true);
 
     public static final TagPrefix pipeSmallItem = new TagPrefix("pipeSmallItem")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Small %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Small %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M).unificationEnabled(true);
     public static final TagPrefix pipeNormalItem = new TagPrefix("pipeNormalItem")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Normal %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Normal %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 3)
             .unificationEnabled(true);
     public static final TagPrefix pipeLargeItem = new TagPrefix("pipeLargeItem")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Large %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Large %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 6)
             .unificationEnabled(true);
     public static final TagPrefix pipeHugeItem = new TagPrefix("pipeHugeItem")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Huge %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Huge %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 12)
             .unificationEnabled(true);
 
     public static final TagPrefix pipeSmallRestrictive = new TagPrefix("pipeSmallRestrictive")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Small Restrictive %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Small Restrictive %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M).unificationEnabled(true);
     public static final TagPrefix pipeNormalRestrictive = new TagPrefix("pipeNormalRestrictive")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Normal Restrictive %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Normal Restrictive %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 3)
             .unificationEnabled(true);
     public static final TagPrefix pipeLargeRestrictive = new TagPrefix("pipeLargeRestrictive")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Large Restrictive %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Large Restrictive %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 6)
             .unificationEnabled(true);
     public static final TagPrefix pipeHugeRestrictive = new TagPrefix("pipeHugeRestrictive")
-            .itemTable(() -> GTBlocks.ITEM_PIPE_BLOCKS).langValue("Huge Restrictive %s Item Pipe")
+            .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Huge Restrictive %s Item Pipe")
             .miningToolTag(GTToolType.WRENCH.harvestTags.get(0)).materialAmount(GTValues.M * 12)
             .unificationEnabled(true);
 
     // Wires and cables
-    public static final TagPrefix wireGtHex = new TagPrefix("wireGtHex").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix wireGtHex = new TagPrefix("wireGtHex").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("16x %s Wire").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M * 8).materialIconType(MaterialIconType.wire).unificationEnabled(true);
-    public static final TagPrefix wireGtOctal = new TagPrefix("wireGtOctal").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix wireGtOctal = new TagPrefix("wireGtOctal").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("8x %s Wire").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M * 4).materialIconType(MaterialIconType.wire).unificationEnabled(true);
     public static final TagPrefix wireGtQuadruple = new TagPrefix("wireGtQuadruple")
-            .itemTable(() -> GTBlocks.CABLE_BLOCKS).langValue("4x %s Wire")
+            .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS).langValue("4x %s Wire")
             .miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0)).materialAmount(GTValues.M * 2)
             .materialIconType(MaterialIconType.wire).unificationEnabled(true);
-    public static final TagPrefix wireGtDouble = new TagPrefix("wireGtDouble").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix wireGtDouble = new TagPrefix("wireGtDouble").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("2x %s Wire").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0)).materialAmount(GTValues.M)
             .materialIconType(MaterialIconType.wire).unificationEnabled(true);
-    public static final TagPrefix wireGtSingle = new TagPrefix("wireGtSingle").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix wireGtSingle = new TagPrefix("wireGtSingle").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("1x %s Wire").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M / 2).materialIconType(MaterialIconType.wire).unificationEnabled(true);
 
-    public static final TagPrefix cableGtHex = new TagPrefix("cableGtHex").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix cableGtHex = new TagPrefix("cableGtHex").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("16x %s Cable").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M * 8).unificationEnabled(true);
-    public static final TagPrefix cableGtOctal = new TagPrefix("cableGtOctal").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix cableGtOctal = new TagPrefix("cableGtOctal").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("8x %s Cable").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M * 4).unificationEnabled(true);
     public static final TagPrefix cableGtQuadruple = new TagPrefix("cableGtQuadruple")
-            .itemTable(() -> GTBlocks.CABLE_BLOCKS).langValue("4x %s Cable")
+            .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS).langValue("4x %s Cable")
             .miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0)).materialAmount(GTValues.M * 2)
             .unificationEnabled(true);
-    public static final TagPrefix cableGtDouble = new TagPrefix("cableGtDouble").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix cableGtDouble = new TagPrefix("cableGtDouble").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("2x %s Cable").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M).unificationEnabled(true);
-    public static final TagPrefix cableGtSingle = new TagPrefix("cableGtSingle").itemTable(() -> GTBlocks.CABLE_BLOCKS)
+    public static final TagPrefix cableGtSingle = new TagPrefix("cableGtSingle").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("1x %s Cable").miningToolTag(GTToolType.WIRE_CUTTER.harvestTags.get(0))
             .materialAmount(GTValues.M / 2).unificationEnabled(true);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -7,8 +7,8 @@ import com.gregtechceu.gtceu.api.data.worldgen.WorldGeneratorUtils;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.IndicatorGenerator;
 import com.gregtechceu.gtceu.api.data.worldgen.ores.GeneratedVeinMetadata;
 import com.gregtechceu.gtceu.api.data.worldgen.ores.OreIndicatorPlacer;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
 
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -114,7 +114,7 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
     }
 
     private static void validateSurfaceRockMaterial(Material material) {
-        if (GTBlocks.SURFACE_ROCK_BLOCKS.get(material) == null)
+        if (GTMaterialBlocks.SURFACE_ROCK_BLOCKS.get(material) == null)
             throw new IllegalArgumentException("No surface rock registered for material " + material.getName());
     }
 
@@ -220,7 +220,7 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
         private static BlockState getBlockState(Either<BlockState, Material> block, Direction direction) {
             return block.map(
                     state -> state,
-                    material -> GTBlocks.SURFACE_ROCK_BLOCKS.get(material).get().getStateForDirection(direction));
+                    material -> GTMaterialBlocks.SURFACE_ROCK_BLOCKS.get(material).get().getStateForDirection(direction));
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -17,6 +17,7 @@ import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.data.machines.GTMachineUtils;
@@ -170,7 +171,7 @@ public class ToolHelper {
 
     public static ItemStack get(GTToolType toolType, Material material) {
         if (material.hasProperty(PropertyKey.TOOL)) {
-            var entry = GTItems.TOOL_ITEMS.get(material, toolType);
+            var entry = GTMaterialItems.TOOL_ITEMS.get(material, toolType);
             if (entry != null) {
                 return entry.get().get();
             }
@@ -248,7 +249,7 @@ public class ToolHelper {
     public static ItemStack getAndSetToolData(GTToolType toolType, Material material, int maxDurability,
                                               int harvestLevel,
                                               float toolSpeed, float attackDamage) {
-        var entry = GTItems.TOOL_ITEMS.get(material, toolType);
+        var entry = GTMaterialItems.TOOL_ITEMS.get(material, toolType);
         if (entry == null) return ItemStack.EMPTY;
         ItemStack stack = entry.get().getRaw();
         stack.getOrCreateTag().putInt(HIDE_FLAGS, 2);
@@ -756,7 +757,7 @@ public class ToolHelper {
      */
     @NotNull
     public static List<ItemStack> getSilkTouchDrop(ServerLevel world, BlockPos origin, @NotNull BlockState state) {
-        ItemStack tool = GTItems.TOOL_ITEMS.get(GTMaterials.Neutronium, GTToolType.PICKAXE).get().get();
+        ItemStack tool = GTMaterialItems.TOOL_ITEMS.get(GTMaterials.Neutronium, GTToolType.PICKAXE).get().get();
         tool.enchant(Enchantments.SILK_TOUCH, 1);
 
         return state.getDrops(new LootParams.Builder(world).withParameter(LootContextParams.BLOCK_STATE, state)

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/Predicates.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/Predicates.java
@@ -17,7 +17,7 @@ import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.common.block.BatteryBlock;
 import com.gregtechceu.gtceu.common.block.CoilBlock;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.PowerSubstationMachine;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
@@ -264,7 +264,7 @@ public class Predicates {
      * Use this predicate for Frames in your Multiblock. Allows for Framed Pipes as well as normal Frame blocks.
      */
     public static TraceabilityPredicate frames(Material... frameMaterials) {
-        return blocks(Arrays.stream(frameMaterials).map(m -> GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, m))
+        return blocks(Arrays.stream(frameMaterials).map(m -> GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, m))
                 .filter(Objects::nonNull).filter(RegistryEntry::isPresent).map(RegistryEntry::get)
                 .toArray(Block[]::new))
                 .or(new TraceabilityPredicate(blockWorldState -> {
@@ -273,7 +273,7 @@ public class Predicates {
                         return false;
                     }
                     return ArrayUtils.contains(frameMaterials, pipeNode.getFrameMaterial());
-                }, () -> Arrays.stream(frameMaterials).map(m -> GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, m))
+                }, () -> Arrays.stream(frameMaterials).map(m -> GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, m))
                         .filter(Objects::nonNull).filter(RegistryEntry::isPresent).map(RegistryEntry::get)
                         .map(BlockInfo::fromBlock).toArray(BlockInfo[]::new)));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ToolHeadReplaceRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ToolHeadReplaceRecipe.java
@@ -8,8 +8,8 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.common.data.GTItems;
 
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceLocation;
@@ -111,7 +111,7 @@ public class ToolHeadReplaceRecipe extends CustomRecipe {
             IElectricItem powerUnit = GTCapabilityHelper.getElectricItem(realTool);
             if (toolHead == null) return ItemStack.EMPTY;
             GTToolType[] toolArray = TOOL_HEAD_TO_TOOL_MAP.get(toolHead.tagPrefix);
-            ItemStack newTool = GTItems.TOOL_ITEMS.get(toolHead.material, toolArray[tool.getElectricTier()])
+            ItemStack newTool = GTMaterialItems.TOOL_ITEMS.get(toolHead.material, toolArray[tool.getElectricTier()])
                     .get().get(powerUnit.getCharge(), powerUnit.getMaxCharge());
             if (newTool == null) return ItemStack.EMPTY;
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/block/PipeBlockRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/block/PipeBlockRenderer.java
@@ -5,8 +5,8 @@ import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.client.renderer.cover.ICoverableRenderer;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
 
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.lowdragmc.lowdraglib.LDLib;
 import com.lowdragmc.lowdraglib.client.model.ModelFactory;
 import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
@@ -93,7 +93,7 @@ public class PipeBlockRenderer implements IRenderer, ICoverableRenderer {
             if (pipeNode.getFrameMaterial() != null) {
                 ResourceLocation rl = MaterialIconType.frameGt
                         .getBlockTexturePath(pipeNode.getFrameMaterial().getMaterialIconSet(), true);
-                BlockState blockState = GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
+                BlockState blockState = GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
                         .getDefaultState();
                 var frameModel = Minecraft.getInstance().getBlockRenderer().getBlockModel(blockState);
                 for (Direction face : Direction.values()) {

--- a/src/main/java/com/gregtechceu/gtceu/common/block/CableBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/CableBlock.java
@@ -13,8 +13,8 @@ import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.common.blockentity.CableBlockEntity;
 import com.gregtechceu.gtceu.common.data.GTBlockEntities;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTDamageTypes;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.pipelike.cable.Insulation;
 import com.gregtechceu.gtceu.common.pipelike.cable.LevelEnergyNet;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -124,7 +124,7 @@ public class CableBlock extends MaterialPipeBlock<Insulation, WireProperties, Le
             return;
         }
         if (pipeNode.getFrameMaterial() != null) {
-            BlockState frameState = GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
+            BlockState frameState = GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
                     .getDefaultState();
             frameState.getBlock().entityInside(frameState, level, pos, entity);
             return;

--- a/src/main/java/com/gregtechceu/gtceu/common/block/FluidPipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/FluidPipeBlock.java
@@ -11,7 +11,7 @@ import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.common.blockentity.FluidPipeBlockEntity;
 import com.gregtechceu.gtceu.common.data.GTBlockEntities;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.pipelike.fluidpipe.FluidPipeType;
 import com.gregtechceu.gtceu.common.pipelike.fluidpipe.LevelFluidPipeNet;
 import com.gregtechceu.gtceu.utils.EntityDamageUtil;
@@ -127,7 +127,7 @@ public class FluidPipeBlock extends MaterialPipeBlock<FluidPipeType, FluidPipePr
             return;
         }
         if (pipeNode.getFrameMaterial() != null) {
-            BlockState frameState = GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
+            BlockState frameState = GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, pipeNode.getFrameMaterial())
                     .getDefaultState();
             frameState.getBlock().entityInside(frameState, level, pos, entity);
             return;

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -11,7 +11,7 @@ import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.feature.IDataInfoProvider;
 import com.gregtechceu.gtceu.common.block.CableBlock;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.item.PortableScannerBehavior;
 import com.gregtechceu.gtceu.common.pipelike.cable.*;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
@@ -285,7 +285,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
         int temp = temperature;
         setTemperature(getDefaultTemp());
         int index = getPipeType().insulationLevel;
-        CableBlock newBlock = GTBlocks.CABLE_BLOCKS.get(Insulation.values()[index].tagPrefix, getPipeBlock().material)
+        CableBlock newBlock = GTMaterialBlocks.CABLE_BLOCKS.get(Insulation.values()[index].tagPrefix, getPipeBlock().material)
                 .get();
         level.setBlockAndUpdate(getBlockPos(), newBlock.defaultBlockState());
         CableBlockEntity newCable = (CableBlockEntity) level.getBlockEntity(getBlockPos());

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlockEntities.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlockEntities.java
@@ -20,21 +20,21 @@ public class GTBlockEntities {
     public static final BlockEntityEntry<CableBlockEntity> CABLE = REGISTRATE
             .blockEntity("cable", CableBlockEntity::create)
             .onRegister(CableBlockEntity::onBlockEntityRegister)
-            .validBlocks(GTBlocks.CABLE_BLOCKS.values().toArray(BlockEntry[]::new))
+            .validBlocks(GTMaterialBlocks.CABLE_BLOCKS.values().toArray(BlockEntry[]::new))
             .register();
 
     @SuppressWarnings("unchecked")
     public static final BlockEntityEntry<FluidPipeBlockEntity> FLUID_PIPE = REGISTRATE
             .blockEntity("fluid_pipe", FluidPipeBlockEntity::new)
             .onRegister(FluidPipeBlockEntity::onBlockEntityRegister)
-            .validBlocks(GTBlocks.FLUID_PIPE_BLOCKS.values().toArray(BlockEntry[]::new))
+            .validBlocks(GTMaterialBlocks.FLUID_PIPE_BLOCKS.values().toArray(BlockEntry[]::new))
             .register();
 
     @SuppressWarnings("unchecked")
     public static final BlockEntityEntry<ItemPipeBlockEntity> ITEM_PIPE = REGISTRATE
             .blockEntity("item_pipe", ItemPipeBlockEntity::create)
             .onRegister(ItemPipeBlockEntity::onBlockEntityRegister)
-            .validBlocks(GTBlocks.ITEM_PIPE_BLOCKS.values().toArray(BlockEntry[]::new))
+            .validBlocks(GTMaterialBlocks.ITEM_PIPE_BLOCKS.values().toArray(BlockEntry[]::new))
             .register();
 
     public static final BlockEntityEntry<LaserPipeBlockEntity> LASER_PIPE = REGISTRATE

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -9,7 +9,6 @@ import com.gregtechceu.gtceu.api.block.*;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
-import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.tag.TagUtil;
@@ -17,21 +16,16 @@ import com.gregtechceu.gtceu.api.item.*;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.multiblock.IBatteryData;
 import com.gregtechceu.gtceu.api.pipenet.longdistance.LongDistancePipeBlock;
-import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.common.block.*;
 import com.gregtechceu.gtceu.common.block.explosive.IndustrialTNTBlock;
 import com.gregtechceu.gtceu.common.block.explosive.PowderbarrelBlock;
-import com.gregtechceu.gtceu.common.pipelike.cable.Insulation;
 import com.gregtechceu.gtceu.common.pipelike.duct.DuctPipeType;
-import com.gregtechceu.gtceu.common.pipelike.fluidpipe.FluidPipeType;
 import com.gregtechceu.gtceu.common.pipelike.fluidpipe.longdistance.LDFluidPipeType;
-import com.gregtechceu.gtceu.common.pipelike.item.ItemPipeType;
 import com.gregtechceu.gtceu.common.pipelike.item.longdistance.LDItemPipeType;
 import com.gregtechceu.gtceu.common.pipelike.laser.LaserPipeType;
 import com.gregtechceu.gtceu.common.pipelike.optical.OpticalPipeType;
 import com.gregtechceu.gtceu.core.mixins.BlockPropertiesAccessor;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
-import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.SupplierMemoizer;
 
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
@@ -100,294 +94,17 @@ import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
  */
 @SuppressWarnings("removal")
 public class GTBlocks {
+    //////////////////////////////////////
+    // ***** Procedural Blocks *****//
 
-    //////////////////////////////////////
-    // ***** Tables Builders *****//
-    //////////////////////////////////////
-    private static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<? extends MaterialBlock>> MATERIAL_BLOCKS_BUILDER = ImmutableTable
-            .builder();
-    private static ImmutableMap.Builder<Material, BlockEntry<SurfaceRockBlock>> SURFACE_ROCK_BLOCKS_BUILDER = ImmutableMap
-            .builder();
-    private static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<CableBlock>> CABLE_BLOCKS_BUILDER = ImmutableTable
-            .builder();
-    private static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<FluidPipeBlock>> FLUID_PIPE_BLOCKS_BUILDER = ImmutableTable
-            .builder();
-    private static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<ItemPipeBlock>> ITEM_PIPE_BLOCKS_BUILDER = ImmutableTable
-            .builder();
-
-    //////////////////////////////////////
-    // ***** Reference Tables *****//
-    //////////////////////////////////////
-    public static Table<TagPrefix, Material, BlockEntry<? extends MaterialBlock>> MATERIAL_BLOCKS;
-    public static Map<Material, BlockEntry<SurfaceRockBlock>> SURFACE_ROCK_BLOCKS;
-    public static Table<TagPrefix, Material, BlockEntry<CableBlock>> CABLE_BLOCKS;
-    public static Table<TagPrefix, Material, BlockEntry<FluidPipeBlock>> FLUID_PIPE_BLOCKS;
-    public static Table<TagPrefix, Material, BlockEntry<ItemPipeBlock>> ITEM_PIPE_BLOCKS;
     public static final BlockEntry<LaserPipeBlock>[] LASER_PIPES = new BlockEntry[LaserPipeType.values().length];
     public static final BlockEntry<OpticalPipeBlock>[] OPTICAL_PIPES = new BlockEntry[OpticalPipeType.values().length];
     public static final BlockEntry<DuctPipeBlock>[] DUCT_PIPES = new BlockEntry[DuctPipeType.VALUES.length];
 
     //////////////////////////////////////
-    // ***** Procedural Blocks *****//
+    //           Pipes Blocks           //
     //////////////////////////////////////
-
-    // Compressed Blocks
-    private static void generateMaterialBlocks() {
-        GTCEu.LOGGER.debug("Generating GTCEu Material Blocks...");
-
-        for (TagPrefix tagPrefix : TagPrefix.values()) {
-            if (!TagPrefix.ORES.containsKey(tagPrefix) && tagPrefix.doGenerateBlock()) {
-                for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-                    GTRegistrate registrate = registry.getRegistrate();
-                    for (Material material : registry.getAllMaterials()) {
-                        if (tagPrefix.doGenerateBlock(material)) {
-                            MATERIAL_BLOCKS_BUILDER.put(tagPrefix, material, registrate
-                                    .block(tagPrefix.idPattern().formatted(material.getName()),
-                                            properties -> new MaterialBlock(properties, tagPrefix, material))
-                                    .initialProperties(() -> Blocks.IRON_BLOCK)
-                                    .properties(p -> tagPrefix.blockProperties().properties().apply(p).noLootTable())
-                                    .transform(unificationBlock(tagPrefix, material))
-                                    .addLayer(tagPrefix.blockProperties().renderType())
-                                    .setData(ProviderType.BLOCKSTATE, NonNullBiConsumer.noop())
-                                    .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                                    .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
-                                    .color(() -> MaterialBlock::tintedColor)
-                                    .item(MaterialBlockItem::create)
-                                    .onRegister(MaterialBlockItem::onRegister)
-                                    .model(NonNullBiConsumer.noop())
-                                    .color(() -> MaterialBlockItem::tintColor)
-                                    .build()
-                                    .register());
-                        }
-                    }
-                }
-            }
-        }
-        GTCEu.LOGGER.debug("Generating GTCEu Material Blocks... Complete!");
-    }
-
-    // Ore Blocks
-    private static void generateOreBlocks() {
-        GTCEu.LOGGER.debug("Generating GTCEu Ore Blocks...");
-        for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-            GTRegistrate registrate = registry.getRegistrate();
-            for (Material material : registry.getAllMaterials()) {
-                if (allowOreBlock(material)) {
-                    registerOreBlock(material, registrate);
-                }
-            }
-        }
-        GTCEu.LOGGER.debug("Generating GTCEu Ore Blocks... Complete!");
-    }
-
-    private static boolean allowOreBlock(Material material) {
-        return material.hasProperty(PropertyKey.ORE);
-    }
-
-    private static void registerOreBlock(Material material, GTRegistrate registrate) {
-        for (var ore : TagPrefix.ORES.entrySet()) {
-            if (ore.getKey().isIgnored(material)) continue;
-            var oreTag = ore.getKey();
-            final TagPrefix.OreType oreType = ore.getValue();
-            var entry = registrate
-                    .block("%s%s_ore".formatted(
-                            oreTag != TagPrefix.ore ? FormattingUtil.toLowerCaseUnder(oreTag.name) + "_" : "",
-                            material.getName()),
-                            properties -> new OreBlock(properties, oreTag, material, true))
-                    .initialProperties(() -> {
-                        if (oreType.stoneType().get().isAir()) { // if the block is not registered (yet), fallback to
-                                                                 // stone
-                            return Blocks.IRON_ORE;
-                        }
-                        return oreType.stoneType().get().getBlock();
-                    })
-                    .properties(properties -> GTBlocks.copy(oreType.template().get(), properties).noLootTable())
-                    .transform(unificationBlock(oreTag, material))
-                    .blockstate(NonNullBiConsumer.noop())
-                    .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                    .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
-                    .color(() -> MaterialBlock::tintedColor)
-                    .item(MaterialBlockItem::create)
-                    .onRegister(MaterialBlockItem::onRegister)
-                    .model(NonNullBiConsumer.noop())
-                    .color(() -> MaterialBlockItem::tintColor)
-                    .build()
-                    .register();
-            MATERIAL_BLOCKS_BUILDER.put(oreTag, material, entry);
-        }
-    }
-
-    // Ore Indicator Piles
-    private static void generateOreIndicators() {
-        GTCEu.LOGGER.debug("Generating GTCEu Surface Rock Indicator Blocks...");
-        for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-            GTRegistrate registrate = registry.getRegistrate();
-            for (Material material : registry.getAllMaterials()) {
-                if (allowOreIndicator(material)) {
-                    registerOreIndicator(material, registrate);
-                }
-            }
-        }
-        SURFACE_ROCK_BLOCKS = SURFACE_ROCK_BLOCKS_BUILDER.build();
-        GTCEu.LOGGER.debug("Generating GTCEu Surface Rock Indicator Blocks... Complete!");
-    }
-
-    private static boolean allowOreIndicator(Material material) {
-        return material.hasProperty(PropertyKey.ORE);
-    }
-
-    private static void registerOreIndicator(Material material, GTRegistrate registrate) {
-        var entry = registrate
-                .block("%s_indicator".formatted(material.getName()), p -> new SurfaceRockBlock(p, material))
-                .initialProperties(() -> Blocks.GRAVEL)
-                .properties(p -> p.noLootTable().strength(0.25f))
-                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
-                .setData(ProviderType.BLOCKSTATE, NonNullBiConsumer.noop())
-                .addLayer(() -> RenderType::cutoutMipped)
-                .color(() -> SurfaceRockBlock::tintedBlockColor)
-                .item((b, p) -> SurfaceRockBlockItem.create(b, p, material))
-                .color(() -> SurfaceRockBlock::tintedItemColor)
-                .setData(ProviderType.ITEM_MODEL, NonNullBiConsumer.noop())
-                .build()
-                .register();
-        SURFACE_ROCK_BLOCKS_BUILDER.put(material, entry);
-    }
-
-    // Cable/Wire Blocks
-    private static void generateCableBlocks() {
-        GTCEu.LOGGER.debug("Generating GTCEu Cable/Wire Blocks...");
-        for (Insulation insulation : Insulation.values()) {
-            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-                GTRegistrate registrate = registry.getRegistrate();
-                for (Material material : registry.getAllMaterials()) {
-                    if (allowCableBlock(material, insulation)) {
-                        registerCableBlock(material, insulation, registrate);
-                    }
-                }
-            }
-        }
-        CABLE_BLOCKS = CABLE_BLOCKS_BUILDER.build();
-        GTCEu.LOGGER.debug("Generating GTCEu Cable/Wire Blocks... Complete!");
-    }
-
-    private static boolean allowCableBlock(Material material, Insulation insulation) {
-        return material.hasProperty(PropertyKey.WIRE) && !insulation.tagPrefix.isIgnored(material) &&
-                !(insulation.isCable && material.getProperty(PropertyKey.WIRE).isSuperconductor());
-    }
-
-    private static void registerCableBlock(Material material, Insulation insulation, GTRegistrate registrate) {
-        var entry = registrate
-                .block("%s_%s".formatted(material.getName(), insulation.name),
-                        p -> new CableBlock(p, insulation, material))
-                .initialProperties(() -> Blocks.IRON_BLOCK)
-                .properties(p -> p.dynamicShape().noOcclusion().noLootTable().forceSolidOn())
-                .transform(unificationBlock(insulation.tagPrefix, material))
-                .blockstate(NonNullBiConsumer.noop())
-                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
-                .addLayer(() -> RenderType::cutoutMipped)
-                .color(() -> MaterialPipeBlock::tintedColor)
-                .item(MaterialPipeBlockItem::new)
-                .model(NonNullBiConsumer.noop())
-                .color(() -> MaterialPipeBlockItem::tintColor)
-                .build()
-                .register();
-        CABLE_BLOCKS_BUILDER.put(insulation.tagPrefix, material, entry);
-    }
-
-    // Fluid Pipe Blocks
-    private static void generateFluidPipeBlocks() {
-        GTCEu.LOGGER.debug("Generating GTCEu Fluid Pipe Blocks...");
-        for (var fluidPipeType : FluidPipeType.values()) {
-            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-                GTRegistrate registrate = registry.getRegistrate();
-                for (Material material : registry.getAllMaterials()) {
-                    if (allowFluidPipeBlock(material, fluidPipeType)) {
-                        registerFluidPipeBlock(material, fluidPipeType, registrate);
-                    }
-                }
-            }
-        }
-        FLUID_PIPE_BLOCKS = FLUID_PIPE_BLOCKS_BUILDER.build();
-        GTCEu.LOGGER.debug("Generating GTCEu Fluid Pipe Blocks... Complete!");
-    }
-
-    private static boolean allowFluidPipeBlock(Material material, FluidPipeType fluidPipeType) {
-        return material.hasProperty(PropertyKey.FLUID_PIPE) && !fluidPipeType.tagPrefix.isIgnored(material);
-    }
-
-    private static void registerFluidPipeBlock(Material material, FluidPipeType fluidPipeType,
-                                               GTRegistrate registrate) {
-        var entry = registrate
-                .block("%s_%s_fluid_pipe".formatted(material.getName(), fluidPipeType.name),
-                        p -> new FluidPipeBlock(p, fluidPipeType, material))
-                .initialProperties(() -> Blocks.IRON_BLOCK)
-                .properties(p -> {
-                    if (doMetalPipe(material)) {
-                        p.sound(GTSoundTypes.METAL_PIPE);
-                    }
-                    return p.dynamicShape().noOcclusion().noLootTable().forceSolidOn();
-                })
-                .transform(unificationBlock(fluidPipeType.tagPrefix, material))
-                .blockstate(NonNullBiConsumer.noop())
-                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
-                .addLayer(() -> RenderType::cutoutMipped)
-                .color(() -> MaterialPipeBlock::tintedColor)
-                .item(MaterialPipeBlockItem::new)
-                .model(NonNullBiConsumer.noop())
-                .color(() -> MaterialPipeBlockItem::tintColor)
-                .build()
-                .register();
-        FLUID_PIPE_BLOCKS_BUILDER.put(fluidPipeType.tagPrefix, material, entry);
-    }
-
-    // Item Pipe Blocks
-    private static void generateItemPipeBlocks() {
-        GTCEu.LOGGER.debug("Generating GTCEu Item Pipe Blocks...");
-        for (var itemPipeType : ItemPipeType.values()) {
-            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-                GTRegistrate registrate = registry.getRegistrate();
-                for (Material material : registry.getAllMaterials()) {
-                    if (allowItemPipeBlock(material, itemPipeType)) {
-                        registerItemPipeBlock(material, itemPipeType, registrate);
-                    }
-                }
-            }
-        }
-        ITEM_PIPE_BLOCKS = ITEM_PIPE_BLOCKS_BUILDER.build();
-        GTCEu.LOGGER.debug("Generating GTCEu Item Pipe Blocks... Complete!");
-    }
-
-    private static boolean allowItemPipeBlock(Material material, ItemPipeType itemPipeType) {
-        return material.hasProperty(PropertyKey.ITEM_PIPE) && !itemPipeType.getTagPrefix().isIgnored(material);
-    }
-
-    private static void registerItemPipeBlock(Material material, ItemPipeType itemPipeType, GTRegistrate registrate) {
-        var entry = registrate
-                .block("%s_%s_item_pipe".formatted(material.getName(), itemPipeType.name),
-                        p -> new ItemPipeBlock(p, itemPipeType, material))
-                .initialProperties(() -> Blocks.IRON_BLOCK)
-                .properties(p -> {
-                    if (doMetalPipe(material)) {
-                        p.sound(GTSoundTypes.METAL_PIPE);
-                    }
-                    return p.dynamicShape().noOcclusion().noLootTable().forceSolidOn();
-                })
-                .transform(unificationBlock(itemPipeType.getTagPrefix(), material))
-                .blockstate(NonNullBiConsumer.noop())
-                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
-                .addLayer(() -> RenderType::cutoutMipped)
-                .color(() -> MaterialPipeBlock::tintedColor)
-                .item(MaterialPipeBlockItem::new)
-                .model(NonNullBiConsumer.noop())
-                .color(() -> MaterialPipeBlockItem::tintColor)
-                .build()
-                .register();
-        ITEM_PIPE_BLOCKS_BUILDER.put(itemPipeType.getTagPrefix(), material, entry);
-    }
+    static { REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.MATERIAL_PIPE); }
 
     // Laser Pipe Blocks
     private static void generateLaserPipeBlocks() {
@@ -397,7 +114,6 @@ public class GTBlocks {
         }
         GTCEu.LOGGER.debug("Generating GTCEu Laser Pipe Blocks... Complete!");
     }
-
     private static void registerLaserPipeBlock(int index) {
         var type = LaserPipeType.values()[index];
         var entry = REGISTRATE
@@ -425,7 +141,6 @@ public class GTBlocks {
         }
         GTCEu.LOGGER.debug("Generating GTCEu Optical Pipe Blocks... Complete!");
     }
-
     private static void registerOpticalPipeBlock(int index) {
         var type = OpticalPipeType.values()[index];
         var entry = REGISTRATE
@@ -445,7 +160,7 @@ public class GTBlocks {
         OPTICAL_PIPES[index] = entry;
     }
 
-    // Optical Pipe Blocks
+    // Duct Pipe Blocks
     private static void generateDuctPipeBlocks() {
         GTCEu.LOGGER.debug("Generating GTCEu Duct Pipe Blocks...");
         for (int i = 0; i < DuctPipeType.VALUES.length; ++i) {
@@ -453,7 +168,6 @@ public class GTBlocks {
         }
         GTCEu.LOGGER.debug("Generating GTCEu Duct Pipe Blocks... Complete!");
     }
-
     private static void registerDuctPipeBlock(int index) {
         var type = DuctPipeType.VALUES[index];
         var entry = REGISTRATE
@@ -471,12 +185,7 @@ public class GTBlocks {
         DUCT_PIPES[index] = entry;
     }
 
-    //////////////////////////////////////
-    // ***** General Pipes ******//
-    //////////////////////////////////////
-    static {
-        REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.MATERIAL_PIPE);
-    }
+    // Long Distance Item Pipe Blocks
     public static final BlockEntry<LongDistancePipeBlock> LD_ITEM_PIPE = REGISTRATE
             .block("long_distance_item_pipeline",
                     properties -> new LongDistancePipeBlock(properties, LDItemPipeType.INSTANCE))
@@ -486,6 +195,7 @@ public class GTBlocks {
             .simpleItem()
             .register();
 
+    // Long Distance Fluid Pipe Blocks
     public static final BlockEntry<LongDistancePipeBlock> LD_FLUID_PIPE = REGISTRATE
             .block("long_distance_fluid_pipeline",
                     properties -> new LongDistancePipeBlock(properties, LDFluidPipeType.INSTANCE))
@@ -495,13 +205,13 @@ public class GTBlocks {
             .simpleItem()
             .register();
 
-    static {
-        REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.DECORATION);
-    }
 
     //////////////////////////////////////
     // ****** Casing Blocks *****//
     //////////////////////////////////////
+    static {
+        REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.DECORATION);
+    }
 
     // Multiblock Machine Casing Blocks
     public static final BlockEntry<Block> CASING_WOOD_WALL = createSidedCasingBlock("wood_wall",
@@ -1664,7 +1374,7 @@ public class GTBlocks {
             builder.onRegister(block -> {
                 Supplier<Block> blockSupplier = SupplierMemoizer.memoizeBlockSupplier(() -> block);
                 UnificationEntry entry = new UnificationEntry(tagPrefix, mat);
-                GTItems.toUnify.put(entry, blockSupplier);
+                GTMaterialItems.toUnify.put(entry, blockSupplier);
                 ChemicalHelper.registerUnificationItems(entry, blockSupplier);
             });
             return builder;
@@ -1677,26 +1387,26 @@ public class GTBlocks {
 
         // Procedural Blocks
         REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.MATERIAL_BLOCK);
-        generateMaterialBlocks();   // Compressed Blocks
-        generateOreBlocks();        // Ore Blocks
-        generateOreIndicators();    // Ore Indicators
-        MATERIAL_BLOCKS = MATERIAL_BLOCKS_BUILDER.build();
+        GTMaterialBlocks.generateMaterialBlocks();   // Compressed Blocks
+        GTMaterialBlocks.generateOreBlocks();        // Ore Blocks
+        GTMaterialBlocks.generateOreIndicators();    // Ore Indicators
+        GTMaterialBlocks.MATERIAL_BLOCKS = GTMaterialBlocks.MATERIAL_BLOCKS_BUILDER.build();
 
         // Procedural Pipes/Wires
         REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.MATERIAL_PIPE);
-        generateCableBlocks();        // Cable & Wire Blocks
-        generateFluidPipeBlocks();    // Fluid Pipe Blocks
-        generateItemPipeBlocks();     // Item Pipe Blocks
+        GTMaterialBlocks.generateCableBlocks();        // Cable & Wire Blocks
+        GTMaterialBlocks.generateFluidPipeBlocks();    // Fluid Pipe Blocks
+        GTMaterialBlocks.generateItemPipeBlocks();     // Item Pipe Blocks
         generateLaserPipeBlocks();    // Laser Pipe Blocks
         generateOpticalPipeBlocks();  // Optical Pipe Blocks
         generateDuctPipeBlocks();     // Duct Pipe Blocks
 
         // Remove Builder Tables
-        MATERIAL_BLOCKS_BUILDER = null;
-        SURFACE_ROCK_BLOCKS_BUILDER = null;
-        CABLE_BLOCKS_BUILDER = null;
-        FLUID_PIPE_BLOCKS_BUILDER = null;
-        ITEM_PIPE_BLOCKS_BUILDER = null;
+        GTMaterialBlocks.MATERIAL_BLOCKS_BUILDER = null;
+        GTMaterialBlocks.SURFACE_ROCK_BLOCKS_BUILDER = null;
+        GTMaterialBlocks.CABLE_BLOCKS_BUILDER = null;
+        GTMaterialBlocks.FLUID_PIPE_BLOCKS_BUILDER = null;
+        GTMaterialBlocks.ITEM_PIPE_BLOCKS_BUILDER = null;
 
         // GCYM
         GCYMBlocks.init();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTFluids.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTFluids.java
@@ -25,11 +25,14 @@ import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
 public class GTFluids {
 
     public static void init() {
+
+        // Register fluids for non-materials
         handleNonMaterialFluids(GTMaterials.Water, Fluids.WATER);
         handleNonMaterialFluids(GTMaterials.Lava, Fluids.LAVA);
         handleNonMaterialFluids(GTMaterials.Milk, ForgeMod.MILK);
+
+        // Register fluids for materials
         REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.MATERIAL_FLUID);
-        // register fluids for materials
         for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
             GTRegistrate registrate = registry.getRegistrate();
             for (var material : registry.getAllMaterials()) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -9,7 +9,6 @@ import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterial;
 import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterials;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
-import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
@@ -18,13 +17,10 @@ import com.gregtechceu.gtceu.api.data.tag.TagUtil;
 import com.gregtechceu.gtceu.api.gui.misc.ProspectorMode;
 import com.gregtechceu.gtceu.api.item.ComponentItem;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
-import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
 import com.gregtechceu.gtceu.api.item.component.*;
-import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.item.tool.MaterialToolTier;
-import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.common.data.materials.GTFoods;
 import com.gregtechceu.gtceu.common.entity.GTBoat;
 import com.gregtechceu.gtceu.common.item.*;
@@ -64,15 +60,11 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fluids.FluidUtil;
 
-import com.google.common.collect.ArrayTable;
-import com.google.common.collect.ImmutableTable;
-import com.google.common.collect.Table;
 import com.tterrag.registrate.builders.ItemBuilder;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.ProviderType;
 import com.tterrag.registrate.providers.RegistrateLangProvider;
 import com.tterrag.registrate.util.entry.ItemEntry;
-import com.tterrag.registrate.util.entry.ItemProviderEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import com.tterrag.registrate.util.nullness.NonNullConsumer;
 import com.tterrag.registrate.util.nullness.NonNullFunction;
@@ -96,87 +88,6 @@ import static com.gregtechceu.gtceu.utils.FormattingUtil.toEnglishName;
  * @implNote GTItems
  */
 public class GTItems {
-
-    //////////////////////////////////////
-    // ***** Material Items ******//
-    //////////////////////////////////////
-
-    public static final Map<UnificationEntry, Supplier<? extends ItemLike>> toUnify = new HashMap<>();
-    public static final Map<TagPrefix, TagPrefix> purifyMap = new HashMap<>();
-
-    static {
-        purifyMap.put(TagPrefix.crushed, TagPrefix.crushedPurified);
-        purifyMap.put(TagPrefix.dustImpure, TagPrefix.dust);
-        purifyMap.put(TagPrefix.dustPure, TagPrefix.dust);
-    }
-
-    public static Table<TagPrefix, Material, ItemEntry<TagPrefixItem>> MATERIAL_ITEMS;
-
-    public static void generateMaterialItems() {
-        REGISTRATE.creativeModeTab(() -> MATERIAL_ITEM);
-        ImmutableTable.Builder<TagPrefix, Material, ItemEntry<TagPrefixItem>> builder = ImmutableTable.builder();
-        for (var tagPrefix : TagPrefix.values()) {
-            if (tagPrefix.doGenerateItem()) {
-                for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-                    GTRegistrate registrate = registry.getRegistrate();
-                    for (Material material : registry.getAllMaterials()) {
-                        if (tagPrefix.doGenerateItem(material)) {
-                            builder.put(tagPrefix, material, registrate
-                                    .item(tagPrefix.idPattern().formatted(material.getName()),
-                                            properties -> new TagPrefixItem(properties, tagPrefix, material))
-                                    .onRegister(TagPrefixItem::onRegister)
-                                    .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                                    .transform(unificationItem(tagPrefix, material))
-                                    .properties(p -> p.stacksTo(tagPrefix.maxStackSize()))
-                                    .model(NonNullBiConsumer.noop())
-                                    .color(() -> TagPrefixItem::tintColor)
-                                    .onRegister(GTItems::cauldronInteraction)
-                                    .register());
-                        }
-                    }
-                }
-            }
-        }
-        MATERIAL_ITEMS = builder.build();
-    }
-
-    //////////////////////////////////////
-    // ***** Material Tools ******//
-    //////////////////////////////////////
-    public final static Table<Material, GTToolType, ItemProviderEntry<IGTTool>> TOOL_ITEMS = ArrayTable.create(
-            GTCEuAPI.materialManager.getRegisteredMaterials().stream().filter(mat -> mat.hasProperty(PropertyKey.TOOL))
-                    .toList(),
-            GTToolType.getTypes().values().stream().toList());
-
-    public static void generateTools() {
-        REGISTRATE.creativeModeTab(() -> TOOL);
-
-        for (GTToolType toolType : GTToolType.getTypes().values()) {
-            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
-                GTRegistrate registrate = registry.getRegistrate();
-                for (Material material : registry.getAllMaterials()) {
-                    if (material.hasProperty(PropertyKey.TOOL)) {
-                        var property = material.getProperty(PropertyKey.TOOL);
-                        var tier = material.getToolTier();
-
-                        if (property.hasType(toolType)) {
-                            TOOL_ITEMS
-                                    .put(material, toolType,
-                                            (ItemProviderEntry<IGTTool>) (ItemProviderEntry<?>) registrate
-                                                    .item(toolType.idFormat.formatted(tier.material.getName()),
-                                                            p -> toolType.constructor.apply(toolType, tier, material,
-                                                                    toolType.toolDefinition, p).asItem())
-                                                    .properties(p -> p.craftRemainder(Items.AIR))
-                                                    .setData(ProviderType.LANG, NonNullBiConsumer.noop())
-                                                    .model(NonNullBiConsumer.noop())
-                                                    .color(() -> IGTTool::tintColor)
-                                                    .register());
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     //////////////////////////////////////
     // ******* Misc Items ********//
@@ -2674,8 +2585,8 @@ public class GTItems {
             .register();
 
     public static void init() {
-        generateMaterialItems();
-        generateTools();
+        GTMaterialItems.generateMaterialItems();
+        GTMaterialItems.generateTools();
     }
 
     public static <T extends ItemLike> NonNullConsumer<T> materialInfo(ItemMaterialInfo materialInfo) {
@@ -2689,7 +2600,7 @@ public class GTItems {
             builder.onRegister(item -> {
                 Supplier<ItemLike> supplier = SupplierMemoizer.memoize(() -> item);
                 UnificationEntry entry = new UnificationEntry(tagPrefix, mat);
-                toUnify.put(entry, supplier);
+                GTMaterialItems.toUnify.put(entry, supplier);
                 ChemicalHelper.registerUnificationItems(entry, supplier);
             });
             return builder;
@@ -2697,12 +2608,12 @@ public class GTItems {
     }
 
     public static <T extends Item> void cauldronInteraction(T item) {
-        if (item instanceof TagPrefixItem tagPrefixItem && purifyMap.containsKey(tagPrefixItem.tagPrefix)) {
+        if (item instanceof TagPrefixItem tagPrefixItem && GTMaterialItems.purifyMap.containsKey(tagPrefixItem.tagPrefix)) {
             CauldronInteraction.WATER.put(item, (state, world, pos, player, hand, stack) -> {
                 if (!world.isClientSide) {
                     Item stackItem = stack.getItem();
                     if (stackItem instanceof TagPrefixItem prefixItem) {
-                        if (!purifyMap.containsKey(prefixItem.tagPrefix))
+                        if (!GTMaterialItems.purifyMap.containsKey(prefixItem.tagPrefix))
                             return InteractionResult.PASS;
                         if (!state.hasProperty(LayeredCauldronBlock.LEVEL)) {
                             return InteractionResult.PASS;
@@ -2712,7 +2623,7 @@ public class GTItems {
                         if (level == 0)
                             return InteractionResult.PASS;
 
-                        player.setItemInHand(hand, ChemicalHelper.get(purifyMap.get(prefixItem.tagPrefix),
+                        player.setItemInHand(hand, ChemicalHelper.get(GTMaterialItems.purifyMap.get(prefixItem.tagPrefix),
                                 prefixItem.material, stack.getCount()));
                         player.awardStat(Stats.USE_CAULDRON);
                         player.awardStat(Stats.ITEM_USED.get(stackItem));

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialBlocks.java
@@ -1,0 +1,302 @@
+package com.gregtechceu.gtceu.common.data;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
+import com.gregtechceu.gtceu.api.block.MaterialBlock;
+import com.gregtechceu.gtceu.api.block.MaterialPipeBlock;
+import com.gregtechceu.gtceu.api.block.OreBlock;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
+import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.item.MaterialBlockItem;
+import com.gregtechceu.gtceu.api.item.MaterialPipeBlockItem;
+import com.gregtechceu.gtceu.api.item.SurfaceRockBlockItem;
+import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
+import com.gregtechceu.gtceu.common.block.*;
+import com.gregtechceu.gtceu.common.pipelike.cable.Insulation;
+import com.gregtechceu.gtceu.common.pipelike.fluidpipe.FluidPipeType;
+import com.gregtechceu.gtceu.common.pipelike.item.ItemPipeType;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
+import com.tterrag.registrate.providers.ProviderType;
+import com.tterrag.registrate.util.entry.BlockEntry;
+import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.world.level.block.Blocks;
+
+import java.util.Map;
+
+public class GTMaterialBlocks {
+
+    // Reference Table Builders
+    static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<? extends MaterialBlock>>
+            MATERIAL_BLOCKS_BUILDER = ImmutableTable.builder();
+    static ImmutableMap.Builder<Material, BlockEntry<SurfaceRockBlock>>
+            SURFACE_ROCK_BLOCKS_BUILDER = ImmutableMap.builder();
+    static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<CableBlock>>
+            CABLE_BLOCKS_BUILDER = ImmutableTable.builder();
+    static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<FluidPipeBlock>>
+            FLUID_PIPE_BLOCKS_BUILDER = ImmutableTable.builder();
+    static ImmutableTable.Builder<TagPrefix, Material, BlockEntry<ItemPipeBlock>>
+            ITEM_PIPE_BLOCKS_BUILDER = ImmutableTable.builder();
+
+    // Reference Tables
+    public static Table<TagPrefix, Material, BlockEntry<? extends MaterialBlock>> MATERIAL_BLOCKS;
+    public static Map<Material, BlockEntry<SurfaceRockBlock>> SURFACE_ROCK_BLOCKS;
+    public static Table<TagPrefix, Material, BlockEntry<CableBlock>> CABLE_BLOCKS;
+    public static Table<TagPrefix, Material, BlockEntry<FluidPipeBlock>> FLUID_PIPE_BLOCKS;
+    public static Table<TagPrefix, Material, BlockEntry<ItemPipeBlock>> ITEM_PIPE_BLOCKS;
+
+    // Material Blocks
+    public static void generateMaterialBlocks() {
+        GTCEu.LOGGER.debug("Generating GTCEu Material Blocks...");
+
+        for (TagPrefix tagPrefix : TagPrefix.values()) {
+            if (!TagPrefix.ORES.containsKey(tagPrefix) && tagPrefix.doGenerateBlock()) {
+                for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+                    GTRegistrate registrate = registry.getRegistrate();
+                    for (Material material : registry.getAllMaterials()) {
+                        if (tagPrefix.doGenerateBlock(material)) {
+                            registerMaterialBlock(tagPrefix, material, registrate);
+                        }
+                    }
+                }
+            }
+        }
+        GTCEu.LOGGER.debug("Generating GTCEu Material Blocks... Complete!");
+    }
+    private static void registerMaterialBlock(TagPrefix tagPrefix, Material material, GTRegistrate registrate) {
+        MATERIAL_BLOCKS_BUILDER.put(tagPrefix, material, registrate
+                .block(tagPrefix.idPattern().formatted(material.getName()),
+                        properties -> new MaterialBlock(properties, tagPrefix, material))
+                .initialProperties(() -> Blocks.IRON_BLOCK)
+                .properties(p -> tagPrefix.blockProperties().properties().apply(p).noLootTable())
+                .transform(GTBlocks.unificationBlock(tagPrefix, material))
+                .addLayer(tagPrefix.blockProperties().renderType())
+                .setData(ProviderType.BLOCKSTATE, NonNullBiConsumer.noop())
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
+                .color(() -> MaterialBlock::tintedColor)
+                .item(MaterialBlockItem::create)
+                .onRegister(MaterialBlockItem::onRegister)
+                .model(NonNullBiConsumer.noop())
+                .color(() -> MaterialBlockItem::tintColor)
+                .build()
+                .register());
+    }
+
+    // Material Ore Blocks
+    public static void generateOreBlocks() {
+        GTCEu.LOGGER.debug("Generating GTCEu Ore Blocks...");
+        for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+            GTRegistrate registrate = registry.getRegistrate();
+            for (Material material : registry.getAllMaterials()) {
+                if (allowOreBlock(material)) {
+                    registerOreBlock(material, registrate);
+                }
+            }
+        }
+        GTCEu.LOGGER.debug("Generating GTCEu Ore Blocks... Complete!");
+    }
+    private static boolean allowOreBlock(Material material) {
+        return material.hasProperty(PropertyKey.ORE);
+    }
+    private static void registerOreBlock(Material material, GTRegistrate registrate) {
+        for (var ore : TagPrefix.ORES.entrySet()) {
+            if (ore.getKey().isIgnored(material)) continue;
+            var oreTag = ore.getKey();
+            final TagPrefix.OreType oreType = ore.getValue();
+            var entry = registrate
+                    .block("%s%s_ore".formatted(
+                            oreTag != TagPrefix.ore ? FormattingUtil.toLowerCaseUnder(oreTag.name) + "_" : "",
+                            material.getName()),
+                            properties -> new OreBlock(properties, oreTag, material, true))
+                    .initialProperties(() -> {
+                        if (oreType.stoneType().get().isAir()) { // if the block is not registered (yet), fallback to
+                                                                 // stone
+                            return Blocks.IRON_ORE;
+                        }
+                        return oreType.stoneType().get().getBlock();
+                    })
+                    .properties(properties -> GTBlocks.copy(oreType.template().get(), properties).noLootTable())
+                    .transform(GTBlocks.unificationBlock(oreTag, material))
+                    .blockstate(NonNullBiConsumer.noop())
+                    .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                    .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
+                    .color(() -> MaterialBlock::tintedColor)
+                    .item(MaterialBlockItem::create)
+                    .onRegister(MaterialBlockItem::onRegister)
+                    .model(NonNullBiConsumer.noop())
+                    .color(() -> MaterialBlockItem::tintColor)
+                    .build()
+                    .register();
+            MATERIAL_BLOCKS_BUILDER.put(oreTag, material, entry);
+        }
+    }
+
+    // Material Ore Indicator Piles
+    public static void generateOreIndicators() {
+        GTCEu.LOGGER.debug("Generating GTCEu Surface Rock Indicator Blocks...");
+        for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+            GTRegistrate registrate = registry.getRegistrate();
+            for (Material material : registry.getAllMaterials()) {
+                if (allowOreIndicator(material)) {
+                    registerOreIndicator(material, registrate);
+                }
+            }
+        }
+        SURFACE_ROCK_BLOCKS = SURFACE_ROCK_BLOCKS_BUILDER.build();
+        GTCEu.LOGGER.debug("Generating GTCEu Surface Rock Indicator Blocks... Complete!");
+    }
+    private static boolean allowOreIndicator(Material material) {
+        return material.hasProperty(PropertyKey.ORE);
+    }
+    private static void registerOreIndicator(Material material, GTRegistrate registrate) {
+        var entry = registrate
+                .block("%s_indicator".formatted(material.getName()), p -> new SurfaceRockBlock(p, material))
+                .initialProperties(() -> Blocks.GRAVEL)
+                .properties(p -> p.noLootTable().strength(0.25f))
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
+                .setData(ProviderType.BLOCKSTATE, NonNullBiConsumer.noop())
+                .addLayer(() -> RenderType::cutoutMipped)
+                .color(() -> SurfaceRockBlock::tintedBlockColor)
+                .item((b, p) -> SurfaceRockBlockItem.create(b, p, material))
+                .color(() -> SurfaceRockBlock::tintedItemColor)
+                .setData(ProviderType.ITEM_MODEL, NonNullBiConsumer.noop())
+                .build()
+                .register();
+        SURFACE_ROCK_BLOCKS_BUILDER.put(material, entry);
+    }
+
+    // Material Cable & Wire Blocks
+    public static void generateCableBlocks() {
+        GTCEu.LOGGER.debug("Generating GTCEu Cable/Wire Blocks...");
+        for (Insulation insulation : Insulation.values()) {
+            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+                GTRegistrate registrate = registry.getRegistrate();
+                for (Material material : registry.getAllMaterials()) {
+                    if (allowCableBlock(material, insulation)) {
+                        registerCableBlock(material, insulation, registrate);
+                    }
+                }
+            }
+        }
+        CABLE_BLOCKS = CABLE_BLOCKS_BUILDER.build();
+        GTCEu.LOGGER.debug("Generating GTCEu Cable/Wire Blocks... Complete!");
+    }
+    private static boolean allowCableBlock(Material material, Insulation insulation) {
+        return material.hasProperty(PropertyKey.WIRE) && !insulation.tagPrefix.isIgnored(material) &&
+                !(insulation.isCable && material.getProperty(PropertyKey.WIRE).isSuperconductor());
+    }
+    private static void registerCableBlock(Material material, Insulation insulation, GTRegistrate registrate) {
+        var entry = registrate
+                .block("%s_%s".formatted(material.getName(), insulation.name),
+                        p -> new CableBlock(p, insulation, material))
+                .initialProperties(() -> Blocks.IRON_BLOCK)
+                .properties(p -> p.dynamicShape().noOcclusion().noLootTable().forceSolidOn())
+                .transform(GTBlocks.unificationBlock(insulation.tagPrefix, material))
+                .blockstate(NonNullBiConsumer.noop())
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
+                .addLayer(() -> RenderType::cutoutMipped)
+                .color(() -> MaterialPipeBlock::tintedColor)
+                .item(MaterialPipeBlockItem::new)
+                .model(NonNullBiConsumer.noop())
+                .color(() -> MaterialPipeBlockItem::tintColor)
+                .build()
+                .register();
+        CABLE_BLOCKS_BUILDER.put(insulation.tagPrefix, material, entry);
+    }
+
+    // Material Fluid Pipe Blocks
+    public static void generateFluidPipeBlocks() {
+        GTCEu.LOGGER.debug("Generating GTCEu Fluid Pipe Blocks...");
+        for (var fluidPipeType : FluidPipeType.values()) {
+            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+                GTRegistrate registrate = registry.getRegistrate();
+                for (Material material : registry.getAllMaterials()) {
+                    if (allowFluidPipeBlock(material, fluidPipeType)) {
+                        registerFluidPipeBlock(material, fluidPipeType, registrate);
+                    }
+                }
+            }
+        }
+        FLUID_PIPE_BLOCKS = FLUID_PIPE_BLOCKS_BUILDER.build();
+        GTCEu.LOGGER.debug("Generating GTCEu Fluid Pipe Blocks... Complete!");
+    }
+    private static boolean allowFluidPipeBlock(Material material, FluidPipeType fluidPipeType) {
+        return material.hasProperty(PropertyKey.FLUID_PIPE) && !fluidPipeType.tagPrefix.isIgnored(material);
+    }
+    private static void registerFluidPipeBlock(Material material, FluidPipeType fluidPipeType, GTRegistrate registrate) {
+        var entry = registrate
+                .block("%s_%s_fluid_pipe".formatted(material.getName(), fluidPipeType.name),
+                        p -> new FluidPipeBlock(p, fluidPipeType, material))
+                .initialProperties(() -> Blocks.IRON_BLOCK)
+                .properties(p -> {
+                    if (GTBlocks.doMetalPipe(material)) {
+                        p.sound(GTSoundTypes.METAL_PIPE);
+                    }
+                    return p.dynamicShape().noOcclusion().noLootTable().forceSolidOn();
+                })
+                .transform(GTBlocks.unificationBlock(fluidPipeType.tagPrefix, material))
+                .blockstate(NonNullBiConsumer.noop())
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
+                .addLayer(() -> RenderType::cutoutMipped)
+                .color(() -> MaterialPipeBlock::tintedColor)
+                .item(MaterialPipeBlockItem::new)
+                .model(NonNullBiConsumer.noop())
+                .color(() -> MaterialPipeBlockItem::tintColor)
+                .build()
+                .register();
+        FLUID_PIPE_BLOCKS_BUILDER.put(fluidPipeType.tagPrefix, material, entry);
+    }
+
+    // Material Item Pipe Blocks
+    public static void generateItemPipeBlocks() {
+        GTCEu.LOGGER.debug("Generating GTCEu Item Pipe Blocks...");
+        for (var itemPipeType : ItemPipeType.values()) {
+            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+                GTRegistrate registrate = registry.getRegistrate();
+                for (Material material : registry.getAllMaterials()) {
+                    if (allowItemPipeBlock(material, itemPipeType)) {
+                        registerItemPipeBlock(material, itemPipeType, registrate);
+                    }
+                }
+            }
+        }
+        ITEM_PIPE_BLOCKS = ITEM_PIPE_BLOCKS_BUILDER.build();
+        GTCEu.LOGGER.debug("Generating GTCEu Item Pipe Blocks... Complete!");
+    }
+    private static boolean allowItemPipeBlock(Material material, ItemPipeType itemPipeType) {
+        return material.hasProperty(PropertyKey.ITEM_PIPE) && !itemPipeType.getTagPrefix().isIgnored(material);
+    }
+    private static void registerItemPipeBlock(Material material, ItemPipeType itemPipeType, GTRegistrate registrate) {
+        var entry = registrate
+                .block("%s_%s_item_pipe".formatted(material.getName(), itemPipeType.name),
+                        p -> new ItemPipeBlock(p, itemPipeType, material))
+                .initialProperties(() -> Blocks.IRON_BLOCK)
+                .properties(p -> {
+                    if (GTBlocks.doMetalPipe(material)) {
+                        p.sound(GTSoundTypes.METAL_PIPE);
+                    }
+                    return p.dynamicShape().noOcclusion().noLootTable().forceSolidOn();
+                })
+                .transform(GTBlocks.unificationBlock(itemPipeType.getTagPrefix(), material))
+                .blockstate(NonNullBiConsumer.noop())
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .setData(ProviderType.LOOT, NonNullBiConsumer.noop())
+                .addLayer(() -> RenderType::cutoutMipped)
+                .color(() -> MaterialPipeBlock::tintedColor)
+                .item(MaterialPipeBlockItem::new)
+                .model(NonNullBiConsumer.noop())
+                .color(() -> MaterialPipeBlockItem::tintColor)
+                .build()
+                .register();
+        ITEM_PIPE_BLOCKS_BUILDER.put(itemPipeType.getTagPrefix(), material, entry);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialItems.java
@@ -1,0 +1,116 @@
+package com.gregtechceu.gtceu.common.data;
+
+import com.google.common.collect.ArrayTable;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
+import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.api.item.TagPrefixItem;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
+import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
+import com.tterrag.registrate.providers.ProviderType;
+import com.tterrag.registrate.util.entry.ItemEntry;
+import com.tterrag.registrate.util.entry.ItemProviderEntry;
+import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.ItemLike;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.gregtechceu.gtceu.common.data.GTCreativeModeTabs.MATERIAL_ITEM;
+import static com.gregtechceu.gtceu.common.data.GTCreativeModeTabs.TOOL;
+import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
+
+public class GTMaterialItems {
+
+    // Reference Table Builders
+    static ImmutableTable.Builder<TagPrefix, Material, ItemEntry<TagPrefixItem>>
+            MATERIAL_ITEMS_BUILDER = ImmutableTable.builder();
+
+    // Reference Maps
+    public static final Map<UnificationEntry, Supplier<? extends ItemLike>> toUnify = new HashMap<>();
+    public static final Map<TagPrefix, TagPrefix> purifyMap = new HashMap<>();
+    static {
+        purifyMap.put(TagPrefix.crushed, TagPrefix.crushedPurified);
+        purifyMap.put(TagPrefix.dustImpure, TagPrefix.dust);
+        purifyMap.put(TagPrefix.dustPure, TagPrefix.dust);
+    }
+
+    // Reference Tables
+    public static Table<TagPrefix, Material, ItemEntry<TagPrefixItem>> MATERIAL_ITEMS;
+    public final static Table<Material, GTToolType, ItemProviderEntry<IGTTool>>
+            TOOL_ITEMS = ArrayTable.create(
+            GTCEuAPI.materialManager.getRegisteredMaterials().stream()
+                    .filter(mat -> mat.hasProperty(PropertyKey.TOOL))
+                    .toList(),
+            GTToolType.getTypes().values().stream().toList()
+    );
+
+    // Material Items
+    public static void generateMaterialItems() {
+        REGISTRATE.creativeModeTab(() -> MATERIAL_ITEM);
+        for (var tagPrefix : TagPrefix.values()) {
+            if (tagPrefix.doGenerateItem()) {
+                for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+                    GTRegistrate registrate = registry.getRegistrate();
+                    for (Material material : registry.getAllMaterials()) {
+                        if (tagPrefix.doGenerateItem(material)) {
+                            generateMaterialItem(tagPrefix, material, registrate);
+                        }
+                    }
+                }
+            }
+        }
+        MATERIAL_ITEMS = MATERIAL_ITEMS_BUILDER.build();
+    }
+    private static void generateMaterialItem(TagPrefix tagPrefix, Material material, GTRegistrate registrate) {
+        MATERIAL_ITEMS_BUILDER.put(tagPrefix, material, registrate
+                .item(tagPrefix.idPattern().formatted(material.getName()),
+                        properties -> new TagPrefixItem(properties, tagPrefix, material))
+                .onRegister(TagPrefixItem::onRegister)
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .transform(GTItems.unificationItem(tagPrefix, material))
+                .properties(p -> p.stacksTo(tagPrefix.maxStackSize()))
+                .model(NonNullBiConsumer.noop())
+                .color(() -> TagPrefixItem::tintColor)
+                .onRegister(GTItems::cauldronInteraction)
+                .register());
+    }
+
+    // Material Tools
+    public static void generateTools() {
+        REGISTRATE.creativeModeTab(() -> TOOL);
+        for (GTToolType toolType : GTToolType.getTypes().values()) {
+            for (MaterialRegistry registry : GTCEuAPI.materialManager.getRegistries()) {
+                GTRegistrate registrate = registry.getRegistrate();
+                for (Material material : registry.getAllMaterials()) {
+                    if (material.hasProperty(PropertyKey.TOOL)) {
+                        var property = material.getProperty(PropertyKey.TOOL);
+                        if (property.hasType(toolType)) {
+                            generateTool(material, toolType, registrate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    private static void generateTool(Material material, GTToolType toolType, GTRegistrate registrate) {
+        var tier = material.getToolTier();
+        TOOL_ITEMS.put(material, toolType, (ItemProviderEntry<IGTTool>) (ItemProviderEntry<?>) registrate
+                .item(toolType.idFormat.formatted(tier.material.getName()),
+                        p -> toolType.constructor.apply(toolType, tier, material,
+                                toolType.toolDefinition, p).asItem())
+                .properties(p -> p.craftRemainder(Items.AIR))
+                .setData(ProviderType.LANG, NonNullBiConsumer.noop())
+                .model(NonNullBiConsumer.noop())
+                .color(() -> IGTTool::tintColor)
+                .register());
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -720,7 +720,7 @@ public class GTOres {
     }
 
     private static Supplier<? extends Block> ore(TagPrefix oreTag, Material material) {
-        var block = GTBlocks.MATERIAL_BLOCKS.get(oreTag, material);
+        var block = GTMaterialBlocks.MATERIAL_BLOCKS.get(oreTag, material);
         if (block == null) {
             ResourceLocation oreKey;
             if (oreTag == ore) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
@@ -512,7 +512,7 @@ public class GTMachineUtils {
                             .build();
                 })
                 .recoveryItems(
-                        () -> new ItemLike[] { GTItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
+                        () -> new ItemLike[] { GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
                 .renderer(() -> new LargeBoilerRenderer(texture, firebox,
                         GTCEu.id("block/multiblock/generator/large_%s_boiler".formatted(name))))
                 .tooltips(
@@ -559,7 +559,7 @@ public class GTMachineUtils {
                         .where('Y', controller(blocks(definition.getBlock())))
                         .build())
                 .recoveryItems(
-                        () -> new ItemLike[] { GTItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
+                        () -> new ItemLike[] { GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
                 .workableCasingRenderer(casingTexture, overlayModel)
                 .tooltips(
                         Component.translatable("gtceu.universal.tooltip.base_production_eut", V[tier]),
@@ -612,7 +612,7 @@ public class GTMachineUtils {
                                 .or(autoAbilities(true, true, false)))
                         .build())
                 .recoveryItems(
-                        () -> new ItemLike[] { GTItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
+                        () -> new ItemLike[] { GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
                 .workableCasingRenderer(casingTexture, overlayModel)
                 .tooltips(
                         Component.translatable("gtceu.universal.tooltip.base_production_eut", V[tier] * 2),

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -165,7 +165,7 @@ public class GTMultiMachines {
                 return shapeInfo;
             })
             .recoveryItems(
-                    () -> new ItemLike[] { GTItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
+                    () -> new ItemLike[] { GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
             .workableCasingRenderer(GTCEu.id("block/casings/solid/machine_casing_heatproof"),
                     GTCEu.id("block/multiblock/electric_blast_furnace"))
             .tooltips(Component.translatable("gtceu.machine.electric_blast_furnace.tooltip.0"),
@@ -374,7 +374,7 @@ public class GTMultiMachines {
                 return shapeInfo;
             })
             .recoveryItems(
-                    () -> new ItemLike[] { GTItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
+                    () -> new ItemLike[] { GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
             .workableCasingRenderer(GTCEu.id("block/casings/solid/machine_casing_heatproof"),
                     GTCEu.id("block/multiblock/multi_furnace"))
             .additionalDisplay((controller, components) -> {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/BedrockOreMinerMachine.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMa
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.machine.trait.BedrockOreMinerLogic;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
@@ -142,12 +143,12 @@ public class BedrockOreMinerMachine extends WorkableElectricMultiblockMachine im
 
     public static Block getFrameState(int tier) {
         if (tier == GTValues.MV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
+            return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
         if (tier == GTValues.HV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Titanium).get();
+            return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Titanium).get();
         if (tier == GTValues.EV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.TungstenSteel).get();
-        return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
+            return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.TungstenSteel).get();
+        return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
     }
 
     public static ResourceLocation getBaseTexture(int tier) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/FluidDrillMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/FluidDrillMachine.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMa
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.machine.trait.FluidDrillLogic;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
@@ -140,12 +141,12 @@ public class FluidDrillMachine extends WorkableElectricMultiblockMachine impleme
     @SuppressWarnings("DataFlowIssue")
     public static Block getFrameState(int tier) {
         if (tier == GTValues.MV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
+            return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
         if (tier == GTValues.HV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Titanium).get();
+            return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Titanium).get();
         if (tier == GTValues.EV)
-            return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.TungstenSteel).get();
-        return GTBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
+            return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.TungstenSteel).get();
+        return GTMaterialBlocks.MATERIAL_BLOCKS.get(TagPrefix.frameGt, GTMaterials.Steel).get();
     }
 
     public static ResourceLocation getBaseTexture(int tier) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -13,7 +13,7 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.transfer.item.NotifiableAccountedInvWrapper;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
-import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
@@ -140,7 +140,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         this.currentRadius = maximumRadius;
         this.maximumRadius = maximumRadius;
         this.isDone = false;
-        this.pickaxeTool = GTItems.TOOL_ITEMS.get(GTMaterials.Neutronium, GTToolType.PICKAXE).get().get();
+        this.pickaxeTool = GTMaterialItems.TOOL_ITEMS.get(GTMaterials.Neutronium, GTToolType.PICKAXE).get().get();
         this.pickaxeTool.enchant(Enchantments.BLOCK_FORTUNE, fortune);
         this.capabilitiesProxy = Tables.newCustomTable(new EnumMap<>(IO.class), IdentityHashMap::new);
         this.inputItemHandler = new ItemRecipeHandler(IO.IN,

--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -16,7 +16,8 @@ import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.registry.registrate.forge.GTClientFluidTypeExtensions;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
-import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.BlockBehaviourAccessor;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
@@ -76,7 +77,7 @@ public class MixinHelpers {
                 }
             });
 
-            GTItems.TOOL_ITEMS.rowMap().forEach((material, map) -> {
+            GTMaterialItems.TOOL_ITEMS.rowMap().forEach((material, map) -> {
                 map.forEach((type, item) -> {
                     if (item != null) {
                         var entry = new TagLoader.EntryWithSource(TagEntry.element(item.getId()),
@@ -88,16 +89,16 @@ public class MixinHelpers {
                 });
             });
         } else if (registry == BuiltInRegistries.BLOCK) {
-            GTBlocks.MATERIAL_BLOCKS.rowMap().forEach((prefix, map) -> {
+            GTMaterialBlocks.MATERIAL_BLOCKS.rowMap().forEach((prefix, map) -> {
                 MixinHelpers.addMaterialBlockTags(tagMap, prefix, map);
             });
-            GTBlocks.CABLE_BLOCKS.rowMap().forEach((prefix, map) -> {
+            GTMaterialBlocks.CABLE_BLOCKS.rowMap().forEach((prefix, map) -> {
                 MixinHelpers.addMaterialBlockTags(tagMap, prefix, map);
             });
-            GTBlocks.FLUID_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
+            GTMaterialBlocks.FLUID_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
                 MixinHelpers.addMaterialBlockTags(tagMap, prefix, map);
             });
-            GTBlocks.ITEM_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
+            GTMaterialBlocks.ITEM_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
                 MixinHelpers.addMaterialBlockTags(tagMap, prefix, map);
             });
             GTRegistries.MACHINES.forEach(machine -> {
@@ -190,7 +191,7 @@ public class MixinHelpers {
     private static final VanillaBlockLoot BLOCK_LOOT = new VanillaBlockLoot();
 
     public static void generateGTDynamicLoot(Map<ResourceLocation, LootTable> lootTables) {
-        GTBlocks.MATERIAL_BLOCKS.rowMap().forEach((prefix, map) -> {
+        GTMaterialBlocks.MATERIAL_BLOCKS.rowMap().forEach((prefix, map) -> {
             if (TagPrefix.ORES.containsKey(prefix)) {
                 final TagPrefix.OreType type = TagPrefix.ORES.get(prefix);
                 map.forEach((material, blockEntry) -> {
@@ -241,16 +242,16 @@ public class MixinHelpers {
                 MixinHelpers.addMaterialBlockLootTables(lootTables, prefix, map);
             }
         });
-        GTBlocks.CABLE_BLOCKS.rowMap().forEach((prefix, map) -> {
+        GTMaterialBlocks.CABLE_BLOCKS.rowMap().forEach((prefix, map) -> {
             MixinHelpers.addMaterialBlockLootTables(lootTables, prefix, map);
         });
-        GTBlocks.FLUID_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
+        GTMaterialBlocks.FLUID_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
             MixinHelpers.addMaterialBlockLootTables(lootTables, prefix, map);
         });
-        GTBlocks.ITEM_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
+        GTMaterialBlocks.ITEM_PIPE_BLOCKS.rowMap().forEach((prefix, map) -> {
             MixinHelpers.addMaterialBlockLootTables(lootTables, prefix, map);
         });
-        GTBlocks.SURFACE_ROCK_BLOCKS.forEach((material, blockEntry) -> {
+        GTMaterialBlocks.SURFACE_ROCK_BLOCKS.forEach((material, blockEntry) -> {
             ResourceLocation lootTableId = new ResourceLocation(blockEntry.getId().getNamespace(),
                     "blocks/" + blockEntry.getId().getPath());
             LootTable.Builder builder = BLOCK_LOOT

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
@@ -11,10 +11,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.UnificationEntry;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKeys;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
-import com.gregtechceu.gtceu.common.data.GTItems;
-import com.gregtechceu.gtceu.common.data.GTMaterials;
-import com.gregtechceu.gtceu.common.data.GTRecipeCategories;
+import com.gregtechceu.gtceu.common.data.*;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.CraftingComponent;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
@@ -632,7 +629,7 @@ public class MaterialRecipeHandler {
             for (Material material : registry.getAllMaterials()) {
                 if (material.hasProperty(PropertyKey.ORE)) {
                     VanillaRecipeHelper.addShapedRecipe(provider, "%s_surface_indicator".formatted(material.getName()),
-                            GTBlocks.SURFACE_ROCK_BLOCKS.get(material).asStack(2),
+                            GTMaterialBlocks.SURFACE_ROCK_BLOCKS.get(material).asStack(2),
                             "DDD", "DGD", "DDD",
                             'D', ChemicalHelper.get(dustSmall, material),
                             'G', Items.GRAVEL);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
@@ -15,6 +15,7 @@ import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.api.recipe.ToolHeadReplaceRecipe;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
@@ -380,7 +381,7 @@ public class ToolRecipeHandler {
             int tier = toolType.electricTier;
             ItemStack powerUnitStack = powerUnitItems.get(tier).asStack();
             IElectricItem powerUnit = GTCapabilityHelper.getElectricItem(powerUnitStack);
-            ItemStack tool = GTItems.TOOL_ITEMS.get(material, toolType).get().get(0, powerUnit.getMaxCharge());
+            ItemStack tool = GTMaterialItems.TOOL_ITEMS.get(material, toolType).get().get(0, powerUnit.getMaxCharge());
             VanillaRecipeHelper.addShapedEnergyTransferRecipe(provider,
                     true, true, true,
                     String.format("%s_%s", material.getName(), toolType.name),

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/ItemTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/ItemTagLoader.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterials.Color;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
 
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -35,22 +36,22 @@ public class ItemTagLoader {
                 Items.LIGHT_GRAY_CONCRETE_POWDER, Items.CYAN_CONCRETE_POWDER, Items.PURPLE_CONCRETE_POWDER,
                 Items.BLUE_CONCRETE_POWDER, Items.BROWN_CONCRETE_POWDER, Items.GREEN_CONCRETE_POWDER,
                 Items.RED_CONCRETE_POWDER, Items.BLACK_CONCRETE_POWDER);
-        create(provider, lens, Color.White, GTItems.MATERIAL_ITEMS.get(lens, Glass).get());
-        create(provider, lens, Color.White, GTItems.MATERIAL_ITEMS.get(lens, NetherStar).get());
-        create(provider, lens, Color.LightBlue, GTItems.MATERIAL_ITEMS.get(lens, Diamond).get());
-        create(provider, lens, Color.Red, GTItems.MATERIAL_ITEMS.get(lens, Ruby).get());
-        create(provider, lens, Color.Green, GTItems.MATERIAL_ITEMS.get(lens, Emerald).get());
-        create(provider, lens, Color.Blue, GTItems.MATERIAL_ITEMS.get(lens, Sapphire).get());
-        create(provider, lens, Color.Purple, GTItems.MATERIAL_ITEMS.get(lens, Amethyst).get());
+        create(provider, lens, Color.White, GTMaterialItems.MATERIAL_ITEMS.get(lens, Glass).get());
+        create(provider, lens, Color.White, GTMaterialItems.MATERIAL_ITEMS.get(lens, NetherStar).get());
+        create(provider, lens, Color.LightBlue, GTMaterialItems.MATERIAL_ITEMS.get(lens, Diamond).get());
+        create(provider, lens, Color.Red, GTMaterialItems.MATERIAL_ITEMS.get(lens, Ruby).get());
+        create(provider, lens, Color.Green, GTMaterialItems.MATERIAL_ITEMS.get(lens, Emerald).get());
+        create(provider, lens, Color.Blue, GTMaterialItems.MATERIAL_ITEMS.get(lens, Sapphire).get());
+        create(provider, lens, Color.Purple, GTMaterialItems.MATERIAL_ITEMS.get(lens, Amethyst).get());
 
         create(provider, CustomTags.PISTONS, Items.PISTON, Items.STICKY_PISTON);
 
-        create(provider, dye, Color.Brown, GTItems.MATERIAL_ITEMS.get(dust, MetalMixture).get());
+        create(provider, dye, Color.Brown, GTMaterialItems.MATERIAL_ITEMS.get(dust, MetalMixture).get());
 
         // add treated wood stick to vanilla sticks tag
         // noinspection DataFlowIssue ChemicalHelper#getTag can't return null with treated wood rod
         provider.addTag(Tags.Items.RODS_WOODEN)
-                .add(TagEntry.element(GTItems.MATERIAL_ITEMS.get(TagPrefix.rod, TreatedWood).getId()));
+                .add(TagEntry.element(GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.rod, TreatedWood).getId()));
 
         // todo match ae2 certus quartz tag
         // OreDictionary.registerUnificationEntry("crystalCertusQuartz", ChemicalHelper.get(TagPrefix.gem,
@@ -58,8 +59,8 @@ public class ItemTagLoader {
 
         // add treated and untreated wood plates to vanilla planks tag
         provider.addTag(ItemTags.PLANKS)
-                .add(TagEntry.element(GTItems.MATERIAL_ITEMS.get(plate, TreatedWood).getId()))
-                .add(TagEntry.element(GTItems.MATERIAL_ITEMS.get(plate, Wood).getId()));
+                .add(TagEntry.element(GTMaterialItems.MATERIAL_ITEMS.get(plate, TreatedWood).getId()))
+                .add(TagEntry.element(GTMaterialItems.MATERIAL_ITEMS.get(plate, Wood).getId()));
 
         provider.addTag(CustomTags.CIRCUITS)
                 .addTag(CustomTags.ULV_CIRCUITS)

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -29,9 +29,7 @@ import com.gregtechceu.gtceu.common.capability.WorldIDSaveData;
 import com.gregtechceu.gtceu.common.commands.GTCommands;
 import com.gregtechceu.gtceu.common.commands.HazardCommands;
 import com.gregtechceu.gtceu.common.commands.MedicalConditionCommands;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
-import com.gregtechceu.gtceu.common.data.GTItems;
-import com.gregtechceu.gtceu.common.data.GTMachines;
+import com.gregtechceu.gtceu.common.data.*;
 import com.gregtechceu.gtceu.common.data.machines.GTAEMachines;
 import com.gregtechceu.gtceu.common.item.ToggleEnergyConsumerBehavior;
 import com.gregtechceu.gtceu.common.item.armor.IJetpack;
@@ -525,7 +523,7 @@ public class ForgeCommonEventListener {
             event.getMappings(Registries.BLOCK, GTCEu.MOD_ID).forEach(mapping -> {
                 Matcher matcher = idPattern.matcher(mapping.getKey().getPath());
                 if (matcher.matches()) {
-                    BlockEntry<? extends MaterialBlock> block = GTBlocks.MATERIAL_BLOCKS.get(prefix,
+                    BlockEntry<? extends MaterialBlock> block = GTMaterialBlocks.MATERIAL_BLOCKS.get(prefix,
                             GTCEuAPI.materialManager.getRegistry(GTCEu.MOD_ID).get(matcher.group(1)));
                     if (block != null && block.isPresent()) {
                         mapping.remap(block.get());
@@ -535,12 +533,12 @@ public class ForgeCommonEventListener {
             event.getMappings(Registries.ITEM, GTCEu.MOD_ID).forEach(mapping -> {
                 Matcher matcher = idPattern.matcher(mapping.getKey().getPath());
                 if (matcher.matches()) {
-                    BlockEntry<? extends MaterialBlock> block = GTBlocks.MATERIAL_BLOCKS.get(prefix,
+                    BlockEntry<? extends MaterialBlock> block = GTMaterialBlocks.MATERIAL_BLOCKS.get(prefix,
                             GTCEuAPI.materialManager.getRegistry(GTCEu.MOD_ID).get(matcher.group(1)));
                     if (block != null && block.isPresent()) {
                         mapping.remap(block.asItem());
                     } else {
-                        ItemEntry<? extends TagPrefixItem> item = GTItems.MATERIAL_ITEMS.get(prefix,
+                        ItemEntry<? extends TagPrefixItem> item = GTMaterialItems.MATERIAL_ITEMS.get(prefix,
                                 GTCEuAPI.materialManager.getRegistry(GTCEu.MOD_ID).get(matcher.group(1)));
                         if (item != null && item.isPresent()) {
                             mapping.remap(item.asItem());

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
@@ -3,7 +3,7 @@ package com.gregtechceu.gtceu.integration.jade;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.common.blockentity.FluidPipeBlockEntity;
-import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.integration.jade.provider.*;
 
 import net.minecraft.world.item.Item;
@@ -82,7 +82,7 @@ public class GTJadePlugin implements IWailaPlugin {
     }
 
     static {
-        GTItems.TOOL_ITEMS.columnMap().forEach((type, map) -> {
+        GTMaterialItems.TOOL_ITEMS.columnMap().forEach((type, map) -> {
             if (type.harvestTags.isEmpty() || type.harvestTags.get(0).location().getNamespace().equals("minecraft"))
                 return;
             HarvestToolProvider.registerHandler(new SimpleToolHandler(type.name, type.harvestTags.get(0),

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
@@ -5,8 +5,8 @@ import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.data.machines.GTMultiMachines;
 import com.gregtechceu.gtceu.config.ConfigHolder;
@@ -96,7 +96,7 @@ public class GTREIPlugin implements REIClientPlugin {
             // EntryIngredients.ofItemStacks(GTItems.TOOL_ITEMS.column(toolType).values().stream().filter(Objects::nonNull).map(ItemProviderEntry::get).map(IGTTool::get).collect(Collectors.toSet()))
         }
 
-        for (var cell : GTBlocks.MATERIAL_BLOCKS.columnMap().entrySet()) {
+        for (var cell : GTMaterialBlocks.MATERIAL_BLOCKS.columnMap().entrySet()) {
             var value = cell.getValue();
             if (value.size() <= 1) continue;
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/ToolItemHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/ToolItemHelper.java
@@ -4,7 +4,7 @@ import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IElectricItem;
 import com.gregtechceu.gtceu.api.item.capability.ElectricItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
-import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 
 import net.minecraft.world.item.Item;
@@ -47,9 +47,9 @@ public class ToolItemHelper {
     public static ItemStack getToolItem(GTToolType toolType) {
         return TOOL_CACHE.computeIfAbsent(toolType, type -> {
             if (type == GTToolType.SOFT_MALLET) {
-                return GTItems.TOOL_ITEMS.get(GTMaterials.Rubber, type).asStack();
+                return GTMaterialItems.TOOL_ITEMS.get(GTMaterials.Rubber, type).asStack();
             }
-            return GTItems.TOOL_ITEMS.get(GTMaterials.Neutronium, type).asStack();
+            return GTMaterialItems.TOOL_ITEMS.get(GTMaterials.Neutronium, type).asStack();
         });
     }
 }


### PR DESCRIPTION
## What
In order to make a distinction between items/blocks that are generated from GTMaterials vs those explicitly added by developers for features, I propose we move implementations for generated materials to two new folders: `GTMaterialBlocks.java` and `GTMaterialItems.java`

## Implementation Details
As mentioned above.

## Outcome
There should be 0 changes to the game. This is entirely a source-code change for readability.