### PR TITLE
Fix Robot Arm Keep Exact functionality with item pipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -12,7 +12,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.items.ItemHandlerHelper;
 
 import lombok.Getter;
 
@@ -160,9 +159,9 @@ public class SimpleItemFilter implements ItemFilter {
         int totalCount = 0;
 
         for (var candidate : matches) {
-            if (ignoreNbt && ItemStack.isSameItemSameTags(candidate, itemStack)) {
+            if (ignoreNbt && ItemStack.isSameItem(candidate, itemStack)) {
                 totalCount += candidate.getCount();
-            } else if (ItemHandlerHelper.canItemStacksStack(candidate, itemStack)) {
+            } else if (ItemStack.isSameItemSameTags(candidate, itemStack)) {
                 totalCount += candidate.getCount();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -401,20 +401,12 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         if (arm == null) return 0;
         int count = 0;
         ItemFilter filter = arm.getFilterHandler().getFilter();
+        boolean ignoreNBT = filter instanceof SimpleItemFilter simple && simple.isIgnoreNbt();
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
-            boolean ignoreNBT;
-            if (filter instanceof SimpleItemFilter) {
-                ignoreNBT = ((SimpleItemFilter) filter).isIgnoreNbt();
-            } else {
-                ignoreNBT = false;
-            }
-            if (ignoreNBT && !ItemStack.isSameItemSameTags(stack, slot)) {
-                continue;
-            } else if (!ItemHandlerHelper.canItemStacksStack(stack, slot)) {
-                continue;
-            }
+            if (ignoreNBT && !ItemStack.isSameItem(stack, slot)) continue;
+            else if (!ItemStack.isSameItemSameTags(stack, slot)) continue;
             if (arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -365,8 +365,7 @@ public class ItemNetHandler implements IItemHandlerModifiable {
 
     public ItemStack insertOverRobotArm(IItemHandler handler, RobotArmCover arm, ItemStack stack, boolean simulate,
                                         int allowed, boolean ignoreLimit) {
-        int rate;
-        rate = arm.getFilterHandler().getFilter().testItemCount(stack);
+        int rate = arm.getFilterHandler().getFilter().testItemCount(stack);
         int count;
         switch (arm.getTransferMode()) {
             case TRANSFER_ANY:

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -371,8 +371,11 @@ public class ItemNetHandler implements IItemHandlerModifiable {
             case TRANSFER_ANY:
                 return insert(handler, stack, simulate, allowed, ignoreLimit);
             case KEEP_EXACT:
-                boolean isSupportAmounts = !arm.getFilterHandler().getFilter().supportsAmounts();
-                count = rate - countStack(handler, stack, arm, isSupportAmounts);
+                if (arm.getFilterHandler().getFilter().supportsAmounts()) {
+                    count = rate - countStack(handler, stack, arm);
+                } else {
+                    count = rate;
+                }
                 if (count <= 0) return stack;
                 count = Math.min(allowed, Math.min(stack.getCount(), count));
                 return insert(handler, stack, simulate, count, ignoreLimit);
@@ -393,10 +396,7 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         return stack;
     }
 
-    public static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm, boolean isSupportAmounts) {
-        if (!isSupportAmounts) {
-            return 0;
-        }
+    public static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm) {
         if (arm == null) return 0;
         int count = 0;
         for (int i = 0; i < handler.getSlots(); i++) {

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -371,7 +371,8 @@ public class ItemNetHandler implements IItemHandlerModifiable {
             case TRANSFER_ANY:
                 return insert(handler, stack, simulate, allowed, ignoreLimit);
             case KEEP_EXACT:
-                count = rate - countStack(handler, stack, arm);
+                boolean isSupportAmounts = !arm.getFilterHandler().getFilter().supportsAmounts();
+                count = rate - countStack(handler, stack, arm,isSupportAmounts);
                 if (count <= 0) return stack;
                 count = Math.min(allowed, Math.min(stack.getCount(), count));
                 return insert(handler, stack, simulate, count, ignoreLimit);
@@ -392,7 +393,10 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         return stack;
     }
 
-    private static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm) {
+    private static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm, boolean isSupportAmounts) {
+        if (!isSupportAmounts) {
+            return 0;
+        }
         if (arm == null) return 0;
         int count = 0;
         for (int i = 0; i < handler.getSlots(); i++) {

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -372,7 +372,7 @@ public class ItemNetHandler implements IItemHandlerModifiable {
                 return insert(handler, stack, simulate, allowed, ignoreLimit);
             case KEEP_EXACT:
                 boolean isSupportAmounts = !arm.getFilterHandler().getFilter().supportsAmounts();
-                count = rate - countStack(handler, stack, arm,isSupportAmounts);
+                count = rate - countStack(handler, stack, arm, isSupportAmounts);
                 if (count <= 0) return stack;
                 count = Math.min(allowed, Math.min(stack.getCount(), count));
                 return insert(handler, stack, simulate, count, ignoreLimit);
@@ -393,7 +393,7 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         return stack;
     }
 
-    private static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm, boolean isSupportAmounts) {
+    public static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm, boolean isSupportAmounts) {
         if (!isSupportAmounts) {
             return 0;
         }
@@ -402,7 +402,8 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
-            if (ItemStackHashStrategy.comparingAllButCount().equals(stack, slot) && arm.getFilterHandler().getFilter().test(slot)) {
+            if (ItemStackHashStrategy.comparingAllButCount().equals(stack, slot) &&
+                    arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -365,14 +365,13 @@ public class ItemNetHandler implements IItemHandlerModifiable {
     public ItemStack insertOverRobotArm(IItemHandler handler, RobotArmCover arm, ItemStack stack, boolean simulate,
                                         int allowed, boolean ignoreLimit) {
         int rate;
-        boolean isStackSpecific = false;
         rate = arm.getFilterHandler().getFilter().testItemCount(stack);
         int count;
         switch (arm.getTransferMode()) {
             case TRANSFER_ANY:
                 return insert(handler, stack, simulate, allowed, ignoreLimit);
             case KEEP_EXACT:
-                count = rate - countStack(handler, stack, arm, isStackSpecific);
+                count = rate - countStack(handler, stack, arm);
                 if (count <= 0) return stack;
                 count = Math.min(allowed, Math.min(stack.getCount(), count));
                 return insert(handler, stack, simulate, count, ignoreLimit);
@@ -393,14 +392,13 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         return stack;
     }
 
-    public static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm, boolean isStackSpecific) {
+    private static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm) {
         if (arm == null) return 0;
         int count = 0;
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
-            if (isStackSpecific ? ItemStackHashStrategy.comparingAllButCount().equals(stack, slot) :
-                    arm.getFilterHandler().getFilter().test(slot)) {
+            if (ItemStackHashStrategy.comparingAllButCount().equals(stack, slot) && arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -4,6 +4,8 @@ import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
+import com.gregtechceu.gtceu.api.cover.filter.ItemFilter;
+import com.gregtechceu.gtceu.api.cover.filter.SimpleItemFilter;
 import com.gregtechceu.gtceu.common.blockentity.ItemPipeBlockEntity;
 import com.gregtechceu.gtceu.common.cover.ConveyorCover;
 import com.gregtechceu.gtceu.common.cover.ItemFilterCover;
@@ -11,7 +13,6 @@ import com.gregtechceu.gtceu.common.cover.RobotArmCover;
 import com.gregtechceu.gtceu.common.cover.data.DistributionMode;
 import com.gregtechceu.gtceu.common.cover.data.FilterMode;
 import com.gregtechceu.gtceu.utils.FacingPos;
-import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -399,11 +400,22 @@ public class ItemNetHandler implements IItemHandlerModifiable {
     public static int countStack(IItemHandler handler, ItemStack stack, RobotArmCover arm) {
         if (arm == null) return 0;
         int count = 0;
+        ItemFilter filter = arm.getFilterHandler().getFilter();
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
-            if (ItemStackHashStrategy.comparingAllButCount().equals(stack, slot) &&
-                    arm.getFilterHandler().getFilter().test(slot)) {
+            boolean ignoreNBT;
+            if (filter instanceof SimpleItemFilter) {
+                ignoreNBT = ((SimpleItemFilter) filter).isIgnoreNbt();
+            } else {
+                ignoreNBT = false;
+            }
+            if (ignoreNBT && !ItemStack.isSameItemSameTags(stack, slot)) {
+                continue;
+            } else if (!ItemHandlerHelper.canItemStacksStack(stack, slot)) {
+                continue;
+            }
+            if (arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }
         }


### PR DESCRIPTION
## What
Fixes #2799 
This PR fixes an item count calculation issue in RobotArmCover's KEEP_EXACT transfer mode. The previous implementation didn't properly verify if the items being moved matched the target slot's contents, leading to incorrect item quantity returns.

## Implementation Details
- Removed the redundant `isStackSpecific` parameter from `countStack` method  
- Revised item matching logic to require both:  
  - ItemStack matching (using `ItemStackHashStrategy.comparingAllButCount`)  
  - Filter test from RobotArmCover  
- Simplified conditional checks in item counting logic  

## Outcome
- Correctly verifies item type matches before counting items in destination container  
- Ensures RobotArmCover's KEEP_EXACT mode only counts matching items that pass its filter  
