### PR TITLE
Add assembler recipes for fishing rods

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -871,6 +871,23 @@ public class VanillaStandardRecipes {
      * Adds polished stone variant autoclave recipes
      */
     private static void miscRecipes(Consumer<FinishedRecipe> provider) {
+        if (ConfigHolder.INSTANCE.recipes.hardToolArmorRecipes) {
+            ASSEMBLER_RECIPES.recipeBuilder("fishing_rod")
+                    .inputItems(new ItemStack(Items.STRING))
+                    .inputItems(rodLong, Wood, 2)
+                    .inputItems(ring, Iron)
+                    .outputItems(new ItemStack(Items.FISHING_ROD, 1))
+                    .circuitMeta(16)
+                    .duration(100).EUt(4).save(provider);
+        } else {
+            ASSEMBLER_RECIPES.recipeBuilder("fishing_rod")
+                    .inputItems(new ItemStack(Items.STRING, 2))
+                    .inputItems(rod, Wood, 3)
+                    .outputItems(new ItemStack(Items.FISHING_ROD, 1))
+                    .circuitMeta(16)
+                    .duration(100).EUt(4).save(provider);
+        }
+
         ASSEMBLER_RECIPES.recipeBuilder("book_from_leather")
                 .inputItems(new ItemStack(Items.PAPER, 3))
                 .inputItems(new ItemStack(Items.LEATHER))


### PR DESCRIPTION
## What
Adds recipes for fishing rods to the assembler (for both with `hardToolArmorRecipes` turned on and off)

## Outcome
Closes #2685 