### PR TITLE
Fix the rotor holder renderer crashing due to syncing of held item

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/RotorHolderMachineRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/RotorHolderMachineRenderer.java
@@ -59,9 +59,9 @@ public class RotorHolderMachineRenderer extends TieredHullMachineRenderer {
                             modelState, -101, 0, true, false));
                     quads.add(StaticFaceBakery.bakeFace(aabb, modelFacing, ModelFactory.getBlockSprite(BASE_BG),
                             modelState, -101, 0, true, false));
-                    if (rotorHolderMachine.hasRotor()) {
-                        Material mat = TurbineRotorBehaviour.getBehaviour(rotorHolderMachine.getRotorStack())
-                                .getPartMaterial(rotorHolderMachine.getRotorStack());
+                    var rotorBehaviour = TurbineRotorBehaviour.getBehaviour(rotorHolderMachine.getRotorStack());
+                    if (rotorBehaviour != null) {
+                        Material mat = rotorBehaviour.getPartMaterial(rotorHolderMachine.getRotorStack());
                         boolean emissive = mat.hasProperty(PropertyKey.ORE) &&
                                 mat.getProperty(PropertyKey.ORE).isEmissive();
                         if (rotorHolderMachine.isRotorSpinning()) {


### PR DESCRIPTION
## What
When replacing the item in the rotor holder from one with a `TurbineRotorBehaviour` to one without the rotor holder would crash your game (most of the time).

## Implementation Details
Instead of assuming the item didn't change mid-rendering, just get and null check our instance of the behaviour.

## Outcome
Fix #2819