### PR TITLE
Add sign and sheep dying capability to Chemical Dyes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -2224,12 +2224,13 @@ public class GTItems {
             .onRegister(attach(new MetaMachineConfigCopyBehaviour()))
             .register();
 
-    public static final ItemEntry<Item>[] DYE_ONLY_ITEMS = new ItemEntry[DyeColor.values().length];
+    public static final ItemEntry<DyeItem>[] DYE_ONLY_ITEMS = new ItemEntry[DyeColor.values().length];
     static {
         DyeColor[] colors = DyeColor.values();
         for (int i = 0; i < colors.length; i++) {
             var dyeColor = colors[i];
-            DYE_ONLY_ITEMS[i] = REGISTRATE.item("chemical_%s_dye".formatted(dyeColor.getName()), Item::new)
+            DYE_ONLY_ITEMS[i] = REGISTRATE
+                    .item("chemical_%s_dye".formatted(dyeColor.getName()), (props) -> new DyeItem(dyeColor, props))
                     .lang("Chemical %s Dye".formatted(toEnglishName(dyeColor.getName())))
                     .tag(TagUtil.createItemTag("dyes/" + dyeColor.getName()))
                     .register();


### PR DESCRIPTION
## What
This PR turns the Chemical Dye items into instances of the `DyeItem` class, which allows them to be used on signs and sheeps.
Resolves #2703