### PR TITLE
Fix MultiParts not calling `removeFromController` on unload

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
@@ -85,6 +85,7 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
         for (BlockPos pos : controllerPositions) {
             if (level instanceof ServerLevel && level.isLoaded(pos) &&
                     MetaMachine.getMachine(level, pos) instanceof IMultiController controller) {
+                removedFromController(controller);
                 controller.onPartUnload();
             }
         }


### PR DESCRIPTION
## What
When MultiParts are broken, their `onUnload` method is called but not their `removedFromController` method.
In particular, this led to the Cleaning Maintenance Hatch not setting its controller's cleanroom to null when being broken.
MultiParts will now call this for each controller in the controller positions list.
Fixes #2534 