### PR TITLE
Allow disabling small/tiny piles of dust via material flags.

### DIFF
--- a/docs/content/Modpacks/Materials-and-Elements/Material-Flags.md
+++ b/docs/content/Modpacks/Materials-and-Elements/Material-Flags.md
@@ -37,6 +37,7 @@ can influence how the material behaves, as well as which items are generated for
 - `GENERATE_SMALL_GEAR`
 - `GENERATE_SPRING`
 - `GENERATE_SPRING_SMALL`
+- `NO_GENERATE_DUST_PILES`
 
 
 ## Other Flags

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialFlags.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialFlags.java
@@ -130,6 +130,14 @@ public class MaterialFlags {
             .build();
 
     /**
+     * Prevent generating small/tiny piles of dust for this material.
+     */
+    public static final MaterialFlag NO_GENERATE_DUST_PILES = new MaterialFlag.Builder(
+            "no_generate_dust_piles")
+            .requireProps(PropertyKey.DUST)
+            .build();
+
+    /**
      * This will prevent material from creating Shapeless recipes for dust to block and vice versa
      * Also preventing extruding and alloy smelting recipes via SHAPE_EXTRUDING/MOLD_BLOCK
      */

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -339,7 +339,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.dustSmall)
             .unificationEnabled(true)
             .generateItem(true)
-            .generationCondition(hasDustProperty);
+            .generationCondition(mat -> mat.hasProperty(PropertyKey.DUST) && !mat.hasFlag(MaterialFlags.NO_GENERATE_DUST_PILES));
 
     // 1/9th of a Dust.
     public static final TagPrefix dustTiny = new TagPrefix("tinyDust")
@@ -351,7 +351,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.dustTiny)
             .unificationEnabled(true)
             .generateItem(true)
-            .generationCondition(hasDustProperty);
+            .generationCondition(mat -> mat.hasProperty(PropertyKey.DUST) && !mat.hasFlag(MaterialFlags.NO_GENERATE_DUST_PILES));
 
     // Dust with impurities. 1 Unit of Main Material and 1/9 - 1/4 Unit of secondary Material
     public static final TagPrefix dustImpure = new TagPrefix("impureDust")

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -339,7 +339,8 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.dustSmall)
             .unificationEnabled(true)
             .generateItem(true)
-            .generationCondition(mat -> mat.hasProperty(PropertyKey.DUST) && !mat.hasFlag(MaterialFlags.NO_GENERATE_DUST_PILES));
+            .generationCondition(
+                    mat -> mat.hasProperty(PropertyKey.DUST) && !mat.hasFlag(MaterialFlags.NO_GENERATE_DUST_PILES));
 
     // 1/9th of a Dust.
     public static final TagPrefix dustTiny = new TagPrefix("tinyDust")
@@ -351,7 +352,8 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.dustTiny)
             .unificationEnabled(true)
             .generateItem(true)
-            .generationCondition(mat -> mat.hasProperty(PropertyKey.DUST) && !mat.hasFlag(MaterialFlags.NO_GENERATE_DUST_PILES));
+            .generationCondition(
+                    mat -> mat.hasProperty(PropertyKey.DUST) && !mat.hasFlag(MaterialFlags.NO_GENERATE_DUST_PILES));
 
     // Dust with impurities. 1 Unit of Main Material and 1/9 - 1/4 Unit of secondary Material
     public static final TagPrefix dustImpure = new TagPrefix("impureDust")

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
@@ -225,9 +225,6 @@ public class GTMaterials {
         plate.setIgnored(BorosilicateGlass);
         foil.setIgnored(BorosilicateGlass);
 
-        dustSmall.setIgnored(Lapotron);
-        dustTiny.setIgnored(Lapotron);
-
         dye.setIgnored(DyeBlack, Items.BLACK_DYE);
         dye.setIgnored(DyeRed, Items.RED_DYE);
         dye.setIgnored(DyeGreen, Items.GREEN_DYE);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
@@ -538,7 +538,7 @@ public class UnknownCompositionMaterials {
         Lapotron = new Material.Builder(GTCEu.id("lapotron"))
                 .gem()
                 .color(0x7497ea).secondaryColor(0x1c0b39).iconSet(DIAMOND)
-                .flags(NO_UNIFICATION)
+                .flags(NO_UNIFICATION, NO_GENERATE_DUST_PILES)
                 .buildAndRegister();
 
         TreatedWood = new Material.Builder(GTCEu.id("treated_wood"))


### PR DESCRIPTION
## What
Add a flag to avoid generating piles of dust for a material. This avoids the need to override `GTCEuStartupEvents.materialModification` to add the material to the ignore list (resulting in the configuration for the material being split into multiple places.

## Implementation Details
This could have been two flags (and my original implementation was), but I suspect the most common use would be to simply remove both types of piles.

## Outcome
Fixes #2514.

## Potential Compatibility Issues
If a modpack has added tiny/small piles of lapotron dust, they'll need to adjust their code to continue to do that.