### PR TITLE
Fix item capabilities not being attached

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/ComponentItem.java
@@ -245,7 +245,7 @@ public class ComponentItem extends Item
         for (IItemComponent component : components) {
             if (component instanceof IInteractionItem interactionItem) {
                 // this will cancel the left click animation
-                return interactionItem.onEntitySwing(stack, entity);
+                return true;
             }
         }
         // normal behavior

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -20,6 +20,8 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
 
 import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import lombok.Getter;
@@ -278,13 +280,27 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         if (canCapOutput()) {
-            return storage.extractItem(slot, amount, simulate);
+            ItemStack stack = storage.extractItem(slot, amount, simulate);
+
+            // Trigger AttachCapabilitiesEvent to ensure items are compatible with other mods
+            if (!stack.isEmpty() && !simulate) {
+                MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<>(ItemStack.class, stack));
+            }
+
+            return stack;
         }
         return ItemStack.EMPTY;
     }
 
     public ItemStack extractItemInternal(int slot, int amount, boolean simulate) {
-        return storage.extractItem(slot, amount, simulate);
+        ItemStack stack = storage.extractItem(slot, amount, simulate);
+
+        // Trigger AttachCapabilitiesEvent to ensure items are compatible with other mods
+        if (!stack.isEmpty() && !simulate) {
+            MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<>(ItemStack.class, stack));
+        }
+
+        return stack;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -281,12 +281,15 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         if (canCapOutput()) {
             ItemStack stack = storage.extractItem(slot, amount, simulate);
+<<<<<<< HEAD
 
 <<<<<<< HEAD
             // Trigger AttachCapabilitiesEvent to ensure items are compatible with other mods
 =======
             // Trigger the forge attach capabilities event to ensure item compatibility with other mods
 >>>>>>> ec79286e4 (added comments)
+=======
+>>>>>>> 9986bd75c (Revert "added comments")
             if (!stack.isEmpty() && !simulate) {
                 MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<>(ItemStack.class, stack));
             }
@@ -298,9 +301,12 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
 
     public ItemStack extractItemInternal(int slot, int amount, boolean simulate) {
         ItemStack stack = storage.extractItem(slot, amount, simulate);
+<<<<<<< HEAD
 
         // Trigger AttachCapabilitiesEvent to ensure items are compatible with other mods
 
+=======
+>>>>>>> 9986bd75c (Revert "added comments")
         if (!stack.isEmpty() && !simulate) {
             MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<>(ItemStack.class, stack));
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -282,7 +282,11 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         if (canCapOutput()) {
             ItemStack stack = storage.extractItem(slot, amount, simulate);
 
+<<<<<<< HEAD
             // Trigger AttachCapabilitiesEvent to ensure items are compatible with other mods
+=======
+            // Trigger the forge attach capabilities event to ensure item compatibility with other mods
+>>>>>>> ec79286e4 (added comments)
             if (!stack.isEmpty() && !simulate) {
                 MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<>(ItemStack.class, stack));
             }
@@ -296,6 +300,7 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         ItemStack stack = storage.extractItem(slot, amount, simulate);
 
         // Trigger AttachCapabilitiesEvent to ensure items are compatible with other mods
+
         if (!stack.isEmpty() && !simulate) {
             MinecraftForge.EVENT_BUS.post(new AttachCapabilitiesEvent<>(ItemStack.class, stack));
         }


### PR DESCRIPTION
## What
This PR is a small bugfix, caused by forge item capabilities not being applied to items crafted by machines.

GregTech machines don't apply capabilities to items when produced. When the items are created, the Forge AttachCapabilitiesEvent should be triggered to attach capabilities provided by other mods. However the custom implementation of an ItemStackHandler, in this case the NotifiableItemStackHandler, overrides this behaviour and causes items to be incorrectly classified as different items by mods such as AE2.   

## Outcome
Triggers the AttachCapabilitiesEvent when ItemStacks are extracted. Now when gregtech is combined with other mods items are recognized correctly.

_(This fixes a bug, but I could not find any previous issue related to this)_

