### PR TITLE
Fix Various KJS issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -220,6 +220,10 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         return renderer(() -> new WorkableTieredHullMachineRenderer(tier, workableModel));
     }
 
+    public MachineBuilder<DEFINITION> simpleGeneratorMachineRenderer(ResourceLocation workableModel) {
+        return renderer(() -> new SimpleGeneratorMachineRenderer(tier, workableModel));
+    }
+
     public MachineBuilder<DEFINITION> workableSteamHullRenderer(boolean isHighPressure,
                                                                 ResourceLocation workableModel) {
         return renderer(() -> new WorkableSteamMachineRenderer(isHighPressure, workableModel));

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -2322,7 +2322,7 @@ public class GTMachines {
                         .recipeModifier(SimpleGeneratorMachine::recipeModifier, true)
                         .addOutputLimit(ItemRecipeCapability.CAP, 0)
                         .addOutputLimit(FluidRecipeCapability.CAP, 0)
-                        .renderer(() -> new SimpleGeneratorMachineRenderer(tier, GTCEu.id("block/generators/" + name)))
+                        .simpleGeneratorMachineRenderer(GTCEu.id("block/generators/" + name))
                         .tooltips(workableTiered(tier, GTValues.V[tier], GTValues.V[tier] * 64, recipeType,
                                 tankScalingFunction.apply(tier), false))
                         .register(),

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -60,6 +60,7 @@ import com.gregtechceu.gtceu.integration.kjs.builders.block.CoilBlockBuilder;
 import com.gregtechceu.gtceu.integration.kjs.builders.machine.*;
 import com.gregtechceu.gtceu.integration.kjs.builders.prefix.BasicTagPrefixBuilder;
 import com.gregtechceu.gtceu.integration.kjs.builders.prefix.OreTagPrefixBuilder;
+import com.gregtechceu.gtceu.integration.kjs.helpers.MachineModifiers;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MaterialStackWrapper;
 import com.gregtechceu.gtceu.integration.kjs.recipe.GTRecipeSchema;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.ExtendedOutputItem;
@@ -282,6 +283,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         event.add("GTRecipeModifiers", GTRecipeModifiers.class);
         event.add("OverclockingLogic", OverclockingLogic.class);
         event.add("ModifierFunction", ModifierFunction.class);
+        event.add("MachineModifiers", MachineModifiers.class);
         event.add("GTWorldGenLayers", WorldGenLayers.class);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -45,6 +45,7 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
+import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder;
 import com.gregtechceu.gtceu.common.data.*;
@@ -280,6 +281,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         event.add("GTOres", GTOres.class);
         event.add("GTRecipeModifiers", GTRecipeModifiers.class);
         event.add("OverclockingLogic", OverclockingLogic.class);
+        event.add("ModifierFunction", ModifierFunction.class);
         event.add("GTWorldGenLayers", WorldGenLayers.class);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeCategoryBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeCategoryBuilder.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
 import com.gregtechceu.gtceu.common.data.GTRecipeCategories;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ItemStackTexture;
@@ -12,12 +13,22 @@ import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
+import dev.latvian.mods.kubejs.client.LangEventJS;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Accessors(chain = true, fluent = true)
 public class GTRecipeCategoryBuilder extends BuilderBase<GTRecipeCategory> {
 
-    public transient String name;
-    public transient GTRecipeType recipeType;
+    private final transient String name;
+    @Setter
+    private transient GTRecipeType recipeType;
+    @Setter
     private transient IGuiTexture icon;
+    @Setter
     private transient boolean isXEIVisible;
+    @Setter
+    private transient String langValue;
 
     public GTRecipeCategoryBuilder(ResourceLocation id) {
         super(id);
@@ -25,16 +36,7 @@ public class GTRecipeCategoryBuilder extends BuilderBase<GTRecipeCategory> {
         recipeType = null;
         icon = null;
         isXEIVisible = true;
-    }
-
-    public GTRecipeCategoryBuilder recipeType(GTRecipeType recipeType) {
-        this.recipeType = recipeType;
-        return this;
-    }
-
-    public GTRecipeCategoryBuilder setIcon(IGuiTexture guiTexture) {
-        this.icon = guiTexture;
-        return this;
+        langValue = null;
     }
 
     public GTRecipeCategoryBuilder setCustomIcon(ResourceLocation location) {
@@ -47,9 +49,11 @@ public class GTRecipeCategoryBuilder extends BuilderBase<GTRecipeCategory> {
         return this;
     }
 
-    public GTRecipeCategoryBuilder isXEIVisible(boolean flag) {
-        this.isXEIVisible = flag;
-        return this;
+    @Override
+    public void generateLang(LangEventJS lang) {
+        super.generateLang(lang);
+        if (langValue != null) lang.add(value.getLanguageKey(), langValue);
+        else lang.add(value.getLanguageKey(), FormattingUtil.toEnglishName(value.name));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -22,7 +22,10 @@ import lombok.experimental.Accessors;
 import java.util.Locale;
 import java.util.function.BiFunction;
 
+import static com.gregtechceu.gtceu.api.GTValues.VLVH;
+import static com.gregtechceu.gtceu.api.GTValues.VLVT;
 import static com.gregtechceu.gtceu.common.data.GTMachines.workableTiered;
+import static com.gregtechceu.gtceu.utils.FormattingUtil.toEnglishName;
 
 @Accessors(fluent = true, chain = true)
 public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
@@ -67,14 +70,15 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                 "example: `builder.machine((holder, tier) => new SimpleTieredMachine(holder, tier, t => t * 3200)`");
         Preconditions.checkNotNull(definition, "You must set a definition function! " +
                 "See GTMachines for examples");
-        MachineDefinition[] definitions = new MachineDefinition[GTValues.TIER_COUNT];
+        MachineDefinition[] definitions = new MachineDefinition[tiers.length];
         for (final int tier : tiers) {
             String tierName = GTValues.VN[tier].toLowerCase(Locale.ROOT);
             MachineBuilder<?> builder = GTRegistration.REGISTRATE.machine(
                     String.format("%s_%s", tierName, this.id.getPath()),
                     holder -> machine.create(holder, tier, tankScalingFunction));
 
-            builder.workableTieredHullRenderer(id.withPrefix("block/machines/"))
+            builder.langValue("%s %s %s".formatted(VLVH[tier], toEnglishName(this.id.getPath()), VLVT[tier]))
+                    .workableTieredHullRenderer(id.withPrefix("block/machines/"))
                     .tier(tier);
             this.definition.apply(tier, builder);
             if (builder.recipeTypes() != null && builder.recipeTypes().length > 0) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -56,10 +56,9 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     @Override
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
-        for (MachineDefinition def : this.value) {
-            if (def != null) {
-                lang.add(def.getDescriptionId(), def.getLangValue());
-            }
+        for (int tier : tiers) {
+            MachineDefinition def = value[tier];
+            lang.add(def.getDescriptionId(), def.getLangValue());
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -22,8 +22,7 @@ import lombok.experimental.Accessors;
 import java.util.Locale;
 import java.util.function.BiFunction;
 
-import static com.gregtechceu.gtceu.api.GTValues.VLVH;
-import static com.gregtechceu.gtceu.api.GTValues.VLVT;
+import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.common.data.GTMachines.workableTiered;
 import static com.gregtechceu.gtceu.utils.FormattingUtil.toEnglishName;
 
@@ -58,7 +57,9 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
         for (MachineDefinition def : this.value) {
-            lang.add(def.getDescriptionId(), def.getLangValue());
+            if (def != null) {
+                lang.add(def.getDescriptionId(), def.getLangValue());
+            }
         }
     }
 
@@ -70,7 +71,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                 "example: `builder.machine((holder, tier) => new SimpleTieredMachine(holder, tier, t => t * 3200)`");
         Preconditions.checkNotNull(definition, "You must set a definition function! " +
                 "See GTMachines for examples");
-        MachineDefinition[] definitions = new MachineDefinition[tiers.length];
+        MachineDefinition[] definitions = new MachineDefinition[TIER_COUNT];
         for (final int tier : tiers) {
             String tierName = GTValues.VN[tier].toLowerCase(Locale.ROOT);
             MachineBuilder<?> builder = GTRegistration.REGISTRATE.machine(

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -42,10 +42,9 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
     @Override
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
-        for (MachineDefinition def : this.value) {
-            if (def != null) {
-                lang.add(def.getDescriptionId(), def.getLangValue());
-            }
+        for (int tier : tiers) {
+            MachineDefinition def = value[tier];
+            lang.add(def.getDescriptionId(), def.getLangValue());
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -55,7 +55,7 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
                 "example: `builder.machine((holder, tier) => new SimpleTieredMachine(holder, tier, t => t * 3200)`");
         Preconditions.checkNotNull(definition, "You must set a definition function! " +
                 "See GTMachines for examples");
-        MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[GTValues.TIER_COUNT];
+        MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[tiers.length];
         for (final int tier : tiers) {
             String tierName = GTValues.VN[tier].toLowerCase(Locale.ROOT);
             MultiblockMachineBuilder builder = GTRegistration.REGISTRATE.multiblock(

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -43,7 +43,9 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
         for (MachineDefinition def : this.value) {
-            lang.add(def.getDescriptionId(), def.getLangValue());
+            if (def != null) {
+                lang.add(def.getDescriptionId(), def.getLangValue());
+            }
         }
     }
 
@@ -55,7 +57,7 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
                 "example: `builder.machine((holder, tier) => new SimpleTieredMachine(holder, tier, t => t * 3200)`");
         Preconditions.checkNotNull(definition, "You must set a definition function! " +
                 "See GTMachines for examples");
-        MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[tiers.length];
+        MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[GTValues.TIER_COUNT];
         for (final int tier : tiers) {
             String tierName = GTValues.VN[tier].toLowerCase(Locale.ROOT);
             MultiblockMachineBuilder builder = GTRegistration.REGISTRATE.multiblock(

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
 
 import net.minecraft.resources.ResourceLocation;
 
+import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import lombok.Getter;
@@ -45,6 +46,12 @@ public class KJSWrappingMachineBuilder extends BuilderBase<MachineDefinition> {
     public KJSWrappingMachineBuilder addDefaultTooltips(boolean addDefaultTooltips) {
         tieredBuilder.addDefaultTooltips(addDefaultTooltips);
         return this;
+    }
+
+    @Override
+    public void generateLang(LangEventJS lang) {
+        super.generateLang(lang);
+        tieredBuilder.generateLang(lang);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.common.registry.GTRegistration;
 
 import net.minecraft.resources.ResourceLocation;
 
+import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import lombok.Getter;
 
@@ -41,6 +42,12 @@ public class KJSWrappingMultiblockBuilder extends BuilderBase<MultiblockMachineD
     public KJSWrappingMultiblockBuilder definition(KJSTieredMultiblockBuilder.DefinitionFunction definition) {
         tieredBuilder.definition(definition);
         return this;
+    }
+
+    @Override
+    public void generateLang(LangEventJS lang) {
+        super.generateLang(lang);
+        tieredBuilder.generateLang(lang);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/MachineModifiers.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/MachineModifiers.java
@@ -1,0 +1,28 @@
+package com.gregtechceu.gtceu.integration.kjs.helpers;
+
+import com.gregtechceu.gtceu.api.machine.SimpleGeneratorMachine;
+import com.gregtechceu.gtceu.api.machine.steam.SimpleSteamMachine;
+import com.gregtechceu.gtceu.api.machine.steam.SteamBoilerMachine;
+import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
+import com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.generator.LargeCombustionEngineMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.generator.LargeTurbineMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.steam.LargeBoilerMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
+
+/**
+ * Collection of Recipe Modifiers for different machines
+ * Makes using them for KJS machines easier
+ */
+@SuppressWarnings("unused")
+public final class MachineModifiers {
+
+    public static RecipeModifier SIMPLE_STEAM = SimpleSteamMachine::recipeModifier;
+    public static RecipeModifier SIMPLE_GENERATOR = SimpleGeneratorMachine::recipeModifier;
+    public static RecipeModifier STEAM_BOILER = SteamBoilerMachine::recipeModifier;
+    public static RecipeModifier LARGE_BOILER = LargeBoilerMachine::recipeModifier;
+    public static RecipeModifier LARGE_TURBINE = LargeTurbineMachine::recipeModifier;
+    public static RecipeModifier LARGE_COMBUSTION_ENGINE = LargeCombustionEngineMachine::recipeModifier;
+    public static RecipeModifier STEAM_PARALLEL_MULTIBLOCK = SteamParallelMultiblockMachine::recipeModifier;
+    public static RecipeModifier FUSION_REACTOR = FusionReactorMachine::recipeModifier;
+}


### PR DESCRIPTION
## What
Fixes #2568 
Fixes HP Steam machines trying to be registered with the `lp_` id
Fixes Steam and Wrapped builders not auto-generating Lang
Adds `langValue` field to Recipe Category Builder to make it easier to add lang
Adds default lang to TieredMachine builder
Adds `simpleGeneratorMachineRenderer` to `MachineBuilder`
Adds new class `MachineModifiers` to provide easy access to the random machine modifiers laying around the codebase
Adds `ModifierFunction` to KJS bindings
