### PR TITLE
Fix solvent spray can not actually removing paint color

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -215,10 +215,10 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
 
     private static boolean paintPaintable(IPaintable paintable, DyeColor color) {
         if (color == null) {
-            if (paintable.getDefaultPaintingColor() == paintable.getPaintingColor()) {
+            if (paintable.getPaintingColor() == -1) {
                 return false;
             }
-            paintable.setPaintingColor(paintable.getDefaultPaintingColor());
+            paintable.setPaintingColor(-1);
         } else if (paintable.getPaintingColor() != color.getTextColor()) {
             paintable.setPaintingColor(color.getTextColor());
         } else {


### PR DESCRIPTION
## What
Make the solvent spray can make GT paintables have no set color, rather than explicitly setting the color to match the default color. Without this, the Jade tooltip for the block would show the block as colored with an explicit color, and the block would not match changes to the default color in new versions of the mod/modpack.

## Implementation Details
To address the issue with the tooltip, it could have been hidden if the color matches the default. However, given the difference in behavior when the default changes, I think it makes sense to show an explicitly set default color.

## Outcome
Using the solvent spray on a machine block will no longer show an explicit color in the Jade tooltip.