### PR TITLE
Change electric Wire Cutter IDs to be consistent with the unpowered version

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
@@ -404,7 +404,7 @@ public class GTToolType {
             .build();
 
     public static final GTToolType WIRE_CUTTER_LV = GTToolType.builder("lv_wirecutter")
-            .idFormat("lv_%s_wirecutter")
+            .idFormat("lv_%s_wire_cutter")
             .toolTag(CustomTags.CRAFTING_WIRE_CUTTERS)
             .toolTag(CustomTags.WIRE_CUTTERS)
             .harvestTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
@@ -417,7 +417,7 @@ public class GTToolType {
             .build();
 
     public static final GTToolType WIRE_CUTTER_HV = GTToolType.builder("hv_wirecutter")
-            .idFormat("hv_%s_wirecutter")
+            .idFormat("hv_%s_wire_cutter")
             .toolTag(CustomTags.CRAFTING_WIRE_CUTTERS)
             .toolTag(CustomTags.WIRE_CUTTERS)
             .harvestTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
@@ -430,7 +430,7 @@ public class GTToolType {
             .build();
 
     public static final GTToolType WIRE_CUTTER_IV = GTToolType.builder("iv_wirecutter")
-            .idFormat("iv_%s_wirecutter")
+            .idFormat("iv_%s_wire_cutter")
             .toolTag(CustomTags.CRAFTING_WIRE_CUTTERS)
             .toolTag(CustomTags.WIRE_CUTTERS)
             .harvestTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
@@ -391,7 +391,7 @@ public class GTToolType {
             .build();
 
     public static final GTToolType WIRE_CUTTER_LV = GTToolType.builder("lv_wirecutter")
-            .idFormat("lv_%s_wirecutter")
+            .idFormat("lv_%s_wire_cutter")
             .toolTag(CustomTags.WIRE_CUTTERS)
             .harvestTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
             .toolStats(b -> b.blockBreaking().crafting().sneakBypassUse()
@@ -403,7 +403,7 @@ public class GTToolType {
             .build();
 
     public static final GTToolType WIRE_CUTTER_HV = GTToolType.builder("hv_wirecutter")
-            .idFormat("hv_%s_wirecutter")
+            .idFormat("hv_%s_wire_cutter")
             .toolTag(CustomTags.WIRE_CUTTERS)
             .harvestTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
             .toolStats(b -> b.blockBreaking().crafting().sneakBypassUse()
@@ -415,7 +415,7 @@ public class GTToolType {
             .build();
 
     public static final GTToolType WIRE_CUTTER_IV = GTToolType.builder("iv_wirecutter")
-            .idFormat("iv_%s_wirecutter")
+            .idFormat("iv_%s_wire_cutter")
             .toolTag(CustomTags.WIRE_CUTTERS)
             .harvestTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
             .toolStats(b -> b.blockBreaking().crafting().sneakBypassUse()

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -19,6 +19,7 @@ import com.gregtechceu.gtceu.api.item.DrumMachineItem;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine;
 import com.gregtechceu.gtceu.api.misc.forge.FilteredFluidHandlerItemStack;
@@ -522,6 +523,25 @@ public class ForgeCommonEventListener {
             }
             if (mapping.getKey().equals(GTCEu.id("avanced_nanomuscle_chestplate"))) {
                 mapping.remap(GTItems.NANO_CHESTPLATE_ADVANCED.get());
+            }
+            String path = mapping.getKey().getPath();
+            if (path.matches("[lhi]v_.+_wirecutter")) {
+                String suffix = "_wirecutter";
+                String typeString = path.substring(0, 2) + suffix; // [lhi]v_wirecutter -- tooltype name
+                String matString = path.substring(3, path.length() - suffix.length()); // material name
+
+                GTToolType type = GTToolType.getTypes().get(typeString);
+                Material material = GTMaterials.get(matString);
+                if (type == null || material == null) {
+                    mapping.warn();
+                    return;
+                }
+                var tool = GTMaterialItems.TOOL_ITEMS.get(material, type);
+                if (tool == null) {
+                    mapping.warn();
+                    return;
+                }
+                mapping.remap(tool.asItem());
             }
         });
         event.getMappings(Registries.BLOCK_ENTITY_TYPE, GTCEu.MOD_ID).forEach(mapping -> {


### PR DESCRIPTION
## What
The item ID of electric wire cutters was for example `"iv_%s_wirecutter"`, which is inconsistent with the non-electric version, as well as the tag `#forge:tools/wire_cutters`

## Outcome
| Old | New |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/33bf89e2-b5de-4eec-a1e5-3a307d47365f) | ![image](https://github.com/user-attachments/assets/25f6ded8-7fa1-447e-a9a1-78784a03d5be) |

**Note the ID changed**

## Potential Compatibility Issues
This will cause all existing items to cease existence