### PR TITLE
Change damping to be a property of definition rather than class

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
@@ -91,7 +91,7 @@ public class MachineDefinition implements Supplier<IMachineBlock> {
     private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
     @Getter
     @Setter
-    private boolean dampingWhenWaiting = true;
+    private boolean regressWhenWaiting = true;
 
     @Getter
     @Setter

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
@@ -89,6 +89,9 @@ public class MachineDefinition implements Supplier<IMachineBlock> {
     @Getter
     @Setter
     private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
+    @Getter
+    @Setter
+    private boolean dampingWhenWaiting = true;
 
     @Getter
     @Setter

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -108,7 +108,7 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
      * Whether progress decrease when machine is waiting for pertick ingredients. (e.g. lack of EU)
      */
     default boolean dampingWhenWaiting() {
-        return self().getDefinition().isDampingWhenWaiting();
+        return self().getDefinition().isRegressWhenWaiting();
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -108,7 +108,7 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
      * Whether progress decrease when machine is waiting for pertick ingredients. (e.g. lack of EU)
      */
     default boolean dampingWhenWaiting() {
-        return true;
+        return self().getDefinition().isDampingWhenWaiting();
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -148,7 +148,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
     @Getter
     @Setter
-    private boolean dampingWhenWaiting = true;
+    private boolean regressWhenWaiting = true;
 
     @Setter
     private Supplier<BlockState> appearance;
@@ -368,7 +368,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         definition.setOnWorking(this.onWorking);
         definition.setOnWaiting(this.onWaiting);
         definition.setAfterWorking(this.afterWorking);
-        definition.setDampingWhenWaiting(this.dampingWhenWaiting);
+        definition.setRegressWhenWaiting(this.regressWhenWaiting);
 
         if (renderer == null) {
             renderer = () -> new MachineRenderer(new ResourceLocation(registrate.getModid(), "block/machine/" + name));

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -146,6 +146,9 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     @Getter
     @Setter
     private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
+    @Getter
+    @Setter
+    private boolean dampingWhenWaiting = true;
 
     @Setter
     private Supplier<BlockState> appearance;
@@ -365,6 +368,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         definition.setOnWorking(this.onWorking);
         definition.setOnWaiting(this.onWaiting);
         definition.setAfterWorking(this.afterWorking);
+        definition.setDampingWhenWaiting(this.dampingWhenWaiting);
 
         if (renderer == null) {
             renderer = () -> new MachineRenderer(new ResourceLocation(registrate.getModid(), "block/machine/" + name));

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -369,8 +369,8 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     }
 
     @Override
-    public MultiblockMachineBuilder dampingWhenWaiting(boolean dampingWhenWaiting) {
-        return (MultiblockMachineBuilder) super.dampingWhenWaiting(dampingWhenWaiting);
+    public MultiblockMachineBuilder regressWhenWaiting(boolean dampingWhenWaiting) {
+        return (MultiblockMachineBuilder) super.regressWhenWaiting(dampingWhenWaiting);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -369,6 +369,11 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     }
 
     @Override
+    public MultiblockMachineBuilder dampingWhenWaiting(boolean dampingWhenWaiting) {
+        return (MultiblockMachineBuilder) super.dampingWhenWaiting(dampingWhenWaiting);
+    }
+
+    @Override
     public MultiblockMachineBuilder editableUI(@Nullable EditableMachineUI editableUI) {
         return (MultiblockMachineBuilder) super.editableUI(editableUI);
     }


### PR DESCRIPTION
## What
Make `dampingWhenWaiting` a property of a machine definition, which allows it to be set from KJS, and avoid the need for addons to subclass only to override that method.

## Outcome
Fixes #1633.
KubeJS can now set `regressWhenWaiting` on machines (in particular generators).
