### PR TITLE
Fix cover overlays to prevent Z-fighting

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/OverlayTieredMachineRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/OverlayTieredMachineRenderer.java
@@ -20,6 +20,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -43,9 +44,12 @@ public class OverlayTieredMachineRenderer extends TieredHullMachineRenderer impl
                               ModelState modelState) {
         super.renderMachine(quads, definition, machine, frontFacing, side, rand, modelFacing, modelState);
         // expand the overlay quads ever so slightly to combat z-fighting.
-        quads.addAll(overlayModel.getRotatedModel(frontFacing)
-                .getQuads(definition.defaultBlockState(), side, rand)
-                .stream()
+        var overlayQuads = new LinkedList<>(overlayModel.getRotatedModel(frontFacing)
+                .getQuads(definition.defaultBlockState(), side, rand));
+        renderCovers(overlayQuads, side, rand, machine.getCoverContainer(), modelFacing, machine.getPos(),
+                machine.getLevel(),
+                modelState);
+        quads.addAll(overlayQuads.stream()
                 .map(quad -> Quad.from(quad, this.reBakeOverlayQuadsOffset()).rebake())
                 .toList());
     }


### PR DESCRIPTION
## What
Fixes the cover overlay offset when rendering machines with overlays.

## Implementation Details
Adds the cover overlay quads to the list of quads that need rebaking with the proper offset.

## Outcome
Before:
![image](https://github.com/user-attachments/assets/6b63e769-bf4b-456d-b24e-3d15bbd2ec77)

After:
![video](https://github.com/user-attachments/assets/1f039acb-d4a3-407e-80a6-8b2cb6155114)

