### PR TITLE
Implement vanilla getFoodProperties() method

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
@@ -382,6 +382,14 @@ public class ComponentItem extends Item
     }
 
     @Override
+    @Deprecated
+    @SuppressWarnings("deprecation") // Used by Botania
+    public @Nullable FoodProperties getFoodProperties() {
+        // Fake item stack is ok for now, since we do not yet have foods which generate stats from NBT
+        return getFoodProperties(new ItemStack(this), null);
+    }
+
+    @Override
     public boolean isEdible() {
         for (IItemComponent component : components) {
             if (component instanceof IEdibleItem foodBehavior) {

--- a/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
@@ -383,7 +383,7 @@ public class ComponentItem extends Item
 
     @Override
     @Deprecated
-    @SuppressWarnings("deprecation") // Used by Botania
+    @SuppressWarnings("deprecation")
     public @Nullable FoodProperties getFoodProperties() {
         // Fake item stack is ok for now, since we do not yet have foods which generate stats from NBT
         return getFoodProperties(new ItemStack(this), null);


### PR DESCRIPTION
## What
Currently, GregTech foods (such as the Purple Drink) do not override vanilla's `Item#getFoodProperties()`, and return the default value of null. This is dangerous for items where `Item#isEdible()` returns true.
Ideally, mods would use Forge's `IForgeItem#getFoodProperties(ItemStack, LivingEntity)` method. However, this can be awkward for cross-loader mods, so we should provide a best-effort implementation for `Item#getFoodProperties()` as well.

## Implementation Details
Using a fake item stack prevents any components from generating stats based off NBT data; currently, none of GregTech's foods do this.

## Outcome
The vanilla method returns correct (non-null) food properties
Fixes #2794 

## Additional Information
In Botania v446 and lower the Gourmaryllis crashes without this; v447 uses the forge API.
