### PR TITLE
 Refactors ore gen cache entries to expire after 30 seconds

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OreGenCache.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OreGenCache.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -44,16 +45,19 @@ public class OreGenCache {
 
     private final Cache<ChunkPos, List<GeneratedVeinMetadata>> veinMetadataByOrigin = CacheBuilder.newBuilder()
             .maximumSize(veinMetadataCacheSize)
+            .expireAfterAccess(30, TimeUnit.SECONDS)
             .softValues()
             .build();
 
     private final Cache<ChunkPos, List<GeneratedVein>> generatedVeinsByOrigin = CacheBuilder.newBuilder()
             .maximumSize(oreGenerationCacheSize)
+            .expireAfterAccess(30, TimeUnit.SECONDS)
             .softValues()
             .build();
 
     private final Cache<ChunkPos, List<GeneratedIndicators>> indicatorsByOrigin = CacheBuilder.newBuilder()
             .maximumSize(oreIndicatorCacheSize)
+            .expireAfterAccess(30, TimeUnit.SECONDS)
             .softValues()
             .build();
 


### PR DESCRIPTION
In my profiling, the `OreGenCache` can hold on to quite a bit of memory that the GC is not too eager to release even though the values are soft referenced. Putting an expiry time of 30 seconds after the last access should evict unused entries sooner while keeping the used entries around as long as necessary.