### PR TITLE
Better error messages for `asyncCheckPattern`.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldSavedData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldSavedData.java
@@ -117,10 +117,14 @@ public class MultiblockWorldSavedData extends SavedData {
             if (Platform.isServerNotSafe()) return;
             IN_SERVICE.set(true);
             for (var controller : controllers) {
-                controller.asyncCheckPattern(periodID);
+                try {
+                    controller.asyncCheckPattern(periodID);
+                } catch (Throwable e) {
+                    GTCEu.LOGGER.error("Error while assembling multiblock {}: {}", controller, e.getMessage());
+                }
             }
         } catch (Throwable e) {
-            GTCEu.LOGGER.error("asyncThreadLogic error: {}", e.getMessage());
+            GTCEu.LOGGER.error("Error while assembling multiblocks: {}", e.getMessage());
         } finally {
             IN_SERVICE.set(false);
         }


### PR DESCRIPTION
## What
Show what controller is causing an issue when checking multiblock patterns.  Also, give a more descriptive error message than `asyncThreadLogic error:`.