### PR TITLE
Make steam miners also break miner pipe when broken

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamMinerMachine.java
@@ -112,6 +112,7 @@ public class SteamMinerMachine extends SteamWorkableMachine implements IMiner, I
 
     @Override
     public void onMachineRemoved() {
+        getRecipeLogic().onRemove();
         clearInventory(exportItems.storage);
     }
 


### PR DESCRIPTION
the other PR got nuked when I renamed the patch branch. this is a note to self to not rename branches AFTER making the PR

This fixes a bug where the steam miner wouldn't break its associated miner pipe after being broken. I actually tested it, and it indeed works.