### PR TITLE
Mark required research data as a catalyst in XEI.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -507,7 +507,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                             }
                             CycleItemStackHandler handler = new CycleItemStackHandler(List.of(dataItems));
                             slot.setHandlerSlot(handler, 0);
-                            slot.setIngredientIO(IngredientIO.INPUT);
+                            slot.setIngredientIO(IngredientIO.CATALYST);
                             slot.setCanTakeItems(false);
                             slot.setCanPutItems(false);
                         }


### PR DESCRIPTION
## What
Mark the research data for assembly line recipes as a catalyst for recipe viewers, to make AE2 patterns easier, and for nicer EMI trees.

## Outcome
Research data for assembly lines will no longer be added to AE2 processing patterns, or show up in EMI recipe trees.