### PR TITLE
Fix Voiding Cover + Soft Mallet interaction

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -518,7 +518,6 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     public boolean shouldRenderGrid(Player player, BlockPos pos, BlockState state, ItemStack held,
                                     Set<GTToolType> toolTypes) {
         if (toolTypes.contains(GTToolType.WRENCH)) return true;
-        if (toolTypes.contains(GTToolType.HARD_HAMMER) && this instanceof IMufflableMachine) return true;
         if (toolTypes.contains(GTToolType.SCREWDRIVER) &&
                 (this instanceof IAutoOutputItem || this instanceof IAutoOutputFluid))
             return true;
@@ -531,6 +530,12 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     @Override
     public ResourceTexture sideTips(Player player, BlockPos pos, BlockState state, Set<GTToolType> toolTypes,
                                     Direction side) {
+        var cover = coverContainer.getCoverAtSide(side);
+        if (cover != null) {
+            var tips = cover.sideTips(player, pos, state, toolTypes, side);
+            if (tips != null) return tips;
+        }
+
         if (toolTypes.contains(GTToolType.WRENCH)) {
             if (player.isShiftKeyDown()) {
                 if (isFacingValid(side)) {
@@ -539,16 +544,12 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
             }
         } else if (toolTypes.contains(GTToolType.SOFT_MALLET)) {
             if (this instanceof IControllable controllable) {
-                return controllable.isWorkingEnabled() ? GuiTextures.TOOL_PAUSE : GuiTextures.TOOL_START;
+                return controllable.isWorkingEnabled() ? GuiTextures.TOOL_START : GuiTextures.TOOL_PAUSE;
             }
         } else if (toolTypes.contains(GTToolType.HARD_HAMMER)) {
             if (this instanceof IMufflableMachine mufflableMachine) {
                 return mufflableMachine.isMuffled() ? GuiTextures.TOOL_SOUND : GuiTextures.TOOL_MUTE;
             }
-        }
-        var cover = coverContainer.getCoverAtSide(side);
-        if (cover != null) {
-            return cover.sideTips(player, pos, state, toolTypes, side);
         }
         return null;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -90,6 +90,7 @@ public class ConveyorCover extends CoverBehavior implements IUICover, IControlla
     @Getter
     protected ManualIOMode manualIOMode = ManualIOMode.DISABLED;
     @Persisted
+    @DescSynced
     @Getter
     protected boolean isWorkingEnabled = true;
     protected int itemsLeftToTransferLastSecond;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
@@ -87,6 +87,7 @@ public class PumpCover extends CoverBehavior implements IUICover, IControllable 
     protected ManualIOMode manualIOMode = ManualIOMode.DISABLED;
 
     @Persisted
+    @DescSynced
     @Getter
     protected boolean isWorkingEnabled = true;
     protected int mBLeftToTransferLastSecond;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/ItemVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/ItemVoidingCover.java
@@ -7,21 +7,30 @@ import com.gregtechceu.gtceu.api.cover.IUICover;
 import com.gregtechceu.gtceu.api.cover.filter.ItemFilter;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.widget.ToggleButtonWidget;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.common.cover.ConveyorCover;
 
+import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
-import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.items.IItemHandler;
 
-import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -29,17 +38,14 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public class ItemVoidingCover extends ConveyorCover implements IUICover, IControllable {
 
-    @Persisted
-    @Getter
-    protected boolean isEnabled = false;
-
     public ItemVoidingCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide) {
         super(definition, coverHolder, attachedSide, 0);
+        setWorkingEnabled(false);
     }
 
     @Override
     protected boolean isSubscriptionActive() {
-        return isWorkingEnabled() && isEnabled();
+        return isWorkingEnabled();
     }
 
     //////////////////////////////////////////////
@@ -75,16 +81,6 @@ public class ItemVoidingCover extends ConveyorCover implements IUICover, IContro
         }
     }
 
-    public void setWorkingEnabled(boolean workingEnabled) {
-        isWorkingEnabled = workingEnabled;
-        subscriptionHandler.updateSubscription();
-    }
-
-    public void setEnabled(boolean enabled) {
-        isEnabled = enabled;
-        subscriptionHandler.updateSubscription();
-    }
-
     //////////////////////////////////////
     // *********** GUI ***********//
     //////////////////////////////////////
@@ -95,7 +91,7 @@ public class ItemVoidingCover extends ConveyorCover implements IUICover, IContro
         group.addWidget(new LabelWidget(10, 5, getUITitle()));
 
         group.addWidget(new ToggleButtonWidget(10, 20, 20, 20,
-                GuiTextures.BUTTON_POWER, this::isEnabled, this::setEnabled));
+                GuiTextures.BUTTON_POWER, this::isWorkingEnabled, this::setWorkingEnabled));
 
         // group.addWidget(filterHandler.createFilterSlotUI(36, 21));
         group.addWidget(filterHandler.createFilterSlotUI(148, 91));
@@ -111,12 +107,33 @@ public class ItemVoidingCover extends ConveyorCover implements IUICover, IContro
         return "cover.item.voiding.title";
     }
 
-    protected void buildAdditionalUI(WidgetGroup group) {
-        // Do nothing in the base implementation. This is intended to be overridden by subclasses.
+    @Override
+    public InteractionResult onSoftMalletClick(Player playerIn, InteractionHand hand, BlockHitResult hitResult) {
+        if (!isRemote()) {
+            setWorkingEnabled(!isWorkingEnabled);
+            playerIn.sendSystemMessage(Component.translatable(isWorkingEnabled() ?
+                    "cover.voiding.message.enabled" : "cover.voiding.message.disabled"));
+        }
+        playerIn.swing(hand);
+        return InteractionResult.CONSUME;
     }
 
-    protected void configureFilter() {
-        // Do nothing in the base implementation. This is intended to be overridden by subclasses.
+    // TODO: Decide grid behavior
+    @Override
+    public boolean shouldRenderGrid(Player player, BlockPos pos, BlockState state, ItemStack held,
+                                    Set<GTToolType> toolTypes) {
+        return super.shouldRenderGrid(player, pos, state, held, toolTypes);
+    }
+
+    @Override
+    public ResourceTexture sideTips(Player player, BlockPos pos, BlockState state, Set<GTToolType> toolTypes,
+                                    Direction side) {
+        var superTips = super.sideTips(player, pos, state, toolTypes, side);
+        if (superTips != null) return superTips;
+        if (toolTypes.contains(GTToolType.SOFT_MALLET)) {
+            return isWorkingEnabled() ? GuiTextures.TOOL_START : GuiTextures.TOOL_PAUSE;
+        }
+        return null;
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
## What
Voiding covers can now be toggled using a soft mallet, as the tooltip suggests you can.

## Implementation Details
Voiding covers + soft mallet will not draw grid, but grid is still logically there.
Hard hammer muffle no longer draws grid
Flip pause/unpause side tip texture
