### PR TITLE
Update Electrolysis recipe for Apatite

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
@@ -466,7 +466,7 @@ public class SeparationRecipes {
         ELECTROLYZER_RECIPES.recipeBuilder("apatite_electrolysis")
                 .inputItems(dust, Apatite, 9)
                 .outputItems(dust, Calcium, 5)
-                .outputItems(dust, Phosphorus, 3)
+                .outputItems(dust, Phosphate, 3)
                 .outputFluids(Chlorine.getFluid(1000))
                 .duration(288).EUt(60).save(provider);
 


### PR DESCRIPTION
Apatite's electrolysis recipe returned phosphorus instead of phosphate.

## What
Apatite should have a consistent definition and electrolysis recipe and this fixes the inconsistency in favor of the definition (which closer matches reality).

## Outcome
Fixes #3000 

## Potential Compatibility Issues
Changes a recipe and so will break some processing pipelines/automation that relied on old behavior.
