### PR TITLE
Fix killing/shearing mobs adding empty NBT tag

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -712,7 +712,8 @@ public class ToolHelper {
                 if (shearable.isShearable(tool, world, pos)) {
                     List<ItemStack> shearedDrops = shearable.onSheared(player, tool, world, pos,
                             tool.getEnchantmentLevel(Enchantments.BLOCK_FORTUNE));
-                    boolean relocateMinedBlocks = hasBehaviorsTag(tool) && getBehaviorsTag(tool).getBoolean(RELOCATE_MINED_BLOCKS_KEY);
+                    boolean relocateMinedBlocks = hasBehaviorsTag(tool) &&
+                            getBehaviorsTag(tool).getBoolean(RELOCATE_MINED_BLOCKS_KEY);
                     Iterator<ItemStack> iter = shearedDrops.iterator();
                     while (iter.hasNext()) {
                         ItemStack stack = iter.next();

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -712,7 +712,7 @@ public class ToolHelper {
                 if (shearable.isShearable(tool, world, pos)) {
                     List<ItemStack> shearedDrops = shearable.onSheared(player, tool, world, pos,
                             tool.getEnchantmentLevel(Enchantments.BLOCK_FORTUNE));
-                    boolean relocateMinedBlocks = getBehaviorsTag(tool).getBoolean(RELOCATE_MINED_BLOCKS_KEY);
+                    boolean relocateMinedBlocks = hasBehaviorsTag(tool) && getBehaviorsTag(tool).getBoolean(RELOCATE_MINED_BLOCKS_KEY);
                     Iterator<ItemStack> iter = shearedDrops.iterator();
                     while (iter.hasNext()) {
                         ItemStack stack = iter.next();

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/ToolEventHandlers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/ToolEventHandlers.java
@@ -194,6 +194,7 @@ public class ToolEventHandlers {
 
     public static Collection<ItemEntity> onPlayerKilledEntity(ItemStack tool, Player player,
                                                               Collection<ItemEntity> drops) {
+        if (!ToolHelper.hasBehaviorsTag(tool)) return drops;
         CompoundTag behaviorTag = ToolHelper.getBehaviorsTag(tool);
 
         if (behaviorTag.getBoolean(ToolHelper.RELOCATE_MOB_DROPS_KEY)) {


### PR DESCRIPTION
## What
fix killing or shearing mobs unconditionally adding the GT.Behaviours tag without checking if it exists first

## Implementation Details
just an extra if check.

## Outcome
no more random `GT.Behaviours:{}` on your torches and planks
