### PR TITLE
Add ability to ignore tag prefixes when building Material

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.*;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.tag.TagUtil;
 import com.gregtechceu.gtceu.api.fluids.FluidBuilder;
 import com.gregtechceu.gtceu.api.fluids.FluidState;
@@ -531,6 +532,7 @@ public class Material implements Comparable<Material> {
         private final MaterialInfo materialInfo;
         private final MaterialProperties properties;
         private final MaterialFlags flags;
+        private Set<TagPrefix> ignoredTagPrefixes = null;
 
         /*
          * The temporary list of components for this Material.
@@ -1010,6 +1012,17 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        /**
+         * Add {@link TagPrefixes} to be ignored by this Material.<br>
+         */
+        public Builder ignoredTagPrefixes(TagPrefix... prefixes) {
+            if (this.ignoredTagPrefixes == null) {
+                this.ignoredTagPrefixes = new HashSet<>();
+            }
+            this.ignoredTagPrefixes.addAll(Arrays.asList(prefixes));
+            return this;
+        }
+
         public Builder element(Element element) {
             this.materialInfo.element = element;
             return this;
@@ -1239,6 +1252,9 @@ public class Material implements Comparable<Material> {
             var mat = new Material(materialInfo, properties, flags);
             materialInfo.verifyInfo(properties, averageRGB);
             mat.registerMaterial();
+            if (ignoredTagPrefixes != null) {
+                ignoredTagPrefixes.forEach(p -> p.setIgnored(mat));
+            }
             return mat;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
@@ -225,9 +225,6 @@ public class GTMaterials {
         plate.setIgnored(BorosilicateGlass);
         foil.setIgnored(BorosilicateGlass);
 
-        dustSmall.setIgnored(Lapotron);
-        dustTiny.setIgnored(Lapotron);
-
         dye.setIgnored(DyeBlack, Items.BLACK_DYE);
         dye.setIgnored(DyeRed, Items.RED_DYE);
         dye.setIgnored(DyeGreen, Items.GREEN_DYE);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
@@ -11,6 +11,7 @@ import com.gregtechceu.gtceu.common.data.GTMedicalConditions;
 
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags.*;
 import static com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet.*;
+import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
 
 public class UnknownCompositionMaterials {
@@ -542,6 +543,7 @@ public class UnknownCompositionMaterials {
                 .gem()
                 .color(0x7497ea).secondaryColor(0x1c0b39).iconSet(DIAMOND)
                 .flags(NO_UNIFICATION)
+                .ignoredTagPrefixes(dustTiny, dustSmall)
                 .buildAndRegister();
 
         TreatedWood = new Material.Builder(GTCEu.id("treated_wood"))


### PR DESCRIPTION
## What
This allows setting `TagPrefix`es to be ignored for a material. This is particularly useful for defining materials in KubeJS, 
where you currently need to override GTCEuStartupEvents.materialModification to add the material to the ignore list (resulting in the configuration for the material being split into multiple places.


## Outcome
This add a new material builder function `.ignoredTagPrefixes`, which takes a list of `TagPrefix`es, and calls `.addIgnored` on each of the with the material, when it is registered.
Fixes #2514. Closes #2595.