### PR TITLE
Refactor fusion reactor renderer

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1797,6 +1797,7 @@
   "config.gtceu.option.machines": "sǝuıɥɔɐɯ",
   "config.gtceu.option.machinesEmissiveTextures": "sǝɹnʇxǝ⟘ǝʌıssıɯƎsǝuıɥɔɐɯ",
   "config.gtceu.option.meHatchEnergyUsage": "ǝbɐs∩ʎbɹǝuƎɥɔʇɐHǝɯ",
+  "config.gtceu.option.minerSpeed": "pǝǝdSɹǝuıɯ",
   "config.gtceu.option.minimap": "dɐɯıuıɯ",
   "config.gtceu.option.nanoSaber": "ɹǝqɐSouɐu",
   "config.gtceu.option.nanoSaberBaseDamage": "ǝbɐɯɐᗡǝsɐᗺɹǝqɐSouɐu",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1797,6 +1797,7 @@
   "config.gtceu.option.machines": "machines",
   "config.gtceu.option.machinesEmissiveTextures": "machinesEmissiveTextures",
   "config.gtceu.option.meHatchEnergyUsage": "meHatchEnergyUsage",
+  "config.gtceu.option.minerSpeed": "minerSpeed",
   "config.gtceu.option.minimap": "minimap",
   "config.gtceu.option.nanoSaber": "nanoSaber",
   "config.gtceu.option.nanoSaberBaseDamage": "nanoSaberBaseDamage",

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/GTRenderTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/GTRenderTypes.java
@@ -16,6 +16,7 @@ public class GTRenderTypes extends RenderType {
             RenderType.CompositeState.builder()
                     .setCullState(NO_CULL)
                     .setShaderState(RenderStateShard.POSITION_COLOR_SHADER)
+                    .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
                     .createCompositeState(false));
 
     private GTRenderTypes(String name, VertexFormat format, VertexFormat.Mode mode, int bufferSize,


### PR DESCRIPTION
## What
Refactor fusion reactor renderer and add a fade effect.
It used to just render the ring then suddenly stop when no longer crafting, now there's ~3 seconds of fading to transparent.
Early return to prevent copying posestack when shimmer is installed.
No LDLib imports.

## Outcome
Just better looking imo.

## Additional Information
Before:
https://github.com/user-attachments/assets/75fbf7e2-3183-48d9-b182-5e096b226c24

After:
https://github.com/user-attachments/assets/f7f7748c-bab9-42f7-9f3e-882754b17609

