### PR TITLE
Use `LinkedHashSet` for Breadth First Search.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/utils/BreadthFirstBlockSearch.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/BreadthFirstBlockSearch.java
@@ -18,7 +18,7 @@ public class BreadthFirstBlockSearch {
 
     public static Set<BlockPos> search(Predicate<BlockPos> value, BlockPos start, int limit) {
         Set<BlockPos> alreadyVisited = new HashSet<>();
-        Set<BlockPos> valid = new HashSet<>();
+        Set<BlockPos> valid = new LinkedHashSet<>();
         int iteration = 0;
 
         Queue<BlockPos> queue = new ArrayDeque<>();
@@ -58,7 +58,7 @@ public class BreadthFirstBlockSearch {
         var level = start.getLevel();
         if (level == null) return Set.of();
 
-        var passed = new HashSet<T>();
+        var passed = new LinkedHashSet<T>();
         var queue = new ObjectArrayFIFOQueue<Triple<T, T, Direction>>(16);
         queue.enqueue(new ImmutableTriple<>(null, start, null));
 
@@ -87,7 +87,7 @@ public class BreadthFirstBlockSearch {
 
     public static Set<BlockPos> conditionalBlockPosSearch(BlockPos start, BiPredicate<BlockPos, BlockPos> condition,
                                                           int blockLimit, int iterationLimit) {
-        var passed = new HashSet<BlockPos>();
+        var passed = new LinkedHashSet<BlockPos>();
         var queue = new ObjectArrayFIFOQueue<Tuple<BlockPos, BlockPos>>(16);
         queue.enqueue(new Tuple<>(null, start));
 


### PR DESCRIPTION
## What

When using a spray can that runs out partway through, we want to paint the nearest blocks, rather than a random selection of discovered blocks.

## Implementation Details

I changed all the methods of `BreadthFirstBlockSearch` to return a `LinkedHashSet` instead of a `HashSet`, so that the caller can iterate the results in the order found. I could have left `.search` unchanged, but I think having a consistent behavior for all the methods makes more sense.

## Outcome

When a spray can runs out while spraying, the nearest blocks to the initial block will be painted, rather than a random assortment of blocks within range.