### PR TITLE
Add LEVEL state to PotionFluid

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/fluid/potion/PotionFluid.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/fluid/potion/PotionFluid.java
@@ -14,6 +14,8 @@ import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.fluids.FluidStack;
@@ -30,6 +32,13 @@ public class PotionFluid extends ForgeFlowingFluid {
         super(properties
                 .bucket(() -> Items.AIR)
                 .block(() -> (LiquidBlock) Blocks.WATER));
+        registerDefaultState(getStateDefinition().any().setValue(LEVEL, 7));
+    }
+
+    @Override
+    protected void createFluidStateDefinition(StateDefinition.Builder<Fluid, FluidState> builder) {
+        super.createFluidStateDefinition(builder);
+        builder.add(LEVEL);
     }
 
     public static FluidStack of(int amount, Potion potion) {
@@ -74,7 +83,7 @@ public class PotionFluid extends ForgeFlowingFluid {
 
     @Override
     public int getAmount(FluidState state) {
-        return 0;
+        return state.getValue(LEVEL);
     }
 
     public static class PotionFluidType extends FluidType {


### PR DESCRIPTION
## What
This PR changes the getAmount() method in PotionFluid to not return a static value of `0`. It is needed so that calling `defaultFluidState().createLegacyBlock().getBlock()` on the flowing potion fluid doesn't error. 


## Implementation Details
Adds the IntegerProperty LEVEL to the fluid state with a default value of 7. 

## Outcome
The getAmount method of PotionFluid returns the value associated with the LEVEL property.
Resolves: #2644 

## Additional Information
When calling `defaultFluidState().createLegacyBlock().getBlock()` the fluid's getAmount() method is utilized to determine what value to set for an IntegerProperty that ranges from 0 to 15. If getAmount() returns 0, the value it attempts to set is 16 and results in `Cannot set property IntegerProperty{name=level, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]} to 16 on Block{minecraft:water}, it is not an allowed value`. 
I cannot say I understand this well if at all, but my rudimentary understanding is that a block is being constructed of flowing fluid, and the issue arises when the amount of flowing fluid is none.