### PR TITLE
Fix ME machine copy-paste tooltip

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2871,7 +2871,7 @@
   "gtceu.machine.maintenance_hatch_full_auto.tooltip": "sʞɔoןqıʇןnW buıuıɐʇuıɐɯ ʎןןɐɔıʇɐɯoʇnɐ ɹoℲ",
   "gtceu.machine.maintenance_hatch_tape_slot.tooltip": "sɯǝןqoɹd ʇuǝʌǝɹd oʇ ǝdɐ⟘ ʇɹǝsuI",
   "gtceu.machine.maintenance_hatch_tool_slot.tooltip": "sɯǝןqoɹd ǝʌןos oʇ ʎɹoʇuǝʌuı uı ǝɹɐ sןooʇ pǝɹınbǝɹ uǝɥʍ puɐɥ ʎʇdɯǝ ɥʇıʍ ʇoןs ʞɔıןƆ",
-  "gtceu.machine.me.copy_paste.tooltip": "ʎןddɐ oʇ ʞɔıןɔ-ʇɥbıɹ 'sbuıʇʇǝs ʎdoɔ oʇ ʞɔıʇS ɐʇɐᗡ ɥʇıʍ ʞɔıןɔ-ʇɟǝꞀ",
+  "gtceu.machine.me.copy_paste.tooltip": "ʎןddɐ oʇ ʞɔıןɔ-ʇɥbıɹ 'sbuıʇʇǝs ʎdoɔ oʇ ʞɔıʇS ɐʇɐᗡ ɥʇıʍ ʞɔıןɔ-ʇɥbıɹ ʞɐǝuS",
   "gtceu.machine.me.export.tooltip": "˙ʞɹoʍʇǝu ƎW oʇ buıʇɔǝuuoɔ ǝɹoɟǝq ʎʇıɔɐdɐɔ ǝʇıuıɟuı sɐH",
   "gtceu.machine.me.fluid_export.tooltip": "˙ʞɹoʍʇǝu ƎW uɐ oʇuı ʎןʇɔǝɹıp spınןɟ sǝɹoʇS",
   "gtceu.machine.me.fluid_import.data_stick.name": "ɐʇɐᗡ uoıʇɐɹnbıɟuoƆ ɥɔʇɐH ʇnduI ƎWo§",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2871,7 +2871,7 @@
   "gtceu.machine.maintenance_hatch_full_auto.tooltip": "For automatically maintaining Multiblocks",
   "gtceu.machine.maintenance_hatch_tape_slot.tooltip": "Insert Tape to prevent problems",
   "gtceu.machine.maintenance_hatch_tool_slot.tooltip": "Click slot with empty hand when required tools are in inventory to solve problems",
-  "gtceu.machine.me.copy_paste.tooltip": "Left-click with Data Stick to copy settings, right-click to apply",
+  "gtceu.machine.me.copy_paste.tooltip": "Sneak right-click with Data Stick to copy settings, right-click to apply",
   "gtceu.machine.me.export.tooltip": "Has infinite capacity before connecting to ME network.",
   "gtceu.machine.me.fluid_export.tooltip": "Stores fluids directly into an ME network.",
   "gtceu.machine.me.fluid_import.data_stick.name": "§oME Input Hatch Configuration Data",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/MachineLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/MachineLang.java
@@ -789,7 +789,7 @@ public class MachineLang {
         provider.add("gtceu.machine.me.stocking_auto_pull_disabled",
                 "Auto-Pull Disabled");
         provider.add("gtceu.machine.me.copy_paste.tooltip",
-                "Left-click with Data Stick to copy settings, right-click to apply");
+                "Sneak right-click with Data Stick to copy settings, right-click to apply");
         provider.add("gtceu.machine.me.import_copy_settings",
                 "Saved settings to Data Stick");
         provider.add("gtceu.machine.me.import_paste_settings",


### PR DESCRIPTION
## What
Tooltip stated that data-sticks should be left clicked on ME hatches/buses/etc; in reality, they should be sneak right-clicked.

## Outcome
Resolves #2836 