### PR TITLE
Use "B" instead of "kmB" in ME Input Hatches.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/slot/AEFluidConfigSlotWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/slot/AEFluidConfigSlotWidget.java
@@ -7,10 +7,10 @@ import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEFluidSlot;
 import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAESlot;
 import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlot;
 import com.gregtechceu.gtceu.integration.ae2.utils.AEUtil;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTMath;
 
 import com.lowdragmc.lowdraglib.gui.util.DrawerHelper;
-import com.lowdragmc.lowdraglib.gui.util.TextFormattingUtil;
 import com.lowdragmc.lowdraglib.side.fluid.forge.FluidHelperImpl;
 import com.lowdragmc.lowdraglib.utils.Position;
 import com.lowdragmc.lowdraglib.utils.Size;
@@ -70,7 +70,8 @@ public class AEFluidConfigSlotWidget extends AEConfigSlotWidget implements IGhos
                 DrawerHelper.drawFluidForGui(graphics, FluidHelperImpl.toFluidStack(stack), config.amount(), stackX,
                         stackY, 16, 16);
                 if (!parentWidget.isStocking()) {
-                    String amountStr = TextFormattingUtil.formatLongToCompactString(config.amount(), 4) + "mB";
+                    String amountStr = FormattingUtil.formatNumberReadable(config.amount(), true,
+                            FormattingUtil.DECIMAL_FORMAT_0F, "B");
                     drawStringFixedCorner(graphics, amountStr, stackX + 17, stackY + 17, 16777215, true, 0.5f);
                 }
             }
@@ -81,7 +82,8 @@ public class AEFluidConfigSlotWidget extends AEConfigSlotWidget implements IGhos
                 DrawerHelper.drawFluidForGui(graphics, FluidHelperImpl.toFluidStack(stack), stock.amount(), stackX,
                         stackY + 18, 16,
                         16);
-                String amountStr = TextFormattingUtil.formatLongToCompactString(stock.amount(), 4) + "mB";
+                String amountStr = FormattingUtil.formatNumberReadable(stock.amount(), true,
+                        FormattingUtil.DECIMAL_FORMAT_0F, "B");
                 drawStringFixedCorner(graphics, amountStr, stackX + 17, stackY + 18 + 17, 16777215, true, 0.5f);
             }
         }


### PR DESCRIPTION
## Outcome
ME Input Hatches now display buckets with "B" rather than "kmB".