### PR TITLE
Downgrade journeymap-api

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,7 @@ dependencyResolutionManagement {
         def xaerosWorldMapVersion = "5658224"
         def xaerosMinimapVersion = "5773012"
         def journeyMapVersion = "5789363"
-        def journeyMapApiVersion = "2.0.0"
+        def journeyMapApiVersion = "1.20-1.9"
         def ftbteamsForgeFile = "5267190"
         def ftblibraryForgeFile = "5567591"
         def ftbchunksForgeFile = "5956390"
@@ -121,8 +121,8 @@ dependencyResolutionManagement {
             def xaerosMiniMap = version("xaerosMinimap", xaerosMinimapVersion)
             library("xaerosminimap", "curse.maven", "xaeros-minimap-263420").versionRef(xaerosMiniMap)
 
-            def journeyMapApi = version("journeyMapApi", journeyMapApiVersion + "-" + minecraftVersion + "-SNAPSHOT")
-            library("journeymap-api", "info.journeymap", "journeymap-api-forge").versionRef(journeyMapApi)
+            def journeyMapApi = version("journeyMapApi", journeyMapApiVersion + "-SNAPSHOT")
+            library("journeymap-api", "info.journeymap", "journeymap-api").versionRef(journeyMapApi)
 
             def journeyMap = version("journeyMap", journeyMapVersion)
             library("journeymap-forge", "curse.maven", "journeymap-32274").versionRef(journeyMap)


### PR DESCRIPTION
## What
According to JourneyMap's developer, the `2.0.0-SNAPSHOT` version was never meant to exist for 1.20.1. It has been removed from their maven and thus we need to downgrade to `1.9-SNAPSHOT`, [as recommended by the dev](https://discord.com/channels/239040424214396929/1332819611594264591/1332819611594264591)
![image](https://cdn.discordapp.com/attachments/1089296351906504835/1332870183072829500/image.png?ex=6796d397&is=67958217&hm=02b5e6e16bf6f1c84ef827d79ceed91cc37581111740c00e8df92b9df9b91ec0&)

## Outcome
Can actually build the mod

## Additional Information
Seems like everything in-game still works.
