### PR TITLE
Fix KJS replacement order & custom json recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -55,6 +55,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -874,6 +875,18 @@ public interface GTRecipeSchema {
         /*
          * KubeJS overrides
          */
+
+        @Override
+        public ResourceLocation getOrCreateId() {
+            if (id == null) {
+                String prefix = type.id.getNamespace() + ":";
+                String path = "%s/%s".formatted(type.id.getPath(), "kjs_custom");
+                id = type.event.takeId(this, prefix, path);
+                String pathWithoutType = StringUtils.substringAfter(id.getPath(), '/');
+                idWithoutType = new ResourceLocation(id.getNamespace(), pathWithoutType);
+            }
+            return id;
+        }
 
         @Override
         public @Nullable Recipe<?> createRecipe() {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/CapabilityMapComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/CapabilityMapComponent.java
@@ -15,8 +15,8 @@ import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.ReplacementMatch;
 import dev.latvian.mods.kubejs.recipe.component.ComponentRole;
 import dev.latvian.mods.kubejs.recipe.component.RecipeComponent;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public record CapabilityMapComponent(boolean isOutput) implements RecipeComponent<CapabilityMap> {
@@ -77,7 +77,7 @@ public record CapabilityMapComponent(boolean isOutput) implements RecipeComponen
                         GTRegistries.RECIPE_CAPABILITIES.get(key) != null) {
                     RecipeCapability<?> cap = GTRegistries.RECIPE_CAPABILITIES.get(key);
                     var pair = GTRecipeComponents.VALID_CAPS.get(cap);
-                    Set<Content> result = new HashSet<>();
+                    Set<Content> result = new ObjectLinkedOpenHashSet<>();
                     JsonArray value = GsonHelper.getAsJsonArray(json, key, new JsonArray());
                     for (int i = 0; i < value.size(); ++i) {
                         result.add((isOutput ? pair.getSecond() : pair.getFirst()).read(recipe, value.get(i)));


### PR DESCRIPTION
## What
When replacing inputs/outputs, the original recipe is deserialized from JSON and its contents are stored in a Set. Previously, it was a normal HashSet which did not maintain the original order and jumbled the order of contents. It has been changed to a LinkedHashSet in order to preserve this order.

When a custom recipe is defined via JSONObject in `event.custom`, the recipe builder tries to pull the `idWithoutType` which is `null` since that cannot be set via JSON. We can manually set this (and the actual recipe ID) by overriding `RecipeJS#getOrCreateID` which generates the ID for these custom recipes.
Fixes #2281 

## Outcome
Kubers rejoice