### PR TITLE
Filter nitpicks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/Filter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/Filter.java
@@ -23,4 +23,8 @@ public interface Filter<T, S extends Filter<T, S>> extends Predicate<T> {
     default boolean isBlackList() {
         return false;
     }
+
+    default boolean isBlank() {
+        return false;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FilterHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FilterHandler.java
@@ -117,7 +117,13 @@ public abstract class FilterHandler<T, F extends Filter<T, F>> implements IEnhan
 
     private CustomItemStackHandler getFilterSlot() {
         if (this.filterSlot == null) {
-            this.filterSlot = new CustomItemStackHandler(this.filterItem);
+            this.filterSlot = new CustomItemStackHandler(this.filterItem) {
+
+                @Override
+                public int getSlotLimit(int slot) {
+                    return 1;
+                }
+            };
 
             this.filterSlot.setFilter(this::canInsertFilterItem);
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
@@ -73,8 +73,13 @@ public class SimpleFluidFilter implements FluidFilter {
         };
     }
 
+    @Override
+    public boolean isBlank() {
+        return !isBlackList && !ignoreNbt && Arrays.stream(matches).allMatch(FluidStack::isEmpty);
+    }
+
     public CompoundTag saveFilter() {
-        if (!isBlackList && !ignoreNbt && Arrays.stream(matches).allMatch(FluidStack::isEmpty)) {
+        if (isBlank()) {
             return null;
         }
         var tag = new CompoundTag();

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
@@ -74,6 +74,9 @@ public class SimpleFluidFilter implements FluidFilter {
     }
 
     public CompoundTag saveFilter() {
+        if (!isBlackList && !ignoreNbt && Arrays.stream(matches).allMatch(FluidStack::isEmpty)) {
+            return null;
+        }
         var tag = new CompoundTag();
         tag.putBoolean("isBlackList", isBlackList);
         tag.putBoolean("matchNbt", ignoreNbt);

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -72,8 +72,13 @@ public class SimpleItemFilter implements ItemFilter {
         };
     }
 
+    @Override
+    public boolean isBlank() {
+        return !isBlackList && !ignoreNbt && Arrays.stream(matches).allMatch(ItemStack::isEmpty);
+    }
+
     public CompoundTag saveFilter() {
-        if (!isBlackList && !ignoreNbt && Arrays.stream(matches).allMatch(ItemStack::isEmpty)) {
+        if (isBlank()) {
             return null;
         }
         var tag = new CompoundTag();

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -73,6 +73,9 @@ public class SimpleItemFilter implements ItemFilter {
     }
 
     public CompoundTag saveFilter() {
+        if (!isBlackList && !ignoreNbt && Arrays.stream(matches).allMatch(ItemStack::isEmpty)) {
+            return null;
+        }
         var tag = new CompoundTag();
         tag.putBoolean("isBlackList", isBlackList);
         tag.putBoolean("matchNbt", ignoreNbt);

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
@@ -50,8 +50,13 @@ public class SmartItemFilter implements ItemFilter {
     }
 
     @Override
+    public boolean isBlank() {
+        return filterMode.ordinal() == 0;
+    }
+
+    @Override
     public CompoundTag saveFilter() {
-        if (filterMode.ordinal() == 0) {
+        if (isBlank()) {
             return null;
         }
         var tag = new CompoundTag();

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
@@ -51,6 +51,9 @@ public class SmartItemFilter implements ItemFilter {
 
     @Override
     public CompoundTag saveFilter() {
+        if (filterMode.ordinal() == 0) {
+            return null;
+        }
         var tag = new CompoundTag();
         tag.putInt("filterMode", filterMode.ordinal());
         return tag;

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
@@ -40,8 +40,13 @@ public abstract class TagFilter<T, S extends Filter<T, S>> implements Filter<T, 
 
     protected TagFilter() {}
 
+    @Override
+    public boolean isBlank() {
+        return oreDictFilterExpression.isBlank();
+    }
+
     public CompoundTag saveFilter() {
-        if (oreDictFilterExpression.isBlank()) {
+        if (isBlank()) {
             return null;
         }
         var tag = new CompoundTag();

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
@@ -41,6 +41,9 @@ public abstract class TagFilter<T, S extends Filter<T, S>> implements Filter<T, 
     protected TagFilter() {}
 
     public CompoundTag saveFilter() {
+        if (oreDictFilterExpression.isBlank()) {
+            return null;
+        }
         var tag = new CompoundTag();
         tag.putString("oreDict", oreDictFilterExpression);
         return tag;

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
@@ -25,7 +25,7 @@ public class TagFluidFilter extends TagFilter<FluidStack, FluidFilter> implement
     protected TagFluidFilter() {}
 
     public static TagFluidFilter loadFilter(ItemStack itemStack) {
-        return loadFilter(Objects.requireNonNullElseGet(itemStack.getTag(), CompoundTag::new), 
+        return loadFilter(Objects.requireNonNullElseGet(itemStack.getTag(), CompoundTag::new),
                 filter -> itemStack.setTag(filter.saveFilter()));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
@@ -10,6 +10,7 @@ import net.minecraftforge.fluids.FluidStack;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -24,13 +25,11 @@ public class TagFluidFilter extends TagFilter<FluidStack, FluidFilter> implement
     protected TagFluidFilter() {}
 
     public static TagFluidFilter loadFilter(ItemStack itemStack) {
-        return loadFilter(itemStack.getTag(), filter -> itemStack.setTag(filter.saveFilter()));
+        return loadFilter(Objects.requireNonNullElseGet(itemStack.getTag(), CompoundTag::new), 
+                filter -> itemStack.setTag(filter.saveFilter()));
     }
 
     private static TagFluidFilter loadFilter(CompoundTag tag, Consumer<FluidFilter> itemWriter) {
-        if (tag == null) {
-            tag = new CompoundTag();
-        }
         var handler = new TagFluidFilter();
         handler.itemWriter = itemWriter;
         handler.oreDictFilterExpression = tag.getString("oreDict");

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
@@ -24,10 +24,13 @@ public class TagFluidFilter extends TagFilter<FluidStack, FluidFilter> implement
     protected TagFluidFilter() {}
 
     public static TagFluidFilter loadFilter(ItemStack itemStack) {
-        return loadFilter(itemStack.getOrCreateTag(), filter -> itemStack.setTag(filter.saveFilter()));
+        return loadFilter(itemStack.getTag(), filter -> itemStack.setTag(filter.saveFilter()));
     }
 
     private static TagFluidFilter loadFilter(CompoundTag tag, Consumer<FluidFilter> itemWriter) {
+        if (tag == null) {
+            tag = new CompoundTag();
+        }
         var handler = new TagFluidFilter();
         handler.itemWriter = itemWriter;
         handler.oreDictFilterExpression = tag.getString("oreDict");

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
@@ -23,10 +23,13 @@ public class TagItemFilter extends TagFilter<ItemStack, ItemFilter> implements I
     protected TagItemFilter() {}
 
     public static TagItemFilter loadFilter(ItemStack itemStack) {
-        return loadFilter(itemStack.getOrCreateTag(), filter -> itemStack.setTag(filter.saveFilter()));
+        return loadFilter(itemStack.getTag(), filter -> itemStack.setTag(filter.saveFilter()));
     }
 
     private static TagItemFilter loadFilter(CompoundTag tag, Consumer<ItemFilter> itemWriter) {
+        if (tag == null) {
+            tag = new CompoundTag();
+        }
         var handler = new TagItemFilter();
         handler.itemWriter = itemWriter;
         handler.oreDictFilterExpression = tag.getString("oreDict");

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
@@ -24,7 +24,7 @@ public class TagItemFilter extends TagFilter<ItemStack, ItemFilter> implements I
     protected TagItemFilter() {}
 
     public static TagItemFilter loadFilter(ItemStack itemStack) {
-        return loadFilter(Objects.requireNonNullElseGet(itemStack.getTag(), CompoundTag::new), 
+        return loadFilter(Objects.requireNonNullElseGet(itemStack.getTag(), CompoundTag::new),
                 filter -> itemStack.setTag(filter.saveFilter()));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.ItemStack;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -23,13 +24,11 @@ public class TagItemFilter extends TagFilter<ItemStack, ItemFilter> implements I
     protected TagItemFilter() {}
 
     public static TagItemFilter loadFilter(ItemStack itemStack) {
-        return loadFilter(itemStack.getTag(), filter -> itemStack.setTag(filter.saveFilter()));
+        return loadFilter(Objects.requireNonNullElseGet(itemStack.getTag(), CompoundTag::new), 
+                filter -> itemStack.setTag(filter.saveFilter()));
     }
 
     private static TagItemFilter loadFilter(CompoundTag tag, Consumer<ItemFilter> itemWriter) {
-        if (tag == null) {
-            tag = new CompoundTag();
-        }
         var handler = new TagItemFilter();
         handler.itemWriter = itemWriter;
         handler.oreDictFilterExpression = tag.getString("oreDict");


### PR DESCRIPTION
## What
Limit the filter handler slot to hold a single filter (down from 64).
Stop saving NBT data if the filter state is the default.

## Implementation Details
There's some weird edge case for the tag filters, the `getTag()` followed by null check is intentional.

## Potential Compatibility Issues
Any addon that extends the existing filters in a way that doesn't make sense will probably need to reimplement `saveFilter()` or `isBlank()`.