### PR TITLE
Fix data bank not requiring energy

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/OpticalDataHatchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/OpticalDataHatchMachine.java
@@ -48,7 +48,8 @@ public class OpticalDataHatchMachine extends MultiblockPartMachine implements IO
 
         if (isTransmitter()) {
             IMultiController controller = getControllers().first();
-            if (!(controller instanceof IWorkableMultiController workable) || !workable.getRecipeLogic().isWorking()) return false;
+            if (!(controller instanceof IWorkableMultiController workable) || !workable.getRecipeLogic().isWorking())
+                return false;
 
             List<IDataAccessHatch> dataAccesses = new ArrayList<>();
             List<IDataAccessHatch> transmitters = new ArrayList<>();

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/OpticalDataHatchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/OpticalDataHatchMachine.java
@@ -2,10 +2,10 @@ package com.gregtechceu.gtceu.common.machine.multiblock.part;
 
 import com.gregtechceu.gtceu.api.capability.IDataAccessHatch;
 import com.gregtechceu.gtceu.api.capability.IOpticalDataAccessHatch;
-import com.gregtechceu.gtceu.api.capability.IWorkable;
 import com.gregtechceu.gtceu.api.capability.forge.GTCapability;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IWorkableMultiController;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -48,7 +48,7 @@ public class OpticalDataHatchMachine extends MultiblockPartMachine implements IO
 
         if (isTransmitter()) {
             IMultiController controller = getControllers().first();
-            if (!(controller instanceof IWorkable workable) || !workable.isActive()) return false;
+            if (!(controller instanceof IWorkableMultiController workable) || !workable.getRecipeLogic().isWorking()) return false;
 
             List<IDataAccessHatch> dataAccesses = new ArrayList<>();
             List<IDataAccessHatch> transmitters = new ArrayList<>();


### PR DESCRIPTION
## What
Data bank currently doesn't require energy to transmit data to other data banks and/or assembly lines, despite the multiblock requiring an energy hatch to form.

## Outcome
Data bank will now no longer transmit data if it is lacking power.