### PR TITLE
Fix harmful effects applying for a tick with QuarkTech Helmet

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
@@ -31,20 +31,19 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
-import net.minecraftforge.event.entity.living.MobEffectEvent;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.IdentityHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
 
-    protected static final Map<MobEffect, Integer> potionRemovalCost = new IdentityHashMap<>();
+    public static final Map<MobEffect, Integer> potionRemovalCost = new IdentityHashMap<>();
     private float charge = 0.0F;
     private static final byte RUNNING_TIMER = 10; // .5 seconds
     private static final byte JUMPING_TIMER = 10; // .5 seconds
@@ -88,6 +87,8 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         boolean ret = false;
         if (type == ArmorItem.Type.HELMET) {
             ret = supplyAir(item, player) || supplyFood(item, player);
+
+            removeNegativeEffects(item, player);
 
             boolean nightVision = data.contains("nightVision") && data.getBoolean("nightVision");
             if (toggleTimer == 0 && KeyBind.ARMOR_MODE_SWITCH.isKeyDown(player)) {
@@ -248,14 +249,16 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         return false;
     }
 
-    public void removeNegativeEffects(@NotNull IElectricItem item, MobEffectEvent.Applicable event) {
-        MobEffectInstance effect = event.getEffectInstance();
-        Integer cost = potionRemovalCost.get(effect.getEffect());
-        if (cost != null) {
-            cost = cost * (effect.getAmplifier() + 1);
-            if (item.canUse(cost)) {
-                item.discharge(cost, item.getTier(), true, false, false);
-                event.setResult(Event.Result.DENY);
+    public static void removeNegativeEffects(@NotNull IElectricItem item, Player player) {
+        for (MobEffectInstance effect : new LinkedList<>(player.getActiveEffects())) {
+            MobEffect potion = effect.getEffect();
+            Integer cost = potionRemovalCost.get(potion);
+            if (cost != null) {
+                cost = cost * (effect.getAmplifier() + 1);
+                if (item.canUse(cost)) {
+                    item.discharge(cost, item.getTier(), true, false, false);
+                    player.removeEffect(potion);
+                }
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
@@ -31,13 +31,14 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.event.entity.living.MobEffectEvent;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.util.IdentityHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -87,8 +88,6 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         boolean ret = false;
         if (type == ArmorItem.Type.HELMET) {
             ret = supplyAir(item, player) || supplyFood(item, player);
-
-            removeNegativeEffects(item, player);
 
             boolean nightVision = data.contains("nightVision") && data.getBoolean("nightVision");
             if (toggleTimer == 0 && KeyBind.ARMOR_MODE_SWITCH.isKeyDown(player)) {
@@ -249,16 +248,14 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
         return false;
     }
 
-    public void removeNegativeEffects(@NotNull IElectricItem item, Player player) {
-        for (MobEffectInstance effect : new LinkedList<>(player.getActiveEffects())) {
-            MobEffect potion = effect.getEffect();
-            Integer cost = potionRemovalCost.get(potion);
-            if (cost != null) {
-                cost = cost * (effect.getAmplifier() + 1);
-                if (item.canUse(cost)) {
-                    item.discharge(cost, item.getTier(), true, false, false);
-                    player.removeEffect(potion);
-                }
+    public void removeNegativeEffects(@NotNull IElectricItem item, MobEffectEvent.Applicable event) {
+        MobEffectInstance effect = event.getEffectInstance();
+        Integer cost = potionRemovalCost.get(effect.getEffect());
+        if (cost != null) {
+            cost = cost * (effect.getAmplifier() + 1);
+            if (item.canUse(cost)) {
+                item.discharge(cost, item.getTier(), true, false, false);
+                event.setResult(Event.Result.DENY);
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.block.MaterialBlock;
 import com.gregtechceu.gtceu.api.block.MetaMachineBlock;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
+import com.gregtechceu.gtceu.api.capability.IElectricItem;
 import com.gregtechceu.gtceu.api.capability.IMedicalConditionTracker;
 import com.gregtechceu.gtceu.api.capability.compat.EUToFEProvider;
 import com.gregtechceu.gtceu.api.capability.forge.GTCapability;
@@ -59,6 +60,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Difficulty;
+import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.Mob;
@@ -85,6 +87,7 @@ import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppedEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
+import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fluids.FluidStack;
@@ -262,11 +265,18 @@ public class ForgeCommonEventListener {
     @SubscribeEvent
     public static void onMobEffectEvent(MobEffectEvent.Applicable event) {
         if (event.getEntity() instanceof Player player) {
-            ItemStack helmet = player.getItemBySlot(EquipmentSlot.HEAD);
-            if (helmet.is(GTItems.QUANTUM_HELMET.asItem()) &&
-                    helmet.getItem() instanceof ArmorComponentItem helmetComponent &&
-                    helmetComponent.getArmorLogic() instanceof QuarkTechSuite quarkHelmet) {
-                quarkHelmet.removeNegativeEffects(GTCapabilityHelper.getElectricItem(helmet), event);
+            ItemStack item = player.getItemBySlot(EquipmentSlot.HEAD);
+            if (item.is(GTItems.QUANTUM_HELMET.asItem()) && GTCapabilityHelper.getElectricItem(item) != null) {
+                IElectricItem helmet = GTCapabilityHelper.getElectricItem(item);
+                MobEffectInstance effect = event.getEffectInstance();
+                Integer cost = QuarkTechSuite.potionRemovalCost.get(effect.getEffect());
+                if (cost != null) {
+                    cost = cost * (effect.getAmplifier() + 1);
+                    if (helmet.canUse(cost)) {
+                        helmet.discharge(cost, helmet.getTier(), true, false, false);
+                        event.setResult(Event.Result.DENY);
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -35,6 +35,7 @@ import com.gregtechceu.gtceu.common.data.machines.GTAEMachines;
 import com.gregtechceu.gtceu.common.fluid.potion.PotionFluidHelper;
 import com.gregtechceu.gtceu.common.item.ToggleEnergyConsumerBehavior;
 import com.gregtechceu.gtceu.common.item.armor.IJetpack;
+import com.gregtechceu.gtceu.common.item.armor.QuarkTechSuite;
 import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
 import com.gregtechceu.gtceu.common.network.GTNetwork;
 import com.gregtechceu.gtceu.common.network.packets.*;
@@ -75,10 +76,7 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.*;
-import net.minecraftforge.event.entity.living.LivingDeathEvent;
-import net.minecraftforge.event.entity.living.LivingEvent;
-import net.minecraftforge.event.entity.living.LivingFallEvent;
-import net.minecraftforge.event.entity.living.MobSpawnEvent;
+import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.BlockEvent;
@@ -258,6 +256,18 @@ public class ForgeCommonEventListener {
                 continue;
             }
             tracker.progressRelatedCondition(material);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onMobEffectEvent(MobEffectEvent.Applicable event) {
+        if (event.getEntity() instanceof Player player) {
+            ItemStack helmet = player.getItemBySlot(EquipmentSlot.HEAD);
+            if (helmet.is(GTItems.QUANTUM_HELMET.asItem()) &&
+                    helmet.getItem() instanceof ArmorComponentItem helmetComponent &&
+                    helmetComponent.getArmorLogic() instanceof QuarkTechSuite quarkHelmet) {
+                quarkHelmet.removeNegativeEffects(GTCapabilityHelper.getElectricItem(helmet), event);
+            }
         }
     }
 


### PR DESCRIPTION
## What
Instead of removing the effect after it was applied, the effect won't be applied so effects like Wither won't do any damage.

## Implementation Details
Listens to `MobEffectEvent.Applicable` event and sets the result to DENY.

## Outcome
Quantum Armor too OP pls nerf