### PR TITLE
Config option to enable/disable ore indicator generation

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1812,6 +1812,7 @@
   "config.gtceu.option.oreGenerationChunkCacheSize": "ǝzıSǝɥɔɐƆʞunɥƆuoıʇɐɹǝuǝ⅁ǝɹo",
   "config.gtceu.option.oreIconSize": "ǝzıSuoɔIǝɹo",
   "config.gtceu.option.oreIndicatorChunkCacheSize": "ǝzıSǝɥɔɐƆʞunɥƆɹoʇɐɔıpuIǝɹo",
+  "config.gtceu.option.oreIndicators": "sɹoʇɐɔıpuIǝɹo",
   "config.gtceu.option.oreNamePrefix": "xıɟǝɹԀǝɯɐNǝɹo",
   "config.gtceu.option.oreScaleStop": "doʇSǝןɐɔSǝɹo",
   "config.gtceu.option.oreVeinGridSize": "ǝzıSpıɹ⅁uıǝΛǝɹo",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1812,6 +1812,7 @@
   "config.gtceu.option.oreGenerationChunkCacheSize": "oreGenerationChunkCacheSize",
   "config.gtceu.option.oreIconSize": "oreIconSize",
   "config.gtceu.option.oreIndicatorChunkCacheSize": "oreIndicatorChunkCacheSize",
+  "config.gtceu.option.oreIndicators": "oreIndicators",
   "config.gtceu.option.oreNamePrefix": "oreNamePrefix",
   "config.gtceu.option.oreScaleStop": "oreScaleStop",
   "config.gtceu.option.oreVeinGridSize": "oreVeinGridSize",

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
@@ -88,6 +88,7 @@ public class OrePlacer {
     }
 
     private void placeIndicators(ChunkAccess chunk, BulkSectionAccess access, GeneratedIndicators generatedVein) {
+        if (!ConfigHolder.INSTANCE.worldgen.oreVeins.oreIndicators) return;
         generatedVein.consumeIndicators(chunk.getPos()).forEach(placer -> {
             placer.placeIndicators(access);
         });

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -390,6 +390,9 @@ public class ConfigHolder {
             @Configurable.Comment({ "Make bedrock ore/fluid veins infinite?", "Default: false" })
             public boolean infiniteBedrockOresFluids = false;
             @Configurable
+            @Configurable.Comment({ "Generate ores indicators above ore veins", "Default: true" })
+            public boolean oreIndicators = true;
+            @Configurable
             @Configurable.Comment({
                     "Sets the maximum number of chunks that may be cached for ore vein generation.",
                     "Higher values may improve world generation performance, but at the cost of more RAM usage.",


### PR DESCRIPTION
## What
Adds a config option to enable/disable ore indicator generation (default: true)

## Implementation Details
Simply early exits OrePlacer#placeIndicators if oreIndicators is false

## Outcome
Resolves  #2766 