### PR TITLE
Add various GUI changes relating to Parallel Recipes

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3271,6 +3271,7 @@
   "gtceu.multiblock.page_switcher.io.export": "sʇndʇnOㄣ§",
   "gtceu.multiblock.page_switcher.io.import": "sʇnduIᄅ§",
   "gtceu.multiblock.parallel": "ןǝןןɐɹɐԀ uı sǝdıɔǝᴚ %d oʇ dn buıɯɹoɟɹǝԀ",
+  "gtceu.multiblock.parallel.exact": "ןǝןןɐɹɐԀ uı sǝdıɔǝᴚ %d buıɯɹoɟɹǝԀ",
   "gtceu.multiblock.parallelizable.tooltip": "˙sǝɥɔʇɐH ןoɹʇuoƆ ןǝןןɐɹɐԀ ɥʇıʍ ǝzıןǝןןɐɹɐd uɐƆ",
   "gtceu.multiblock.pattern.clear_amount_1": "ɹ§ʇuoɹɟ uı ǝɔɐds ƖxƖxƖ ɹɐǝןɔ ɐ ǝʌɐɥ ʇsnW9§",
   "gtceu.multiblock.pattern.clear_amount_3": "ɹ§ʇuoɹɟ uı ǝɔɐds ƖxƐxƐ ɹɐǝןɔ ɐ ǝʌɐɥ ʇsnW9§",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3271,6 +3271,7 @@
   "gtceu.multiblock.page_switcher.io.export": "§4Outputs",
   "gtceu.multiblock.page_switcher.io.import": "§2Inputs",
   "gtceu.multiblock.parallel": "Performing up to %d Recipes in Parallel",
+  "gtceu.multiblock.parallel.exact": "Performing %d Recipes in Parallel",
   "gtceu.multiblock.parallelizable.tooltip": "Can parallelize with Parallel Control Hatches.",
   "gtceu.multiblock.pattern.clear_amount_1": "§6Must have a clear 1x1x1 space in front§r",
   "gtceu.multiblock.pattern.clear_amount_3": "§6Must have a clear 3x3x1 space in front§r",

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -402,6 +402,10 @@ public class MultiblockDisplayText {
             return this;
         }
 
+        public Builder addParallelsLine(int numParallels) {
+            return addParallelsLine(numParallels, false);
+        }
+
         /**
          * Adds a line indicating how many parallels this multi can potentially perform.
          * <br>

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -407,16 +407,15 @@ public class MultiblockDisplayText {
          * <br>
          * Added if structure is formed and the number of parallels is greater than one.
          */
-        public Builder addParallelsLine(int numParallels) {
+        public Builder addParallelsLine(int numParallels, boolean exact) {
             if (!isStructureFormed)
                 return this;
             if (numParallels > 1) {
                 Component parallels = Component.literal(FormattingUtil.formatNumbers(numParallels))
                         .withStyle(ChatFormatting.DARK_PURPLE);
-
-                textList.add(Component.translatable(
-                        "gtceu.multiblock.parallel",
-                        parallels)
+                String key = "gtceu.multiblock.parallel";
+                if (exact) key += ".exact";
+                textList.add(Component.translatable(key, parallels)
                         .withStyle(ChatFormatting.GRAY));
             }
             return this;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -83,16 +83,23 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
 
     @Override
     public void addDisplayText(List<Component> textList) {
-        int numParallels = this.getParallelHatch()
-                .map(IParallelHatch::getCurrentParallel)
-                .orElse(0);
+        int numParallels;
+        boolean exact = false;
+        if (recipeLogic.isActive() && recipeLogic.getLastRecipe() != null) {
+            numParallels = recipeLogic.getLastRecipe().parallels;
+            exact = true;
+        } else {
+            numParallels = getParallelHatch()
+                    .map(IParallelHatch::getCurrentParallel)
+                    .orElse(0);
+        }
 
         MultiblockDisplayText.builder(textList, isFormed())
                 .setWorkingStatus(recipeLogic.isWorkingEnabled(), recipeLogic.isActive())
                 .addEnergyUsageLine(energyContainer)
                 .addEnergyTierLine(tier)
                 .addMachineModeLine(getRecipeType(), getRecipeTypes().length > 1)
-                .addParallelsLine(numParallels)
+                .addParallelsLine(numParallels, exact)
                 .addWorkingStatusLine()
                 .addProgressLine(recipeLogic.getProgress(), recipeLogic.getMaxProgress(),
                         recipeLogic.getProgressPercent())

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1142,6 +1142,7 @@ public class LangHandler {
         provider.add("gtceu.multiblock.universal.distinct.info",
                 "If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.");
         provider.add("gtceu.multiblock.parallel", "Performing up to %d Recipes in Parallel");
+        provider.add("gtceu.multiblock.parallel.exact", "Performing %d Recipes in Parallel");
         provider.add("gtceu.multiblock.multiple_recipemaps.header", "Machine Mode:");
         provider.add("gtceu.multiblock.multiple_recipemaps.tooltip",
                 "Screwdriver the controller to change which machine mode to use.");

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/ParallelProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/ParallelProvider.java
@@ -3,7 +3,9 @@ package com.gregtechceu.gtceu.integration.top.provider;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.IParallelHatch;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -31,17 +33,27 @@ public class ParallelProvider implements IProbeInfoProvider {
         BlockEntity blockEntity = level.getBlockEntity(iProbeHitData.getPos());
         if (blockEntity instanceof MetaMachineBlockEntity machineBlockEntity) {
             int parallel = 0;
+            boolean exact = false;
             if (machineBlockEntity.getMetaMachine() instanceof IParallelHatch parallelHatch) {
                 parallel = parallelHatch.getCurrentParallel();
             } else if (machineBlockEntity.getMetaMachine() instanceof IMultiController controller) {
-                parallel = controller.getParallelHatch()
-                        .map(IParallelHatch::getCurrentParallel)
-                        .orElse(0);
+                if (controller instanceof IRecipeLogicMachine rlm &&
+                        rlm.getRecipeLogic().isActive() &&
+                        rlm.getRecipeLogic().getLastRecipe() != null) {
+                    parallel = rlm.getRecipeLogic().getLastRecipe().parallels;
+                    exact = true;
+                } else {
+                    parallel = controller.getParallelHatch()
+                            .map(IParallelHatch::getCurrentParallel)
+                            .orElse(0);
+                }
             }
             if (parallel > 0) {
-                iProbeInfo.text(Component.translatable(
-                        "gtceu.multiblock.parallel",
-                        Component.literal(parallel + "").withStyle(ChatFormatting.DARK_PURPLE)));
+                Component parallels = Component.literal(FormattingUtil.formatNumbers(parallel))
+                        .withStyle(ChatFormatting.DARK_PURPLE);
+                String key = "gtceu.multiblock.parallel";
+                if (exact) key += ".exact";
+                iProbeInfo.text(Component.translatable(key, parallels));
             }
         }
     }

--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -2024,6 +2024,7 @@
     "gtceu.multiblock.multiple_recipemaps_recipes.tooltip": "Режим машин: §e%s§r",
     "gtceu.multiblock.not_enough_energy": "ВНИМАНИЕ: Машине нужно больше энергии.",
     "gtceu.multiblock.parallel": "Выполняет до %d рецептов одновременно",
+    "gtceu.multiblock.parallel.exact": "Выполняет %d рецептов одновременно",
     "gtceu.multiblock.parallelizable.tooltip": "Можно распараллелить с Люком контроля Парралелей.",
     "gtceu.multiblock.pattern.clear_amount_1": "§6Спереди должно быть свободное пространство 1x1x1§r",
     "gtceu.multiblock.pattern.clear_amount_3": "§6Спереди должно быть свободное пространство 3x3x1§r",


### PR DESCRIPTION
## What
This PR adds various GUI changes relating to parallel recipes.
Resolves #2715 

## Implementation Details
- Multiblock GUIs, Jade, and TOP now show the exact parallel amount when a recipe is running, rather than the 'up to' amount from the parallel hatch
- Chanced parallel contents are now shown properly in Jade and TOP
- `GTRecipePayload` has been changed to make sure that recipe parallel amount and OC level are relayed when a recipe is persisted

## Additional Details
Waiting for zh_cn translation for new lang key as to not force CN TLs to make another PR