### PR TITLE
Add multiblock constructors to KJS + lang

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.registry.registrate;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.data.RotationState;
@@ -42,6 +43,7 @@ import com.tterrag.registrate.builders.BlockBuilder;
 import com.tterrag.registrate.builders.ItemBuilder;
 import com.tterrag.registrate.util.nullness.NonNullConsumer;
 import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
+import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import lombok.Getter;
@@ -377,6 +379,14 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     }
 
     @Override
+    public void generateLang(LangEventJS lang) {
+        super.generateLang(lang);
+        if (langValue() != null) {
+            lang.add(GTCEu.MOD_ID, value.getDescriptionId(), value.getLangValue());
+        }
+    }
+
+    @Override
     @HideFromJS
     public MultiblockMachineDefinition register() {
         var definition = (MultiblockMachineDefinition) super.register();
@@ -399,6 +409,6 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
         }
         definition.setPartAppearance(partAppearance);
         definition.setAdditionalDisplay(additionalDisplay);
-        return definition;
+        return value = definition;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -62,6 +62,7 @@ import com.gregtechceu.gtceu.integration.kjs.builders.block.CoilBlockBuilder;
 import com.gregtechceu.gtceu.integration.kjs.builders.machine.*;
 import com.gregtechceu.gtceu.integration.kjs.builders.prefix.BasicTagPrefixBuilder;
 import com.gregtechceu.gtceu.integration.kjs.builders.prefix.OreTagPrefixBuilder;
+import com.gregtechceu.gtceu.integration.kjs.helpers.MachineConstructors;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MachineModifiers;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MaterialStackWrapper;
 import com.gregtechceu.gtceu.integration.kjs.recipe.GTRecipeSchema;
@@ -267,6 +268,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         event.add("GTMedicalConditions", GTMedicalConditions.class);
         event.add("GTRecipeModifiers", GTRecipeModifiers.class);
         event.add("OverclockingLogic", OverclockingLogic.class);
+        event.add("MachineConstructors", MachineConstructors.class);
         event.add("MachineModifiers", MachineModifiers.class);
         event.add("ModifierFunction", ModifierFunction.class);
         event.add("RecipeCapability", RecipeCapability.class);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
@@ -62,7 +62,7 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
     @Override
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
-        lang.add(value.getDescriptionId(), value.getLangValue());
+        lang.add(GTCEu.MOD_ID, value.getDescriptionId(), value.getLangValue());
         if (hp != null) {
             lang.add(GTCEu.MOD_ID, hp.getDescriptionId(), hp.getLangValue());
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -45,7 +45,9 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
         super.generateLang(lang);
         for (int tier : tiers) {
             MachineDefinition def = value[tier];
-            lang.add(GTCEu.MOD_ID, def.getDescriptionId(), def.getLangValue());
+            if (def.getLangValue() != null) {
+                lang.add(GTCEu.MOD_ID, def.getDescriptionId(), def.getLangValue());
+            }
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/MachineConstructors.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/MachineConstructors.java
@@ -1,0 +1,34 @@
+package com.gregtechceu.gtceu.integration.kjs.helpers;
+
+import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.generator.LargeCombustionEngineMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.generator.LargeTurbineMachine;
+import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
+
+/**
+ * Collection of functions that can be used in the Machine Creation Functions in KJS definitions
+ * Makes using them for KJS easier, as loading the relevant class won't be required.
+ */
+@SuppressWarnings("unused")
+public final class MachineConstructors {
+
+    // This one in particular stops a crash when trying to define a new LCE
+    // The crash is caused by the static FluidStack members in LargeCombustionEngine.class
+    public static MultiblockControllerMachine createLargeCombustionEngine(IMachineBlockEntity holder, int tier) {
+        return new LargeCombustionEngineMachine(holder, tier);
+    }
+
+    public static MultiblockControllerMachine createLargeTurbine(IMachineBlockEntity holder, int tier) {
+        return new LargeTurbineMachine(holder, tier);
+    }
+
+    public static MultiblockControllerMachine createFusionReactor(IMachineBlockEntity holder, int tier) {
+        return new FusionReactorMachine(holder, tier);
+    }
+
+    public static MultiblockControllerMachine createSteamMultiblock(IMachineBlockEntity holder, int parallels) {
+        return new SteamParallelMultiblockMachine(holder, parallels);
+    }
+}


### PR DESCRIPTION
## What
This PR adds a new class `MachineConstructors` which is exposed to KJS as an easy way to use constructors for non-default machine types without having to manually load the class. This class is readily expandable.

Also, lang generation has been added to `MultiblockMachineBuilder` so that Kubers can make multiblock lang in-place.

## Outcome
This incidentally fixes a funny issue where loading the `LargeCombustionEngineMachine` class in a KJS server script will crash the game, as it tries to initialize the static FluidStack before the materials have valid fluids.
