### PR TITLE
Fix ME Output Parts being inefficient

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputBusPartMachine.java
@@ -23,6 +23,9 @@ import appeng.api.config.Actionable;
 import appeng.api.stacks.AEItemKey;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
+import java.util.List;
+
 import javax.annotation.ParametersAreNonnullByDefault;
 
 /**
@@ -114,6 +117,21 @@ public class MEOutputBusPartMachine extends MEBusPartMachine implements IMachine
         public InaccessibleInfiniteHandler(MetaMachine holder) {
             super(holder, 1, IO.OUT, IO.NONE, ItemStackHandlerDelegate::new);
             internalBuffer.setOnContentsChanged(this::onContentsChanged);
+        }
+
+        @Override
+        public List<Object> getContents() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public double getTotalContentAmount() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
@@ -26,6 +26,7 @@ import appeng.api.stacks.AEFluidKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -117,12 +118,12 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine implements IMac
 
     private class InaccessibleInfiniteTank extends NotifiableFluidTank {
 
-        CustomFluidTank storage;
+        FluidStorageDelegate storage;
 
         public InaccessibleInfiniteTank(MetaMachine holder) {
             super(holder, List.of(new FluidStorageDelegate()), IO.OUT, IO.NONE);
             internalBuffer.setOnContentsChanged(this::onContentsChanged);
-            storage = getStorages()[0];
+            storage = (FluidStorageDelegate) getStorages()[0];
             allowSameFluids = true;
         }
 
@@ -132,9 +133,27 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine implements IMac
         }
 
         @Override
-        public @NotNull FluidStack getFluidInTank(int tank) {
-            return storage.getFluid();
+        public List<Object> getContents() {
+            return Collections.emptyList();
         }
+
+        @Override
+        public double getTotalContentAmount() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public @NotNull FluidStack getFluidInTank(int tank) {
+            return FluidStack.EMPTY;
+        }
+
+        @Override
+        public void setFluidInTank(int tank, @NotNull FluidStack fluidStack) {}
 
         @Override
         public int getTankCapacity(int tank) {
@@ -143,7 +162,7 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine implements IMac
 
         @Override
         public boolean isFluidValid(int tank, @NotNull FluidStack stack) {
-            return storage.isFluidValid(stack);
+            return true;
         }
 
         @Override


### PR DESCRIPTION
## What
Hardcodes some values so that the IRecipeHandler comparator doesn't need to do calculations, as the ME parts should always report as empty.
