### PR TITLE
Stop showing "Running 1 parallel." in Jade/TOP.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/ParallelProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/ParallelProvider.java
@@ -24,7 +24,7 @@ public class ParallelProvider implements IBlockComponentProvider, IServerDataPro
     public void appendTooltip(ITooltip iTooltip, BlockAccessor blockAccessor, IPluginConfig iPluginConfig) {
         if (blockAccessor.getServerData().contains("parallel")) {
             int parallel = blockAccessor.getServerData().getInt("parallel");
-            if (parallel > 0) {
+            if (parallel > 1) {
                 Component parallels = Component.literal(FormattingUtil.formatNumbers(parallel))
                         .withStyle(ChatFormatting.DARK_PURPLE);
                 String key = "gtceu.multiblock.parallel";

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/ParallelProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/ParallelProvider.java
@@ -48,7 +48,7 @@ public class ParallelProvider implements IProbeInfoProvider {
                             .orElse(0);
                 }
             }
-            if (parallel > 0) {
+            if (parallel > 1) {
                 Component parallels = Component.literal(FormattingUtil.formatNumbers(parallel))
                         .withStyle(ChatFormatting.DARK_PURPLE);
                 String key = "gtceu.multiblock.parallel";


### PR DESCRIPTION
## Outcome
Machines no longer display "Running 1 parallel." in Jade/The One Probe overlays.