### PR TITLE
Fix recently connected pipes not transfering fluid/items from machines/busses/hatches

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -290,7 +290,7 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
             connections = withSideConnection(connections, side, connected);
 
             updateNetworkConnection(side, connected);
-            //notify neighbor of change so Auto Output updates its ticking status
+            // notify neighbor of change so Auto Output updates its ticking status
             getLevel().neighborChanged(getBlockPos().relative(side), getPipeBlock(), getBlockPos());
             setChanged();
 

--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -290,6 +290,8 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
             connections = withSideConnection(connections, side, connected);
 
             updateNetworkConnection(side, connected);
+            //notify neighbor of change so Auto Output updates its ticking status
+            getLevel().neighborChanged(getBlockPos().relative(side), getPipeBlock(), getBlockPos());
             setChanged();
 
             if (!fromNeighbor && tile instanceof IPipeNode<?, ?> pipeTile) {


### PR DESCRIPTION
## What
Fixes hatches not auto ejecting into pipes if the pipe is not placed directly against the machine/bus/hatch until an update is forced

## Implementation Details

This PR adds a neighborChanged notification to pipes setConnection so machines/hatches/busses that use Auto Output can have their auto output ticking status updated

## Outcome
Items and fluids come out of hatches as soon as the pipe is wrenched to connect them