### PR TITLE
Updates registrate dependency

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
 
         // Forge
         def forgeVersion = "47.1.47"
-        def registrateForgeVersion = "MC1.20-1.3.3"
+        def registrateForgeVersion = "MC1.20-1.3.11"
         def topForgeVersion = "1.20.1-10.0.1-3"
         def jadeForgeVersion = "11.6.3"
         def curiosForgeVersion = "5.9.1"


### PR DESCRIPTION
Our forge registrate was on 1.3.3 now its on the current version 