### PR TITLE
Fix missing spaces in stone recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -583,7 +583,7 @@ public class StoneMachineRecipes {
                 if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
                     VanillaRecipeHelper.addShapedRecipe(provider, entry.stoneName + "_polished_hammer",
                             new ItemStack(entry.chiselStone),
-                            "mSd", " S", " S",
+                            "mSd", " S ", " S ",
                             'S', entry.slab);
                 }
                 GTRecipeTypes.FORMING_PRESS_RECIPES.recipeBuilder("form_" + entry.stoneName + "_slab_into_pillar")


### PR DESCRIPTION
## What
Fixes hard mode crafting recipes for stones

## Implementation Details
Add 2 missing spaces

## Outcome
No more KubeJS/log complaints 
