### PR TITLE
Fix furnace recipe serialization

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/category/GTRecipeCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/category/GTRecipeCategory.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 
+import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ItemStackTexture;
 
@@ -67,6 +68,11 @@ public class GTRecipeCategory {
 
     public void addRecipe(GTRecipe recipe) {
         recipeType.addToCategoryMap(this, recipe);
+    }
+
+    public boolean shouldRegisterDisplays() {
+        return (isXEIVisible || Platform.isDevEnv()) &&
+                this != GTRecipeTypes.FURNACE_RECIPES.getCategory();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeCategories.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeCategories.java
@@ -14,12 +14,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class GTRecipeCategories {
 
-    // Alias for recipes that shouldn't be in the category registry
-    public static final GTRecipeCategory DUMMY = GTRecipeTypes.DUMMY_RECIPES.getCategory();
-    // Alias for recipes you don't want visible in XEI
-    public static final GTRecipeCategory HIDDEN = register("hidden", GTRecipeTypes.DUMMY_RECIPES)
-            .setXEIVisible(false);
-
     public static final GTRecipeCategory ARC_FURNACE_RECYCLING = register("arc_furnace_recycling",
             GTRecipeTypes.ARC_FURNACE_RECIPES)
             .setIcon(GuiTextures.ARC_FURNACE_RECYCLING_CATEGORY);
@@ -45,9 +39,6 @@ public class GTRecipeCategories {
     }
 
     public static void init() {
-        // Remove these categories, so they don't get registered in XEI at all, dev or not
-        GTRegistries.RECIPE_CATEGORIES.remove(DUMMY.registryKey);
-        GTRegistries.RECIPE_CATEGORIES.remove(GTRecipeTypes.FURNACE_RECIPES.getCategory().registryKey);
         if (GTCEu.isKubeJSLoaded()) {
             GTRegistryInfo.registerFor(GTRegistries.RECIPE_CATEGORIES.getRegistryName());
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/GTEMIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/GTEMIPlugin.java
@@ -23,7 +23,6 @@ import com.gregtechceu.gtceu.integration.emi.recipe.GTEmiRecipeHandler;
 import com.gregtechceu.gtceu.integration.emi.recipe.GTRecipeEMICategory;
 
 import com.lowdragmc.lowdraglib.LDLib;
-import com.lowdragmc.lowdraglib.Platform;
 import com.lowdragmc.lowdraglib.gui.modular.ModularUIContainer;
 
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -58,7 +57,7 @@ public class GTEMIPlugin implements EmiPlugin {
         if (ConfigHolder.INSTANCE.machines.doBedrockOres)
             registry.addCategory(GTBedrockOreEmiCategory.CATEGORY);
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
-            if (Platform.isDevEnv() || category.isXEIVisible()) {
+            if (category.shouldRegisterDisplays()) {
                 registry.addCategory(GTRecipeEMICategory.CATEGORIES.apply(category));
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/GTRecipeEMICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/GTRecipeEMICategory.java
@@ -32,7 +32,7 @@ public class GTRecipeEMICategory extends EmiRecipeCategory {
 
     public static void registerDisplays(EmiRegistry registry) {
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
-            if (!category.isXEIVisible() && !Platform.isDevEnv()) continue;
+            if (!category.shouldRegisterDisplays()) continue;
             var type = category.getRecipeType();
             if (category == type.getCategory()) type.buildRepresentativeRecipes();
             EmiRecipeCategory emiCategory = CATEGORIES.apply(category);

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/GTJEIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/GTJEIPlugin.java
@@ -20,7 +20,6 @@ import com.gregtechceu.gtceu.integration.jei.recipe.GTRecipeJEICategory;
 import com.gregtechceu.gtceu.integration.jei.subtype.PotionFluidSubtypeInterpreter;
 
 import com.lowdragmc.lowdraglib.LDLib;
-import com.lowdragmc.lowdraglib.Platform;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -70,7 +69,7 @@ public class GTJEIPlugin implements IModPlugin {
         if (ConfigHolder.INSTANCE.machines.doBedrockOres)
             registry.addRecipeCategories(new GTBedrockOreInfoCategory(jeiHelpers));
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
-            if (Platform.isDevEnv() || category.isXEIVisible()) {
+            if (category.shouldRegisterDisplays()) {
                 registry.addRecipeCategories(new GTRecipeJEICategory(jeiHelpers, category));
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
@@ -50,7 +50,7 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipeWrapper
 
     public static void registerRecipes(IRecipeRegistration registration) {
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
-            if (!category.isXEIVisible() && !Platform.isDevEnv()) continue;
+            if (!category.shouldRegisterDisplays()) continue;
             var type = category.getRecipeType();
             if (category == type.getCategory()) type.buildRepresentativeRecipes();
             var wrapped = type.getRecipesInCategory(category).stream()

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
@@ -18,8 +18,6 @@ import com.gregtechceu.gtceu.integration.rei.orevein.GTBedrockOreDisplayCategory
 import com.gregtechceu.gtceu.integration.rei.orevein.GTOreVeinDisplayCategory;
 import com.gregtechceu.gtceu.integration.rei.recipe.GTRecipeREICategory;
 
-import com.lowdragmc.lowdraglib.Platform;
-
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.alchemy.Potion;
@@ -60,7 +58,7 @@ public class GTREIPlugin implements REIClientPlugin {
         if (ConfigHolder.INSTANCE.machines.doBedrockOres)
             registry.add(new GTBedrockOreDisplayCategory());
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
-            if (Platform.isDevEnv() || category.isXEIVisible()) {
+            if (category.shouldRegisterDisplays()) {
                 registry.add(new GTRecipeREICategory(category));
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/recipe/GTRecipeREICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/recipe/GTRecipeREICategory.java
@@ -46,7 +46,7 @@ public class GTRecipeREICategory extends ModularUIDisplayCategory<GTRecipeDispla
 
     public static void registerDisplays(DisplayRegistry registry) {
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
-            if (!category.isXEIVisible() && !Platform.isDevEnv()) continue;
+            if (!category.shouldRegisterDisplays()) continue;
             var type = category.getRecipeType();
             if (category == type.getCategory()) type.buildRepresentativeRecipes();
             var identifier = CATEGORIES.apply(category);


### PR DESCRIPTION
## What
This PR fixes a naive mistake I made when expanding the RecipeCategory system. I removed the `FURNACE_RECIPES` category from the registry, which causes electric furnace recipes to not be able to be serialized by the `GTRecipeSerializer` codec.

## Implementation Details
The condition for registering categories in recipe viewers has been moved to an instance method of `GTRecipeCategory`. This predicate specifically blacklists the GT furnace recipe category, as to solve the usual duplication issue.
`isXEIVisible` still exists in order to register workstations and keep the recipe button in machine UIs functional

## Outcome
Fixes #2645 