### PR TITLE
Fix `DistillationTowerLogic` consuming inputs when matching recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
@@ -196,7 +196,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
 
         private ActionResult matchDTRecipe(GTRecipe recipe) {
             var result = RecipeHelper.handleRecipe(machine, recipe, IO.IN, recipe.inputs,
-                    Collections.emptyMap(), false, false);
+                    Collections.emptyMap(), false, true);
             if (!result.isSuccess()) return result;
 
             var items = recipe.getOutputContents(ItemRecipeCapability.CAP);


### PR DESCRIPTION
## What
Distillation towers voided fluids inserted into any hatches if the structure was formed.

## Implementation Details
Switched `Simulated` from false to true, that's it.
## Outcome
No longer screws up the DT working
