### PR TITLE
Fix Programmed Circuit Crash on Output Parts

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/IntCircuitBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/IntCircuitBehaviour.java
@@ -147,10 +147,9 @@ public class IntCircuitBehaviour implements IItemUIFactory, IAddInformation {
         int circuitSetting = getCircuitConfiguration(stack);
         BlockEntity entity = context.getLevel().getBlockEntity(context.getClickedPos());
         if (entity instanceof MetaMachineBlockEntity machineEntity && context.isSecondaryUseActive()) {
-            if (machineEntity.metaMachine instanceof IHasCircuitSlot hasCircuitSlot) {
-                setCircuitConfig(hasCircuitSlot.getCircuitInventory(), circuitSetting);
+            if (machineEntity.metaMachine instanceof IHasCircuitSlot circuitMachine && circuitMachine.getCircuitInventory().getSlots() > 0) {
+                setCircuitConfig(circuitMachine.getCircuitInventory(), circuitSetting);
             }
-
             if (!ConfigHolder.INSTANCE.machines.ghostCircuit)
                 stack.shrink(1);
             return InteractionResult.SUCCESS;

--- a/src/main/java/com/gregtechceu/gtceu/common/item/IntCircuitBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/IntCircuitBehaviour.java
@@ -147,7 +147,8 @@ public class IntCircuitBehaviour implements IItemUIFactory, IAddInformation {
         int circuitSetting = getCircuitConfiguration(stack);
         BlockEntity entity = context.getLevel().getBlockEntity(context.getClickedPos());
         if (entity instanceof MetaMachineBlockEntity machineEntity && context.isSecondaryUseActive()) {
-            if (machineEntity.metaMachine instanceof IHasCircuitSlot circuitMachine && circuitMachine.getCircuitInventory().getSlots() > 0) {
+            if (machineEntity.metaMachine instanceof IHasCircuitSlot circuitMachine &&
+                    circuitMachine.getCircuitInventory().getSlots() > 0) {
                 setCircuitConfig(circuitMachine.getCircuitInventory(), circuitSetting);
             }
             if (!ConfigHolder.INSTANCE.machines.ghostCircuit)


### PR DESCRIPTION
## What
Fix Programmed Circuit Crash on Output Parts

## Implementation Details
Added check for circuit slot

## Outcome
no more crash when using programmed circuit on output parts