### PR TITLE
Change Muffler hatch particles to campfire smoke

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
@@ -61,11 +61,9 @@ public interface IMufflerMachine extends IMultiPart, IEnvironmentalHazardEmitter
         }
         self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE, 
                 xPos + GTValues.RNG.nextFloat() * 0.5F,
-                yPos + GTValues.RNG.nextFloat() * 0.5F, 
-                zPos + GTValues.RNG.nextFloat() * 0.5F, 
-                xSpd, 
-                ySpd, 
-                zSpd);
+                yPos + GTValues.RNG.nextFloat() * 0.5F,
+                zPos + GTValues.RNG.nextFloat() * 0.5F,
+                xSpd, ySpd, zSpd);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
@@ -62,7 +62,7 @@ public interface IMufflerMachine extends IMultiPart, IEnvironmentalHazardEmitter
         self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE, 
                 xPos + GTValues.RNG.nextFloat() * 0.5F,
                 yPos + GTValues.RNG.nextFloat() * 0.5F, 
-                Pos + GTValues.RNG.nextFloat() * 0.5F, 
+                zPos + GTValues.RNG.nextFloat() * 0.5F, 
                 xSpd, 
                 ySpd, 
                 zSpd);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
@@ -59,7 +59,13 @@ public interface IMufflerMachine extends IMultiPart, IEnvironmentalHazardEmitter
             xSpd = facing.getStepX() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
             zSpd = facing.getStepZ() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
         }
-        self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE, xPos, yPos, zPos, xSpd, ySpd * 0.8, zSpd);
+        self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE, 
+                xPos + GTValues.RNG.nextFloat() * 0.5F,
+                yPos + GTValues.RNG.nextFloat() * 0.5F, 
+                Pos + GTValues.RNG.nextFloat() * 0.5F, 
+                xSpd, 
+                ySpd, 
+                zSpd);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
@@ -59,7 +59,7 @@ public interface IMufflerMachine extends IMultiPart, IEnvironmentalHazardEmitter
             xSpd = facing.getStepX() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
             zSpd = facing.getStepZ() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
         }
-        self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE, 
+        self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE,
                 xPos + GTValues.RNG.nextFloat() * 0.5F,
                 yPos + GTValues.RNG.nextFloat() * 0.5F,
                 zPos + GTValues.RNG.nextFloat() * 0.5F,

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMufflerMachine.java
@@ -43,9 +43,9 @@ public interface IMufflerMachine extends IMultiPart, IEnvironmentalHazardEmitter
             return;
         }
 
-        float xPos = facing.getStepX() * 0.76F + pos.getX() + 0.25F;
-        float yPos = facing.getStepY() * 0.76F + pos.getY() + 0.25F;
-        float zPos = facing.getStepZ() * 0.76F + pos.getZ() + 0.25F;
+        float xPos = facing.getStepX() + pos.getX() + 0.25F;
+        float yPos = facing.getStepY() + pos.getY() + 0.25F;
+        float zPos = facing.getStepZ() + pos.getZ() + 0.25F;
 
         float ySpd = facing.getStepY() * 0.1F + 0.2F + 0.1F * GTValues.RNG.nextFloat();
         float xSpd;
@@ -53,17 +53,13 @@ public interface IMufflerMachine extends IMultiPart, IEnvironmentalHazardEmitter
 
         if (facing.getStepY() == -1) {
             float temp = GTValues.RNG.nextFloat() * 2 * (float) Math.PI;
-            xSpd = (float) Math.sin(temp) * 0.1F;
-            zSpd = (float) Math.cos(temp) * 0.1F;
+            xSpd = (float) Math.sin(temp) * 0.08F;
+            zSpd = (float) Math.cos(temp) * 0.08F;
         } else {
             xSpd = facing.getStepX() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
             zSpd = facing.getStepZ() * (0.1F + 0.2F * GTValues.RNG.nextFloat());
         }
-        self().getLevel().addParticle(ParticleTypes.LARGE_SMOKE,
-                xPos + GTValues.RNG.nextFloat() * 0.5F,
-                yPos + GTValues.RNG.nextFloat() * 0.5F,
-                zPos + GTValues.RNG.nextFloat() * 0.5F,
-                xSpd, ySpd, zSpd);
+        self().getLevel().addParticle(ParticleTypes.CAMPFIRE_SIGNAL_SMOKE, xPos, yPos, zPos, xSpd, ySpd * 0.8, zSpd);
     }
 
     @Override


### PR DESCRIPTION
## What
Muffler hatches use campfire smoke as their particle now. Yippee

## Implementation Details
Speed of particle has been altered to match the new, bigger particle
