### PR TITLE
Fix StackOverflowError caused by infinite food recursion

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
@@ -385,8 +385,12 @@ public class ComponentItem extends Item
     @Deprecated
     @SuppressWarnings("deprecation")
     public @Nullable FoodProperties getFoodProperties() {
-        // Fake item stack is ok for now, since we do not yet have foods which generate stats from NBT
-        return getFoodProperties(new ItemStack(this), null);
+        // If item has `foodProperties` from super, return it.
+        if (super.isEdible()) return super.getFoodProperties();
+        // If item has `IEdibleItem` components, return food stats from default stack
+        if (isEdible()) return getFoodProperties(this.getDefaultInstance(), null);
+        // Not edible, so null.
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes StackOverflowError
`ComponentItem#getFoodProperties()` introduced some infinite recursion due to `super` calls, which was overlooked when added in #2839.