### PR TITLE
Fixed ForgeCapabilities not being added to created items

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -31,6 +31,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import net.minecraft.nbt.CompoundTag;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+
 /**
  * @author KilaBash
  * @date 2023/2/20
@@ -278,7 +281,22 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
         if (canCapOutput()) {
-            return storage.extractItem(slot, amount, simulate);
+            ItemStack stack = storage.extractItem(slot, amount, simulate, notifyChange);
+            if (!stack.isEmpty()) {
+
+                // Serialize ITEM_HANDLER capability into NBT and attach it to the ItemStack
+                stack.getCapability(ForgeCapabilities.ITEM_HANDLER).ifPresent(handler -> {
+                    CompoundTag handlerTag = new CompoundTag();
+                    for (int i = 0; i < handler.getSlots(); i++) {
+                        ItemStack slotStack = handler.getStackInSlot(i);
+                        handlerTag.put("Slot" + i, slotStack.save(new CompoundTag()));
+                    }
+                    stack.getOrCreateTag().put("ForgeCaps", handlerTag);
+                });
+
+            }
+            
+            return stack;
         }
         return ItemStack.EMPTY;
     }


### PR DESCRIPTION
## What
This PR is a small bugfix, caused by forge item capabilities not being applied to items crafted by machines.

GregTech machines don't apply capabilities to items when produced. When the items are created, the Forge AttachCapabilitiesEvent should be triggered to attach capabilities provided by other mods. However the custom implementation of an ItemStackHandler, in this case the NotifiableItemStackHandler, overrides this behaviour and causes items to be incorrectly classified as different items by mods such as AE2.   

## Outcome
Triggers the AttachCapabilitiesEvent when ItemStacks are extracted. Now when gregtech is combined with other mods items are recognized correctly.

_(This fixes a bug, but I could not find any previous issue related to this)_

