### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# add spotless formatting to 1.20.1 (#1334)
+5f59025e1044042dcd0913799d873f810f2fb220

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
 # add spotless formatting to 1.20.1 (#1334)
 5f59025e1044042dcd0913799d873f810f2fb220
+# Drop Fabric Support (1.20) (#735)
+5f9f2d8303d19aa1c749ee5ca8cd4149d90520f0


### PR DESCRIPTION
## What
This PR adds a `.git-blame-ignore-revs` file, which GitHub and local development environments can use to ignore certain commits when looking at git blame. This is useful for ignoring large commits which haven't actually changed content, like formatting commits.

The following commits have been added to this file:
- 5f9f2d8, associated with #735, the 1.20.1 commit that removed Fabric support
- 5f59025, associated with #1334, the initial spotless commit

Developers can use this file locally by running the following command:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```