### PR TITLE
Fixes pipe block shape for empty-handed interaction

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -418,7 +418,8 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
                     types = Set.of(pipeTile.getPipeTuneTool());
                 }
 
-                if (types.stream().anyMatch(type -> type.itemTags.stream().anyMatch(held::is)) ||
+                if ((player.isShiftKeyDown() && held.isEmpty() && coverable.hasAnyCover()) ||
+                        types.stream().anyMatch(type -> type.itemTags.stream().anyMatch(held::is)) ||
                         CoverPlaceBehavior.isCoverBehaviorItem(held, coverable::hasAnyCover,
                                 coverDef -> ICoverable.canPlaceCover(coverDef, coverable)) ||
                         (held.getItem() instanceof BlockItem blockItem &&


### PR DESCRIPTION
## What
When the player is empty handed and pressing sneak key while looking at a pipe that has a cover it returns the full block shape.

## Implementation Details
Added the empty handed sneak key condition to the if statement.

## Outcome
Fixes #2571