### PR TITLE
Remove Deprecated Dual Hatch config

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -520,14 +520,6 @@ public class ConfigHolder {
 
         @Configurable
         @Configurable.Comment({
-                "Let Dual Hatch has more ability. (DEPRECATED: does nothing now)",
-                "When enabled it, Dual Hatch will can used to assemble line and so on.",
-                "Need restart Minecraft to apply."
-        })
-        public boolean enableMoreDualHatchAbility = false;
-
-        @Configurable
-        @Configurable.Comment({
                 "Default maximum parallel of steam multiblocks",
                 "Default: 8"
         })


### PR DESCRIPTION
## What
Remove config that does nothing and has been deprecated already.

## Outcome
No more uselesss config.