### PR TITLE
Allow batteries to charge curios

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/ItemMagnetBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ItemMagnetBehavior.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.item;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IElectricItem;
@@ -31,6 +32,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import top.theillusivec4.curios.api.CuriosApi;
 
 import java.util.List;
 
@@ -159,20 +161,26 @@ public class ItemMagnetBehavior implements IInteractionItem, IItemLifeCycle, IAd
     @SubscribeEvent
     public void onItemToss(@NotNull ItemTossEvent event) {
         if (event.getPlayer() == null) return;
+        if (hasMagnet(event.getPlayer())) {
+            event.getEntity().setPickUpDelay(60);
+        }
+    }
 
-        Inventory inventory = event.getPlayer().getInventory();
-        // TODO work out curios compat
-        // if (Platform.isModLoaded(GTValues.MODID_CURIOS)) {
-        // inventory = BaublesModule.getBaublesWrappedInventory(event.getPlayer());
-        // }
-
+    private boolean hasMagnet(@NotNull Player player) {
+        Inventory inventory = player.getInventory();
         for (int i = 0; i < inventory.getContainerSize(); i++) {
             ItemStack stackInSlot = inventory.getItem(i);
             if (isMagnet(stackInSlot) && isActive(stackInSlot)) {
-                event.getEntity().setPickUpDelay(60);
-                return;
+                return true;
             }
         }
+
+        if (!GTCEu.isCuriosLoaded()) {
+            return false;
+        }
+        return CuriosApi.getCuriosInventory(player)
+                .map(curios -> curios.findFirstCurio(i -> isMagnet(i) && isActive(i)).isPresent())
+                .orElse(false);
     }
 
     private boolean isMagnet(@NotNull ItemStack stack) {


### PR DESCRIPTION
## What
Allow batteries to charge curios slots. 
Also fix a TODO in ItemMagnetBehavior to check curio slots when tossing items.

## Implementation Details
For charging, I think charging curios before the main inventory makes more sense?

## Outcome
Fixes #2550