### PR TITLE
Fix crafting component issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -43,6 +43,7 @@ import com.gregtechceu.gtceu.data.loot.DungeonLootLoader;
 import com.gregtechceu.gtceu.data.pack.GTDynamicDataPack;
 import com.gregtechceu.gtceu.data.pack.GTDynamicResourcePack;
 import com.gregtechceu.gtceu.data.pack.GTPackSource;
+import com.gregtechceu.gtceu.data.recipe.GTCraftingComponents;
 import com.gregtechceu.gtceu.forge.AlloyBlastPropertyAddition;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuStartupEvents;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
@@ -271,6 +272,7 @@ public class CommonProxy {
 
             long startTime = System.currentTimeMillis();
             ItemMaterialData.reinitializeMaterialData();
+            GTCraftingComponents.init();
             GTRecipes.recipeRemoval();
             GTRecipes.recipeAddition(GTDynamicDataPack::addRecipe);
             // Initialize dungeon loot additions

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/CraftingComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/CraftingComponent.java
@@ -33,9 +33,10 @@ public class CraftingComponent {
     }
 
     public static CraftingComponent of(@NotNull String id, @NotNull Object fallback) {
-        if (ALL_COMPONENTS.containsKey(id)) {
-            GTCEu.LOGGER.error("Duplicate crafting component id: {}, returning empty", id);
-            return EMPTY;
+        var existing = ALL_COMPONENTS.get(id);
+        if (existing != null) {
+            GTCEu.LOGGER.error("Duplicate crafting component id: {}, check components", id);
+            return existing;
         }
         var ret = new CraftingComponent(fallback);
         ALL_COMPONENTS.put(id, ret);
@@ -47,6 +48,7 @@ public class CraftingComponent {
     }
 
     public @NotNull Object get(int tier) {
+        if (this == EMPTY) return ItemStack.EMPTY;
         if (tier < 0 || tier >= values.length)
             throw new IllegalArgumentException("Tier out of range of ULV-MAX, tier: " + tier);
         var val = values[tier];
@@ -54,6 +56,7 @@ public class CraftingComponent {
     }
 
     public @NotNull CraftingComponent add(int tier, @NotNull Object value) {
+        if (this == EMPTY) return this;
         checkType(value);
         values[tier] = value;
         return this;
@@ -64,6 +67,7 @@ public class CraftingComponent {
     }
 
     public void remove(int tier) {
+        if (this == EMPTY) return;
         if (tier < 0 || tier >= values.length)
             throw new IllegalArgumentException("Tier out of range of ULV-MAX, tier: " + tier);
         values[tier] = null;
@@ -80,10 +84,10 @@ public class CraftingComponent {
     }
 
     public static CraftingComponent getByID(String id) {
-        if (!CraftingComponent.ALL_COMPONENTS.containsKey(id)) {
+        if (!ALL_COMPONENTS.containsKey(id)) {
             GTCEu.LOGGER.error("No such crafting component: {}", id);
-            return CraftingComponent.EMPTY;
+            return EMPTY;
         }
-        return CraftingComponent.ALL_COMPONENTS.get(id);
+        return ALL_COMPONENTS.get(id);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/GTCraftingComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/GTCraftingComponents.java
@@ -48,7 +48,6 @@ public class GTCraftingComponents {
     public static CraftingComponent SENSOR;
     public static CraftingComponent GRINDER;
     public static CraftingComponent SAWBLADE;
-    public static CraftingComponent DIAMOND;
     public static CraftingComponent PISTON;
     public static CraftingComponent EMITTER;
     public static CraftingComponent CONVEYOR;

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/GTCraftingComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/GTCraftingComponents.java
@@ -6,10 +6,9 @@ import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.data.recipe.event.CraftingComponentModificationEvent;
-import com.gregtechceu.gtceu.integration.kjs.GTCEuStartupEvents;
+import com.gregtechceu.gtceu.integration.kjs.GTCEuServerEvents;
 import com.gregtechceu.gtceu.integration.kjs.events.CraftingComponentsEventJS;
 
-import net.minecraft.world.item.Items;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.Tags;
 
@@ -57,11 +56,11 @@ public class GTCraftingComponents {
     public static CraftingComponent COIL_HEATING;
     public static CraftingComponent COIL_HEATING_DOUBLE;
     public static CraftingComponent COIL_ELECTRIC;
-    public static CraftingComponent STICK_MAGNETIC;
-    public static CraftingComponent STICK_DISTILLATION;
+    public static CraftingComponent ROD_MAGNETIC;
+    public static CraftingComponent ROD_DISTILLATION;
     public static CraftingComponent FIELD_GENERATOR;
-    public static CraftingComponent STICK_ELECTROMAGNETIC;
-    public static CraftingComponent STICK_RADIOACTIVE;
+    public static CraftingComponent ROD_ELECTROMAGNETIC;
+    public static CraftingComponent ROD_RADIOACTIVE;
     public static CraftingComponent PIPE_REACTOR;
     public static CraftingComponent POWER_COMPONENT;
     public static CraftingComponent VOLTAGE_COIL;
@@ -72,7 +71,9 @@ public class GTCraftingComponents {
     public static CraftingComponent SMALL_SPRING_TRANSFORMER;
     public static CraftingComponent SPRING_TRANSFORMER;
 
-    public static void initializeComponents() {
+    public static void init() {
+        CraftingComponent.ALL_COMPONENTS.clear();
+
         /*
          * GTCEu must supply values for at least tiers 1 through 8 (through UV)
          */
@@ -426,8 +427,6 @@ public class GTCraftingComponents {
                 .add(UV, toolHeadBuzzSaw, Duranium)
                 .add(UHV, toolHeadBuzzSaw, Duranium);
 
-        DIAMOND = CraftingComponent.of("diamond", gem, Diamond);
-
         MOTOR = CraftingComponent.of("motor", GTItems.ELECTRIC_MOTOR_LV.asStack())
                 .add(LV, GTItems.ELECTRIC_MOTOR_LV.asStack())
                 .add(MV, GTItems.ELECTRIC_MOTOR_MV.asStack())
@@ -601,7 +600,7 @@ public class GTCraftingComponents {
                 .add(UV, wireGtOctal, YttriumBariumCuprate)
                 .add(UHV, wireGtOctal, Europium);
 
-        STICK_MAGNETIC = CraftingComponent.of("rod_magnetic", rod, IronMagnetic)
+        ROD_MAGNETIC = CraftingComponent.of("rod_magnetic", rod, IronMagnetic)
                 .add(ULV, rod, IronMagnetic)
                 .add(LV, rod, IronMagnetic)
                 .add(MV, rod, SteelMagnetic)
@@ -613,7 +612,7 @@ public class GTCraftingComponents {
                 .add(UV, block, NeodymiumMagnetic)
                 .add(UHV, block, SamariumMagnetic);
 
-        STICK_DISTILLATION = CraftingComponent.of("rod_distillation", rod, Blaze)
+        ROD_DISTILLATION = CraftingComponent.of("rod_distillation", rod, Blaze)
                 .add(ULV, rod, Blaze)
                 .add(LV, spring, Copper)
                 .add(MV, spring, Cupronickel)
@@ -625,7 +624,7 @@ public class GTCraftingComponents {
                 .add(UV, spring, NaquadahAlloy)
                 .add(UHV, spring, Trinium);
 
-        STICK_ELECTROMAGNETIC = CraftingComponent.of("rod_electromagnetic", rod, Iron)
+        ROD_ELECTROMAGNETIC = CraftingComponent.of("rod_electromagnetic", rod, Iron)
                 .add(ULV, rod, Iron)
                 .add(LV, rod, Iron)
                 .add(MV, rod, Steel)
@@ -637,7 +636,7 @@ public class GTCraftingComponents {
                 .add(UV, rod, VanadiumGallium)
                 .add(UHV, rod, VanadiumGallium);
 
-        STICK_RADIOACTIVE = CraftingComponent.of("rod_radioactive", rod, Uranium235)
+        ROD_RADIOACTIVE = CraftingComponent.of("rod_radioactive", rod, Uranium235)
                 .add(EV, rod, Uranium235)
                 .add(IV, rod, Plutonium241)
                 .add(LuV, rod, NaquadahEnriched)
@@ -759,7 +758,7 @@ public class GTCraftingComponents {
     private static final class KJSCallWrapper {
 
         private static void craftingComponentModification() {
-            GTCEuStartupEvents.CRAFTING_COMPONENTS.post(new CraftingComponentsEventJS());
+            GTCEuServerEvents.CRAFTING_COMPONENTS.post(new CraftingComponentsEventJS());
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
@@ -793,19 +793,19 @@ public class MetaTileEntityLoader {
         registerMachineRecipe(provider, GTMachines.PACKER, "BCB", "RMV", "WCW", 'M', HULL, 'R', ROBOT_ARM, 'V',
                 CONVEYOR, 'C', CIRCUIT, 'W', CABLE, 'B', Tags.Items.CHESTS_WOODEN);
         registerMachineRecipe(provider, GTMachines.BREWERY, "GPG", "WMW", "CBC", 'M', HULL, 'P', PUMP, 'B',
-                STICK_DISTILLATION, 'C', CIRCUIT, 'W', CABLE, 'G', GLASS);
+                ROD_DISTILLATION, 'C', CIRCUIT, 'W', CABLE, 'G', GLASS);
         registerMachineRecipe(provider, GTMachines.FERMENTER, "WPW", "GMG", "WCW", 'M', HULL, 'P', PUMP, 'C', CIRCUIT,
                 'W', CABLE, 'G', GLASS);
         registerMachineRecipe(provider, GTMachines.DISTILLERY, "GBG", "CMC", "WPW", 'M', HULL, 'P', PUMP, 'B',
-                STICK_DISTILLATION, 'C', CIRCUIT, 'W', CABLE, 'G', GLASS);
+                ROD_DISTILLATION, 'C', CIRCUIT, 'W', CABLE, 'G', GLASS);
         registerMachineRecipe(provider, GTMachines.FLUID_SOLIDIFIER, "PGP", "WMW", "CBC", 'M', HULL, 'P', PUMP, 'C',
                 CIRCUIT, 'W', CABLE, 'G', GLASS, 'B', Tags.Items.CHESTS_WOODEN);
         registerMachineRecipe(provider, GTMachines.CHEMICAL_BATH, "VGW", "PGV", "CMC", 'M', HULL, 'P', PUMP, 'V',
                 CONVEYOR, 'C', CIRCUIT, 'W', CABLE, 'G', GLASS);
         registerMachineRecipe(provider, GTMachines.POLARIZER, "ZSZ", "WMW", "ZSZ", 'M', HULL, 'S',
-                STICK_ELECTROMAGNETIC, 'Z', COIL_ELECTRIC, 'W', CABLE);
+                ROD_ELECTROMAGNETIC, 'Z', COIL_ELECTRIC, 'W', CABLE);
         registerMachineRecipe(provider, GTMachines.ELECTROMAGNETIC_SEPARATOR, "VWZ", "WMS", "CWZ", 'M', HULL, 'S',
-                STICK_ELECTROMAGNETIC, 'Z', COIL_ELECTRIC, 'V', CONVEYOR, 'C', CIRCUIT, 'W', CABLE);
+                ROD_ELECTROMAGNETIC, 'Z', COIL_ELECTRIC, 'V', CONVEYOR, 'C', CIRCUIT, 'W', CABLE);
         registerMachineRecipe(provider, GTMachines.AUTOCLAVE, "IGI", "IMI", "CPC", 'M', HULL, 'P', PUMP, 'C', CIRCUIT,
                 'I', PLATE, 'G', GLASS);
         registerMachineRecipe(provider, GTMachines.MIXER, "GRG", "GEG", "CMC", 'M', HULL, 'E', MOTOR, 'R', ROTOR, 'C',

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
@@ -34,9 +34,6 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.ASSEMBLY_LINE_RECI
 public class MetaTileEntityMachineRecipeLoader {
 
     public static void init(Consumer<FinishedRecipe> provider) {
-        // this needs to exist here now :)
-        GTCraftingComponents.initializeComponents();
-
         // Reservoir Hatch
         ASSEMBLER_RECIPES.recipeBuilder("reservoir_hatch")
                 .inputItems(COVER_INFINITE_WATER)

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuServerEvents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuServerEvents.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs;
 
+import com.gregtechceu.gtceu.integration.kjs.events.CraftingComponentsEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTBedrockOreVeinEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTFluidVeinEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTOreVeinEventJS;
@@ -14,4 +15,6 @@ public interface GTCEuServerEvents {
     EventHandler ORE_VEIN_MODIFICATION = GROUP.server("oreVeins", () -> GTOreVeinEventJS.class);
     EventHandler BEDROCK_ORE_VEIN_MODIFICATION = GROUP.server("bedrockOreVeins", () -> GTBedrockOreVeinEventJS.class);
     EventHandler FLUID_VEIN_MODIFICATION = GROUP.server("fluidVeins", () -> GTFluidVeinEventJS.class);
+
+    EventHandler CRAFTING_COMPONENTS = GROUP.startup("craftingComponents", () -> CraftingComponentsEventJS.class);
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuStartupEvents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuStartupEvents.java
@@ -2,7 +2,6 @@ package com.gregtechceu.gtceu.integration.kjs;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.registry.GTRegistry;
-import com.gregtechceu.gtceu.integration.kjs.events.CraftingComponentsEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTRegistryEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.MaterialModificationEventJS;
 
@@ -27,6 +26,4 @@ public interface GTCEuStartupEvents {
 
     EventHandler REGISTRY = GROUP.startup("registry", () -> GTRegistryEventJS.class).extra(REGISTRY_EXTRA);
     EventHandler MATERIAL_MODIFICATION = GROUP.startup("materialModification", () -> MaterialModificationEventJS.class);
-
-    EventHandler CRAFTING_COMPONENTS = GROUP.startup("craftingComponents", () -> CraftingComponentsEventJS.class);
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/events/CraftingComponentsEventJS.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/events/CraftingComponentsEventJS.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings({ "unused", "unchecked" })
+@SuppressWarnings({ "unused" })
 @NoArgsConstructor
 public class CraftingComponentsEventJS extends StartupEventJS {
 


### PR DESCRIPTION
## What
- Move `GTCraftingComponents#init` to `registerPackFinders`
  - Functionally equivalent, but makes more sense semantically
- Makes the `CraftingComponent` modification event a ServerEvent rather than a StartupEvent
- Returns the existing component from `Component#of` if one already exists for the given ID
- Renames some components from `STICK` to `ROD`
- Clears `ALL_COMPONENTS` upon init