### PR TITLE
Fix ParallelHatchPartMachine starting with 0 parallels

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ParallelHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ParallelHatchPartMachine.java
@@ -30,7 +30,7 @@ public class ParallelHatchPartMachine extends TieredPartMachine implements IFanc
 
     @Persisted
     @Getter
-    private int currentParallel;
+    private int currentParallel = 1;
 
     public ParallelHatchPartMachine(IMachineBlockEntity holder, int tier) {
         super(holder, tier);


### PR DESCRIPTION
## What
When placing a new Parallel Hatch, its current parallel is set to 0 until you open the UI, as the currentParallel field was not initialized. This causes multiblocks to not run recipes until you open the UI. 
This PR makes it start at 1, fixing the issue.
