### PR TITLE
Fix typo in recipe name

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/ReactorRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/ReactorRecipes.java
@@ -107,7 +107,7 @@ public class ReactorRecipes {
                 .outputFluids(DilutedHydrochloricAcid.getFluid(2000))
                 .duration(480).EUt(96).save(provider);
 
-        CHEMICAL_RECIPES.recipeBuilder("polydimetnylsiloxane_from_elements")
+        CHEMICAL_RECIPES.recipeBuilder("polydimethylsiloxane_from_elements")
                 .circuitMeta(2)
                 .inputItems(dust, Silicon)
                 .inputFluids(Water.getFluid(1000))


### PR DESCRIPTION
This changes `polydimetnylsiloxane` to `polydimethylsiloxane`. That's it.

## Outcome
no more typo, meaning packdevs can mess with the recipe more easily

## Potential Compatibility Issues
people who were already messing with the recipe will need to change the name in their own code as well!