### PR TITLE
Fix Stone Variant maceration having conflicting recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -708,7 +708,7 @@ public class TagPrefix {
             .defaultTagPath("%s")
             .langValue("%s")
             .miningToolTag(BlockTags.MINEABLE_WITH_PICKAXE)
-            .unificationEnabled(true)
+            .unificationEnabled(false)
             .generateBlock(true) // generate a block but not really, for TagPrefix#setIgnoredBlock
             .generationCondition((material) -> false);
 
@@ -867,6 +867,7 @@ public class TagPrefix {
     private long materialAmount = -1;
 
     @Setter
+    @Getter
     private boolean unificationEnabled;
     @Setter
     private boolean generateItem;

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/RecyclingRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/RecyclingRecipes.java
@@ -114,7 +114,7 @@ public class RecyclingRecipes {
 
         UnificationEntry entry = ChemicalHelper.getUnificationEntry(input.getItem());
         TagKey<Item> inputTag = null;
-        if (entry != null) {
+        if (entry != null && entry.tagPrefix.unificationEnabled()) {
             inputTag = ChemicalHelper.getTag(entry.tagPrefix, entry.material);
         }
 


### PR DESCRIPTION
## What
Fixes #2632 

## Implementation Details
Uses the TagPrefix `UnificationEnabled` boolean to test whether item tags should be used for recycling recipes

## Outcome
all the rock stone blocks (granite, deepslate, etc) should not not generate decomp recipes through tag recycling, just through material info addition in the StoneTypeEntries 