### PR TITLE
make tape recipe use glue instead of resin

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -888,7 +888,8 @@ public class MachineRecipeLoader {
 
         VanillaRecipeHelper.addShapedRecipe(provider, "basic_tape", BASIC_TAPE.asStack(),
                 " P ", "PSP", " P ", 'P', new UnificationEntry(plate, Paper), 'S', STICKY_RESIN.asItem());
-        ASSEMBLER_RECIPES.recipeBuilder("basic_tape").EUt(VA[ULV]).inputItems(plate, Paper, 2).inputFluids(Glue.getFluid(100))
+        ASSEMBLER_RECIPES.recipeBuilder("basic_tape").EUt(VA[ULV]).inputItems(plate, Paper, 2)
+                .inputFluids(Glue.getFluid(100))
                 .outputItems(BASIC_TAPE, 2)
                 .duration(100).save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -888,7 +888,7 @@ public class MachineRecipeLoader {
 
         VanillaRecipeHelper.addShapedRecipe(provider, "basic_tape", BASIC_TAPE.asStack(),
                 " P ", "PSP", " P ", 'P', new UnificationEntry(plate, Paper), 'S', STICKY_RESIN.asItem());
-        ASSEMBLER_RECIPES.recipeBuilder("basic_tape").EUt(VA[ULV]).inputItems(plate, Paper, 2).inputItems(STICKY_RESIN)
+        ASSEMBLER_RECIPES.recipeBuilder("basic_tape").EUt(VA[ULV]).inputItems(plate, Paper, 2).inputFluids(Glue.getFluid(100))
                 .outputItems(BASIC_TAPE, 2)
                 .duration(100).save(provider);
 


### PR DESCRIPTION
## What
replaces the resin in the recipe with glue

## Implementation Details
1 piece of resin --> 100 mB of glue

## Outcome
now I can actually make tape lol

## Additional Information
most assembler variants of recipes that use resin take glue. tape is an exception.

## Potential Compatibility Issues
random AE2 patterns will suddenly become useless