### PR TITLE
Fix tree felling helper memory leak

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -29,8 +29,7 @@ public class TreeFellingHelper {
     private final Deque<BlockPos> orderedBlocks;
     private int tick;
 
-    public static final Set<TreeFellingHelper> helpers = new HashSet<>();
-    public static final Set<TreeFellingHelper> finished = new HashSet<>();
+    public static final Set<TreeFellingHelper> helpers = new ObjectOpenHashSet<>();
 
     private TreeFellingHelper(ServerPlayer player, ItemStack tool, Deque<BlockPos> orderedBlocks) {
         this.player = player;
@@ -85,12 +84,14 @@ public class TreeFellingHelper {
     @SubscribeEvent
     public static void onWorldTick(TickEvent.LevelTickEvent event) {
         if (event.phase == TickEvent.Phase.START && event.side == LogicalSide.SERVER && !helpers.isEmpty()) {
-            for (var helper : helpers) {
+            var iterator = helpers.iterator();
+            while (iterator.hasNext()) {
+                var helper = iterator.next();
                 if (event.level == helper.player.level()) {
                     if (helper.orderedBlocks.isEmpty() || helper.tool.isEmpty() ||
                             !(hasBehaviorsTag(helper.player.getMainHandItem()) &&
                                     getBehaviorsTag(helper.player.getMainHandItem()).getBoolean(TREE_FELLING_KEY))) {
-                        finished.add(helper);
+                        iterator.remove();
                         continue;
                     }
                     if (helper.tick % ConfigHolder.INSTANCE.tools.treeFellingDelay == 0)
@@ -98,10 +99,6 @@ public class TreeFellingHelper {
                                 true);
                     helper.tick++;
                 }
-            }
-            if (!finished.isEmpty()) {
-                helpers.removeAll(finished);
-                finished.clear();
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -14,6 +14,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.fml.common.Mod;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 
 import java.util.*;
@@ -29,7 +30,7 @@ public class TreeFellingHelper {
     private final Deque<BlockPos> orderedBlocks;
     private int tick;
 
-    public static final Set<TreeFellingHelper> helpers = new ObjectOpenHashSet<>();
+    public static final List<TreeFellingHelper> helpers = ObjectArrayList.of();
 
     private TreeFellingHelper(ServerPlayer player, ItemStack tool, Deque<BlockPos> orderedBlocks) {
         this.player = player;

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -101,6 +101,7 @@ public class TreeFellingHelper {
             }
             if (!finished.isEmpty()) {
                 helpers.removeAll(finished);
+                finished.clear();
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -29,7 +29,8 @@ public class TreeFellingHelper {
     private final Deque<BlockPos> orderedBlocks;
     private int tick;
 
-    public static Set<TreeFellingHelper> helpers = new HashSet<>();
+    public static final Set<TreeFellingHelper> helpers = new HashSet<>();
+    public static final Set<TreeFellingHelper> finished = new HashSet<>();
 
     private TreeFellingHelper(ServerPlayer player, ItemStack tool, Deque<BlockPos> orderedBlocks) {
         this.player = player;
@@ -83,12 +84,13 @@ public class TreeFellingHelper {
 
     @SubscribeEvent
     public static void onWorldTick(TickEvent.LevelTickEvent event) {
-        if (event.phase == TickEvent.Phase.START && event.side == LogicalSide.SERVER) {
+        if (event.phase == TickEvent.Phase.START && event.side == LogicalSide.SERVER && !helpers.isEmpty()) {
             for (var helper : helpers) {
                 if (event.level == helper.player.level()) {
                     if (helper.orderedBlocks.isEmpty() || helper.tool.isEmpty() ||
                             !(hasBehaviorsTag(helper.player.getMainHandItem()) &&
                                     getBehaviorsTag(helper.player.getMainHandItem()).getBoolean(TREE_FELLING_KEY))) {
+                        finished.add(helper);
                         continue;
                     }
                     if (helper.tick % ConfigHolder.INSTANCE.tools.treeFellingDelay == 0)
@@ -96,6 +98,9 @@ public class TreeFellingHelper {
                                 true);
                     helper.tick++;
                 }
+            }
+            if (!finished.isEmpty()) {
+                helpers.removeAll(finished);
             }
         }
     }


### PR DESCRIPTION
## What
Previously we would allocate helpers but never release them, moreover we would iterate over all finished ones every level tick.

## Implementation Details
Just added a set to collect the inactive helpers each iteration to remove them at the end.

## Outcome
Players cannot bring down servers by chopping too many trees.