### PR TITLE
Fix distinctness not being preserved

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -28,6 +28,7 @@ import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
@@ -35,6 +36,7 @@ import net.minecraft.world.level.block.Block;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -163,6 +165,19 @@ public class ItemBusPartMachine extends TieredIOPartMachine implements IDistinct
             }
         }
         setCircuitSlotEnabled(true);
+    }
+
+    @Override
+    public void loadCustomPersistedData(@NotNull CompoundTag tag) {
+        super.loadCustomPersistedData(tag);
+        // todo: delete for 1.8
+        // fix to preserve distinctness from pre 1.7 versions
+        if (tag.contains("inventory")) {
+            var invTag = tag.getCompound("inventory");
+            if (invTag.contains("isDistinct")) {
+                this.isDistinct = invTag.getBoolean("isDistinct");
+            }
+        }
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
## What
Fixes small issue with #2544, where the distinct field for Item Buses was hoisted up to the machine class rather than using the inventory class. Reads old distinctness value from nbt.

## Outcome
Old distinctness value preserved (YAY!!)