### PR TITLE
Remove Quartz Slab Cutter recipe due to conflict

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -253,7 +253,7 @@ public class StoneMachineRecipes {
                             .stone(Items.QUARTZ_BLOCK)
                             .polishedStone(Items.QUARTZ_BRICKS)
                             .chiselStone(Items.CHISELED_QUARTZ_BLOCK)
-                            .slab(Items.QUARTZ_SLAB)
+                            // .slab(Items.QUARTZ_SLAB) TODO: Fix plate conflict
                             .stair(Items.QUARTZ_STAIRS)
                             .material(GTMaterials.NetherQuartz, 4 * GTValues.M)
                             .registerAllUnificationInfo()


### PR DESCRIPTION
## What
Disables the Quartz Slab stone entry due to conflict with the Quartz Plate recipe