### PR TITLE
Replace getGameTime calls with getTickCount for performance

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -142,7 +142,7 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
 
     @Override
     public long getOffsetTimer() {
-        return level == null ? offset : (level.getGameTime() + offset);
+        return level == null ? offset : (level.getServer().getTickCount() + offset);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/IMachineBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/IMachineBlockEntity.java
@@ -53,7 +53,7 @@ public interface IMachineBlockEntity extends IToolGridHighlight, IAsyncAutoSyncB
     }
 
     default long getOffsetTimer() {
-        return level() == null ? getOffset() : (level().getGameTime() + getOffset());
+        return level() == null ? getOffset() : (level().getServer().getTickCount() + getOffset());
     }
 
     default MachineDefinition getDefinition() {


### PR DESCRIPTION
## What
`level.getGameTime()` is surprisingly expensive to use as a tick counter. 
Since we should only need tick counters on the server, we can use `level.getServer().getTickCount()` instead.