### PR TITLE
Optimize ParallelLogic for Fluids and Items when using ME Bus/Hatch

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -167,6 +167,11 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
                 .map(ingredient -> ingredient.getStacks()[0])
                 .toList();
 
+        if (recipeOutputs.size() < overlayedFluidHandler.getInfiniteEmptyTanks()) {
+            // if we have fewer outputs than infinite tanks, skip simulating and return the max multiplier
+            return multiplier;
+        }
+
         while (minMultiplier != maxMultiplier) {
             overlayedFluidHandler.reset();
 

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -237,6 +237,14 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
         return true;
     }
 
+    /**
+     * Calculates the limits based on the recipe outputs.
+     *
+     * @param recipe     The recipe to be executed.
+     * @param holder     The holder of the recipe capabilities.
+     * @param multiplier The initial multiplier for parallel execution.
+     * @return The limited multiplier for parallel execution.
+     */
     @Override
     public int limitParallel(GTRecipe recipe, IRecipeCapabilityHolder holder, int multiplier) {
         if (holder instanceof ICustomParallel p) return p.limitParallel(recipe, multiplier);
@@ -259,6 +267,12 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                         .filter(ingredient -> !ingredient.isEmpty())
                         .map(ingredient -> ingredient.getItems()[0])
                         .toList());
+
+        if (itemHandler.getEmptyInfiniteSlots() > recipeOutputs.size()) {
+            // If the output inventory is infinitely sized with more empty slots than outputs (ignores merging),
+            // return the maximum multiplier without actually simulating
+            return multiplier;
+        }
 
         while (minMultiplier != maxMultiplier) {
             itemHandler.reset();

--- a/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.utils;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 public class OverlayedItemHandler {
@@ -11,10 +12,22 @@ public class OverlayedItemHandler {
     private final OverlayedItemHandlerSlot[] slots;
     private final IItemHandlerModifiable overlayedHandler;
 
+    @Getter
+    private int emptyInfiniteSlots = 0;
+
     public OverlayedItemHandler(@NotNull IItemHandlerModifiable toOverlay) {
         this.slots = new OverlayedItemHandlerSlot[toOverlay.getSlots()];
         this.originalSlots = new OverlayedItemHandlerSlot[toOverlay.getSlots()];
         this.overlayedHandler = toOverlay;
+
+        if (toOverlay.getSlots() >= 0) {
+            for (int i = 0; i < toOverlay.getSlots(); i++) {
+                if (toOverlay.getStackInSlot(i) != ItemStack.EMPTY) continue;
+                if (toOverlay.getSlotLimit(i) == Integer.MAX_VALUE) {
+                    emptyInfiniteSlots += 1;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/utils/OverlayedTankHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/OverlayedTankHandler.java
@@ -5,6 +5,8 @@ import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
 
 import net.minecraftforge.fluids.FluidStack;
 
+import lombok.Getter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -16,12 +18,21 @@ public class OverlayedTankHandler {
 
     private final List<OverlayedTank> overlayedTanks;
 
+    @Getter
+    private int infiniteEmptyTanks = 0;
+
     public OverlayedTankHandler(List<NotifiableFluidTank> tanks) {
         overlayedTanks = new ArrayList<>(tanks.size());
         var copy = new ArrayList<>(tanks);
         copy.sort(IRecipeHandler.ENTRY_COMPARATOR);
         for (var tank : copy) {
-            overlayedTanks.add(new OverlayedTank(tank));
+            var overlayedTank = new OverlayedTank(tank);
+            overlayedTanks.add(overlayedTank);
+
+            for (int i = 0; i < tank.getTanks(); i++) {
+                if (tank.getTankCapacity(i) == Integer.MAX_VALUE)
+                    infiniteEmptyTanks += 1;
+            }
         }
     }
 


### PR DESCRIPTION
## What
_This section describes what this PR is about. It should be a clear and concise description concerning what this PR is for, why this PR is needed, and why it should be accepted._
_Linking an issue can be used alternatively to writing a description._

Calculates if the monte-carlo simulations for determining item and fluid output limiting behavior can be skipped based on the total number of infinite slots/tanks

## Implementation Details
_Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed._

## Outcome
_A short description of what this PR added/fixed/changed/removed._
_For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"_

Pre:
![image](https://github.com/user-attachments/assets/4f54c730-25aa-4e31-ae6e-0972626dfa73)

Post:
![image](https://github.com/user-attachments/assets/89928ddb-02c6-4004-bc7d-23f4e70741ec)

The world generating these traces is a Monifactory world that my friends and I completed earlier this week. It has only 3 multiblocks using 1024 parallels and one multiblock using 4096 parallels; and running 1 recipe per tick; so the impact should be quite significant on more-demanding worlds.


## Additional Information
_This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of._

It seems weird to enumerate all possible bus slots/hatches for every recipe craft and join into new objects/lists. This is likely quite memory intensive (slow). I looked at adding a new PartAbility to mark infinite busses/hatches however those aren't cached on the MachineDefinition and so aren't really queryable through the `limitParallel` interface (I think - didn't spend too long on this). A possible re-work would be to cache a lot of this per-tick computation when multiblocks successfully validate

## Potential Compatibility Issues
_This section is for defining possible compatibility issues. It must be used when there are API changes, item/block/material/machine changes, or recipe changes._

This change may conflict with the upcoming recipe logic changes but so far I didn't see much overlap.

**Please fill in as much useful information as possible. Also, please remove all unused sections, including this and the other explanations.**