### PR TITLE
Add overrides for setFluid and getFluid calls to PotionItem

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -140,7 +140,18 @@ public class ForgeCommonEventListener {
         } else if (itemStack.getItem() instanceof PotionItem) {
             LazyOptional<IFluidHandlerItem> handler = LazyOptional.of(() -> {
                 var fluidHandler = new FluidHandlerItemStack.SwapEmpty(itemStack, new ItemStack(Items.GLASS_BOTTLE),
-                        PotionFluidHelper.BOTTLE_AMOUNT);
+                        PotionFluidHelper.BOTTLE_AMOUNT) {
+
+                    @Override
+                    protected void setFluid(FluidStack fluid) {
+                        // do nada
+                    }
+
+                    @Override
+                    public @NotNull FluidStack getFluid() {
+                        return PotionFluidHelper.getFluidFromPotionItem(itemStack, PotionFluidHelper.BOTTLE_AMOUNT);
+                    }
+                };
                 fluidHandler.fill(PotionFluidHelper.getFluidFromPotionItem(itemStack, PotionFluidHelper.BOTTLE_AMOUNT),
                         IFluidHandler.FluidAction.EXECUTE);
                 return fluidHandler;


### PR DESCRIPTION
## What
See #2704 

## Outcome
Tested and confirmed that the Brewery retains the ability to have potions added/removed by clicking potions/glass bottles on the input/output.
Fixes: #2704 