### PR TITLE
Fix client crashing when failing to send keybinds to the server

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/utils/input/KeyBind.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/KeyBind.java
@@ -67,7 +67,11 @@ public enum KeyBind {
             }
         }
         if (!updating.isEmpty()) {
-            GTNetwork.NETWORK.sendToServer(new CPacketKeysPressed(updating));
+            try {
+                GTNetwork.NETWORK.sendToServer(new CPacketKeysPressed(updating));
+            } catch (Exception exception) {
+                GTCEu.LOGGER.error("Keys pressed packet failed to send with an exception", exception);
+            }
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/KeyBind.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/KeyBind.java
@@ -69,7 +69,7 @@ public enum KeyBind {
         if (!updating.isEmpty()) {
             try {
                 GTNetwork.NETWORK.sendToServer(new CPacketKeysPressed(updating));
-            } catch (Exception exception) {
+            } catch (NullPointerException exception) {
                 GTCEu.LOGGER.error("Keys pressed packet failed to send with an exception", exception);
             }
         }


### PR DESCRIPTION
## What
When the server closes and the client is in the middle of sending a message it could crash.

## Implementation Details
Surround the sending of keybinds in a try-catch for NPEs and log the exception instead.

## Outcome
Fix #2828 