### PR TITLE
Fix various steam miner issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -131,8 +131,8 @@ public class GTMachines {
             "rock_crusher", GTRecipeTypes.ROCK_BREAKER_RECIPES);
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_MINER = registerSteamMachines(
             "steam_miner",
-            (holder, isHP) -> isHP ? new SteamMinerMachine(holder, 240, 6, 0, 32) :
-                    new SteamMinerMachine(holder, 320, 4, 0, 16),
+            (holder, isHP) -> isHP ? new SteamMinerMachine(holder, true, 240, 6, 0, 32) :
+                    new SteamMinerMachine(holder, false, 320, 4, 0, 16),
             (isHP, builder) -> builder
                     .rotationState(RotationState.NON_Y_AXIS)
                     .recipeType(DUMMY_RECIPES)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -110,10 +110,10 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     @Getter
     @Setter
     @Persisted
-    private int currentRadius;
+    protected int currentRadius;
     @Getter
     @Persisted
-    private boolean isDone;
+    protected boolean isDone;
     @Getter
     private boolean isInventoryFull;
     @Getter
@@ -465,7 +465,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
      *
      * @return {@code true} if the coordinates are invalid, else false
      */
-    private boolean checkCoordinatesInvalid() {
+    protected boolean checkCoordinatesInvalid() {
         return x == Integer.MAX_VALUE && y == Integer.MAX_VALUE && z == Integer.MAX_VALUE;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -110,10 +110,10 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     @Getter
     @Setter
     @Persisted
-    protected int currentRadius;
+    private int currentRadius;
     @Getter
     @Persisted
-    protected boolean isDone;
+    private boolean isDone;
     @Getter
     private boolean isInventoryFull;
     @Getter
@@ -465,7 +465,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
      *
      * @return {@code true} if the coordinates are invalid, else false
      */
-    protected boolean checkCoordinatesInvalid() {
+    private boolean checkCoordinatesInvalid() {
         return x == Integer.MAX_VALUE && y == Integer.MAX_VALUE && z == Integer.MAX_VALUE;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/SteamMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/SteamMinerLogic.java
@@ -19,17 +19,8 @@ public class SteamMinerLogic extends MinerLogic {
 
     @Override
     protected boolean checkCanMine() {
-        if (!isDone && checkCoordinatesInvalid()) {
-            initPos(getMiningPos(), currentRadius);
-        }
-
         IExhaustVentMachine machine = (IExhaustVentMachine) this.machine;
-        if (machine.checkVenting()) {
-            if (machine.isVentingBlocked())
-                return false;
-        }
-
-        return super.checkCanMine();
+        return super.checkCanMine() && machine.checkVenting();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/SteamMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/SteamMinerLogic.java
@@ -19,6 +19,10 @@ public class SteamMinerLogic extends MinerLogic {
 
     @Override
     protected boolean checkCanMine() {
+        if (!isDone && checkCoordinatesInvalid()) {
+            initPos(getMiningPos(), currentRadius);
+        }
+
         IExhaustVentMachine machine = (IExhaustVentMachine) this.machine;
         if (machine.checkVenting()) {
             if (machine.isVentingBlocked())


### PR DESCRIPTION
## What
Fixes #2726 
If the exhaust vent of a steam miner is blocked upon placement, it will not call `super.checkCanMine()` which initializes the coordinates. Instead, we can just call super first and then make sure the miner is able to vent properly.

Changed UI of HP steam miner to be steel textures
Add new text in UI for no steam and blocked venting
Add venting damage to steam miners.
Steam Miner now updates its logic on neighbor change, to help resume working once the vent obstruction is removed

## Implementation Details
Constructor changed to have `isHighPressure` passed