### PR TITLE
Fix EU to FE conversion by using actually transferred energy amount

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/compat/EUToFEProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/compat/EUToFEProvider.java
@@ -87,7 +87,7 @@ public class EUToFEProvider extends CapabilityCompatProvider {
 
                 consumable = energyStorage.receiveEnergy(consumable, false);
 
-                // Only able to actually consume less then our buffered amount
+                // Only able to consume less then our buffered amount
                 if (consumable <= receive) {
                     feBuffer = receive - consumable;
                     return 0;
@@ -95,13 +95,13 @@ public class EUToFEProvider extends CapabilityCompatProvider {
 
                 long newPower = consumable - receive;
 
-                // Able to actually consume buffered amount plus an even amount of packets (no buffer needed)
+                // Able to consume buffered amount plus an even amount of packets (no buffer needed)
                 if (newPower % maxPacket == 0) {
                     feBuffer = 0;
                     return newPower / maxPacket;
                 }
 
-                // Able to actually consume buffered amount plus some amount of power with a packet remainder
+                // Able to consume buffered amount plus some amount of power with a packet remainder
                 int ampsToConsume = GTMath.saturatedCast((newPower / maxPacket) + 1);
                 feBuffer = GTMath.saturatedCast((maxPacket * ampsToConsume) - newPower);
                 return ampsToConsume;
@@ -121,7 +121,7 @@ public class EUToFEProvider extends CapabilityCompatProvider {
                 if (consumable == 0)
                     return 0;
 
-                // Able to actually consume an even amount of packets
+                // Able to consume an even amount of packets
                 if (consumable % maxPacket == 0) {
                     feBuffer = 0;
                     return consumable / maxPacket;

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/compat/EUToFEProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/compat/EUToFEProvider.java
@@ -64,14 +64,12 @@ public class EUToFEProvider extends CapabilityCompatProvider {
 
                 // Internal Buffer could provide the max RF the consumer could consume
                 if (feBuffer > receive) {
-                    feBuffer -= receive;
-                    energyStorage.receiveEnergy(receive, false);
+                    feBuffer -= energyStorage.receiveEnergy(receive, false);
                     return 0;
 
                     // Buffer could not provide max value, save the remainder and continue processing
                 } else {
                     receive = GTMath.saturatedCast(feBuffer);
-                    feBuffer = 0;
                 }
             }
 
@@ -87,29 +85,25 @@ public class EUToFEProvider extends CapabilityCompatProvider {
                 if (consumable == 0)
                     return 0;
 
-                // Only able to consume our buffered amount
-                if (consumable == receive) {
-                    energyStorage.receiveEnergy(consumable, false);
-                    return 0;
-                }
+                consumable = energyStorage.receiveEnergy(consumable, false);
 
-                // Able to consume our full packet as well as our remainder buffer
-                if (consumable == maximalValue + receive) {
-                    energyStorage.receiveEnergy(consumable, false);
-                    return amperage;
+                // Only able to actually consume less then our buffered amount
+                if (consumable <= receive) {
+                    feBuffer = receive - consumable;
+                    return 0;
                 }
 
                 long newPower = consumable - receive;
 
-                // Able to consume buffered amount plus an even amount of packets (no buffer needed)
+                // Able to actually consume buffered amount plus an even amount of packets (no buffer needed)
                 if (newPower % maxPacket == 0) {
-                    return energyStorage.receiveEnergy(consumable, false) / maxPacket;
+                    feBuffer = 0;
+                    return newPower / maxPacket;
                 }
 
-                // Able to consume buffered amount plus some amount of power with a packet remainder
+                // Able to actually consume buffered amount plus some amount of power with a packet remainder
                 int ampsToConsume = GTMath.saturatedCast((newPower / maxPacket) + 1);
-                feBuffer = GTMath.saturatedCast((maxPacket * ampsToConsume) - consumable);
-                energyStorage.receiveEnergy(consumable, false);
+                feBuffer = GTMath.saturatedCast((maxPacket * ampsToConsume) - newPower);
                 return ampsToConsume;
 
                 // Else try to draw 1 full packet
@@ -121,21 +115,21 @@ public class EUToFEProvider extends CapabilityCompatProvider {
                 if (consumable == 0)
                     return 0;
 
-                // Able to accept the full amount of power
-                if (consumable == maximalValue) {
-                    energyStorage.receiveEnergy(consumable, false);
-                    return amperage;
-                }
+                consumable = energyStorage.receiveEnergy(consumable, false);
 
-                // Able to consume an even amount of packets
+                // Machine unable to actually consume any power
+                if (consumable == 0)
+                    return 0;
+
+                // Able to actually consume an even amount of packets
                 if (consumable % maxPacket == 0) {
-                    return energyStorage.receiveEnergy(consumable, false) / maxPacket;
+                    feBuffer = 0;
+                    return consumable / maxPacket;
                 }
 
                 // Able to consume power with some amount of power remainder in the packet
                 int ampsToConsume = GTMath.saturatedCast((consumable / maxPacket) + 1);
                 feBuffer = GTMath.saturatedCast((maxPacket * ampsToConsume) - consumable);
-                energyStorage.receiveEnergy(consumable, false);
                 return ampsToConsume;
             }
         }


### PR DESCRIPTION
## What
The current implementation for the EU to FE provider relies on the simulated value and doesn't check the real amount of energy transferred, leading to bugs if these two values don't match.
While normally with single blocks that use energy these two values match, with more complex systems such as LaserIO networks it isn't always the case

## Implementation Details
Before decreasing the energy buffer or requesting more energy packets, perform the real energy transfer and use the returned value for the business logic (assuming that the simulated value >= the real value)

## Outcome
With this fix, energy isn't wasted if the simulated value and the real value don't match

## Additional Information
This bug was discovered by an user who [reported it](https://discord.com/channels/914926812948234260/1318380025447321630/1350105531150372915) on the Moni discord channel