### PR TITLE
Fix Charcoal Pile Igniter crash

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiController.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiController.java
@@ -57,9 +57,11 @@ public interface IMultiController extends IMachineFeature, IInteractedMachine {
     default boolean checkPatternWithLock() {
         var lock = getPatternLock();
         lock.lock();
-        var result = checkPattern();
-        lock.unlock();
-        return result;
+        try {
+            return checkPattern();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
@@ -70,9 +72,11 @@ public interface IMultiController extends IMachineFeature, IInteractedMachine {
     default boolean checkPatternWithTryLock() {
         var lock = getPatternLock();
         if (lock.tryLock()) {
-            var result = checkPattern();
-            lock.unlock();
-            return result;
+            try {
+                return checkPattern();
+            } finally {
+                lock.unlock();
+            }
         } else {
             return false;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CharcoalPileIgniterMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CharcoalPileIgniterMachine.java
@@ -145,11 +145,11 @@ public class CharcoalPileIgniterMachine extends WorkableMultiblockMachine implem
     public BlockPattern getPattern() {
         updateDimensions();
 
-        if (lDist < 1) lDist = MIN_RADIUS;
-        if (rDist < 1) rDist = MIN_RADIUS;
-        if (fDist < 1) fDist = MIN_RADIUS;
-        if (bDist < 1) bDist = MIN_RADIUS;
-        if (hDist < 2) hDist = MIN_RADIUS;
+        if (lDist < MIN_RADIUS) lDist = MIN_RADIUS;
+        if (rDist < MIN_RADIUS) rDist = MIN_RADIUS;
+        if (fDist < MIN_RADIUS) fDist = MIN_RADIUS;
+        if (bDist < MIN_RADIUS) bDist = MIN_RADIUS;
+        if (hDist < MIN_DEPTH) hDist = MIN_DEPTH;
 
         if (this.getFrontFacing().getAxis() == Direction.Axis.X) {
             int tmp = lDist;


### PR DESCRIPTION
## What
This fixes the crash and game lockup when forming the charcoal pile igniter

## Implementation Details
The previous code used the wrong minimum value which resulted in an AIOOB.
In addition it wasn't using try/finally for locks which causes the locks to get stuck

## Outcome
Fixed #2793