### PR TITLE
Fix cleanrooms not allowing 4 full doors in structure

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CleanroomMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CleanroomMachine.java
@@ -390,7 +390,7 @@ public class CleanroomMachine extends WorkableElectricMultiblockMachine
                 .where('K', wallPredicate // very center floor, needed for height check
                         .or(getValidFloorBlocks()))
                 .where('W', wallPredicate.or(basePredicate)// walls
-                        .or(doorPredicate().setMaxGlobalLimited(4)))
+                        .or(doorPredicate().setMaxGlobalLimited(8)))
                 .where('A', wallPredicate.or(basePredicate)) // floor edges
                 .build();
     }


### PR DESCRIPTION
## What
Allows 4 doors to be used in the cleanroom structure.
It currently only accepts 4 half-door blocks. According to Kross, [this is a bug](https://discord.com/channels/701354865217110096/1324095829748879462/1324096062184489053)
