### PR TITLE
Fix harder paper recipes consuming fluid container

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1280,7 +1280,7 @@ public class RecipeAddition {
                 new ItemStack(Items.SUGAR_CANE));
         VanillaRecipeHelper.addShapedRecipe(provider, "sugar", ChemicalHelper.get(TagPrefix.dust, GTMaterials.Sugar, 1),
                 "Sm ", 'S', new ItemStack(Items.SUGAR_CANE));
-        VanillaRecipeHelper.addShapedRecipe(provider, "paper", new ItemStack(Items.PAPER, 2),
+        VanillaRecipeHelper.addShapedFluidContainerRecipe(provider, "paper", new ItemStack(Items.PAPER, 2),
                 " r ", "SSS", " B ",
                 'S', new UnificationEntry(TagPrefix.dust, GTMaterials.Paper),
                 'B', new FluidContainerIngredient(Water.getFluidTag(), 1000));


### PR DESCRIPTION
the paper recipe was using a shaped recipe when it should've been using a addShapedFluidContainerRecipe