### PR TITLE
Fix the handling of extra bocks in cleanroom floor, and adds some mod compatabiity.

### DIFF
--- a/src/generated/resources/data/ae2/tags/items/p2p_attunements/fluid_p2p_tunnel.json
+++ b/src/generated/resources/data/ae2/tags/items/p2p_attunements/fluid_p2p_tunnel.json
@@ -107,6 +107,8 @@
     "gtceu:molten_bismuth_bronze_bucket",
     "gtceu:rtm_alloy_bucket",
     "gtceu:molten_rtm_alloy_bucket",
+    "gtceu:ruridit_bucket",
+    "gtceu:molten_ruridit_bucket",
     "gtceu:soldering_alloy_bucket",
     "gtceu:stainless_steel_bucket",
     "gtceu:molten_stainless_steel_bucket",

--- a/src/generated/resources/data/gtceu/tags/blocks/cleanroom_floors.json
+++ b/src/generated/resources/data/gtceu/tags/blocks/cleanroom_floors.json
@@ -1,6 +1,4 @@
 {
   "values": [
-    "gtceu:plascrete",
-    "gtceu:cleanroom_glass"
   ]
 }

--- a/src/generated/resources/data/gtceu/tags/blocks/cleanroom_floors.json
+++ b/src/generated/resources/data/gtceu/tags/blocks/cleanroom_floors.json
@@ -1,4 +1,28 @@
 {
   "values": [
+    {
+      "id": "#elevatorid:elevators",
+      "required": false
+    },
+    {
+      "id": "enderio:travel_anchor",
+      "required": false
+    },
+    {
+      "id": "rftoolsutility:matter_transmitter",
+      "required": false
+    },
+    {
+      "id": "rftoolsutility:matter_receiver",
+      "required": false
+    },
+    {
+      "id": "rftoolsutility:dialing_device",
+      "required": false
+    },
+    {
+      "id": "travelanchors:travel_anchor",
+      "required": false
+    }
   ]
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -44,7 +44,13 @@ public class BlockTagLoader {
                 .add(TagEntry.element(GTMachines.WOODEN_DRUM.getId()))
                 .add(TagEntry.element(GTMachines.WOODEN_CRATE.getId()));
 
-        provider.addTag(CustomTags.CLEANROOM_FLOORS);
+        provider.addTag(CustomTags.CLEANROOM_FLOORS)
+                .addOptionalTag(new ResourceLocation("elevatorid:elevators"))
+                .addOptional(new ResourceLocation("enderio:travel_anchor"))
+                .addOptional(new ResourceLocation("rftoolsutility:matter_transmitter"))
+                .addOptional(new ResourceLocation("rftoolsutility:matter_receiver"))
+                .addOptional(new ResourceLocation("rftoolsutility:dialing_device"))
+                .addOptional(new ResourceLocation("travelanchors:travel_anchor"));
     }
 
     private static void create(RegistrateTagsProvider<Block> provider, TagPrefix prefix, Material material,

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.data.tags;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
-import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
@@ -45,7 +44,7 @@ public class BlockTagLoader {
                 .add(TagEntry.element(GTMachines.WOODEN_DRUM.getId()))
                 .add(TagEntry.element(GTMachines.WOODEN_CRATE.getId()));
 
-        create(provider, CustomTags.CLEANROOM_FLOORS, GTBlocks.PLASTCRETE.get(), GTBlocks.CLEANROOM_GLASS.get());
+        provider.addTag(CustomTags.CLEANROOM_FLOORS);
     }
 
     private static void create(RegistrateTagsProvider<Block> provider, TagPrefix prefix, Material material,


### PR DESCRIPTION
## What
Fixes the issue [here](https://github.com/GregTechCEu/GregTech-Modern/pull/2466#discussion_r1874342908) with extra cleanroom floor blocks only work in the center position. Also, while I am here, add some compatibility with some common mods that have transport blocks.

## Implementation Details
n/a/

## Outcome
Cleanroom floors can contain up to 4 travel blocks.

(Currently untested, and needs data generation, but my computer is slow)
