### PR TITLE
Add ability for Nano/Quark boots to walk on powder snow 🥶

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorComponentItem.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.component.*;
 import com.gregtechceu.gtceu.api.item.component.forge.IComponentCapability;
 
+import com.gregtechceu.gtceu.common.data.GTItems;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
@@ -319,5 +320,10 @@ public class ArmorComponentItem extends ArmorItem implements IComponentItem {
             }
         }
         return LazyOptional.empty();
+    }
+
+    @Override
+    public boolean canWalkOnPowderedSnow(ItemStack stack, LivingEntity wearer) {
+        return stack.is(GTItems.NANO_BOOTS.asItem()) || stack.is(GTItems.QUANTUM_BOOTS.asItem());
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorComponentItem.java
@@ -3,8 +3,8 @@ package com.gregtechceu.gtceu.api.item.armor;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.component.*;
 import com.gregtechceu.gtceu.api.item.component.forge.IComponentCapability;
-
 import com.gregtechceu.gtceu.common.data.GTItems;
+
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;


### PR DESCRIPTION
## What
Adds override to `ArmorComponentItem` which lets Nano/Quarktech boots to walk over powdered snow
Closes #2693 