### PR TITLE
Fix miner duplication for self-dropping blocks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
@@ -152,6 +152,7 @@ public class LargeMinerLogic extends MinerLogic {
                                        LootParams.Builder builder) {
         if (!super.doPostProcessing(blockDrops, blockState, builder) && getDropCountMultiplier() > 0) {
             for (ItemStack drop : blockDrops) {
+                if (drop.is(blockState.getBlock().asItem())) continue;
                 drop.setCount(drop.getCount() * getDropCountMultiplier());
             }
         }


### PR DESCRIPTION
## What
Adds a check to `LargeMinerLogic#doPostProcessing` to ensure that any block that drops itself will not be multiplied.
Fixes #2671 