### PR TITLE
Change error logging for KJS recipes and add missing builder method

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/prefix/TagPrefixBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/prefix/TagPrefixBuilder.java
@@ -40,6 +40,11 @@ public abstract class TagPrefixBuilder extends BuilderBase<TagPrefix> {
 
     public abstract KJSTagPrefix create(String id);
 
+    public TagPrefixBuilder idPattern(String idPattern) {
+        base.idPattern(idPattern);
+        return this;
+    }
+
     public TagPrefixBuilder langValue(String langValue) {
         base.langValue(langValue);
         return this;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -109,14 +109,14 @@ public interface GTRecipeSchema {
                 map = getValue(ALL_INPUTS);
             }
             if (map != null) {
+                var recipeType = GTRegistries.RECIPE_TYPES.get(this.type.id);
+                if (map.get(capability) != null &&
+                        map.get(capability).length + obj.length > recipeType.getMaxInputs(capability)) {
+                    ConsoleJS.SERVER.warn(String.format(
+                            "Trying to add more inputs than RecipeType can support, id: %s, Max %s%sInputs: %s",
+                            id, (perTick ? "Tick " : ""), capability.name, recipeType.getMaxInputs(capability)));
+                }
                 for (Object object : obj) {
-                    var recipeType = GTRegistries.RECIPE_TYPES.get(this.type.id);
-                    if (map.get(capability) != null &&
-                            map.get(capability).length >= recipeType.getMaxInputs(capability)) {
-                        ConsoleJS.SERVER.warn(String.format(
-                                "Trying to add more inputs than RecipeType can support, id: %s, Max %s%sInputs: %s",
-                                id, (perTick ? "Tick " : ""), capability.name, recipeType.getMaxInputs(capability)));
-                    }
                     map.add(capability, new Content(object, chance, maxChance, tierChanceBoost, null, null));
                 }
             }
@@ -134,14 +134,14 @@ public interface GTRecipeSchema {
                 map = getValue(ALL_OUTPUTS);
             }
             if (map != null) {
+                var recipeType = GTRegistries.RECIPE_TYPES.get(this.type.id);
+                if (map.get(capability) != null &&
+                        map.get(capability).length + obj.length > recipeType.getMaxOutputs(capability)) {
+                    ConsoleJS.SERVER.warn(String.format(
+                            "Trying to add more outputs than RecipeType can support, id: %s, Max %s%sOutputs: %s",
+                            id, (perTick ? "Tick " : ""), capability.name, recipeType.getMaxOutputs(capability)));
+                }
                 for (Object object : obj) {
-                    var recipeType = GTRegistries.RECIPE_TYPES.get(this.type.id);
-                    if (map.get(capability) != null &&
-                            map.get(capability).length >= recipeType.getMaxOutputs(capability)) {
-                        ConsoleJS.SERVER.warn(String.format(
-                                "Trying to add more outputs than RecipeType can support, id: %s, Max %s%sOutputs: %s",
-                                id, (perTick ? "Tick " : ""), capability.name, recipeType.getMaxOutputs(capability)));
-                    }
                     map.add(capability, new Content(object, chance, maxChance, tierChanceBoost, null, null));
                 }
             }


### PR DESCRIPTION
## What
Adds missing kubejs tag prefix builder method.
Parity between java and kubejs recipe builder errors.

## Outcome
Resolves #2947