### PR TITLE
Fix GT Fluid Attributes not registering on Source

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/fluids/FluidBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/fluids/FluidBuilder.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.registry.registrate.IGTFluidBuilder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 
 import com.google.common.base.Preconditions;
@@ -278,8 +279,9 @@ public class FluidBuilder {
         }
 
         builder.onFluidRegister(fluid -> {
-            if (fluid instanceof GTFluid gtFluid) {
-                attributes.forEach(gtFluid::addAttribute);
+            if (fluid instanceof FlowingFluid flowingFluid) {
+                if (flowingFluid.getSource() instanceof GTFluid gtSource) attributes.forEach(gtSource::addAttribute);
+                if (flowingFluid.getFlowing() instanceof GTFluid gtFlowing) attributes.forEach(gtFlowing::addAttribute);
             }
         });
 


### PR DESCRIPTION
## What
Fixes GT Fluid Attributes, like the Acidic property, only being added to the Flowing fluid and not the Source fluid
