### PR TITLE
Fix Fusion Reactor Recipe Widget inconsistencies

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -24,7 +24,6 @@ import com.gregtechceu.gtceu.data.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 import com.gregtechceu.gtceu.integration.xei.handlers.item.CycleItemStackHandler;
-import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
@@ -664,9 +663,8 @@ public class GTRecipeTypes {
             .setProgressBar(GuiTextures.PROGRESS_BAR_FUSION, LEFT_TO_RIGHT)
             .setSound(GTSoundEntries.ARC)
             .setOffsetVoltageText(true)
-            .addDataInfo(data -> LocalizationUtils.format("gtceu.recipe.eu_to_start",
-                    FormattingUtil.formatNumberReadable2F(data.getLong("eu_to_start"), false),
-                    FusionReactorMachine.getFusionTier(data.getLong("eu_to_start"))));
+            .setMaxTooltips(4)
+            .setUiBuilder(FusionReactorMachine::addEUToStartLabel);
 
     public static final GTRecipeType DUMMY_RECIPES = register("dummy", DUMMY)
             .setXEIVisible(false);

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTRecipeWidget.java
@@ -15,6 +15,8 @@ import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
+import com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMachine;
 import com.gregtechceu.gtceu.common.recipe.condition.DimensionCondition;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
@@ -250,6 +252,9 @@ public class GTRecipeWidget extends WidgetGroup {
         }
         if (isShiftClick) {
             oc = OverclockingLogic.PERFECT_OVERCLOCK;
+        }
+        if (recipe.recipeType == GTRecipeTypes.FUSION_RECIPES) {
+            oc = FusionReactorMachine.FUSION_OC;
         }
         setRecipeTextWidget(oc);
         setRecipeWidget();


### PR DESCRIPTION
## What
Fixes Recipe Viewer showing the wrong `MK#` when the recipe's tier is higher than its minimum reactor tier based on the max EU to start.
Makes it so that the OC widget uses the Fusion Reactor OC logic for Fusion Recipes

## Implementation Details
Splits map of pairs into two maps, also keeps track of minimum registered fusion tier.
Uses UIBuilder and new label widget rather than data info

## Outcome
120MEU -> Fusion MK I, but ZPM tier -> Fusion MK II
![image](https://github.com/user-attachments/assets/f0972fec-ba32-4b5a-a5ea-8af0f206ba5e)
Resolves #2754 
