### PR TITLE
Refactor DataStick item and associated interaction interface

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -11,6 +11,7 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.feature.*;
 import com.gregtechceu.gtceu.common.data.GTItems;
+import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -321,17 +322,10 @@ public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
             if (result != InteractionResult.PASS) return result;
         }
         if (shouldOpenUi && machine instanceof IUIMachine uiMachine &&
-                canOpenOwnerMachine(player, machine.getHolder())) {
+                IMachineOwner.canOpenOwnerMachine(player, machine.getHolder())) {
             return uiMachine.tryToOpenUI(player, hand, hit);
         }
         return shouldOpenUi ? InteractionResult.PASS : InteractionResult.CONSUME;
-    }
-
-    public boolean canOpenOwnerMachine(Player player, IMachineBlockEntity machine) {
-        if (!ConfigHolder.INSTANCE.machines.onlyOwnerGUI) return true;
-        if (player.hasPermissions(ConfigHolder.INSTANCE.machines.ownerOPBypass)) return true;
-        if (machine.getOwner() == null) return true;
-        return machine.getOwner().isPlayerInTeam(player) || machine.getOwner().isPlayerFriendly(player);
     }
 
     public static boolean canBreakOwnerMachine(Player player, IMachineBlockEntity machine) {

--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -12,7 +12,6 @@ import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.feature.*;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
-import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
@@ -326,13 +325,6 @@ public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
             return uiMachine.tryToOpenUI(player, hand, hit);
         }
         return shouldOpenUi ? InteractionResult.PASS : InteractionResult.CONSUME;
-    }
-
-    public static boolean canBreakOwnerMachine(Player player, IMachineBlockEntity machine) {
-        if (!ConfigHolder.INSTANCE.machines.onlyOwnerBreak) return true;
-        if (player.hasPermissions(ConfigHolder.INSTANCE.machines.ownerOPBypass)) return true;
-        if (machine.getOwner() == null) return true;
-        return machine.getOwner().isPlayerInTeam(player);
     }
 
     public boolean canConnectRedstone(BlockGetter level, BlockPos pos, Direction side) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IDataStickInteractable.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IDataStickInteractable.java
@@ -1,39 +1,12 @@
 package com.gregtechceu.gtceu.api.machine.feature;
 
-import com.gregtechceu.gtceu.common.data.GTItems;
-
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
 
-public interface IDataStickInteractable extends IInteractedMachine {
+public interface IDataStickInteractable {
 
-    @Override
-    default InteractionResult onUse(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand,
-                                    BlockHitResult hit) {
-        var item = player.getItemInHand(hand);
-        if (item.is(GTItems.TOOL_DATA_STICK.asItem())) {
-            return onDataStickRightClick(player, item);
-        }
-        return IInteractedMachine.super.onUse(state, world, pos, player, hand, hit);
-    }
+    InteractionResult onDataStickUse(Player player, ItemStack dataStick);
 
-    @Override
-    default boolean onLeftClick(Player player, Level world, InteractionHand hand, BlockPos pos, Direction direction) {
-        var item = player.getItemInHand(hand);
-        if (item.is(GTItems.TOOL_DATA_STICK.asItem())) {
-            return onDataStickLeftClick(player, item);
-        }
-        return IInteractedMachine.super.onLeftClick(player, world, hand, pos, direction);
-    }
-
-    InteractionResult onDataStickRightClick(Player player, ItemStack dataStick);
-
-    boolean onDataStickLeftClick(Player player, ItemStack dataStick);
+    InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IDataStickInteractable.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IDataStickInteractable.java
@@ -6,7 +6,11 @@ import net.minecraft.world.item.ItemStack;
 
 public interface IDataStickInteractable {
 
-    InteractionResult onDataStickUse(Player player, ItemStack dataStick);
+    default InteractionResult onDataStickUse(Player player, ItemStack dataStick) {
+        return InteractionResult.PASS;
+    }
 
-    InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick);
+    default InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
+        return InteractionResult.PASS;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -82,7 +82,7 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
     @Override
     public InteractionResult onItemUseFirst(ItemStack itemStack, UseOnContext context) {
         if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof MetaMachineBlockEntity blockEntity) {
-            if (IMachineOwner.canOpenOwnerMachine(context.getPlayer(), blockEntity)) {
+            if (!IMachineOwner.canOpenOwnerMachine(context.getPlayer(), blockEntity)) {
                 return InteractionResult.FAIL;
             }
             var machine = blockEntity.getMetaMachine();

--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -87,7 +87,9 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
             var machine = blockEntity.getMetaMachine();
             if (machine instanceof IDataStickInteractable interactable) {
                 if (context.isSecondaryUseActive()) {
-                    return interactable.onDataStickShiftUse(context.getPlayer(), itemStack);
+                    if (ResearchManager.readResearchId(itemStack) == null) {
+                        return interactable.onDataStickShiftUse(context.getPlayer(), itemStack);
+                    }
                 } else {
                     return interactable.onDataStickUse(context.getPlayer(), itemStack);
                 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.item.component.IInteractionItem;
 import com.gregtechceu.gtceu.api.machine.feature.IDataStickInteractable;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import net.minecraft.ChatFormatting;
@@ -81,7 +82,7 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
     @Override
     public InteractionResult onItemUseFirst(ItemStack itemStack, UseOnContext context) {
         if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof MetaMachineBlockEntity blockEntity) {
-            if (blockEntity.getOwner() != null && !blockEntity.getOwner().isPlayerInTeam(context.getPlayer())) {
+            if (IMachineOwner.canOpenOwnerMachine(context.getPlayer(), blockEntity)) {
                 return InteractionResult.FAIL;
             }
             var machine = blockEntity.getMetaMachine();

--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -1,18 +1,16 @@
 package com.gregtechceu.gtceu.common.item;
 
+import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
 import com.gregtechceu.gtceu.api.item.component.IDataItem;
 import com.gregtechceu.gtceu.api.item.component.IInteractionItem;
-import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IDataStickInteractable;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
-import com.gregtechceu.gtceu.integration.ae2.machine.MEPatternBufferPartMachine;
-import com.gregtechceu.gtceu.integration.ae2.machine.MEPatternBufferProxyPartMachine;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionResult;
@@ -81,27 +79,22 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
     }
 
     @Override
-    public InteractionResult useOn(UseOnContext context) {
-        Level level = context.getLevel();
-        BlockPos pos = context.getClickedPos();
-        ItemStack stack = context.getItemInHand();
-        if (!level.isClientSide) {
-            MetaMachine machine = MetaMachine.getMachine(level, pos);
-            Pair<GTRecipeType, String> researchData = ResearchManager.readResearchId(stack);
-            if (machine instanceof MEPatternBufferPartMachine && researchData == null) {
-                stack.getOrCreateTag().putIntArray("pos", new int[] { pos.getX(), pos.getY(), pos.getZ() });
-            } else if (machine instanceof MEPatternBufferProxyPartMachine proxy) {
-                if (stack.hasTag()) {
-                    if (stack.getOrCreateTag().contains("pos", Tag.TAG_INT_ARRAY)) {
-                        int[] posArray = stack.getOrCreateTag().getIntArray("pos");
-                        BlockPos bufferPos = new BlockPos(posArray[0], posArray[1], posArray[2]);
-                        proxy.setBuffer(bufferPos);
-                    }
+    public InteractionResult onItemUseFirst(ItemStack itemStack, UseOnContext context) {
+        if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof MetaMachineBlockEntity blockEntity) {
+            if (blockEntity.getOwner() != null && !blockEntity.getOwner().isPlayerInTeam(context.getPlayer())) {
+                return InteractionResult.FAIL;
+            }
+            var machine = blockEntity.getMetaMachine();
+            if (machine instanceof IDataStickInteractable interactable) {
+                if (context.isSecondaryUseActive()) {
+                    return interactable.onDataStickShiftUse(context.getPlayer(), itemStack);
+                } else {
+                    return interactable.onDataStickUse(context.getPlayer(), itemStack);
                 }
             } else {
                 return InteractionResult.PASS;
             }
         }
-        return InteractionResult.sidedSuccess(level.isClientSide);
+        return InteractionResult.sidedSuccess(context.getLevel().isClientSide);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/MetaMachineConfigCopyBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/MetaMachineConfigCopyBehaviour.java
@@ -98,7 +98,7 @@ public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInf
     @Override
     public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
         if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof MetaMachineBlockEntity blockEntity) {
-            if (IMachineOwner.canOpenOwnerMachine(context.getPlayer(), blockEntity))
+            if (!IMachineOwner.canOpenOwnerMachine(context.getPlayer(), blockEntity))
                 return InteractionResult.FAIL;
             MetaMachine machine = blockEntity.getMetaMachine();
             if (context.isSecondaryUseActive())

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/MetaMachineConfigCopyBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/MetaMachineConfigCopyBehaviour.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputFluid;
 import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputItem;
 import com.gregtechceu.gtceu.api.machine.feature.IMufflableMachine;
+import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
@@ -97,7 +98,7 @@ public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInf
     @Override
     public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
         if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof MetaMachineBlockEntity blockEntity) {
-            if (blockEntity.getOwner() != null && !blockEntity.getOwner().isPlayerInTeam(context.getPlayer()))
+            if (IMachineOwner.canOpenOwnerMachine(context.getPlayer(), blockEntity))
                 return InteractionResult.FAIL;
             MetaMachine machine = blockEntity.getMetaMachine();
             if (context.isSecondaryUseActive())

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/owner/IMachineOwner.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/owner/IMachineOwner.java
@@ -56,6 +56,13 @@ public sealed interface IMachineOwner permits PlayerOwner, ArgonautsOwner, FTBOw
         return machine.getOwner().isPlayerInTeam(player) || machine.getOwner().isPlayerFriendly(player);
     }
 
+    static boolean canBreakOwnerMachine(Player player, IMachineBlockEntity machine) {
+        if (!ConfigHolder.INSTANCE.machines.onlyOwnerBreak) return true;
+        if (player.hasPermissions(ConfigHolder.INSTANCE.machines.ownerOPBypass)) return true;
+        if (machine.getOwner() == null) return true;
+        return machine.getOwner().isPlayerInTeam(player);
+    }
+
     enum MachineOwnerType {
 
         PLAYER,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/owner/IMachineOwner.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/owner/IMachineOwner.java
@@ -1,6 +1,8 @@
 package com.gregtechceu.gtceu.common.machine.owner;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -46,6 +48,13 @@ public sealed interface IMachineOwner permits PlayerOwner, ArgonautsOwner, FTBOw
     boolean isPlayerInTeam(Player player);
 
     boolean isPlayerFriendly(Player player);
+
+    static boolean canOpenOwnerMachine(Player player, IMachineBlockEntity machine) {
+        if (!ConfigHolder.INSTANCE.machines.onlyOwnerGUI) return true;
+        if (player.hasPermissions(ConfigHolder.INSTANCE.machines.ownerOPBypass)) return true;
+        if (machine.getOwner() == null) return true;
+        return machine.getOwner().isPlayerInTeam(player) || machine.getOwner().isPlayerFriendly(player);
+    }
 
     enum MachineOwnerType {
 

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -37,6 +37,7 @@ import com.gregtechceu.gtceu.common.data.machines.GTAEMachines;
 import com.gregtechceu.gtceu.common.fluid.potion.PotionFluidHelper;
 import com.gregtechceu.gtceu.common.item.ToggleEnergyConsumerBehavior;
 import com.gregtechceu.gtceu.common.item.armor.IJetpack;
+import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
 import com.gregtechceu.gtceu.common.network.GTNetwork;
 import com.gregtechceu.gtceu.common.network.packets.*;
 import com.gregtechceu.gtceu.common.network.packets.hazard.SPacketAddHazardZone;
@@ -267,7 +268,7 @@ public class ForgeCommonEventListener {
     public static void onBreakEvent(BlockEvent.BreakEvent event) {
         var machine = MetaMachine.getMachine(event.getLevel(), event.getPos());
         if (machine != null) {
-            if (!MetaMachineBlock.canBreakOwnerMachine(event.getPlayer(), machine.holder)) {
+            if (!IMachineOwner.canBreakOwnerMachine(event.getPlayer(), machine.holder)) {
                 event.setCanceled(true);
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
@@ -142,10 +142,10 @@ public class MEInputBusPartMachine extends MEBusPartMachine
 
     ////////////////////////////////
     // ******* Interaction *******//
-    ////////////////////////////////
+    /// /////////////////////////////
 
     @Override
-    public final boolean onDataStickLeftClick(Player player, ItemStack dataStick) {
+    public final InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
         if (!isRemote()) {
             CompoundTag tag = new CompoundTag();
             tag.put("MEInputBus", writeConfigToTag());
@@ -153,11 +153,11 @@ public class MEInputBusPartMachine extends MEBusPartMachine
             dataStick.setHoverName(Component.translatable("gtceu.machine.me.item_import.data_stick.name"));
             player.sendSystemMessage(Component.translatable("gtceu.machine.me.import_copy_settings"));
         }
-        return true;
+        return InteractionResult.SUCCESS;
     }
 
     @Override
-    public final InteractionResult onDataStickRightClick(Player player, ItemStack dataStick) {
+    public final InteractionResult onDataStickUse(Player player, ItemStack dataStick) {
         CompoundTag tag = dataStick.getTag();
         if (tag == null || !tag.contains("MEInputBus")) {
             return InteractionResult.PASS;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
@@ -142,7 +142,7 @@ public class MEInputBusPartMachine extends MEBusPartMachine
 
     ////////////////////////////////
     // ******* Interaction *******//
-    /// /////////////////////////////
+    ////////////////////////////////
 
     @Override
     public final InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
@@ -143,7 +143,7 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
 
     ////////////////////////////////
     // ******* Interaction *******//
-    /// /////////////////////////////
+    ////////////////////////////////
 
     @Override
     public final InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
@@ -143,10 +143,10 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
 
     ////////////////////////////////
     // ******* Interaction *******//
-    ////////////////////////////////
+    /// /////////////////////////////
 
     @Override
-    public final boolean onDataStickLeftClick(Player player, ItemStack dataStick) {
+    public final InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
         if (!isRemote()) {
             CompoundTag tag = new CompoundTag();
             tag.put("MEInputHatch", writeConfigToTag());
@@ -154,11 +154,11 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
             dataStick.setHoverName(Component.translatable("gtceu.machine.me.fluid_import.data_stick.name"));
             player.sendSystemMessage(Component.translatable("gtceu.machine.me.import_copy_settings"));
         }
-        return true;
+        return InteractionResult.SUCCESS;
     }
 
     @Override
-    public final InteractionResult onDataStickRightClick(Player player, ItemStack dataStick) {
+    public final InteractionResult onDataStickUse(Player player, ItemStack dataStick) {
         CompoundTag tag = dataStick.getTag();
         if (tag == null || !tag.contains("MEInputHatch")) {
             return InteractionResult.PASS;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -427,9 +427,6 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
 
     @Override
     public InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
-        if (ResearchManager.readResearchId(dataStick) != null) {
-            return InteractionResult.PASS;
-        }
         dataStick.getOrCreateTag().putIntArray("pos", new int[] { getPos().getX(), getPos().getY(), getPos().getZ() });
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -28,7 +28,6 @@ import com.gregtechceu.gtceu.integration.ae2.machine.trait.MEPatternBufferRecipe
 import com.gregtechceu.gtceu.integration.ae2.utils.AEUtil;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTUtil;
-import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
 import com.lowdragmc.lowdraglib.gui.util.ClickData;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -420,11 +420,6 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
     }
 
     @Override
-    public InteractionResult onDataStickUse(Player player, ItemStack dataStick) {
-        return InteractionResult.PASS;
-    }
-
-    @Override
     public InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
         dataStick.getOrCreateTag().putIntArray("pos", new int[] { getPos().getX(), getPos().getY(), getPos().getZ() });
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.api.machine.fancyconfigurator.ButtonConfigurator;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.CircuitFancyConfigurator;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.FancyInvConfigurator;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.FancyTankConfigurator;
+import com.gregtechceu.gtceu.api.machine.feature.IDataStickInteractable;
 import com.gregtechceu.gtceu.api.machine.feature.IHasCircuitSlot;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
@@ -27,6 +28,7 @@ import com.gregtechceu.gtceu.integration.ae2.machine.trait.MEPatternBufferRecipe
 import com.gregtechceu.gtceu.integration.ae2.utils.AEUtil;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTUtil;
+import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
 import com.lowdragmc.lowdraglib.gui.util.ClickData;
@@ -47,6 +49,8 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.fluids.FluidStack;
@@ -79,7 +83,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public class MEPatternBufferPartMachine extends MEBusPartMachine
-                                        implements ICraftingProvider, PatternContainer, IHasCircuitSlot {
+                                        implements ICraftingProvider, PatternContainer, IHasCircuitSlot,
+                                        IDataStickInteractable {
 
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(
             MEPatternBufferPartMachine.class, MEBusPartMachine.MANAGED_FIELD_HOLDER);
@@ -413,6 +418,20 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
     public void onMachineRemoved() {
         clearInventory(patternInventory);
         clearInventory(shareInventory);
+    }
+
+    @Override
+    public InteractionResult onDataStickUse(Player player, ItemStack dataStick) {
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
+        if (ResearchManager.readResearchId(dataStick) != null) {
+            return InteractionResult.PASS;
+        }
+        dataStick.getOrCreateTag().putIntArray("pos", new int[] { getPos().getX(), getPos().getY(), getPos().getZ() });
+        return InteractionResult.SUCCESS;
     }
 
     public class InternalSlot implements ITagSerializable<CompoundTag>, IContentChangeAware {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IDataStickInteractable;
 import com.gregtechceu.gtceu.api.machine.feature.IMachineLife;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.TieredIOPartMachine;
 import com.gregtechceu.gtceu.api.machine.trait.*;
@@ -20,10 +21,13 @@ import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.phys.BlockHitResult;
 
@@ -37,7 +41,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine implements IMachineLife {
+public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine
+                                             implements IMachineLife, IDataStickInteractable {
 
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(
             MEPatternBufferProxyPartMachine.class, TieredIOPartMachine.MANAGED_FIELD_HOLDER);
@@ -137,5 +142,23 @@ public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine impleme
         if (MetaMachine.getMachine(getLevel(), this.bufferPos) instanceof MEPatternBufferPartMachine machine) {
             machine.removeProxy(this);
         }
+    }
+
+    @Override
+    public InteractionResult onDataStickUse(Player player, ItemStack dataStick) {
+        if (dataStick.hasTag()) {
+            if (dataStick.getOrCreateTag().contains("pos", Tag.TAG_INT_ARRAY)) {
+                var posArray = dataStick.getOrCreateTag().getIntArray("pos");
+                var bufferPos = new BlockPos(posArray[0], posArray[1], posArray[2]);
+                setBuffer(bufferPos);
+                return InteractionResult.SUCCESS;
+            }
+        }
+        return InteractionResult.PASS;
+    }
+
+    @Override
+    public InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
+        return InteractionResult.PASS;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferProxyPartMachine.java
@@ -156,9 +156,4 @@ public class MEPatternBufferProxyPartMachine extends TieredIOPartMachine
         }
         return InteractionResult.PASS;
     }
-
-    @Override
-    public InteractionResult onDataStickShiftUse(Player player, ItemStack dataStick) {
-        return InteractionResult.PASS;
-    }
 }


### PR DESCRIPTION
## What
Data stick now copies on sneak + right click and pastes on right click.
Cleanup.

## Implementation Details
Moved from `useOn` to `onItemUseFirst` to be able to use shift clicking.
Machines that implement `IDataStickInteractable` no longer need to implement `IInteractedMachine `.
Removed edge cases from the data stick logic by implementing `IDataStickInteractable`.

## Additionally
Fixes #2556

## Potential Compatibility Issues
Any addon machines that used to implement `IDataStickInteractable` will need to be refactored to match the new method signatures. (although addon machines should probably be handled by the memory card for most cases)
