### PR TITLE
Fix oil spouts not updating the fluid on generation

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/commands/GTCommands.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/commands/GTCommands.java
@@ -94,7 +94,7 @@ public class GTCommands {
                                 .then(argument("vein",
                                         GTRegistryArgument.registry(GTRegistries.ORE_VEINS, ResourceLocation.class))
                                         .executes(context -> GTCommands.placeVein(context,
-                                                context.getSource().getEntityOrException().blockPosition()))
+                                                BlockPos.containing(context.getSource().getPosition())))
                                         .then(argument("position", BlockPosArgument.blockPos())
                                                 .executes(context -> GTCommands.placeVein(context,
                                                         BlockPosArgument.getBlockPos(context, "position")))))));

--- a/src/main/java/com/gregtechceu/gtceu/common/worldgen/feature/FluidSproutFeature.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/worldgen/feature/FluidSproutFeature.java
@@ -46,7 +46,7 @@ public class FluidSproutFeature extends Feature<FluidSproutConfiguration> {
         if (config.fluid().isSame(Fluids.EMPTY)) {
             return false;
         }
-        int surfaceHeight = level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, blockpos.getX(), blockpos.getZ());
+        int surfaceHeight = level.getHeight(Heightmap.Types.WORLD_SURFACE_WG, blockpos.getX(), blockpos.getZ());
         if (blockpos.getY() >= surfaceHeight) {
             return false;
         }
@@ -126,6 +126,7 @@ public class FluidSproutFeature extends Feature<FluidSproutConfiguration> {
         int sectionZ = SectionPos.sectionRelative(currentZ);
         levelchunksection.setBlockState(sectionX, sectionY, sectionZ,
                 config.fluid().defaultFluidState().createLegacyBlock(), false);
+        level.getChunk(mutablePos).markPosForPostprocessing(mutablePos);
         placedAmount.add(1);
     }
 


### PR DESCRIPTION
## What
title. also fixed oil spouts under the ocean not generating up to the surface.

## Implementation Details
just an extra call to get the chunk and tell it to update the blocks after generation.

## Outcome
oil spouts don't look stupid anymore

## Additional Information
![2024-12-27_15 00 12](https://github.com/user-attachments/assets/bbda7df7-e1c9-4c8c-ab2e-1ee2ace2a759)
![2024-12-27_15 00 19](https://github.com/user-attachments/assets/99967361-023f-4930-aa3d-cc25622fcd8d)
