### PR TITLE
Fix meta machines being valid spawn points

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -26,7 +26,9 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -367,5 +369,11 @@ public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
             return machine.getBlockAppearance(state, level, pos, side, sourceState, sourcePos);
         }
         return super.getBlockAppearance(state, level, pos, side, sourceState, sourcePos);
+    }
+
+    @Override
+    public boolean isValidSpawn(BlockState state, BlockGetter level, BlockPos pos, SpawnPlacements.Type type,
+                                EntityType<?> entityType) {
+        return false;
     }
 }


### PR DESCRIPTION
## What
Mobs shouldn't be able to spawn on meta machines anymore.

## Implementation Details
Override `isValidSpawn()` to return `false`.

## Outcome
Mobs shouldn't be able to spawn in your EBF if you misplace your busses/hatches.

## Potential Compatibility Issues
Any addons that rely on meta machines being valid mob spawn spaces need to explicitly override `isValidSpawn()` to work.