### PR TITLE
Fix `LargeBoilerMachine` explosion logic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -129,23 +129,12 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IEx
             }
             if (currentTemperature < 100) {
                 steamGenerated = 0;
-                for (int i = 0; i < inputTanks.size(); i++) {
-                    // noinspection unchecked
-                    drainWater = (List<FluidIngredient>) inputTanks.get(i)
-                            .handleRecipe(IO.IN, null, drainWater, null, true);
+                for (IRecipeHandler<?> tank : inputTanks) {
+                    drainWater = (List<FluidIngredient>) tank.handleRecipe(IO.IN, null, drainWater, null, true);
                     this.hasNoWater = !(drainWater == null || drainWater.isEmpty() ||
                             drainWater.get(0).getAmount() > 0);
                     if (!this.hasNoWater) {
                         break;
-                    }
-                }
-                for (IRecipeHandler<?> tank : inputTanks) {
-                    drainWater = (List<FluidIngredient>) tank.handleRecipe(IO.IN, null, drainWater, null, true);
-                    if (drainWater == null || drainWater.isEmpty() || drainWater.get(0).getAmount() > 0) {
-                        this.hasNoWater = false;
-                        break;
-                    } else {
-                        this.hasNoWater = true;
                     }
                 }
             } else {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -114,7 +114,7 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IEx
             currentTemperature -= getCoolDownRate();
         }
 
-        if (currentTemperature >= 100 && getOffsetTimer() % TICKS_PER_STEAM_GENERATION == 0) {
+        if (getOffsetTimer() % TICKS_PER_STEAM_GENERATION == 0) {
             // drain water
             var maxDrain = currentTemperature * throttle * TICKS_PER_STEAM_GENERATION /
                     (ConfigHolder.INSTANCE.machines.largeBoilers.steamPerWater * 100);
@@ -127,56 +127,76 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IEx
                 inputTanks
                         .addAll(Objects.requireNonNull(getCapabilitiesProxy().get(IO.BOTH, FluidRecipeCapability.CAP)));
             }
-            for (IRecipeHandler<?> tank : inputTanks) {
-                drainWater = (List<FluidIngredient>) tank.handleRecipe(IO.IN, null, drainWater, null, false);
-                if (drainWater == null) break;
-            }
-            var drained = (drainWater == null || drainWater.isEmpty()) ? maxDrain :
-                    maxDrain - drainWater.get(0).getAmount();
-
-            boolean hasDrainedWater = drained > 0;
-            steamGenerated = drained * ConfigHolder.INSTANCE.machines.largeBoilers.steamPerWater;
-
-            if (hasDrainedWater) {
-                // fill steam
-                var fillSteam = List.of(FluidIngredient.of(GTMaterials.Steam.getFluid(steamGenerated)));
-                List<IRecipeHandler<?>> outputTanks = new ArrayList<>();
-                if (getCapabilitiesProxy().contains(IO.OUT, FluidRecipeCapability.CAP)) {
-                    outputTanks.addAll(
-                            Objects.requireNonNull(getCapabilitiesProxy().get(IO.OUT, FluidRecipeCapability.CAP)));
+            if (currentTemperature < 100) {
+                steamGenerated = 0;
+                for (int i = 0; i < inputTanks.size(); i++) {
+                    // noinspection unchecked
+                    drainWater = (List<FluidIngredient>) inputTanks.get(i)
+                            .handleRecipe(IO.IN, null, drainWater, null, true);
+                    this.hasNoWater = !(drainWater == null || drainWater.isEmpty() ||
+                            drainWater.get(0).getAmount() > 0);
+                    if (!this.hasNoWater) {
+                        break;
+                    }
                 }
-                if (getCapabilitiesProxy().contains(IO.BOTH, FluidRecipeCapability.CAP)) {
-                    outputTanks.addAll(
-                            Objects.requireNonNull(getCapabilitiesProxy().get(IO.BOTH, FluidRecipeCapability.CAP)));
-                }
-                for (IRecipeHandler<?> tank : outputTanks) {
-                    fillSteam = (List<FluidIngredient>) tank.handleRecipe(IO.OUT, null, fillSteam, null, false);
-                    if (fillSteam == null) break;
-                }
-            }
-
-            // check explosion
-            if (this.hasNoWater && hasDrainedWater) {
-                doExplosion(2f);
-                var center = getPos().below().relative(getFrontFacing().getOpposite());
-                if (GTValues.RNG.nextInt(100) > 80) {
-                    doExplosion(center, 2f);
-                }
-                for (Direction x : Direction.Plane.HORIZONTAL) {
-                    for (Direction y : Direction.Plane.HORIZONTAL) {
-                        if (GTValues.RNG.nextInt(100) > 80) {
-                            doExplosion(center.relative(x).relative(y), 2f);
-                        }
+                for (IRecipeHandler<?> tank : inputTanks) {
+                    drainWater = (List<FluidIngredient>) tank.handleRecipe(IO.IN, null, drainWater, null, true);
+                    if (drainWater == null || drainWater.isEmpty() || drainWater.get(0).getAmount() > 0) {
+                        this.hasNoWater = false;
+                        break;
+                    } else {
+                        this.hasNoWater = true;
                     }
                 }
             } else {
-                this.hasNoWater = !hasDrainedWater;
+                for (IRecipeHandler<?> tank : inputTanks) {
+                    drainWater = (List<FluidIngredient>) tank.handleRecipe(IO.IN, null, drainWater, null, false);
+                    if (drainWater == null || drainWater.isEmpty()) {
+                        break;
+                    }
+                }
+                var drained = (drainWater == null || drainWater.isEmpty()) ? maxDrain :
+                        maxDrain - drainWater.get(0).getAmount();
+
+                boolean hasDrainedWater = drained > 0;
+                steamGenerated = drained * ConfigHolder.INSTANCE.machines.largeBoilers.steamPerWater;
+
+                if (hasDrainedWater) {
+                    // fill steam
+                    var fillSteam = List.of(FluidIngredient.of(GTMaterials.Steam.getFluid(steamGenerated)));
+                    List<IRecipeHandler<?>> outputTanks = new ArrayList<>();
+                    if (getCapabilitiesProxy().contains(IO.OUT, FluidRecipeCapability.CAP)) {
+                        outputTanks.addAll(
+                                Objects.requireNonNull(getCapabilitiesProxy().get(IO.OUT, FluidRecipeCapability.CAP)));
+                    }
+                    if (getCapabilitiesProxy().contains(IO.BOTH, FluidRecipeCapability.CAP)) {
+                        outputTanks.addAll(
+                                Objects.requireNonNull(getCapabilitiesProxy().get(IO.BOTH, FluidRecipeCapability.CAP)));
+                    }
+                    for (IRecipeHandler<?> tank : outputTanks) {
+                        fillSteam = (List<FluidIngredient>) tank.handleRecipe(IO.OUT, null, fillSteam, null, false);
+                        if (fillSteam == null) break;
+                    }
+                }
+
+                // check explosion
+                if (this.hasNoWater && hasDrainedWater) {
+                    doExplosion(2f);
+                    var center = getPos().below().relative(getFrontFacing().getOpposite());
+                    if (GTValues.RNG.nextInt(100) > 80) {
+                        doExplosion(center, 2f);
+                    }
+                    for (Direction x : Direction.Plane.HORIZONTAL) {
+                        for (Direction y : Direction.Plane.HORIZONTAL) {
+                            if (GTValues.RNG.nextInt(100) > 80) {
+                                doExplosion(center.relative(x).relative(y), 2f);
+                            }
+                        }
+                    }
+                } else {
+                    this.hasNoWater = !hasDrainedWater;
+                }
             }
-        } else {
-            if (currentTemperature < 100) {
-                steamGenerated = 0;
-            }
-            this.hasNoWater = false;
         }
         updateSteamSubscription();
     }


### PR DESCRIPTION
## What
Large boilers didn't explode when they should.
The `hasNoWater` value was set after the explosion check and improperly updated to `false` after every working tick, so it was a noop.

## Implementation Details
Calculate `hasNoWater` only on working ticks.
Calculate `hasNoWater` correctly when temperature is below 100 degrees.

## Outcome
Fixes #2798