### PR TITLE
Add Production Efficiency Modifier

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -363,6 +363,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
         if (handleFuelRecipe()) {
             if (!machine.beforeWorking(recipe)) {
                 setStatus(Status.IDLE);
+                consecutiveRecipes = 0;
                 progress = 0;
                 duration = 0;
                 isActive = false;
@@ -461,6 +462,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
     public void onRecipeFinish() {
         machine.afterWorking();
         if (lastRecipe != null) {
+            consecutiveRecipes++;
             lastRecipe.postWorking(this.machine);
             handleRecipeIO(lastRecipe, IO.OUT);
             if (machine.alwaysTryModifyRecipe()) {
@@ -481,7 +483,6 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                     lastRecipe.matchTickRecipe(this.machine).isSuccess() &&
                     lastRecipe.checkConditions(this).isSuccess()) {
                 setupRecipe(lastRecipe);
-                if (isActive) consecutiveRecipes++;
             } else {
                 if (suspendAfterFinish) {
                     setStatus(Status.SUSPEND);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -143,6 +143,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
         recipeDirty = false;
         lastRecipe = null;
         lastOriginRecipe = null;
+        consecutiveRecipes = 0;
         progress = 0;
         duration = 0;
         isActive = false;
@@ -479,8 +480,8 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                     lastRecipe.matchRecipe(this.machine).isSuccess() &&
                     lastRecipe.matchTickRecipe(this.machine).isSuccess() &&
                     lastRecipe.checkConditions(this).isSuccess()) {
-                consecutiveRecipes++;
                 setupRecipe(lastRecipe);
+                if (isActive) consecutiveRecipes++;
             } else {
                 if (suspendAfterFinish) {
                     setStatus(Status.SUSPEND);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -75,6 +75,10 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
     @Persisted
     @DescSynced
     protected GTRecipe lastRecipe;
+    @Getter
+    @Persisted
+    @DescSynced
+    protected int consecutiveRecipes = 0; // Consecutive recipes that have been run
     /**
      * safe, it is the origin recipe before {@link IRecipeLogicMachine#fullModifyRecipe(GTRecipe)}'
      * which can be found
@@ -368,7 +372,6 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                 if (lastRecipe != null && !recipe.equals(lastRecipe)) {
                     chanceCaches.clear();
                 }
-
                 recipeDirty = false;
                 lastRecipe = recipe;
                 setStatus(Status.WORKING);
@@ -476,6 +479,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                     lastRecipe.matchRecipe(this.machine).isSuccess() &&
                     lastRecipe.matchTickRecipe(this.machine).isSuccess() &&
                     lastRecipe.checkConditions(this).isSuccess()) {
+                consecutiveRecipes++;
                 setupRecipe(lastRecipe);
             } else {
                 if (suspendAfterFinish) {
@@ -484,6 +488,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                 } else {
                     setStatus(Status.IDLE);
                 }
+                consecutiveRecipes = 0;
                 progress = 0;
                 duration = 0;
                 isActive = false;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/EfficiencyModifier.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/EfficiencyModifier.java
@@ -7,11 +7,17 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Recipe Modifier that scales recipe duration based on the number of times the recipe has been consecutively run
+ * Multiplies duration by a base amount, then by a multiplicative amount relative to the number of runs, up to a set
+ * limit
+ */
 public class EfficiencyModifier implements RecipeModifier {
 
     private final double baseMultiplier;
     private final double efficiency;
     private final double hardCap;
+    private final double heuristic;
 
     private EfficiencyModifier(double baseMultiplier, double efficiency, double hardCap) {
         Preconditions.checkArgument(baseMultiplier > 0, "Base multiplier must be > 0: %s", baseMultiplier);
@@ -20,6 +26,7 @@ public class EfficiencyModifier implements RecipeModifier {
         this.baseMultiplier = baseMultiplier;
         this.efficiency = efficiency;
         this.hardCap = hardCap;
+        this.heuristic = 300 * efficiency * efficiency;
     }
 
     /**
@@ -35,11 +42,11 @@ public class EfficiencyModifier implements RecipeModifier {
     }
 
     public static EfficiencyModifier of(double baseMultiplier, double efficiency) {
-        return of(baseMultiplier, efficiency, 0.25);
+        return of(baseMultiplier, efficiency, 0.5);
     }
 
     public static EfficiencyModifier of(double efficiency) {
-        return of(2, efficiency, 0.25);
+        return of(2, efficiency, 0.5);
     }
 
     /**
@@ -56,9 +63,14 @@ public class EfficiencyModifier implements RecipeModifier {
         if (!(machine instanceof IRecipeLogicMachine rlm)) {
             return RecipeModifier.nullWrongType(IRecipeLogicMachine.class, machine);
         }
+        if (recipe.duration <= 1) return ModifierFunction.IDENTITY;
         int runs = rlm.getRecipeLogic().getConsecutiveRecipes();
+        double mult;
+        // Heuristic to not do insane floating point math - if you need more than this to get to the cap, seek help
+        if (runs > heuristic) mult = hardCap;
+        else mult = Math.max(hardCap, baseMultiplier * Math.pow(efficiency, runs));
         return ModifierFunction.builder()
-                .durationMultiplier(Math.max(hardCap, baseMultiplier * Math.pow(efficiency, runs)))
+                .durationMultiplier(mult)
                 .build();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/EfficiencyModifier.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/EfficiencyModifier.java
@@ -4,33 +4,61 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 
+import com.google.common.base.Preconditions;
 import org.jetbrains.annotations.NotNull;
 
 public class EfficiencyModifier implements RecipeModifier {
 
     private final double baseMultiplier;
     private final double efficiency;
+    private final double hardCap;
 
-    private EfficiencyModifier(double baseMultiplier, double efficiency) {
+    private EfficiencyModifier(double baseMultiplier, double efficiency, double hardCap) {
+        Preconditions.checkArgument(baseMultiplier > 0, "Base multiplier must be > 0: %s", baseMultiplier);
+        Preconditions.checkArgument(efficiency > 0, "Efficiency must be > 0: %s", efficiency);
+        Preconditions.checkArgument(hardCap >= 0, "Hard cap must be >= 0: %s", hardCap);
         this.baseMultiplier = baseMultiplier;
         this.efficiency = efficiency;
+        this.hardCap = hardCap;
+    }
+
+    /**
+     * Creates an Efficiency Modifier with the given parameters
+     * 
+     * @param baseMultiplier base duration multiplier to be applied to the recipe
+     * @param efficiency     multiplier to be applied per consecutive recipe run
+     * @param hardCap        limit on how low the duration can be multiplied
+     * @return Efficiency Modifier
+     */
+    public static EfficiencyModifier of(double baseMultiplier, double efficiency, double hardCap) {
+        return new EfficiencyModifier(baseMultiplier, efficiency, hardCap);
     }
 
     public static EfficiencyModifier of(double baseMultiplier, double efficiency) {
-        return new EfficiencyModifier(baseMultiplier, efficiency);
+        return of(baseMultiplier, efficiency, 0.25);
     }
 
     public static EfficiencyModifier of(double efficiency) {
-        return new EfficiencyModifier(2, efficiency);
+        return of(2, efficiency, 0.25);
     }
 
+    /**
+     * Efficiency recipe modifier
+     * <p>
+     * Duration will be multiplied by <code>base × efficiency<sup>runs</sup></code>
+     * 
+     * @param machine an {@link IRecipeLogicMachine}
+     * @param recipe  recipe
+     * @return Efficiency Modifier
+     */
     @Override
     public @NotNull ModifierFunction getModifier(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
         if (!(machine instanceof IRecipeLogicMachine rlm)) {
             return RecipeModifier.nullWrongType(IRecipeLogicMachine.class, machine);
         }
+        int runs = rlm.getRecipeLogic().getConsecutiveRecipes();
         return ModifierFunction.builder()
-                .durationMultiplier(baseMultiplier * Math.pow(efficiency, rlm.getRecipeLogic().getConsecutiveRecipes()))
+                .durationMultiplier(Math.max(hardCap, baseMultiplier * Math.pow(efficiency, runs)))
                 .build();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/EfficiencyModifier.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/EfficiencyModifier.java
@@ -1,0 +1,36 @@
+package com.gregtechceu.gtceu.api.recipe.modifier;
+
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+
+import org.jetbrains.annotations.NotNull;
+
+public class EfficiencyModifier implements RecipeModifier {
+
+    private final double baseMultiplier;
+    private final double efficiency;
+
+    private EfficiencyModifier(double baseMultiplier, double efficiency) {
+        this.baseMultiplier = baseMultiplier;
+        this.efficiency = efficiency;
+    }
+
+    public static EfficiencyModifier of(double baseMultiplier, double efficiency) {
+        return new EfficiencyModifier(baseMultiplier, efficiency);
+    }
+
+    public static EfficiencyModifier of(double efficiency) {
+        return new EfficiencyModifier(2, efficiency);
+    }
+
+    @Override
+    public @NotNull ModifierFunction getModifier(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
+        if (!(machine instanceof IRecipeLogicMachine rlm)) {
+            return RecipeModifier.nullWrongType(IRecipeLogicMachine.class, machine);
+        }
+        return ModifierFunction.builder()
+                .durationMultiplier(baseMultiplier * Math.pow(efficiency, rlm.getRecipeLogic().getConsecutiveRecipes()))
+                .build();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
@@ -34,8 +34,14 @@ import java.util.Map;
 @FunctionalInterface
 public interface ModifierFunction {
 
-    ModifierFunction NULL = r -> null;
-    ModifierFunction IDENTITY = r -> r;
+    /**
+     * Use this static to denote that the recipe should be cancelled
+     */
+    ModifierFunction NULL = recipe -> null;
+    /**
+     * Use this static to denote that the recipe doesn't get modified
+     */
+    ModifierFunction IDENTITY = recipe -> recipe;
 
     /**
      * Applies this modifier to the passed recipe
@@ -54,7 +60,7 @@ public interface ModifierFunction {
      * @return The composed function of {@code this.apply(before.apply(recipe))}
      */
     default ModifierFunction compose(@NotNull ModifierFunction before) {
-        return r -> applySafe(before.apply(r));
+        return recipe -> applySafe(before.apply(recipe));
     }
 
     /**
@@ -64,7 +70,7 @@ public interface ModifierFunction {
      * @return The composed function of {@code after.apply(this.apply(recipe))}
      */
     default ModifierFunction andThen(@NotNull ModifierFunction after) {
-        return r -> after.applySafe(apply(r));
+        return recipe -> after.applySafe(apply(recipe));
     }
 
     private GTRecipe applySafe(@Nullable GTRecipe recipe) {
@@ -167,8 +173,8 @@ public interface ModifierFunction {
             };
         }
 
-        private Map<RecipeCapability<?>, List<Content>> applyAllButEU(ContentModifier cm,
-                                                                      Map<RecipeCapability<?>, List<Content>> contents) {
+        private static Map<RecipeCapability<?>, List<Content>> applyAllButEU(ContentModifier cm,
+                                                                             Map<RecipeCapability<?>, List<Content>> contents) {
             Map<RecipeCapability<?>, List<Content>> copyContents = new HashMap<>();
             for (var entry : contents.entrySet()) {
                 var cap = entry.getKey();

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
@@ -263,6 +263,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
                         lastRecipe.matchTickRecipe(this.machine).isSuccess() &&
                         lastRecipe.checkConditions(this).isSuccess()) {
                     setupRecipe(lastRecipe);
+                    if (isActive) consecutiveRecipes++;
                 } else {
                     if (suspendAfterFinish) {
                         setStatus(Status.SUSPEND);
@@ -270,6 +271,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
                     } else {
                         setStatus(Status.IDLE);
                     }
+                    consecutiveRecipes = 0;
                     progress = 0;
                     duration = 0;
                     isActive = false;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -267,6 +267,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         event.add("GTMedicalConditions", GTMedicalConditions.class);
         event.add("GTRecipeModifiers", GTRecipeModifiers.class);
         event.add("OverclockingLogic", OverclockingLogic.class);
+        event.add("MachineModifiers", MachineModifiers.class);
         event.add("ModifierFunction", ModifierFunction.class);
         event.add("RecipeCapability", RecipeCapability.class);
         event.add("ChanceLogic", ChanceLogic.class);
@@ -293,10 +294,6 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         event.add("GTLayerPattern", GTLayerPattern.class);
         event.add("GTDikeBlockDefinition", DikeVeinGenerator.DikeBlockDefinition.class);
         event.add("GTOres", GTOres.class);
-        event.add("GTRecipeModifiers", GTRecipeModifiers.class);
-        event.add("OverclockingLogic", OverclockingLogic.class);
-        event.add("ModifierFunction", ModifierFunction.class);
-        event.add("MachineModifiers", MachineModifiers.class);
         event.add("GTWorldGenLayers", WorldGenLayers.class);
         // MaterialColor stuff, for TagPrefix
     }


### PR DESCRIPTION
## What
This PR adds a new RecipeModifier, mainly to be used as an example of the RecipeModifier system, that will decrease the duration of a recipe for each consecutive recipe run by the machine.
This resets upon recipe change, and will grow up to a specified hard cap.

## Implementation Details
Added additional field to RecipeLogic which is incremented (or reset) in `onRecipeFinish`

## Outcome
Fun modifier for addons/packdevs
