### PR TITLE
Fix Steam and Plasma turbines requiring mufflers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
@@ -580,6 +580,15 @@ public class GTMachineUtils {
                                                                    Supplier<? extends Block> gear,
                                                                    ResourceLocation casingTexture,
                                                                    ResourceLocation overlayModel) {
+        return registerLargeTurbine(name, tier, recipeType, casing, gear, casingTexture, overlayModel, true);
+    }
+
+    public static MultiblockMachineDefinition registerLargeTurbine(String name, int tier, GTRecipeType recipeType,
+                                                                   Supplier<? extends Block> casing,
+                                                                   Supplier<? extends Block> gear,
+                                                                   ResourceLocation casingTexture,
+                                                                   ResourceLocation overlayModel,
+                                                                   boolean needsMuffler) {
         return REGISTRATE.multiblock(name, holder -> new LargeTurbineMachine(holder, tier))
                 .rotationState(RotationState.ALL)
                 .recipeType(recipeType)
@@ -611,7 +620,7 @@ public class GTMachineUtils {
                                         .or(abilities(PartAbility.OUTPUT_ENERGY)).setExactLimit(1))
                         .where('H', blocks(casing.get())
                                 .or(autoAbilities(definition.getRecipeTypes(), false, false, true, true, true, true))
-                                .or(autoAbilities(true, true, false)))
+                                .or(autoAbilities(true, needsMuffler, false)))
                         .build())
                 .recoveryItems(
                         () -> new ItemLike[] {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -929,20 +929,23 @@ public class GTMultiMachines {
             GTRecipeTypes.STEAM_TURBINE_FUELS,
             CASING_STEEL_TURBINE, CASING_STEEL_GEARBOX,
             GTCEu.id("block/casings/mechanic/machine_casing_turbine_steel"),
-            GTCEu.id("block/multiblock/generator/large_steam_turbine"));
+            GTCEu.id("block/multiblock/generator/large_steam_turbine"),
+            false);
 
     public static final MultiblockMachineDefinition LARGE_GAS_TURBINE = registerLargeTurbine("gas_large_turbine", EV,
             GTRecipeTypes.GAS_TURBINE_FUELS,
             CASING_STAINLESS_TURBINE, CASING_STAINLESS_STEEL_GEARBOX,
             GTCEu.id("block/casings/mechanic/machine_casing_turbine_stainless_steel"),
-            GTCEu.id("block/multiblock/generator/large_gas_turbine"));
+            GTCEu.id("block/multiblock/generator/large_gas_turbine"),
+            true);
 
     public static final MultiblockMachineDefinition LARGE_PLASMA_TURBINE = registerLargeTurbine("plasma_large_turbine",
             IV,
             GTRecipeTypes.PLASMA_GENERATOR_FUELS,
             CASING_TUNGSTENSTEEL_TURBINE, CASING_TUNGSTENSTEEL_GEARBOX,
             GTCEu.id("block/casings/mechanic/machine_casing_turbine_tungstensteel"),
-            GTCEu.id("block/multiblock/generator/large_plasma_turbine"));
+            GTCEu.id("block/multiblock/generator/large_plasma_turbine"),
+            false);
 
     public static final MultiblockMachineDefinition ACTIVE_TRANSFORMER = REGISTRATE
             .multiblock("active_transformer", ActiveTransformerMachine::new)


### PR DESCRIPTION
## What
Large Steam Turbine and Large Plasma Turbine no longer require a muffler as it makes no sense for them to generate emissions. Large Gas Turbine still needs a muffler.

## Implementation Details
New parameter `needsMuffler` added to `GTMachineUtils#registerLargeTurbine`, which is forwarded to the appropriate `autoAbilities` method call. The previous method signature is still available as an overload for backwards compatibility (will call new method with `needsMuffler` set to true).

## Outcome
Large Steam Turbine and Large Plasma Turbine no longer generate pollution. Addons can create their own turbines and choose whether or not to require a muffler.

Fixes: #2290