### PR TITLE
Add overrides for builder accessors

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.data.RotationState;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.item.MetaMachineItem;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
@@ -124,6 +125,16 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     public MultiblockMachineBuilder recoveryStacks(Supplier<ItemStack[]> stacks) {
         this.recoveryItems.add(stacks);
         return this;
+    }
+
+    @Override
+    public MultiblockMachineBuilder definition(Function<ResourceLocation, MultiblockMachineDefinition> definition) {
+        return (MultiblockMachineBuilder) super.definition(definition);
+    }
+
+    @Override
+    public MultiblockMachineBuilder machine(Function<IMachineBlockEntity, MetaMachine> machine) {
+        return (MultiblockMachineBuilder) super.machine(machine);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -42,6 +42,7 @@ import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.builders.ItemBuilder;
 import com.tterrag.registrate.util.nullness.NonNullConsumer;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import lombok.Getter;
 import lombok.Setter;
@@ -376,6 +377,7 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     }
 
     @Override
+    @HideFromJS
     public MultiblockMachineDefinition register() {
         var definition = (MultiblockMachineDefinition) super.register();
         definition.setGenerator(generator);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeCategoryBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeCategoryBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
@@ -53,7 +54,7 @@ public class GTRecipeCategoryBuilder extends BuilderBase<GTRecipeCategory> {
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
         if (langValue != null) lang.add(value.getLanguageKey(), langValue);
-        else lang.add(value.getLanguageKey(), FormattingUtil.toEnglishName(value.name));
+        else lang.add(GTCEu.MOD_ID, value.getLanguageKey(), FormattingUtil.toEnglishName(value.name));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
@@ -63,7 +64,7 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
         super.generateLang(lang);
         lang.add(value.getDescriptionId(), value.getLangValue());
         if (hp != null) {
-            lang.add(hp.getDescriptionId(), hp.getLangValue());
+            lang.add(GTCEu.MOD_ID, hp.getDescriptionId(), hp.getLangValue());
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
@@ -57,7 +58,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
         super.generateLang(lang);
         for (int tier : tiers) {
             MachineDefinition def = value[tier];
-            lang.add(def.getDescriptionId(), def.getLangValue());
+            lang.add(GTCEu.MOD_ID, def.getDescriptionId(), def.getLangValue());
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
@@ -44,7 +45,7 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
         super.generateLang(lang);
         for (int tier : tiers) {
             MachineDefinition def = value[tier];
-            lang.add(def.getDescriptionId(), def.getLangValue());
+            lang.add(GTCEu.MOD_ID, def.getDescriptionId(), def.getLangValue());
         }
     }
 


### PR DESCRIPTION
## What
`MachineBuilder` fields which were given `@Setter` in #2574 were not overridden in `MultiblockMachineBuilder`, so were returning an object of wrong type.