### PR TITLE
Fix various issues with Long Distance Pipelines

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/MetaMachineBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/MetaMachineBlockEntity.java
@@ -13,13 +13,9 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
 import com.gregtechceu.gtceu.api.misc.EnergyInfoProviderList;
 import com.gregtechceu.gtceu.api.misc.LaserContainerList;
-import com.gregtechceu.gtceu.api.pipenet.longdistance.ILDEndpoint;
 import com.gregtechceu.gtceu.client.renderer.GTRendererProvider;
 import com.gregtechceu.gtceu.common.datafixers.TagFixer;
 import com.gregtechceu.gtceu.common.machine.owner.IMachineOwner;
-import com.gregtechceu.gtceu.common.pipelike.fluidpipe.longdistance.LDFluidEndpointMachine;
-import com.gregtechceu.gtceu.common.pipelike.item.longdistance.LDItemEndpointMachine;
-import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
 import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
@@ -201,34 +197,12 @@ public class MetaMachineBlockEntity extends BlockEntity implements IMachineBlock
                         LazyOptional.of(() -> maintenanceMachine));
             }
         } else if (cap == ForgeCapabilities.ITEM_HANDLER) {
-            if (machine instanceof LDItemEndpointMachine itemEndpointMachine) {
-                if (machine.getLevel().isClientSide) return null;
-                ILDEndpoint endpoint = itemEndpointMachine.getLink();
-                if (endpoint == null) return null;
-                Direction outputFacing = endpoint.getOutputFacing();
-                var h = GTTransferUtils.getAdjacentItemHandler(machine.getLevel(), endpoint.getPos(), outputFacing)
-                        .map(LDItemEndpointMachine.ItemHandlerWrapper::new);
-                if (h.isPresent()) {
-                    return ForgeCapabilities.ITEM_HANDLER.orEmpty(cap, LazyOptional.of(h::get));
-                }
-            }
             var handler = machine.getItemHandlerCap(side, true);
             if (handler != null) {
                 return ForgeCapabilities.ITEM_HANDLER.orEmpty(cap,
                         LazyOptional.of(() -> handler));
             }
         } else if (cap == ForgeCapabilities.FLUID_HANDLER) {
-            if (machine instanceof LDFluidEndpointMachine fluidEndpointMachine) {
-                if (machine.getLevel().isClientSide) return null;
-                ILDEndpoint endpoint = fluidEndpointMachine.getLink();
-                if (endpoint == null) return null;
-                Direction outputFacing = endpoint.getOutputFacing();
-                var h = GTTransferUtils.getAdjacentFluidHandler(machine.getLevel(), endpoint.getPos(), outputFacing)
-                        .map(LDFluidEndpointMachine.FluidHandlerWrapper::new);
-                if (h.isPresent()) {
-                    return ForgeCapabilities.FLUID_HANDLER.orEmpty(cap, LazyOptional.of(h::get));
-                }
-            }
             var handler = machine.getFluidHandlerCap(side, true);
             if (handler != null) {
                 return ForgeCapabilities.FLUID_HANDLER.orEmpty(cap,

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/fluidpipe/longdistance/LDFluidEndpointMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/fluidpipe/longdistance/LDFluidEndpointMachine.java
@@ -21,18 +21,14 @@ public class LDFluidEndpointMachine extends LongDistanceEndpointMachine {
 
     @Override
     public @Nullable IFluidHandlerModifiable getFluidHandlerCap(@Nullable Direction side, boolean useCoverCapability) {
-        if (isRemote() || getIoType() != IO.IN) {
+        if (isRemote() || getIoType() != IO.IN || side != getFrontFacing()) {
             return null;
         }
         var endpoint = getLink();
         if (endpoint == null) {
             return null;
         }
-        var outputFacing = endpoint.getOutputFacing();
-        if (side != outputFacing.getOpposite()) {
-            return null;
-        }
-        return GTTransferUtils.getAdjacentFluidHandler(getLevel(), endpoint.getPos(), outputFacing)
+        return GTTransferUtils.getAdjacentFluidHandler(getLevel(), endpoint.getPos(), endpoint.getOutputFacing())
                 .map(LDFluidEndpointMachine.FluidHandlerWrapper::new)
                 .orElse(null);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/fluidpipe/longdistance/LDFluidEndpointMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/fluidpipe/longdistance/LDFluidEndpointMachine.java
@@ -1,18 +1,40 @@
 package com.gregtechceu.gtceu.common.pipelike.fluidpipe.longdistance;
 
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
 import com.gregtechceu.gtceu.common.machine.storage.LongDistanceEndpointMachine;
+import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
+import net.minecraft.core.Direction;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class LDFluidEndpointMachine extends LongDistanceEndpointMachine {
 
     public LDFluidEndpointMachine(IMachineBlockEntity holder) {
         super(holder, LDFluidPipeType.INSTANCE);
+    }
+
+    @Override
+    public @Nullable IFluidHandlerModifiable getFluidHandlerCap(@Nullable Direction side, boolean useCoverCapability) {
+        if (isRemote() || getIoType() != IO.IN) {
+            return null;
+        }
+        var endpoint = getLink();
+        if (endpoint == null) {
+            return null;
+        }
+        var outputFacing = endpoint.getOutputFacing();
+        if (side != outputFacing.getOpposite()) {
+            return null;
+        }
+        return GTTransferUtils.getAdjacentFluidHandler(getLevel(), endpoint.getPos(), outputFacing)
+                .map(LDFluidEndpointMachine.FluidHandlerWrapper::new)
+                .orElse(null);
     }
 
     public static class FluidHandlerWrapper implements IFluidHandlerModifiable {

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/longdistance/LDItemEndpointMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/longdistance/LDItemEndpointMachine.java
@@ -1,12 +1,17 @@
 package com.gregtechceu.gtceu.common.pipelike.item.longdistance;
 
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.common.machine.storage.LongDistanceEndpointMachine;
+import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
+import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class LDItemEndpointMachine extends LongDistanceEndpointMachine {
 
@@ -14,8 +19,25 @@ public class LDItemEndpointMachine extends LongDistanceEndpointMachine {
         super(metaTileEntityId, LDItemPipeType.INSTANCE);
     }
 
-    @SuppressWarnings("UnstableApiUsage")
-    public static class ItemHandlerWrapper implements IItemHandler {
+    @Override
+    public @Nullable IItemHandlerModifiable getItemHandlerCap(@Nullable Direction side, boolean useCoverCapability) {
+        if (isRemote() || getIoType() != IO.IN) {
+            return null;
+        }
+        var endpoint = getLink();
+        if (endpoint == null) {
+            return null;
+        }
+        var outputFacing = endpoint.getOutputFacing();
+        if (side != outputFacing.getOpposite()) {
+            return null;
+        }
+        return GTTransferUtils.getAdjacentItemHandler(getLevel(), endpoint.getPos(), outputFacing)
+                .map(ItemHandlerWrapper::new)
+                .orElse(null);
+    }
+
+    public static class ItemHandlerWrapper implements IItemHandlerModifiable {
 
         private final IItemHandler delegate;
 
@@ -54,6 +76,13 @@ public class LDItemEndpointMachine extends LongDistanceEndpointMachine {
         @Override
         public boolean isItemValid(int slot, @NotNull ItemStack stack) {
             return delegate.isItemValid(slot, stack);
+        }
+
+        @Override
+        public void setStackInSlot(int i, @NotNull ItemStack itemStack) {
+            if (delegate instanceof IItemHandlerModifiable modifiable) {
+                modifiable.setStackInSlot(i, itemStack);
+            }
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/longdistance/LDItemEndpointMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/longdistance/LDItemEndpointMachine.java
@@ -21,18 +21,14 @@ public class LDItemEndpointMachine extends LongDistanceEndpointMachine {
 
     @Override
     public @Nullable IItemHandlerModifiable getItemHandlerCap(@Nullable Direction side, boolean useCoverCapability) {
-        if (isRemote() || getIoType() != IO.IN) {
+        if (isRemote() || getIoType() != IO.IN || side != getFrontFacing()) {
             return null;
         }
         var endpoint = getLink();
         if (endpoint == null) {
             return null;
         }
-        var outputFacing = endpoint.getOutputFacing();
-        if (side != outputFacing.getOpposite()) {
-            return null;
-        }
-        return GTTransferUtils.getAdjacentItemHandler(getLevel(), endpoint.getPos(), outputFacing)
+        return GTTransferUtils.getAdjacentItemHandler(getLevel(), endpoint.getPos(), endpoint.getOutputFacing())
                 .map(ItemHandlerWrapper::new)
                 .orElse(null);
     }


### PR DESCRIPTION
## What
Automatically refresh the long distance network once every second while an endpoint hasn't been found.
Automatically refresh on invalidation.
Decouple meta machine block entity from long distance pipelines (unique capability getters).
Send block update when connection is established to refresh nearby manipulators.
Prevent insertion from non-input sides.

## Outcome
Fixes #2907 

## Potential Compatibility Issues
Addons that implemented custom long distance pipelines will need to provide a proper implementation of the capability getters.