### PR TITLE
Fix fusion reactor renderer logic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/FusionReactorRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/FusionReactorRenderer.java
@@ -39,7 +39,7 @@ public class FusionReactorRenderer extends WorkableCasingMachineRenderer {
                        int combinedLight, int combinedOverlay) {
         if (blockEntity instanceof IMachineBlockEntity machineBlockEntity &&
                 machineBlockEntity.getMetaMachine() instanceof FusionReactorMachine machine) {
-            if (machine.getColor() == -1 && delta < 0) {
+            if (!machine.isWorkingEnabled() && delta <= 0) {
                 return;
             }
             if (GTCEu.Mods.isShimmerLoaded()) {
@@ -56,7 +56,7 @@ public class FusionReactorRenderer extends WorkableCasingMachineRenderer {
                                  MultiBufferSource buffer) {
         var color = machine.getColor();
         var alpha = 1f;
-        if (color != -1) {
+        if (machine.isWorkingEnabled()) {
             lastColor = color;
             delta = FADEOUT;
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/FusionReactorRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/FusionReactorRenderer.java
@@ -39,7 +39,7 @@ public class FusionReactorRenderer extends WorkableCasingMachineRenderer {
                        int combinedLight, int combinedOverlay) {
         if (blockEntity instanceof IMachineBlockEntity machineBlockEntity &&
                 machineBlockEntity.getMetaMachine() instanceof FusionReactorMachine machine) {
-            if (!machine.isWorkingEnabled() && delta <= 0) {
+            if (!machine.recipeLogic.isWorking() && delta <= 0) {
                 return;
             }
             if (GTCEu.Mods.isShimmerLoaded()) {
@@ -56,7 +56,7 @@ public class FusionReactorRenderer extends WorkableCasingMachineRenderer {
                                  MultiBufferSource buffer) {
         var color = machine.getColor();
         var alpha = 1f;
-        if (machine.isWorkingEnabled()) {
+        if (machine.recipeLogic.isWorking()) {
             lastColor = color;
             delta = FADEOUT;
         } else {


### PR DESCRIPTION
## What
Neutronium fusion didn't render the ring.
Rendering logic used a colour of `-1` for when the reactor is off which happens to be white which is the colour of neutronium.

## Implementation Details
Changed the parts that used the colour check to recipe logic `isWorking()`.

## Outcome
Renders all fusion recipes regardless of colour.