### PR TITLE
Add more plasmas and plasma turbine fuels 

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -46,6 +46,7 @@ public class ElementMaterials {
         Americium = new Material.Builder(GTCEu.id("americium"))
                 .ingot(3)
                 .liquid(new FluidBuilder().temperature(1449))
+                .plasma()
                 .color(0x287869).iconSet(RADIOACTIVE)
                 .appendFlags(EXT_METAL, GENERATE_FOIL, GENERATE_FINE_WIRE)
                 .element(GTElements.Am)
@@ -843,6 +844,7 @@ public class ElementMaterials {
         Tin = new Material.Builder(GTCEu.id("tin"))
                 .ingot(1)
                 .liquid(new FluidBuilder().temperature(505))
+                .plasma()
                 .ore()
                 .color(0xfafeff).secondaryColor(0x4e676c)
                 .appendFlags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SPRING, GENERATE_SPRING_SMALL,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -330,7 +330,14 @@ public class FuelRecipes {
         PLASMA_GENERATOR_FUELS.recipeBuilder("iron")
                 .inputFluids(Iron.getFluid(FluidStorageKeys.PLASMA, 1))
                 .outputFluids(Iron.getFluid(1))
-                .duration(96)
+                .duration(112)
+                .EUt(-V[EV])
+                .save(provider);
+
+        PLASMA_GENERATOR_FUELS.recipeBuilder("tin")
+                .inputFluids(Tin.getFluid(FluidStorageKeys.PLASMA, 1))
+                .outputFluids(Tin.getFluid(1))
+                .duration(128)
                 .EUt(-V[EV])
                 .save(provider);
 
@@ -338,6 +345,13 @@ public class FuelRecipes {
                 .inputFluids(Nickel.getFluid(FluidStorageKeys.PLASMA, 1))
                 .outputFluids(Nickel.getFluid(1))
                 .duration(192)
+                .EUt(-V[EV])
+                .save(provider);
+
+        PLASMA_GENERATOR_FUELS.recipeBuilder("americium")
+                .inputFluids(Americium.getFluid(FluidStorageKeys.PLASMA, 1))
+                .outputFluids(Americium.getFluid(1))
+                .duration(320)
                 .EUt(-V[EV])
                 .save(provider);
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -320,6 +320,13 @@ public class FuelRecipes {
                 .EUt(-V[EV])
                 .save(provider);
 
+        PLASMA_GENERATOR_FUELS.recipeBuilder("argon")
+                .inputFluids(Argon.getFluid(FluidStorageKeys.PLASMA, 1))
+                .outputFluids(Argon.getFluid(1))
+                .duration(96)
+                .EUt(-V[EV])
+                .save(provider);
+
         PLASMA_GENERATOR_FUELS.recipeBuilder("iron")
                 .inputFluids(Iron.getFluid(FluidStorageKeys.PLASMA, 1))
                 .outputFluids(Iron.getFluid(1))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FusionLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FusionLoader.java
@@ -210,5 +210,23 @@ public class FusionLoader {
                 .EUt(VA[LuV])
                 .fusionStartEU(200_000_000)
                 .save(provider);
+
+        FUSION_RECIPES.recipeBuilder("plutonium_241_and_hydrogen_gas_to_americium_plasma")
+                .inputFluids(GTMaterials.Plutonium241.getFluid(144))
+                .inputFluids(GTMaterials.Hydrogen.getFluid(FluidStorageKeys.GAS, 2000))
+                .outputFluids(GTMaterials.Americium.getFluid(FluidStorageKeys.PLASMA, 144))
+                .duration(64)
+                .EUt(98304)
+                .fusionStartEU(500_000_000)
+                .save(provider);
+
+        FUSION_RECIPES.recipeBuilder("silver_and_helium_3_to_tin_plasma")
+                .inputFluids(GTMaterials.Silver.getFluid(144))
+                .inputFluids(GTMaterials.Helium3.getFluid(375))
+                .outputFluids(GTMaterials.Tin.getFluid(FluidStorageKeys.PLASMA, 144))
+                .duration(16)
+                .EUt(49152)
+                .fusionStartEU(280_000_000)
+                .save(provider);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FusionLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FusionLoader.java
@@ -77,9 +77,9 @@ public class FusionLoader {
                 .save(provider);
 
         FUSION_RECIPES.recipeBuilder("lutenium_and_chromium_to_americium_plasma")
-                .inputFluids(GTMaterials.Lutetium.getFluid(32))
-                .inputFluids(GTMaterials.Chromium.getFluid(32))
-                .outputFluids(GTMaterials.Americium.getFluid(32))
+                .inputFluids(GTMaterials.Lutetium.getFluid(16))
+                .inputFluids(GTMaterials.Chromium.getFluid(16))
+                .outputFluids(GTMaterials.Americium.getFluid(16))
                 .duration(64)
                 .EUt(49152)
                 .fusionStartEU(200_000_000)
@@ -152,16 +152,16 @@ public class FusionLoader {
                 .inputFluids(GTMaterials.Gallium.getFluid(16))
                 .inputFluids(GTMaterials.Radon.getFluid(125))
                 .outputFluids(GTMaterials.Duranium.getFluid(16))
-                .duration(64)
+                .duration(32)
                 .EUt(16384)
                 .fusionStartEU(140_000_000)
                 .save(provider);
 
         FUSION_RECIPES.recipeBuilder("titanium_and_duranium_to_tritanium_plasma")
-                .inputFluids(GTMaterials.Titanium.getFluid(32))
+                .inputFluids(GTMaterials.Titanium.getFluid(48))
                 .inputFluids(GTMaterials.Duranium.getFluid(32))
                 .outputFluids(GTMaterials.Tritanium.getFluid(16))
-                .duration(64)
+                .duration(16)
                 .EUt(VA[LuV])
                 .fusionStartEU(200_000_000)
                 .save(provider);


### PR DESCRIPTION
## What
Add americium and tin plasmas.
Make argon, tin and americium plasmas fuels for the plasma turbine.
Add recipes for tin and americium plasmas.
Change iron plasma fuel duration from 96 to 112.

## Outcome
Resolves #2899

## Additional notes:
Iron plasma recipe provides 144 mb in 1.12.2 and 16 mb in gtm (gtm makes more sense)
Nickel plasma recipe provides 144 mb in 1.12.2 and 16 mb in gtm (gtm makes more sense)