### PR TITLE
Cover Tick Subscription delay

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -36,6 +36,8 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.TickTask;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.items.IItemHandler;
@@ -200,7 +202,10 @@ public class ConveyorCover extends CoverBehavior implements IUICover, IControlla
 
     @Override
     public void onNeighborChanged(Block block, BlockPos fromPos, boolean isMoving) {
-        subscriptionHandler.updateSubscription();
+        if (isRemote()) return;
+        if (coverHolder.getLevel() instanceof ServerLevel serverLevel) {
+            serverLevel.getServer().tell(new TickTask(10, subscriptionHandler::updateSubscription));
+        }
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
@@ -34,6 +34,8 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.TickTask;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.fluids.FluidStack;
@@ -174,7 +176,10 @@ public class PumpCover extends CoverBehavior implements IUICover, IControllable 
 
     @Override
     public void onNeighborChanged(Block block, BlockPos fromPos, boolean isMoving) {
-        subscriptionHandler.updateSubscription();
+        if (isRemote()) return;
+        if (coverHolder.getLevel() instanceof ServerLevel serverLevel) {
+            serverLevel.getServer().tell(new TickTask(10, subscriptionHandler::updateSubscription));
+        }
     }
 
     @Override


### PR DESCRIPTION
## What
Gives a tick delay for activating cover ticking, to ensure that any containers are initialized before finding them.