### PR TITLE
Fix ME hatches crashing on server side

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AmountSetWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AmountSetWidget.java
@@ -7,8 +7,6 @@ import com.lowdragmc.lowdraglib.gui.widget.TextFieldWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.utils.Position;
 
-import cpw.mods.fml.relauncher.Side;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
@@ -16,7 +14,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import appeng.api.stacks.GenericStack;
 import lombok.Getter;
-import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.NotNull;
 
 import static com.lowdragmc.lowdraglib.gui.util.DrawerHelper.drawStringSized;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AmountSetWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AmountSetWidget.java
@@ -47,7 +47,7 @@ public class AmountSetWidget extends Widget {
         writeClientAction(0, buf -> buf.writeVarInt(this.index));
     }
 
-    public void setSlotIndex(int slotIndex){
+    public void setSlotIndex(int slotIndex) {
         this.index = slotIndex;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AmountSetWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/AmountSetWidget.java
@@ -7,6 +7,8 @@ import com.lowdragmc.lowdraglib.gui.widget.TextFieldWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.utils.Position;
 
+import cpw.mods.fml.relauncher.Side;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.api.distmarker.Dist;
@@ -14,6 +16,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import appeng.api.stacks.GenericStack;
 import lombok.Getter;
+import net.minecraftforge.fml.LogicalSide;
 import org.jetbrains.annotations.NotNull;
 
 import static com.lowdragmc.lowdraglib.gui.util.DrawerHelper.drawStringSized;
@@ -38,9 +41,14 @@ public class AmountSetWidget extends Widget {
                 .setMaxStringLength(10);
     }
 
-    public void setSlotIndex(int slotIndex) {
+    @OnlyIn(Dist.CLIENT)
+    public void setSlotIndexClient(int slotIndex) {
         this.index = slotIndex;
         writeClientAction(0, buf -> buf.writeVarInt(this.index));
+    }
+
+    public void setSlotIndex(int slotIndex){
+        this.index = slotIndex;
     }
 
     public String getAmountStr() {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/ConfigWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/ConfigWidget.java
@@ -55,13 +55,13 @@ public abstract class ConfigWidget extends WidgetGroup {
         this.amountSetWidget.getAmountText().setVisible(false);
     }
 
-    public void enableAmount(int slotIndex){
+    public void enableAmount(int slotIndex) {
         this.amountSetWidget.setSlotIndex(slotIndex);
         this.amountSetWidget.setVisible(true);
         this.amountSetWidget.getAmountText().setVisible(true);
     }
 
-    public void disableAmount(){
+    public void disableAmount() {
         this.amountSetWidget.setSlotIndex(-1);
         this.amountSetWidget.setVisible(false);
         this.amountSetWidget.getAmountText().setVisible(false);

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/ConfigWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/ConfigWidget.java
@@ -41,13 +41,27 @@ public abstract class ConfigWidget extends WidgetGroup {
         this.amountSetWidget.getAmountText().setVisible(false);
     }
 
-    public void enableAmount(int slotIndex) {
+    @OnlyIn(Dist.CLIENT)
+    public void enableAmountClient(int slotIndex) {
+        this.amountSetWidget.setSlotIndexClient(slotIndex);
+        this.amountSetWidget.setVisible(true);
+        this.amountSetWidget.getAmountText().setVisible(true);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    public void disableAmountClient() {
+        this.amountSetWidget.setSlotIndexClient(-1);
+        this.amountSetWidget.setVisible(false);
+        this.amountSetWidget.getAmountText().setVisible(false);
+    }
+
+    public void enableAmount(int slotIndex){
         this.amountSetWidget.setSlotIndex(slotIndex);
         this.amountSetWidget.setVisible(true);
         this.amountSetWidget.getAmountText().setVisible(true);
     }
 
-    public void disableAmount() {
+    public void disableAmount(){
         this.amountSetWidget.setSlotIndex(-1);
         this.amountSetWidget.setVisible(false);
         this.amountSetWidget.getAmountText().setVisible(false);
@@ -66,7 +80,7 @@ public abstract class ConfigWidget extends WidgetGroup {
                 slot.setSelect(false);
             }
         }
-        this.disableAmount();
+        this.disableAmountClient();
         return super.mouseClicked(mouseX, mouseY, button);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/slot/AEFluidConfigSlotWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/slot/AEFluidConfigSlotWidget.java
@@ -121,7 +121,7 @@ public class AEFluidConfigSlotWidget extends AEConfigSlotWidget implements IGhos
                 writeClientAction(REMOVE_ID, buf -> {});
 
                 if (!parentWidget.isStocking()) {
-                    this.parentWidget.disableAmount();
+                    this.parentWidget.disableAmountClient();
                 }
             } else if (button == 0) {
                 // Left click to set/select
@@ -129,7 +129,7 @@ public class AEFluidConfigSlotWidget extends AEConfigSlotWidget implements IGhos
                 FluidUtil.getFluidContained(hold).ifPresent(f -> writeClientAction(UPDATE_ID, f::writeToPacket));
 
                 if (!parentWidget.isStocking()) {
-                    this.parentWidget.enableAmount(this.index);
+                    this.parentWidget.enableAmountClient(this.index);
                     this.select = true;
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/slot/AEItemConfigSlotWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/slot/AEItemConfigSlotWidget.java
@@ -97,7 +97,7 @@ public class AEItemConfigSlotWidget extends AEConfigSlotWidget implements IGhost
                 writeClientAction(REMOVE_ID, buf -> {});
 
                 if (!parentWidget.isStocking()) {
-                    this.parentWidget.disableAmount();
+                    this.parentWidget.disableAmountClient();
                 }
             } else if (button == 0) {
                 // Left click to set/select
@@ -108,7 +108,7 @@ public class AEItemConfigSlotWidget extends AEConfigSlotWidget implements IGhost
                 }
 
                 if (!parentWidget.isStocking()) {
-                    this.parentWidget.enableAmount(this.index);
+                    this.parentWidget.enableAmountClient(this.index);
                     this.select = true;
                 }
             }


### PR DESCRIPTION
## What
This PR distinguishes between the code in ME hatches that runs on the server and the code that runs on the client.

## Implementation Details
```java
public void setSlotIndex(int slotIndex) {
        this.index = slotIndex;
        writeClientAction(0, buf -> buf.writeVarInt(this.index));
}
```
This code contains 
```java
@Environment(EnvType.CLIENT)
protected final void writeClientAction(int id, Consumer<FriendlyByteBuf> FriendlyByteBufWriter) {
    if (uiAccess != null && !isClientSideWidget) {
        uiAccess.writeClientAction(this, id, FriendlyByteBufWriter);
    }
}
``` 
that should only run in client. 

The method `setSlotIndex` was invoked by `enableAmount` and `disableAmount`.

In most cases, calls to the above two methods appear in client code with `@OnlyIn(Dist.CLIENT)`.

But the method 
```java
public void handleClientAction(int id, FriendlyByteBuf buffer) {
...
}
```
in `AEFluidConfigSlotWidget` and `AEItemConfigSlotWidget` will invoke the `enableAmount` and `disableAmount` method.

The server will call a code that only exists in the client then throw  `NoSuchMethodError` and crash.

I added client versions of `enableAmount`, `disableAmount` and `setSlotIndex` then let the `handleClientAction` to invoke server version.

## Outcome
Fix #2805

![2025-02-01_11 37 46](https://github.com/user-attachments/assets/625b91f8-7b77-4a47-8678-f7875ac6464d)
![2025-02-01_11 41 21](https://github.com/user-attachments/assets/7ca6af4b-0f2f-498f-8014-0603c54e6df5)


## Additional Information
Also tested in Monifactory pack.

## Potential Compatibility Issues
I checked these code only exist in ME related hatched/buses.

So it seems unlikely that there is a compatibility issue.