### PR TITLE
Fix xaeros integration not filtering ore veins by dimension on worldmap

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.integration.map.xaeros.XaerosRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
+
 import xaero.map.WorldMap;
 import xaero.map.element.MapElementRenderProvider;
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
@@ -2,6 +2,9 @@ package com.gregtechceu.gtceu.integration.map.xaeros.worldmap.ore;
 
 import com.gregtechceu.gtceu.integration.map.xaeros.XaerosRenderer;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
 import xaero.map.WorldMap;
 import xaero.map.element.MapElementRenderProvider;
 
@@ -15,7 +18,8 @@ public class OreVeinElementRenderProvider extends MapElementRenderProvider<OreVe
 
     public void begin(int location, OreVeinElementContext context) {
         if (WorldMap.settings.waypoints) {
-            this.iterator = XaerosRenderer.oreElements.values()
+            ResourceKey<Level> currentDim = Minecraft.getInstance().level.dimension();
+            this.iterator = XaerosRenderer.oreElements.row(currentDim).values()
                     .stream()
                     .map(element -> new OreVeinElement(element.getVein(), element.getName()))
                     .iterator();


### PR DESCRIPTION
## What
Filters the ore veins by dimension on worldmap.

## Additionally
Fixes #2523