### PR TITLE
Add initial computercraft support.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,6 +58,10 @@ dependencies {
     modCompileOnly(forge.journeymap.api)
     modCompileOnly(forge.journeymap.forge)
 
+    // CC: Tweaked
+    modCompileOnly(forge.cc.tweaked.core.api)
+    modCompileOnly(forge.cc.tweaked.forge.api)
+
     // Standard runtime mods //
     modRuntimeOnly(forge.jade)
     modRuntimeOnly(forge.ae2)
@@ -75,6 +79,7 @@ dependencies {
     modExtraRuntimeOnly(forge.trenzalore)
     modExtraRuntimeOnly(forge.curios)
 //    modExtraRuntimeOnly(forge.worldstripper)
+    modExtraRuntimeOnly(forge.cc.tweaked.forge.impl)
 
     modExtraRuntimeOnly(forge.bundles.kjs)
 
@@ -88,6 +93,7 @@ dependencies {
 
     modExtraRuntimeOnly(forge.spark)
     modExtraRuntimeOnly(forge.observable)
+
     //////////////////////////
 
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -20,6 +20,7 @@ journeyMapApi = "1.20-1.9-SNAPSHOT"
 ftblibrary = "2001.2.4"
 ftbteams = "2001.3.0"
 ftbchunks = "2001.3.4"
+ccTweaked = "1.114.3"
 
 ## modrinth maven ##
 jade = "11.6.3"
@@ -74,6 +75,11 @@ ftbchunks           = { module = "dev.ftb.mods:ftb-chunks-forge", version.ref = 
 jade                = { module = "maven.modrinth:jade", version.ref = "jade" }
 embeddium           = { module = "maven.modrinth:embeddium", version.ref = "embeddium" }
 oculus              = { module = "maven.modrinth:oculus", version.ref = "oculus" }
+
+
+cc-tweaked-core-api   = { module = "cc.tweaked:cc-tweaked-1.20.1-core-api", version.ref = "ccTweaked" }
+cc-tweaked-forge-api  = { module = "cc.tweaked:cc-tweaked-1.20.1-forge-api", version.ref = "ccTweaked" }
+cc-tweaked-forge-impl = { module = "cc.tweaked:cc-tweaked-1.20.1-forge", version.ref = "ccTweaked" }
 
 worldstripper       = { module = "curse.maven:worldStripper-250603", version.ref = "worldStripper" }
 javd                = { module = "curse.maven:javd-370890", version.ref = "javd" }

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -65,4 +65,8 @@ repositories {
         forRepository { maven { url = "https://thedarkcolour.github.io/KotlinForForge/" } }
         filter { includeGroup("thedarkcolour") }
     }
+    exclusiveContent { // CC: Tweaked
+        forRepository { maven { url = "https://maven.squiddev.cc" } }
+        filter { includeGroup("cc.tweaked") }
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/GTCEu.java
+++ b/src/main/java/com/gregtechceu/gtceu/GTCEu.java
@@ -188,5 +188,9 @@ public class GTCEu {
         public static boolean isArgonautsLoaded() {
             return isModLoaded(GTValues.MODID_ARGONAUTS);
         }
+
+        public static boolean isCCTweakedLoaded() {
+            return isModLoaded(GTValues.MODID_CCTWEAKED);
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -131,7 +131,8 @@ public class GTValues {
             MODID_FTB_CHUNKS = "ftbchunks",
             MODID_JAVD = "javd",
             MODID_FTB_TEAMS = "ftbteams",
-            MODID_ARGONAUTS = "argonauts";
+            MODID_ARGONAUTS = "argonauts",
+            MODID_CCTWEAKED = "computercraft";
 
     /**
      * Spray painting compat modids

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -43,6 +43,7 @@ import com.gregtechceu.gtceu.data.pack.GTDynamicDataPack;
 import com.gregtechceu.gtceu.data.pack.GTDynamicResourcePack;
 import com.gregtechceu.gtceu.data.pack.GTPackSource;
 import com.gregtechceu.gtceu.forge.AlloyBlastPropertyAddition;
+import com.gregtechceu.gtceu.integration.cctweaked.CCTweakedPlugin;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuStartupEvents;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 import com.gregtechceu.gtceu.integration.kjs.events.MaterialModificationEventJS;
@@ -235,6 +236,11 @@ public class CommonProxy {
             CraftingHelper.register(IntCircuitIngredient.TYPE, IntCircuitIngredient.SERIALIZER);
             CraftingHelper.register(IntProviderIngredient.TYPE, IntProviderIngredient.SERIALIZER);
             CraftingHelper.register(FluidContainerIngredient.TYPE, FluidContainerIngredient.SERIALIZER);
+
+            if (GTCEu.Mods.isCCTweakedLoaded()) {
+                GTCEu.LOGGER.info("CC: Tweaked found. Enabling integration...");
+                CCTweakedPlugin.init();
+            }
         });
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/cctweaked/CCTweakedPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/cctweaked/CCTweakedPlugin.java
@@ -1,0 +1,15 @@
+package com.gregtechceu.gtceu.integration.cctweaked;
+
+import com.gregtechceu.gtceu.api.capability.forge.GTCapability;
+import com.gregtechceu.gtceu.integration.cctweaked.peripherals.*;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.ForgeComputerCraftAPI;
+
+public class CCTweakedPlugin {
+
+    public static void init() {
+        ComputerCraftAPI.registerGenericSource(new EnergyInfoPeripheral());
+        ForgeComputerCraftAPI.registerGenericCapability(GTCapability.CAPABILITY_ENERGY_INFO_PROVIDER);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/cctweaked/peripherals/EnergyInfoPeripheral.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/cctweaked/peripherals/EnergyInfoPeripheral.java
@@ -1,0 +1,32 @@
+package com.gregtechceu.gtceu.integration.cctweaked.peripherals;
+
+import com.gregtechceu.gtceu.api.capability.IEnergyInfoProvider;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.lua.MethodResult;
+import dan200.computercraft.api.peripheral.GenericPeripheral;
+
+import java.math.BigInteger;
+
+public class EnergyInfoPeripheral implements GenericPeripheral {
+
+    public String id() {
+        return "gtceu:energy_info";
+    }
+
+    @LuaFunction
+    static public MethodResult getEnergyStored(IEnergyInfoProvider infoProvider) {
+        return toResult(infoProvider.getEnergyInfo().stored());
+    }
+
+    @LuaFunction
+    static public MethodResult getEnergyCapacity(IEnergyInfoProvider infoProvider) {
+        return toResult(infoProvider.getEnergyInfo().capacity());
+    }
+
+    private static BigInteger MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
+
+    private static MethodResult toResult(BigInteger val) {
+        return MethodResult.of(val);
+    }
+}


### PR DESCRIPTION
## What
This add computercraft support to some energy containers.
See #806.

## Outcome
EU energy containers (including power substations) now can be queried for their stored energy and energy capacity.

## Additional Information
![image](https://github.com/user-attachments/assets/2e31f7fd-15f0-4369-88f2-cb9347f67f60)

## Potential Compatibility Issues
The names and ids defined for peripherals are exposed to lua code, so changing them in the future will cause compatibility issues.