### PR TITLE
Lazily construct GTRecipeWrappers in JEI recipe category

### DIFF
--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-ldlib = "1.0.33.b"
+ldlib = "1.0.34"
 registrate = "MC1.20-1.3.11"
 configuration = "2.2.0"
 mixinExtras = "0.2.0"

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.integration.jei.recipe;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
@@ -25,12 +26,13 @@ import mezz.jei.api.registration.IRecipeRegistration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.function.Function;
 
-public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipeWrapper> {
+public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipe> {
 
-    public static final Function<GTRecipeCategory, RecipeType<GTRecipeWrapper>> TYPES = Util
-            .memoize(c -> new RecipeType<>(c.registryKey, GTRecipeWrapper.class));
+    public static final Function<GTRecipeCategory, RecipeType<GTRecipe>> TYPES = Util
+            .memoize(c -> new RecipeType<>(c.registryKey, GTRecipe.class));
 
     private final GTRecipeCategory category;
     @Getter
@@ -40,6 +42,7 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipeWrapper
 
     public GTRecipeJEICategory(IJeiHelpers helpers,
                                @NotNull GTRecipeCategory category) {
+        super(GTRecipeWrapper::new);
         this.category = category;
         var recipeType = category.getRecipeType();
         IGuiHelper guiHelper = helpers.getGuiHelper();
@@ -53,9 +56,7 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipeWrapper
             if (!category.shouldRegisterDisplays()) continue;
             var type = category.getRecipeType();
             if (category == type.getCategory()) type.buildRepresentativeRecipes();
-            var wrapped = type.getRecipesInCategory(category).stream()
-                    .map(GTRecipeWrapper::new)
-                    .toList();
+            var wrapped = List.copyOf(type.getRecipesInCategory(category));
             registration.addRecipes(TYPES.apply(category), wrapped);
         }
     }
@@ -80,7 +81,7 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipeWrapper
 
     @Override
     @NotNull
-    public RecipeType<GTRecipeWrapper> getRecipeType() {
+    public RecipeType<GTRecipe> getRecipeType() {
         return TYPES.apply(category);
     }
 
@@ -91,7 +92,7 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipeWrapper
     }
 
     @Override
-    public @Nullable ResourceLocation getRegistryName(@NotNull GTRecipeWrapper wrapper) {
-        return wrapper.recipe.id;
+    public @Nullable ResourceLocation getRegistryName(@NotNull GTRecipe recipe) {
+        return recipe.id;
     }
 }


### PR DESCRIPTION
This PR builds on https://github.com/Low-Drag-MC/LDLib-MultiLoader/pull/59 (which must be merged first) and changes the JEI recipe category to take advantage of the functionality there to only construct the `GTRecipeWrapper` objects (i.e. recipe widgets) on demand. This saves at least 250MB of RAM in larger packs.