### PR TITLE
Change pipes to force connections to covers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -270,6 +270,12 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
                     pipeTile.getPipeType().getClass() != this.getPipeType().getClass()) {
                 return;
             }
+
+            if (!connected) {
+                var cover = getCoverContainer().getCoverAtSide(side);
+                if (cover != null && cover.canPipePassThrough()) return;
+            }
+
             connections = withSideConnection(connections, side, connected);
 
             updateNetworkConnection(side, connected);

--- a/src/main/java/com/gregtechceu/gtceu/api/pipenet/PipeCoverContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pipenet/PipeCoverContainer.java
@@ -186,6 +186,7 @@ public class PipeCoverContainer implements ICoverable, IEnhancedManaged {
     }
 
     public void setCoverAtSide(@Nullable CoverBehavior coverBehavior, Direction side) {
+        var previousCover = getCoverAtSide(side);
         switch (side) {
             case UP -> up = coverBehavior;
             case SOUTH -> south = coverBehavior;
@@ -196,6 +197,11 @@ public class PipeCoverContainer implements ICoverable, IEnhancedManaged {
         }
         if (coverBehavior != null) {
             coverBehavior.getSyncStorage().markAllDirty();
+            if (coverBehavior.canPipePassThrough()) {
+                pipeTile.setConnection(side, true, false);
+            }
+        } else if (previousCover != null && previousCover.canPipePassThrough()) {
+            pipeTile.setConnection(side, false, false);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ComputerMonitorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ComputerMonitorCover.java
@@ -12,5 +12,10 @@ public class ComputerMonitorCover extends CoverBehavior {
         super(definition, coverHolder, attachedSide);
     }
 
+    @Override
+    public boolean canPipePassThrough() {
+        return false;
+    }
+
     // No implementation here, this cover is just for decorative purposes
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
@@ -21,7 +21,6 @@ import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.FluidUtil;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -61,7 +60,7 @@ public class FluidFilterCover extends CoverBehavior implements IUICover {
 
     @Override
     public boolean canAttach() {
-        return FluidUtil.getFluidHandler(coverHolder.getLevel(), coverHolder.getPos(), attachedSide).isPresent();
+        return coverHolder.getFluidHandlerCap(attachedSide, false) != null;
     }
 
     public FluidFilter getFluidFilter() {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/StorageCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/StorageCover.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.cover.IUICover;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.fancy.IFancyConfigurator;
 import com.gregtechceu.gtceu.api.gui.widget.SlotWidget;
+import com.gregtechceu.gtceu.api.machine.MachineCoverContainer;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
@@ -50,11 +51,13 @@ public class StorageCover extends CoverBehavior implements IUICover {
     }
 
     @Override
+    @NotNull
     public ManagedFieldHolder getFieldHolder() {
         return MANAGED_FIELD_HOLDER;
     }
 
     @Override
+    @NotNull
     public List<ItemStack> getAdditionalDrops() {
         var list = super.getAdditionalDrops();
         for (int slot = 0; slot < SIZE; slot++) {
@@ -65,6 +68,7 @@ public class StorageCover extends CoverBehavior implements IUICover {
 
     @Override
     public boolean canAttach() {
+        if (!(coverHolder instanceof MachineCoverContainer)) return false;
         for (var dir : Direction.values()) {
             if (coverHolder.hasCover(dir) && coverHolder.getCoverAtSide(dir) instanceof StorageCover)
                 return false;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/DetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/DetectorCover.java
@@ -98,4 +98,9 @@ public abstract class DetectorCover extends CoverBehavior implements IControllab
     public boolean canConnectRedstone() {
         return true;
     }
+
+    @Override
+    public boolean canPipePassThrough() {
+        return false;
+    }
 }


### PR DESCRIPTION
## What
When placing a filter or transfer cover on a pipe, the pipe is visually forced to connect to the cover. This PR makes it so that applying a cover also forces a logical connection from the pipe to the side that the cover is one. 
In order to prevent mishaps, when a cover is removed from a pipe it will now also forcibly disconnect the pipe.

## Implementation Details
Only applies to covers that return `false` in `canPipePassThrough`.

## Outcome
Fixes #2660 

## Additional Information
Storage covers have been changed to only be placeable on machines.
Fluid Filters use the native `getFluidHandlerCap` of its cover container rather than querying the caps system
