### PR TITLE
Workflow Improvements

### DIFF
--- a/.github/json/config-latest-1.21.json
+++ b/.github/json/config-latest-1.21.json
@@ -21,7 +21,7 @@
   "tag_resolver": {
     "method": "semver",
     "filter": {
-      "pattern": "^(?!v?[0-9\\.]+(-1\\.20\\.1)?$).+$",
+      "pattern": "^(?!v?[0-9\\.]+(-1\\.21)$).+$",
       "flags": "gu"
     },
     "transformer": {

--- a/.github/json/config-latest-1.21.json
+++ b/.github/json/config-latest-1.21.json
@@ -17,7 +17,6 @@
   "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
-  "ignore_labels": ["ignore changelog"],
   "tag_resolver": {
     "method": "semver",
     "filter": {

--- a/.github/json/config-latest-1.21.json
+++ b/.github/json/config-latest-1.21.json
@@ -17,6 +17,7 @@
   "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
+  "ignore_labels": ["ignore changelog"],
   "tag_resolver": {
     "method": "semver",
     "filter": {

--- a/.github/json/config-latest-1.21.json
+++ b/.github/json/config-latest-1.21.json
@@ -14,7 +14,7 @@
     }
   ],
   "sort": "ASC",
-  "template": "## What's Changed since #{{FROM_TAG}}\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}\n[Full changelog here](#{{RELEASE_DIFF}})",
+  "template": "## What's Changed since #{{FROM_TAG}}\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}\n#{{CHANGES}} lines changed - see the [full diff here](#{{RELEASE_DIFF}})",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],

--- a/.github/json/config-latest-1.21.json
+++ b/.github/json/config-latest-1.21.json
@@ -14,7 +14,7 @@
     }
   ],
   "sort": "ASC",
-  "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
+  "template": "## What's Changed since #{{FROM_TAG}}\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}\n[Full changelog here](#{{RELEASE_DIFF}})",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -17,7 +17,6 @@
   "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
-  "ignore_labels": ["ignore changelog"],
   "tag_resolver": {
     "method": "semver",
     "filter": {

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -17,6 +17,7 @@
   "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
+  "ignore_labels": ["ignore changelog"],
   "tag_resolver": {
     "method": "semver",
     "filter": {

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -14,7 +14,7 @@
     }
   ],
   "sort": "ASC",
-  "template": "## What's Changed since #{{FROM_TAG}}\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}\n[Full changelog here](#{{RELEASE_DIFF}})",
+  "template": "## What's Changed since #{{FROM_TAG}}\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}\n#{{CHANGES}} lines changed - see the [full diff here](#{{RELEASE_DIFF}})",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -19,5 +19,5 @@
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],
   "max_pull_requests": 1000,
-  "max_back_track_time_days": 30
+  "max_back_track_time_days": 60
 }

--- a/.github/json/config-latest.json
+++ b/.github/json/config-latest.json
@@ -14,7 +14,7 @@
     }
   ],
   "sort": "ASC",
-  "template": "## What's Changed\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}",
+  "template": "## What's Changed since #{{FROM_TAG}}\n#{{CHANGELOG}}\n#{{UNCATEGORIZED}}\n[Full changelog here](#{{RELEASE_DIFF}})",
   "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
   "empty_template": "",
   "ignore_labels": ["ignore changelog"],

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: ./gradlew build --build-cache
       - name: Publish to Maven
-        if: github.repository_owner == 'GregTechCEu' && env.PUBLISH
+        if: github.repository_owner == 'GregTechCEu' && env.PUBLISH == true
         run: ./gradlew publish --build-cache
       - name: Rename Jars
         if: env.PUBLISH == true
@@ -55,7 +55,7 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ./.github/json/config-latest.json
-          fromTag: latest-${{ github.ref_name }}
+#          fromTag: latest-${{ github.ref_name }}
           toTag: ${{ github.ref }}
           fetchViaCommits: true
           failOnError: false

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -32,7 +32,6 @@ jobs:
         id: suffix
         run: echo "VERSION_SUFFIX=$(echo "${{ github.sha }}" | cut -c 1-7)" >> $GITHUB_ENV
       - run: git fetch origin 1.20.1
-      - run: echo "${{ env.PUBLISH }}"
       - name: Build
         run: ./gradlew build --build-cache
       - name: Publish to Maven
@@ -55,7 +54,6 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: "./.github/json/config-latest${{ contains(github.ref_name, '1.21') && '-1.21' || '' }}.json"
-#          fromTag: latest-${{ github.ref_name }}
           toTag: ${{ github.ref }}
           fetchViaCommits: true
           failOnError: false

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         uses: mikepenz/release-changelog-builder-action@v5
         with:
-          configuration: ./.github/json/config-latest.json
+          configuration: "./.github/json/config-latest${{ contains(github.ref_name, '1.21') && '-1.21' || '' }}.json"
 #          fromTag: latest-${{ github.ref_name }}
           toTag: ${{ github.ref }}
           fetchViaCommits: true

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Build
         run: ./gradlew build --build-cache
       - name: Publish to Maven
-        if: github.repository_owner == 'GregTechCEu' && env.PUBLISH == true
+        if: ${{ github.repository_owner == 'GregTechCEu' && env.PUBLISH == 'true' }}
         run: ./gradlew publish --build-cache
       - name: Rename Jars
-        if: env.PUBLISH == true
+        if: ${{ env.PUBLISH == 'true' }}
         run: for file in build/libs/*; do mv "$file" "${file/SHOT/SHOT-$(date --utc '+%Y%m%d-%H%M%S')-${{ env.VERSION_SUFFIX }}}"; done;
       - name: Upload Artifacts
-        if: env.PUBLISH == true
+        if: ${{ env.PUBLISH == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
@@ -51,7 +51,7 @@ jobs:
           retention-days: 90
       - name: Changelog
         id: changelog
-        if: env.PUBLISH == true
+        if: ${{ env.PUBLISH == 'true' }}
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ./.github/json/config-latest.json
@@ -60,7 +60,7 @@ jobs:
           fetchViaCommits: true
           failOnError: false
       - name: Release Latest
-        if: env.PUBLISH == true
+        if: ${{ env.PUBLISH == 'true' }}
         uses: andelf/nightly-release@46e2d5f80828ecc5c2c3c819eb31186a7cf2156c
         with:
           tag_name: latest-${{ github.ref_name }}

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -32,16 +32,17 @@ jobs:
         id: suffix
         run: echo "VERSION_SUFFIX=$(echo "${{ github.sha }}" | cut -c 1-7)" >> $GITHUB_ENV
       - run: git fetch origin 1.20.1
+      - run: echo "${{ env.PUBLISH }}"
       - name: Build
         run: ./gradlew build --build-cache
       - name: Publish to Maven
         if: github.repository_owner == 'GregTechCEu' && env.PUBLISH
         run: ./gradlew publish --build-cache
       - name: Rename Jars
-        if: env.PUBLISH
+        if: env.PUBLISH == true
         run: for file in build/libs/*; do mv "$file" "${file/SHOT/SHOT-$(date --utc '+%Y%m%d-%H%M%S')-${{ env.VERSION_SUFFIX }}}"; done;
       - name: Upload Artifacts
-        if: env.PUBLISH
+        if: env.PUBLISH == true
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
@@ -50,15 +51,16 @@ jobs:
           retention-days: 90
       - name: Changelog
         id: changelog
-        if: env.PUBLISH
+        if: env.PUBLISH == true
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ./.github/json/config-latest.json
+          fromTag: latest-${{ github.ref_name }}
           toTag: ${{ github.ref }}
           fetchViaCommits: true
           failOnError: false
       - name: Release Latest
-        if: env.PUBLISH
+        if: env.PUBLISH == true
         uses: andelf/nightly-release@46e2d5f80828ecc5c2c3c819eb31186a7cf2156c
         with:
           tag_name: latest-${{ github.ref_name }}

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      PUBLISH: ${{ !contains(github.event.commits[0].message, '[no-snapshot]') }}
       MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
       MAVEN_USER: ${{ secrets.MAVEN_USER }}
       SNAPSHOT: true
@@ -34,11 +35,13 @@ jobs:
       - name: Build
         run: ./gradlew build --build-cache
       - name: Publish to Maven
-        if: github.repository_owner == 'GregTechCEu'
+        if: github.repository_owner == 'GregTechCEu' && env.PUBLISH
         run: ./gradlew publish --build-cache
       - name: Rename Jars
+        if: env.PUBLISH
         run: for file in build/libs/*; do mv "$file" "${file/SHOT/SHOT-$(date --utc '+%Y%m%d-%H%M%S')-${{ env.VERSION_SUFFIX }}}"; done;
       - name: Upload Artifacts
+        if: env.PUBLISH
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
@@ -47,14 +50,15 @@ jobs:
           retention-days: 90
       - name: Changelog
         id: changelog
+        if: env.PUBLISH
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: ./.github/json/config-latest.json
-          fromTag: latest-${{ github.ref_name }}
           toTag: ${{ github.ref }}
           fetchViaCommits: true
           failOnError: false
       - name: Release Latest
+        if: env.PUBLISH
         uses: andelf/nightly-release@46e2d5f80828ecc5c2c3c819eb31186a7cf2156c
         with:
           tag_name: latest-${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,4 +175,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git push --force --set-upstream origin gh/release-${{ inputs.branch }}
-          gh pr create -B ${{ inputs.branch }} -H gh/release-${{ inputs.branch }} --title "RELEASE for ${{ inputs.branch }}" --body "Created by GH Workflow" --label "ignore changelog"
+          gh pr create -B ${{ inputs.branch }} -H gh/release-${{ inputs.branch }} --title "RELEASE for ${{ inputs.branch }} [no-snapshot]" --body "Created by GH Workflow" --label "ignore changelog"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,4 +22,4 @@ jobs:
           git checkout origin/1.20.1 -- .github
           git commit -am "Sync Workflows"
           git push --force --set-upstream origin gh/workflow-sync
-          gh pr create -B 1.21 -H gh/workflow-sync --title "Sync Workflows with 1.20.1" --body "Created by GH Workflow" --label "ignore changelog"
+          gh pr create -B 1.21 -H gh/workflow-sync --title "Sync Workflows with 1.20.1 [no-snapshot]" --body "Created by GH Workflow" --label "ignore changelog"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.caching = true
 # Mod Info
 mod_id = gtceu
 mod_name = GregTech
-mod_version = 1.6.5
+mod_version = 1.7.0
 mod_description = GregTech CE Unofficial, ported from 1.12.2
 mod_license = LGPL-3.0 license
 mod_url = https://github.com/GregTechCEu/GregTech-Modern/

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.caching = true
 # Mod Info
 mod_id = gtceu
 mod_name = GregTech
-mod_version = 1.7.0
+mod_version = 1.6.5
 mod_description = GregTech CE Unofficial, ported from 1.12.2
 mod_license = LGPL-3.0 license
 mod_url = https://github.com/GregTechCEu/GregTech-Modern/


### PR DESCRIPTION
## What
Improves workflows:
- Snapshot releases on GH will include the entire set of changes up until previous release, rather than from the last snapshot, e.g., all changes since 1.6.4
- PR titles can contain `[no-snapshot]` which will stop a snapshot being built for a PR - this is useful for Gradle changes, which should still run the build action to verify everything works, but don't need to be published.

Example of SNAPSHOT release:
![image](https://github.com/user-attachments/assets/9d11d886-a070-46e4-a217-cc5c56ab2895)

