### PR TITLE
Fix prospector waypoint message showing when no waypoint created

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 //    modExtraRuntimeOnly(forge.xaerosminimap)
 //    modExtraRuntimeOnly(forge.xaerosworldmap)
-   modExtraRuntimeOnly(forge.journeymap.forge)
+//    modExtraRuntimeOnly(forge.journeymap.forge)
 //    modExtraRuntimeOnly(forge.ftbchunks)
 
     modExtraRuntimeOnly(forge.spark)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ dependencies {
 
 //    modExtraRuntimeOnly(forge.xaerosminimap)
 //    modExtraRuntimeOnly(forge.xaerosworldmap)
-//    modExtraRuntimeOnly(forge.journeymap.forge)
+   modExtraRuntimeOnly(forge.journeymap.forge)
 //    modExtraRuntimeOnly(forge.ftbchunks)
 
     modExtraRuntimeOnly(forge.spark)

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
@@ -258,6 +258,7 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
     @Override
     @OnlyIn(Dist.CLIENT)
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (!WaypointManager.isActive()) return true;
         var clickedItem = getClickedVein(mouseX, mouseY);
         if (clickedItem == null) {
             return super.mouseClicked(mouseX, mouseY, button);

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/ProspectingMapWidget.java
@@ -22,6 +22,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
@@ -263,13 +264,15 @@ public class ProspectingMapWidget extends WidgetGroup implements SearchComponent
         if (clickedItem == null) {
             return super.mouseClicked(mouseX, mouseY, button);
         }
+        MutableComponent veinName = Component.literal(clickedItem.name());
+        veinName.setStyle(veinName.getStyle().withColor(clickedItem.color));
         WaypointManager.setWaypoint(new ChunkPos(clickedItem.position).toString(),
                 clickedItem.name,
                 clickedItem.color,
                 gui.entityPlayer.level().dimension(),
                 clickedItem.position.getX(), clickedItem.position.getY(), clickedItem.position.getZ());
         gui.entityPlayer.displayClientMessage(
-                Component.translatable("behavior.prospector.added_waypoint", clickedItem.name), true);
+                Component.translatable("behavior.prospector.added_waypoint", veinName), false);
         playButtonClickSound();
         return true;
     }


### PR DESCRIPTION
## What
Fixes prospector waypoint message showing when no waypoint created due to either no map mod or no config enabled.

## Implementation Details
Check if there is any map mods to add waypoints to.

## Outcome
Prospector not being a liar.
Text is now printed in chat and with added colour
![image](https://github.com/user-attachments/assets/25c988f4-01a9-4cd6-bb4e-71e2563d7555)


## Potential Compatibility Issues
Tested without map mod and with map mod and both work as expected.
