### PR TITLE
Optimize MultiPart and ParallelHatch performance

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiController.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiController.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.machine.feature.multiblock;
 
+import com.gregtechceu.gtceu.api.capability.IParallelHatch;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IMachineFeature;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -138,6 +140,15 @@ public interface IMultiController extends IMachineFeature, IInteractedMachine {
      * Get all parts
      */
     List<IMultiPart> getParts();
+
+    /**
+     * The instance of {@link IParallelHatch} attached to this Controller.
+     * <p>
+     * Note that this will return a singular instance, and will not account for multiple attached IParallelHatches
+     * 
+     * @return an {@link Optional} of the attached IParallelHatch, empty if one is not attached
+     */
+    Optional<IParallelHatch> getParallelHatch();
 
     /**
      * Called from part, when part is invalid due to chunk unload or broken.

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.SortedSet;
 
 /**
  * @author KilaBash
@@ -44,7 +45,7 @@ public interface IMultiPart extends IMachineFeature, IFancyUIMachine {
     /**
      * Get all attached controllers
      */
-    List<IMultiController> getControllers();
+    SortedSet<IMultiController> getControllers();
 
     /**
      * Called when it was removed from a multiblock.

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiPart.java
@@ -14,6 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.state.BlockState;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.List;
 import java.util.SortedSet;
@@ -43,8 +44,11 @@ public interface IMultiPart extends IMachineFeature, IFancyUIMachine {
     boolean isFormed();
 
     /**
-     * Get all attached controllers
+     * Get this MultiPart's controllers
+     * 
+     * @return An Unmodifiable View of the part's controllers
      */
+    @UnmodifiableView
     SortedSet<IMultiController> getControllers();
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.machine.multiblock;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
 import com.gregtechceu.gtceu.api.block.MetaMachineBlock;
+import com.gregtechceu.gtceu.api.capability.IParallelHatch;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
@@ -31,10 +32,12 @@ import net.minecraft.world.phys.BlockHitResult;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -54,6 +57,7 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
             MultiblockControllerMachine.class, MetaMachine.MANAGED_FIELD_HOLDER);
     private MultiblockState multiblockState;
     private final List<IMultiPart> parts = new ArrayList<>();
+    private @Nullable IParallelHatch parallelHatch = null;
     @Getter
     @DescSynced
     @UpdateListener(methodName = "onPartsUpdated")
@@ -140,6 +144,11 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
         return this.parts;
     }
 
+    @Override
+    public Optional<IParallelHatch> getParallelHatch() {
+        return Optional.ofNullable(parallelHatch);
+    }
+
     //////////////////////////////////////
     // *** Multiblock LifeCycle ***//
     //////////////////////////////////////
@@ -178,6 +187,9 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
         }
         this.parts.sort(getDefinition().getPartSorter());
         for (var part : parts) {
+            if (part instanceof IParallelHatch pHatch) {
+                parallelHatch = pHatch;
+            }
             part.addedToController(this);
         }
         updatePartPositions();
@@ -189,6 +201,7 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
         for (IMultiPart part : parts) {
             part.removedFromController(this);
         }
+        parallelHatch = null;
         parts.clear();
         updatePartPositions();
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -31,7 +31,6 @@ import lombok.Getter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -84,13 +83,10 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
 
     @Override
     public void addDisplayText(List<Component> textList) {
-        int numParallels = 0;
-        Optional<IParallelHatch> optional = this.getParts().stream().filter(IParallelHatch.class::isInstance)
-                .map(IParallelHatch.class::cast).findAny();
-        if (optional.isPresent()) {
-            IParallelHatch parallelHatch = optional.get();
-            numParallels = parallelHatch.getCurrentParallel();
-        }
+        int numParallels = this.getParallelHatch()
+                .map(IParallelHatch::getCurrentParallel)
+                .orElse(0);
+
         MultiblockDisplayText.builder(textList, isFormed())
                 .setWorkingStatus(recipeLogic.isWorkingEnabled(), recipeLogic.isActive())
                 .addEnergyUsageLine(energyContainer)

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
@@ -14,10 +14,13 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
-import java.util.ArrayList;
+import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -36,10 +39,12 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
     @DescSynced
     @RequireRerender
     protected final Set<BlockPos> controllerPositions;
+    protected final SortedSet<IMultiController> controllers;
 
     public MultiblockPartMachine(IMachineBlockEntity holder) {
         super(holder);
         this.controllerPositions = new HashSet<>();
+        this.controllers = new ReferenceLinkedOpenHashSet<>();
     }
 
     //////////////////////////////////////
@@ -62,14 +67,17 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
     }
 
     @Override
-    public List<IMultiController> getControllers() {
-        List<IMultiController> result = new ArrayList<>();
-        for (var blockPos : controllerPositions) {
-            if (MetaMachine.getMachine(getLevel(), blockPos) instanceof IMultiController controller) {
-                result.add(controller);
+    public SortedSet<IMultiController> getControllers() {
+        // Necessary to rebuild the set of controllers on client-side
+        if (controllers.size() != controllerPositions.size()) {
+            controllers.clear();
+            for (var blockPos : controllerPositions) {
+                if (MetaMachine.getMachine(getLevel(), blockPos) instanceof IMultiController controller) {
+                    controllers.add(controller);
+                }
             }
         }
-        return result;
+        return Collections.unmodifiableSortedSet(controllers);
     }
 
     @Override
@@ -90,6 +98,7 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
             }
         }
         controllerPositions.clear();
+        controllers.clear();
     }
 
     //////////////////////////////////////
@@ -99,10 +108,12 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
     @Override
     public void removedFromController(IMultiController controller) {
         controllerPositions.remove(controller.self().getPos());
+        controllers.remove(controller);
     }
 
     @Override
     public void addedToController(IMultiController controller) {
         controllerPositions.add(controller.self().getPos());
+        controllers.add(controller);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
@@ -17,6 +17,7 @@ import net.minecraft.server.level.ServerLevel;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Collections;
 import java.util.List;
@@ -78,6 +79,7 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
     }
 
     @Override
+    @UnmodifiableView
     public SortedSet<IMultiController> getControllers() {
         // Necessary to rebuild the set of controllers on client-side
         if (controllers.size() != controllerPositions.size()) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
@@ -8,16 +8,17 @@ import com.gregtechceu.gtceu.api.machine.trait.IRecipeHandlerTrait;
 
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.RequireRerender;
+import com.lowdragmc.lowdraglib.syncdata.annotation.UpdateListener;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
@@ -38,13 +39,12 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
 
     @DescSynced
     @RequireRerender
-    protected final Set<BlockPos> controllerPositions;
-    protected final SortedSet<IMultiController> controllers;
+    @UpdateListener(methodName = "onControllersUpdated")
+    protected final Set<BlockPos> controllerPositions = new ObjectOpenHashSet<>(8);
+    protected final SortedSet<IMultiController> controllers = new ReferenceLinkedOpenHashSet<>(8);
 
     public MultiblockPartMachine(IMachineBlockEntity holder) {
         super(holder);
-        this.controllerPositions = new HashSet<>();
-        this.controllers = new ReferenceLinkedOpenHashSet<>();
     }
 
     //////////////////////////////////////
@@ -66,35 +66,45 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
         return !controllerPositions.isEmpty();
     }
 
+    // Not sure if necessary, but added to match the Controller class
+    @SuppressWarnings("unused")
+    public void onControllersUpdated(Set<BlockPos> newPositions, Set<BlockPos> old) {
+        controllers.clear();
+        for (BlockPos blockPos : newPositions) {
+            if (MetaMachine.getMachine(getLevel(), blockPos) instanceof IMultiController controller) {
+                controllers.add(controller);
+            }
+        }
+    }
+
     @Override
     public SortedSet<IMultiController> getControllers() {
         // Necessary to rebuild the set of controllers on client-side
         if (controllers.size() != controllerPositions.size()) {
-            controllers.clear();
-            for (var blockPos : controllerPositions) {
-                if (MetaMachine.getMachine(getLevel(), blockPos) instanceof IMultiController controller) {
-                    controllers.add(controller);
-                }
-            }
+            onControllersUpdated(controllerPositions, Collections.emptySet());
         }
         return Collections.unmodifiableSortedSet(controllers);
     }
 
     @Override
     public List<IRecipeHandlerTrait> getRecipeHandlers() {
-        return traits.stream().filter(IRecipeHandlerTrait.class::isInstance).map(IRecipeHandlerTrait.class::cast)
+        return traits.stream()
+                .filter(IRecipeHandlerTrait.class::isInstance)
+                .map(IRecipeHandlerTrait.class::cast)
                 .toList();
     }
 
     @Override
     public void onUnload() {
         super.onUnload();
-        var level = getLevel();
-        for (BlockPos pos : controllerPositions) {
-            if (level instanceof ServerLevel && level.isLoaded(pos) &&
-                    MetaMachine.getMachine(level, pos) instanceof IMultiController controller) {
-                removedFromController(controller);
-                controller.onPartUnload();
+        if (getLevel() instanceof ServerLevel serverLevel) {
+            // Need to copy if > 1 so that we can call removedFromController safely without CME
+            Set<IMultiController> toIter = controllers.size() > 1 ? new ObjectOpenHashSet<>(controllers) : controllers;
+            for (IMultiController controller : toIter) {
+                if (serverLevel.isLoaded(controller.self().getPos())) {
+                    removedFromController(controller);
+                    controller.onPartUnload();
+                }
             }
         }
         controllerPositions.clear();

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
@@ -63,7 +63,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 if (machine instanceof IOpticalComputationProvider provider) {
                     return provider.requestCWUt(cwut, simulate, seen);
                 } else if (machine instanceof IMultiPart part) {
-                    if (part.getControllers().isEmpty()) {
+                    if (!part.isFormed()) {
                         return 0;
                     }
                     for (IMultiController controller : part.getControllers()) {
@@ -104,7 +104,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 if (machine instanceof IOpticalComputationProvider provider) {
                     return provider.getMaxCWUt(seen);
                 } else if (machine instanceof IMultiPart part) {
-                    if (part.getControllers().isEmpty()) {
+                    if (!part.isFormed()) {
                         return 0;
                     }
                     for (IMultiController controller : part.getControllers()) {
@@ -147,7 +147,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 if (machine instanceof IOpticalComputationProvider provider) {
                     return provider.canBridge(seen);
                 } else if (machine instanceof IMultiPart part) {
-                    if (part.getControllers().isEmpty()) {
+                    if (!part.isFormed()) {
                         return false;
                     }
                     for (IMultiController controller : part.getControllers()) {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/HPCAPartRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/HPCAPartRenderer.java
@@ -70,7 +70,7 @@ public class HPCAPartRenderer extends TieredHullMachineRenderer {
         super.renderMachine(quads, definition, machine, frontFacing, side, rand, modelFacing, modelState);
         if (machine instanceof HPCAComponentPartMachine hpcaComponent) {
             ResourceLocation texture, emissiveTexture = null;
-            var controller = hpcaComponent.getControllers().isEmpty() ? null : hpcaComponent.getControllers().get(0);
+            var controller = hpcaComponent.isFormed() ? hpcaComponent.getControllers().first() : null;
             if (controller != null && (controller instanceof IWorkable workable && workable.isActive())) {
                 if (hpcaComponent.isDamaged()) {
                     texture = damagedActiveTexture;

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/RotorHolderMachineRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/RotorHolderMachineRenderer.java
@@ -51,7 +51,7 @@ public class RotorHolderMachineRenderer extends TieredHullMachineRenderer {
                     modelState));
             if (machine instanceof IRotorHolderMachine rotorHolderMachine) {
                 var aabb = new AABB(-1, -1, -0.01, 2, 2, 1.01);
-                if (!rotorHolderMachine.getControllers().isEmpty()) {
+                if (rotorHolderMachine.isFormed()) {
                     quads.add(StaticFaceBakery.bakeFace(aabb, modelFacing, ModelFactory.getBlockSprite(BASE_RING),
                             modelState, -101, 15, true, false));
                     quads.add(StaticFaceBakery.bakeFace(aabb, modelFacing, ModelFactory.getBlockSprite(BASE_BG),

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.common.data;
 
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.capability.IParallelHatch;
 import com.gregtechceu.gtceu.api.capability.recipe.EURecipeCapability;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
@@ -92,10 +91,7 @@ public class GTRecipeModifiers {
      */
     public static @NotNull ModifierFunction hatchParallel(@NotNull MetaMachine machine, @NotNull GTRecipe recipe) {
         if (machine instanceof IMultiController controller && controller.isFormed()) {
-            int parallels = controller.getParts().stream()
-                    .filter(IParallelHatch.class::isInstance)
-                    .map(IParallelHatch.class::cast)
-                    .findAny()
+            int parallels = controller.getParallelHatch()
                     .map(hatch -> ParallelLogic.getParallelAmount(machine, recipe, hatch.getCurrentParallel()))
                     .orElse(1);
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DataAccessHatchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DataAccessHatchMachine.java
@@ -71,15 +71,13 @@ public class DataAccessHatchMachine extends TieredPartMachine
             @Override
             public void onContentsChanged() {
                 super.onContentsChanged();
-                rebuildData(!getControllers().isEmpty() && getControllers().get(0) instanceof DataBankMachine);
+                rebuildData(isFormed() && getControllers().first() instanceof DataBankMachine);
             }
 
             @NotNull
             @Override
             public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-                var controller = DataAccessHatchMachine.this.getControllers().isEmpty() ? null :
-                        DataAccessHatchMachine.this.getControllers().get(0);
-                boolean isDataBank = controller instanceof DataBankMachine;
+                boolean isDataBank = isFormed() && getControllers().first() instanceof DataBankMachine;
                 if (ResearchManager.isStackDataItem(stack, isDataBank) &&
                         ResearchManager.hasResearchTag(stack)) {
                     return super.insertItem(slot, stack, simulate);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
@@ -115,6 +115,11 @@ public class RotorHolderPartMachine extends TieredPartMachine
         }
     }
 
+    @Override
+    public boolean canShared() {
+        return false;
+    }
+
     //////////////////////////////////////
     // ****** Rotor Holder ******//
     //////////////////////////////////////
@@ -144,12 +149,8 @@ public class RotorHolderPartMachine extends TieredPartMachine
     }
 
     private void updateRotorSpeed() {
-        for (IMultiController controller : getControllers()) {
-            if (controller instanceof IWorkableMultiController workableMultiController) {
-                if (workableMultiController.getRecipeLogic().isWorking()) {
-                    return;
-                }
-            }
+        if (isFormed() && getControllers().first() instanceof IWorkableMultiController workable) {
+            if (workable.getRecipeLogic().isWorking()) return;
         }
         if (!hasRotor()) {
             setRotorSpeed(0);
@@ -167,11 +168,8 @@ public class RotorHolderPartMachine extends TieredPartMachine
         }
         if (self().getOffsetTimer() % 20 == 0) {
             var numMaintenanceProblems = 0;
-            for (IMultiPart part : controller.getParts()) {
-                if (part instanceof IMaintenanceMachine maintenance) {
-                    numMaintenanceProblems = maintenance.getNumMaintenanceProblems();
-                    break;
-                }
+            if (isFormed() && getControllers().first() instanceof IMaintenanceMachine maintenance) {
+                numMaintenanceProblems = maintenance.getNumMaintenanceProblems();
             }
             damageRotor(1 + numMaintenanceProblems);
         }
@@ -179,10 +177,8 @@ public class RotorHolderPartMachine extends TieredPartMachine
     }
 
     public int getTierDifference() {
-        for (IMultiController controller : getControllers()) {
-            if (controller instanceof ITieredMachine tieredMachine) {
-                return getTier() - tieredMachine.getTier();
-            }
+        if (isFormed() && getControllers().first() instanceof ITieredMachine tieredMachine) {
+            return getTier() - tieredMachine.getTier();
         }
         return -1;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/TankValvePartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/TankValvePartMachine.java
@@ -103,7 +103,7 @@ public class TankValvePartMachine extends MultiblockPartMachine {
     }
 
     private Boolean shouldAutoIO() {
-        if (getControllers().isEmpty()) return false;
+        if (!isFormed()) return false;
         if (getFrontFacing() != Direction.DOWN) return false;
         if (tankProxy.isEmpty()) return false;
         if (getTargetTank() == null) return false;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -374,10 +374,9 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
 
     @Override
     public PatternContainerGroup getTerminalGroup() {
-        List<IMultiController> controllers = getControllers();
-        // has controller
-        if (!controllers.isEmpty()) {
-            IMultiController controller = controllers.get(0);
+        // Has controller
+        if (isFormed()) {
+            IMultiController controller = getControllers().first();
             MultiblockMachineDefinition controllerDefinition = controller.self().getDefinition();
             // has customName
             if (!customName.isEmpty()) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/ParallelProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/ParallelProvider.java
@@ -16,8 +16,6 @@ import snownee.jade.api.IServerDataProvider;
 import snownee.jade.api.ITooltip;
 import snownee.jade.api.config.IPluginConfig;
 
-import java.util.Optional;
-
 public class ParallelProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
 
     @Override
@@ -38,12 +36,8 @@ public class ParallelProvider implements IBlockComponentProvider, IServerDataPro
             if (blockEntity.getMetaMachine() instanceof IParallelHatch parallelHatch) {
                 compoundTag.putInt("parallel", parallelHatch.getCurrentParallel());
             } else if (blockEntity.getMetaMachine() instanceof IMultiController controller) {
-                Optional<IParallelHatch> parallelHatch = controller.getParts().stream()
-                        .filter(IParallelHatch.class::isInstance)
-                        .map(IParallelHatch.class::cast)
-                        .findAny();
-                parallelHatch.ifPresent(
-                        iParallelHatch -> compoundTag.putInt("parallel", iParallelHatch.getCurrentParallel()));
+                controller.getParallelHatch()
+                        .ifPresent(parallelHatch -> compoundTag.putInt("parallel", parallelHatch.getCurrentParallel()));
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/ParallelProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/ParallelProvider.java
@@ -18,8 +18,6 @@ import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoProvider;
 import mcjty.theoneprobe.api.ProbeMode;
 
-import java.util.Optional;
-
 public class ParallelProvider implements IProbeInfoProvider {
 
     @Override
@@ -36,13 +34,9 @@ public class ParallelProvider implements IProbeInfoProvider {
             if (machineBlockEntity.getMetaMachine() instanceof IParallelHatch parallelHatch) {
                 parallel = parallelHatch.getCurrentParallel();
             } else if (machineBlockEntity.getMetaMachine() instanceof IMultiController controller) {
-                Optional<IParallelHatch> parallelHatch = controller.getParts().stream()
-                        .filter(IParallelHatch.class::isInstance)
-                        .map(IParallelHatch.class::cast)
-                        .findAny();
-                if (parallelHatch.isPresent()) {
-                    parallel = parallelHatch.get().getCurrentParallel();
-                }
+                parallel = controller.getParallelHatch()
+                        .map(IParallelHatch::getCurrentParallel)
+                        .orElse(0);
             }
             if (parallel > 0) {
                 iProbeInfo.text(Component.translatable(


### PR DESCRIPTION
## What
This PR aims to optimize some parts of the Multiblock Lifecycle. 
1.  Whenever an `IMultiPart` needed to query the controllers it was attached to, it would iterate through all of its known controller positions and return a new List every time. 
2. When the current parallel setting of a multiblock is needed, its parts list would be searched for the parallel hatch *every time*, which is especially noticeable when using many GCYM machines.

## Implementation Details
1. As it is highly unlikely for an `IMultiController` to be moved from its current position without triggering a structure update and thus removing itself from the controller set, we can also keep track of a Set of `IMultiControllers`. I have used a `ReferenceLinkedOpenHashSet` from FastUtil, as we only really care about references and using a LinkedSet provides us with consistent iterations, as well as quick access to the first controller in the set.
This Set does need to be populated manually on the client-side due to an inability to sync, so that is the reason why maintaining the `controllerPositions` set is useful.
2. It is very unlikely that the parallel hatch of a multiblock will change while it is formed, and thus can be cached. This has been implemented in the `MultiblockControllerMachine` class as a simple field. I have chosen to make the method return an `Optional` to better fit in with our current usages, but it can be switched to a `Nullable` if desired.

Additionally, some small tweaks have been added:
- RotorHolderPartMachines now cannot be shared and its methods have been updated to reflect that
- `!getControllers.isEmpty()` calls have been changed to `isFormed()`
- `onUnload` has been cleaned up a bit.
## Outcome

Performance. 

600s runs in fairly stressful situations
Shown is average MSPT spent executing the method
MultiPart example in `RotorHolderPartMachine`
| Before| After|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5c257de6-2a2f-49f6-90d0-88365dd63624) | ![image](https://github.com/user-attachments/assets/811d0140-1dc0-425b-93c7-607e9fd4d3c8) |

Parallel Hatch searching example in `GTRecipeModifiers#hatchParallel` 
(ignore the `Optional.map`, it's the other bits that are relevant)
| Before| After|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7d7e9607-92fa-401d-ad06-60fbcb6b4207) | ![image](https://github.com/user-attachments/assets/e7778653-f9e8-4ac9-9a77-6196527adac1) |
