### PR TITLE
Fix rotors not being distinguishable by recipe viewers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/GTEMIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/GTEMIPlugin.java
@@ -70,9 +70,7 @@ public class GTEMIPlugin implements EmiPlugin {
         registry.addCategory(GTProgrammedCircuitCategory.CATEGORY);
 
         // Recipes
-        try {
-            MultiblockInfoEmiCategory.registerDisplays(registry);
-        } catch (NullPointerException ignored) {}
+        MultiblockInfoEmiCategory.registerDisplays(registry);
         GTRecipeEMICategory.registerDisplays(registry);
         if (!ConfigHolder.INSTANCE.compat.hideOreProcessingDiagrams)
             GTOreProcessingEmiCategory.registerDisplays(registry);
@@ -94,6 +92,8 @@ public class GTEMIPlugin implements EmiPlugin {
                 EmiStack.of(GTMultiMachines.LARGE_CHEMICAL_REACTOR.asStack()));
 
         // Comparators
+        registry.setDefaultComparison(GTItems.TURBINE_ROTOR.asItem(), Comparison.compareNbt());
+
         registry.setDefaultComparison(GTItems.PROGRAMMED_CIRCUIT.asItem(), Comparison.compareNbt());
         registry.removeEmiStacks(EmiStack.of(GTItems.PROGRAMMED_CIRCUIT.asStack()));
         registry.addEmiStack(EmiStack.of(IntCircuitBehaviour.stack(0)));

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/GTJEIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/GTJEIPlugin.java
@@ -114,6 +114,7 @@ public class GTJEIPlugin implements IModPlugin {
     @Override
     public void registerItemSubtypes(ISubtypeRegistration registration) {
         registration.useNbtForSubtypes(GTItems.PROGRAMMED_CIRCUIT.asItem());
+        registration.useNbtForSubtypes(GTItems.TURBINE_ROTOR.asItem());
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/GTREIPlugin.java
@@ -133,6 +133,7 @@ public class GTREIPlugin implements REIClientPlugin {
     @Override
     public void registerItemComparators(ItemComparatorRegistry registry) {
         registry.registerNbt(GTItems.PROGRAMMED_CIRCUIT.asItem());
+        registry.registerNbt(GTItems.TURBINE_ROTOR.asItem());
     }
 
     @Override


### PR DESCRIPTION
## What
Adds NBT comparison to turbine rotors in recipe viewers
Resolves #2700 