### PR TITLE
Fix shutter cover exposing item and fluid handlers

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2020,6 +2020,8 @@
   "cover.robotic_arm.transfer_mode.keep_exact": "ʇɔɐxƎ dǝǝʞ",
   "cover.robotic_arm.transfer_mode.transfer_any": "ʎuⱯ ɹǝɟsuɐɹ⟘",
   "cover.robotic_arm.transfer_mode.transfer_exact": "ʇɔɐxƎ ʎןddnS",
+  "cover.shutter.message.disabled": "ɹǝʇʇnɥs pǝuǝdO",
+  "cover.shutter.message.enabled": "ɹǝʇʇnɥs pǝsoןƆ",
   "cover.storage.title": "ɹǝʌoƆ ǝbɐɹoʇS",
   "cover.tag_filter.info.0": "suoıssǝɹdxǝ xǝןdɯoɔ sʇdǝɔɔⱯq§",
   "cover.tag_filter.info.1": "ᗡNⱯ = &",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2020,6 +2020,8 @@
   "cover.robotic_arm.transfer_mode.keep_exact": "Keep Exact",
   "cover.robotic_arm.transfer_mode.transfer_any": "Transfer Any",
   "cover.robotic_arm.transfer_mode.transfer_exact": "Supply Exact",
+  "cover.shutter.message.disabled": "Opened shutter",
+  "cover.shutter.message.enabled": "Closed shutter",
   "cover.storage.title": "Storage Cover",
   "cover.tag_filter.info.0": "§bAccepts complex expressions",
   "cover.tag_filter.info.1": "& = AND",

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ShutterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ShutterCover.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.capability.IControllable;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
+import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
 
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
@@ -15,10 +16,12 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -57,6 +60,16 @@ public class ShutterCover extends CoverBehavior implements IControllable {
                     "cover.shutter.message.enabled" : "cover.shutter.message.disabled"));
         }
         return InteractionResult.SUCCESS;
+    }
+
+    @Override
+    public @Nullable IItemHandlerModifiable getItemHandlerCap(IItemHandlerModifiable defaultValue) {
+        return null;
+    }
+
+    @Override
+    public @Nullable IFluidHandlerModifiable getFluidHandlerCap(IFluidHandlerModifiable defaultValue) {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ShutterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ShutterCover.java
@@ -64,12 +64,12 @@ public class ShutterCover extends CoverBehavior implements IControllable {
 
     @Override
     public @Nullable IItemHandlerModifiable getItemHandlerCap(IItemHandlerModifiable defaultValue) {
-        return null;
+        return isWorkingEnabled() ? null : super.getItemHandlerCap(defaultValue);
     }
 
     @Override
     public @Nullable IFluidHandlerModifiable getFluidHandlerCap(IFluidHandlerModifiable defaultValue) {
-        return null;
+        return isWorkingEnabled() ? null : super.getFluidHandlerCap(defaultValue);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -470,6 +470,8 @@ public class LangHandler {
                 "Output: Normal\n\n" + advancedItemDetectorInvertDescription);
         provider.add("cover.advanced_item_detector.max", "Max Items");
         provider.add("cover.advanced_item_detector.min", "Min Items");
+        provider.add("cover.shutter.message.enabled", "Closed shutter");
+        provider.add("cover.shutter.message.disabled", "Opened shutter");
 
         replace(provider, "item.gtceu.bucket", "%s Bucket");
         replace(provider, GTMaterials.FullersEarth.getUnlocalizedName(), "Fuller's Earth");


### PR DESCRIPTION
## What
When a machine has a shutter cover the side shouldn't expose an item/fluid handler.

## Implementation Details
Override the get capabilities methods on the shutter cover.

## Outcome
Fixes #2542