### PR TITLE
Add KJS Shaped Recipe Schema with GT Tool Symbols

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -63,11 +63,14 @@ import net.minecraftforge.common.IForgeShearable;
 import net.minecraftforge.common.TierSortingRegistry;
 import net.minecraftforge.event.ForgeEventFactory;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
+import it.unimi.dsi.fastutil.chars.Char2ReferenceMap;
+import it.unimi.dsi.fastutil.chars.Char2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.chars.CharSet;
+import it.unimi.dsi.fastutil.chars.CharSets;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -127,33 +130,27 @@ public class ToolHelper {
     public static final String RELOCATE_MOB_DROPS_KEY = "RelocateMobDrops";
 
     // Crafting Symbols
-    private static final BiMap<Character, GTToolType> symbols = HashBiMap.create();
+    private static final Char2ReferenceMap<GTToolType> symbols = new Char2ReferenceOpenHashMap<>();
 
     private ToolHelper() {/**/}
 
     /**
-     * @return finds the registered crafting symbol with the tool
-     */
-    public static Character getSymbolFromTool(GTToolType tool) {
-        return symbols.inverse().get(tool);
-    }
-
-    /**
      * @return finds the registered tool with the crafting symbol
      */
-    public static GTToolType getToolFromSymbol(Character symbol) {
+    public static GTToolType getToolFromSymbol(char symbol) {
         return symbols.get(symbol);
     }
 
-    public static Set<Character> getToolSymbols() {
-        return symbols.keySet();
+    @UnmodifiableView
+    public static CharSet getToolSymbols() {
+        return CharSets.unmodifiable(symbols.keySet());
     }
 
     /**
      * Registers the tool against a crafting symbol, this is used in
      * {@link com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper}
      */
-    public static void registerToolSymbol(Character symbol, GTToolType tool) {
+    public static void registerToolSymbol(char symbol, GTToolType tool) {
         symbols.put(symbol, tool);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -66,6 +66,7 @@ import net.minecraftforge.event.ForgeEventFactory;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -127,6 +128,7 @@ public class ToolHelper {
     public static final String RELOCATE_MOB_DROPS_KEY = "RelocateMobDrops";
 
     // Crafting Symbols
+    @Getter
     private static final BiMap<Character, GTToolType> symbols = HashBiMap.create();
 
     private ToolHelper() {/**/}

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -66,7 +66,6 @@ import net.minecraftforge.event.ForgeEventFactory;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -128,7 +127,6 @@ public class ToolHelper {
     public static final String RELOCATE_MOB_DROPS_KEY = "RelocateMobDrops";
 
     // Crafting Symbols
-    @Getter
     private static final BiMap<Character, GTToolType> symbols = HashBiMap.create();
 
     private ToolHelper() {/**/}

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -349,23 +349,24 @@ public class VanillaRecipeHelper {
                                                      @NotNull Object... recipe) {
         var builder = new ShapedEnergyTransferRecipeBuilder(regName).output(result);
         builder.chargeIngredient(chargeIngredient).overrideCharge(overrideCharge).transferMaxCharge(transferMaxCharge);
-        CharSet set = new CharOpenHashSet();
+        final CharSet tools = ToolHelper.getToolSymbols();
+        CharSet foundTools = new CharArraySet(9);
         for (int i = 0; i < recipe.length; i++) {
             var o = recipe[i];
             if (o instanceof String pattern) {
                 builder.pattern(pattern);
-                for (Character c : ToolHelper.getToolSymbols()) {
-                    if (pattern.indexOf(c) >= 0) {
-                        set.add(c.charValue());
+                for (char c : pattern.toCharArray()) {
+                    if (tools.contains(c)) {
+                        foundTools.add(c);
                     }
                 }
             }
             if (o instanceof String[] pattern) {
                 for (String s : pattern) {
                     builder.pattern(s);
-                    for (Character c : ToolHelper.getToolSymbols()) {
-                        if (s.indexOf(c) >= 0) {
-                            set.add(c.charValue());
+                    for (char c : s.toCharArray()) {
+                        if (tools.contains(c)) {
+                            foundTools.add(c);
                         }
                     }
                 }
@@ -391,7 +392,8 @@ public class VanillaRecipeHelper {
                 }
             }
         }
-        for (Character c : set) {
+        for (var it = foundTools.iterator(); it.hasNext(); ) {
+            char c = it.nextChar();
             builder.define(c, ToolHelper.getToolFromSymbol(c).itemTags.get(0));
         }
         builder.save(provider);
@@ -414,24 +416,24 @@ public class VanillaRecipeHelper {
                                                      @NotNull ResourceLocation regName, @NotNull ItemStack result,
                                                      @NotNull Object... recipe) {
         var builder = new ShapedFluidContainerRecipeBuilder(regName).output(result);
-        builder.isStrict(isStrict);
-        CharSet set = new CharOpenHashSet();
+        final CharSet tools = ToolHelper.getToolSymbols();
+        CharSet foundTools = new CharArraySet(9);
         for (int i = 0; i < recipe.length; i++) {
             var o = recipe[i];
             if (o instanceof String pattern) {
                 builder.pattern(pattern);
-                for (Character c : ToolHelper.getToolSymbols()) {
-                    if (pattern.indexOf(c) >= 0) {
-                        set.add(c.charValue());
+                for (char c : pattern.toCharArray()) {
+                    if (tools.contains(c)) {
+                        foundTools.add(c);
                     }
                 }
             }
             if (o instanceof String[] pattern) {
                 for (String s : pattern) {
                     builder.pattern(s);
-                    for (Character c : ToolHelper.getToolSymbols()) {
-                        if (s.indexOf(c) >= 0) {
-                            set.add(c.charValue());
+                    for (char c : s.toCharArray()) {
+                        if (tools.contains(c)) {
+                            foundTools.add(c);
                         }
                     }
                 }
@@ -461,7 +463,8 @@ public class VanillaRecipeHelper {
                 }
             }
         }
-        for (Character c : set) {
+        for (var it = foundTools.iterator(); it.hasNext(); ) {
+            char c = it.nextChar();
             builder.define(c, ToolHelper.getToolFromSymbol(c).itemTags.get(0));
         }
 
@@ -551,8 +554,7 @@ public class VanillaRecipeHelper {
         while (recipe[itr] instanceof String s) {
             for (char c : s.toCharArray()) {
                 if (ToolHelper.getToolFromSymbol(c) != null) continue; // skip tools
-                int count = inputCountMap.getOrDefault(c, 0);
-                inputCountMap.put(c, count + 1);
+                inputCountMap.addTo(c, 1);
             }
             itr++;
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -392,7 +392,7 @@ public class VanillaRecipeHelper {
                 }
             }
         }
-        for (var it = foundTools.iterator(); it.hasNext(); ) {
+        for (var it = foundTools.iterator(); it.hasNext();) {
             char c = it.nextChar();
             builder.define(c, ToolHelper.getToolFromSymbol(c).itemTags.get(0));
         }
@@ -463,7 +463,7 @@ public class VanillaRecipeHelper {
                 }
             }
         }
-        for (var it = foundTools.iterator(); it.hasNext(); ) {
+        for (var it = foundTools.iterator(); it.hasNext();) {
             char c = it.nextChar();
             builder.define(c, ToolHelper.getToolFromSymbol(c).itemTags.get(0));
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -253,23 +253,24 @@ public class VanillaRecipeHelper {
                                        @NotNull Object... recipe) {
         var builder = new ShapedRecipeBuilder(regName).output(result);
         builder.isStrict(isStrict);
-        CharSet set = new CharOpenHashSet();
+        final CharSet tools = ToolHelper.getToolSymbols();
+        CharSet foundTools = new CharArraySet(9);
         for (int i = 0; i < recipe.length; i++) {
             var o = recipe[i];
             if (o instanceof String pattern) {
                 builder.pattern(pattern);
-                for (Character c : ToolHelper.getToolSymbols()) {
-                    if (pattern.indexOf(c) >= 0) {
-                        set.add(c.charValue());
+                for (char c : pattern.toCharArray()) {
+                    if (tools.contains(c)) {
+                        foundTools.add(c);
                     }
                 }
             }
             if (o instanceof String[] pattern) {
                 for (String s : pattern) {
                     builder.pattern(s);
-                    for (Character c : ToolHelper.getToolSymbols()) {
-                        if (s.indexOf(c) >= 0) {
-                            set.add(c.charValue());
+                    for (char c : s.toCharArray()) {
+                        if (tools.contains(c)) {
+                            foundTools.add(c);
                         }
                     }
                 }
@@ -299,7 +300,8 @@ public class VanillaRecipeHelper {
                 }
             }
         }
-        for (Character c : set) {
+        for (var it = foundTools.iterator(); it.hasNext();) {
+            char c = it.nextChar();
             builder.define(c, ToolHelper.getToolFromSymbol(c).itemTags.get(0));
         }
         builder.save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -416,6 +416,7 @@ public class VanillaRecipeHelper {
                                                      @NotNull ResourceLocation regName, @NotNull ItemStack result,
                                                      @NotNull Object... recipe) {
         var builder = new ShapedFluidContainerRecipeBuilder(regName).output(result);
+        builder.isStrict(isStrict);
         final CharSet tools = ToolHelper.getToolSymbols();
         CharSet foundTools = new CharArraySet(9);
         for (int i = 0; i < recipe.length; i++) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.data.RotationState;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.Element;
 import com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData;
+import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterial;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet;
@@ -16,6 +17,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconType;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.HazardProperty;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.ToolProperty;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
@@ -32,6 +34,7 @@ import com.gregtechceu.gtceu.api.fluids.attribute.FluidAttributes;
 import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKeys;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
+import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.SimpleGeneratorMachine;
 import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
@@ -78,6 +81,7 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponent
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeSerializer;
@@ -102,11 +106,15 @@ import dev.latvian.mods.kubejs.util.ClassFilter;
 import dev.latvian.mods.rhino.Wrapper;
 import dev.latvian.mods.rhino.mod.util.NBTUtils;
 import dev.latvian.mods.rhino.util.wrap.TypeWrappers;
+import it.unimi.dsi.fastutil.chars.Char2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 
 import java.util.*;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.gregtechceu.gtceu.integration.kjs.recipe.GTShapedRecipeSchema.*;
 
 /**
  * @author KilaBash
@@ -458,86 +466,9 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         // (jankily) parse all GT recipes for extra ones to add, modify
         for (RecipeJS addedRecipe : event.addedRecipes) {
             if (addedRecipe instanceof GTRecipeSchema.GTRecipeJS gtRecipe) {
-                // get the recipe ID without the leading type path
-                GTRecipeBuilder builder = ((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(gtRecipe.type.id))
-                        .recipeBuilder(gtRecipe.idWithoutType());
-
-                if (gtRecipe.getValue(GTRecipeSchema.DURATION) != null) {
-                    builder.duration = gtRecipe.getValue(GTRecipeSchema.DURATION).intValue();
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.DATA) != null) {
-                    builder.data = gtRecipe.getValue(GTRecipeSchema.DATA);
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.CONDITIONS) != null) {
-                    builder.conditions.addAll(Arrays.stream(gtRecipe.getValue(GTRecipeSchema.CONDITIONS)).toList());
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.CATEGORY) != null) {
-                    builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES
-                            .get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
-                }
-                builder.researchRecipeEntries().addAll(gtRecipe.researchRecipeEntries());
-
-                if (gtRecipe.getValue(GTRecipeSchema.ALL_INPUTS) != null) {
-                    builder.input.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_INPUTS).entrySet().stream()
-                            .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
-                                    .map(content -> entry.getKey().serializer
-                                            .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
-                                                    .getFirst().write(gtRecipe, content)))
-                                    .toList()))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.ALL_OUTPUTS) != null) {
-                    builder.output.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_OUTPUTS).entrySet().stream()
-                            .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
-                                    .map(content -> entry.getKey().serializer
-                                            .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
-                                                    .getSecond().write(gtRecipe, content)))
-                                    .toList()))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.ALL_TICK_INPUTS) != null) {
-                    builder.tickInput.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_TICK_INPUTS).entrySet().stream()
-                            .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
-                                    .map(content -> entry.getKey().serializer
-                                            .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
-                                                    .getFirst().write(gtRecipe, content)))
-                                    .toList()))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.ALL_TICK_OUTPUTS) != null) {
-                    builder.tickOutput.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_TICK_OUTPUTS).entrySet().stream()
-                            .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
-                                    .map(content -> entry.getKey().serializer
-                                            .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
-                                                    .getSecond().write(gtRecipe, content)))
-                                    .toList()))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                }
-
-                if (gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS) != null) {
-                    builder.inputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS));
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS) != null) {
-                    builder.outputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS));
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS) != null) {
-                    builder.tickInputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS));
-                }
-                if (gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS) != null) {
-                    builder.tickOutputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS));
-                }
-
-                builder.setTempItemMaterialStacks(gtRecipe.itemMaterialStacks);
-                builder.setTempFluidMaterialStacks(gtRecipe.fluidMaterialStacks);
-                gtRecipe.itemMaterialStacks = null;
-                gtRecipe.fluidMaterialStacks = null;
-
-                builder.addMaterialInfo(gtRecipe.itemMaterialInfo, gtRecipe.fluidMaterialInfo);
-                if (gtRecipe.removeMaterialInfo)
-                    builder.removePreviousMaterialInfo();
-
-                builder.save(builtRecipe -> recipesByName.put(builtRecipe.getId(),
-                        GTRecipeSerializer.SERIALIZER.fromJson(builtRecipe.getId(), builtRecipe.serializeRecipe())));
+                handleGTRecipe(recipesByName, gtRecipe);
+            } else if (addedRecipe instanceof GTShapedRecipeSchema.ShapedRecipeJS gtShaped) {
+                handleGTShaped(gtShaped);
             }
         }
 
@@ -574,5 +505,147 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                         .forEach(gtRecipe -> gtRecipeType.getLookup().addRecipe(gtRecipe));
             }
         }
+    }
+
+    private static void handleGTRecipe(Map<ResourceLocation, Recipe<?>> recipesByName,
+                                       GTRecipeSchema.GTRecipeJS gtRecipe) {
+        // get the recipe ID without the leading type path
+        GTRecipeBuilder builder = ((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(gtRecipe.type.id))
+                .recipeBuilder(gtRecipe.idWithoutType());
+
+        if (gtRecipe.getValue(GTRecipeSchema.DURATION) != null) {
+            builder.duration = gtRecipe.getValue(GTRecipeSchema.DURATION).intValue();
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.DATA) != null) {
+            builder.data = gtRecipe.getValue(GTRecipeSchema.DATA);
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.CONDITIONS) != null) {
+            builder.conditions.addAll(Arrays.stream(gtRecipe.getValue(GTRecipeSchema.CONDITIONS)).toList());
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.CATEGORY) != null) {
+            builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES
+                    .get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
+        }
+        builder.researchRecipeEntries().addAll(gtRecipe.researchRecipeEntries());
+
+        if (gtRecipe.getValue(GTRecipeSchema.ALL_INPUTS) != null) {
+            builder.input.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_INPUTS).entrySet().stream()
+                    .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
+                            .map(content -> entry.getKey().serializer
+                                    .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
+                                            .getFirst().write(gtRecipe, content)))
+                            .toList()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.ALL_OUTPUTS) != null) {
+            builder.output.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_OUTPUTS).entrySet().stream()
+                    .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
+                            .map(content -> entry.getKey().serializer
+                                    .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
+                                            .getSecond().write(gtRecipe, content)))
+                            .toList()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.ALL_TICK_INPUTS) != null) {
+            builder.tickInput.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_TICK_INPUTS).entrySet().stream()
+                    .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
+                            .map(content -> entry.getKey().serializer
+                                    .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
+                                            .getFirst().write(gtRecipe, content)))
+                            .toList()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.ALL_TICK_OUTPUTS) != null) {
+            builder.tickOutput.putAll(gtRecipe.getValue(GTRecipeSchema.ALL_TICK_OUTPUTS).entrySet().stream()
+                    .map(entry -> Map.entry(entry.getKey(), Arrays.stream(entry.getValue())
+                            .map(content -> entry.getKey().serializer
+                                    .fromJsonContent(GTRecipeComponents.VALID_CAPS.get(entry.getKey())
+                                            .getSecond().write(gtRecipe, content)))
+                            .toList()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        }
+
+        if (gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS) != null) {
+            builder.inputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.INPUT_CHANCE_LOGICS));
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS) != null) {
+            builder.outputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.OUTPUT_CHANCE_LOGICS));
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS) != null) {
+            builder.tickInputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_INPUT_CHANCE_LOGICS));
+        }
+        if (gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS) != null) {
+            builder.tickOutputChanceLogic.putAll(gtRecipe.getValue(GTRecipeSchema.TICK_OUTPUT_CHANCE_LOGICS));
+        }
+
+        builder.setTempItemMaterialStacks(gtRecipe.itemMaterialStacks);
+        builder.setTempFluidMaterialStacks(gtRecipe.fluidMaterialStacks);
+        gtRecipe.itemMaterialStacks = null;
+        gtRecipe.fluidMaterialStacks = null;
+
+        builder.addMaterialInfo(gtRecipe.itemMaterialInfo, gtRecipe.fluidMaterialInfo);
+        if (gtRecipe.removeMaterialInfo)
+            builder.removePreviousMaterialInfo();
+
+        builder.save(builtRecipe -> recipesByName.put(builtRecipe.getId(),
+                GTRecipeSerializer.SERIALIZER.fromJson(builtRecipe.getId(), builtRecipe.serializeRecipe())));
+    }
+
+    private static void handleGTShaped(GTShapedRecipeSchema.ShapedRecipeJS shaped) {
+        if (!shaped.isAddMaterialInfo()) return;
+
+        var pattern = shaped.getValue(PATTERN);
+        final var tools = ToolHelper.getToolSymbols();
+        var key = shaped.getValue(KEY);
+        var entries = key.entries();
+
+        // Parse Material Info
+        Char2IntOpenHashMap inputMap = new Char2IntOpenHashMap();
+        for (String s : pattern) {
+            for (char c : s.toCharArray()) {
+                if (tools.contains(c)) continue; // Skip tools for decomp
+                inputMap.addTo(c, 1);
+            }
+        }
+        if (inputMap.isEmpty()) return;
+        var result = shaped.getValue(RESULT);
+        ItemStack outItem = result.item;
+        int outCount = result.getCount();
+        Reference2LongOpenHashMap<Material> materials = new Reference2LongOpenHashMap<>();
+
+        for (var entry : entries) {
+            char c = entry.key();
+            int inCount = inputMap.get(c);
+            if (inCount == 0) continue;
+            ItemStack[] stacks = entry.value().kjs$asIngredient().getItems();
+            if (stacks.length == 0 || stacks[0].isEmpty()) continue;
+            var item = stacks[0].getItem();
+
+            var info = ItemMaterialData.getMaterialInfo(item);
+            if (info != null) {
+                for (var ms : info.getMaterials()) {
+                    if (ms.material() instanceof MarkerMaterial) continue;
+                    materials.addTo(ms.material(), (ms.amount() * inCount) / outCount);
+                }
+                continue;
+            } else {
+                ItemMaterialData.UNRESOLVED_ITEM_MATERIAL_INFO.computeIfAbsent(outItem, i -> new ArrayList<>())
+                        .add(stacks[0].copyWithCount(inCount));
+            }
+
+            var matStack = ChemicalHelper.getMaterialStack(item);
+            if (!matStack.isEmpty() && !(matStack.material() instanceof MarkerMaterial)) {
+                materials.addTo(matStack.material(), (matStack.amount() * inCount) / outCount);
+            }
+
+            var prefix = ChemicalHelper.getPrefix(item);
+            if (!prefix.isEmpty()) {
+                for (var ms : prefix.secondaryMaterials()) {
+                    materials.addTo(ms.material(), (ms.amount() * inCount) / outCount);
+                }
+            }
+        }
+
+        ItemMaterialData.registerMaterialInfo(outItem.getItem(), new ItemMaterialInfo(materials));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -84,7 +84,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
-import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
@@ -95,6 +94,7 @@ import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
 import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
+import dev.latvian.mods.kubejs.recipe.KubeJSRecipeEventHandler;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipesEventJS;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeComponentFactoryRegistryEvent;
@@ -103,6 +103,7 @@ import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.kubejs.script.BindingsEvent;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.util.ClassFilter;
+import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.rhino.Wrapper;
 import dev.latvian.mods.rhino.mod.util.NBTUtils;
 import dev.latvian.mods.rhino.util.wrap.TypeWrappers;
@@ -114,7 +115,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.gregtechceu.gtceu.integration.kjs.recipe.GTShapedRecipeSchema.*;
+import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.KEY;
+import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.PATTERN;
+import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.RESULT;
 
 /**
  * @author KilaBash
@@ -217,7 +220,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         }
         var ns = event.namespace(GTCEu.MOD_ID);
         ns.put("shaped", new WrappingRecipeSchemaType(ns, GTCEu.id("shaped"),
-                GTShapedRecipeSchema.SCHEMA, RecipeSerializer.SHAPED_RECIPE));
+                GTShapedRecipeSchema.SCHEMA, KubeJSRecipeEventHandler.SHAPED.get()));
     }
 
     @Override
@@ -523,8 +526,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
             builder.conditions.addAll(Arrays.stream(gtRecipe.getValue(GTRecipeSchema.CONDITIONS)).toList());
         }
         if (gtRecipe.getValue(GTRecipeSchema.CATEGORY) != null) {
-            builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES
-                    .get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
+            builder.recipeCategory = GTRegistries.RECIPE_CATEGORIES.get(gtRecipe.getValue(GTRecipeSchema.CATEGORY));
         }
         builder.researchRecipeEntries().addAll(gtRecipe.researchRecipeEntries());
 
@@ -584,8 +586,9 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         gtRecipe.fluidMaterialStacks = null;
 
         builder.addMaterialInfo(gtRecipe.itemMaterialInfo, gtRecipe.fluidMaterialInfo);
-        if (gtRecipe.removeMaterialInfo)
+        if (gtRecipe.removeMaterialInfo) {
             builder.removePreviousMaterialInfo();
+        }
 
         builder.save(builtRecipe -> recipesByName.put(builtRecipe.getId(),
                 GTRecipeSerializer.SERIALIZER.fromJson(builtRecipe.getId(), builtRecipe.serializeRecipe())));
@@ -593,6 +596,12 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
     private static void handleGTShaped(GTShapedRecipeSchema.ShapedRecipeJS shaped) {
         if (!shaped.isAddMaterialInfo()) return;
+        // Difficult to deal with ingredient actions, so we just won't support them with decomposition
+        if (shaped.hasIngredientActions()) {
+            ConsoleJS.getCurrent(ConsoleJS.SERVER)
+                    .warnf("Ingredient Actions are not supported with decomposition, check recipe {%s}", shaped.id);
+            return;
+        }
 
         var pattern = shaped.getValue(PATTERN);
         final var tools = ToolHelper.getToolSymbols();
@@ -600,7 +609,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         var entries = key.entries();
 
         // Parse Material Info
-        Char2IntOpenHashMap inputMap = new Char2IntOpenHashMap();
+        Char2IntOpenHashMap inputMap = new Char2IntOpenHashMap(entries.length);
         for (String s : pattern) {
             for (char c : s.toCharArray()) {
                 if (tools.contains(c)) continue; // Skip tools for decomp
@@ -619,6 +628,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
             if (inCount == 0) continue;
             ItemStack[] stacks = entry.value().kjs$asIngredient().getItems();
             if (stacks.length == 0 || stacks[0].isEmpty()) continue;
+            if (stacks[0].getCraftingRemainingItem() != ItemStack.EMPTY) continue;
             var item = stacks[0].getItem();
 
             var info = ItemMaterialData.getMaterialInfo(item);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -43,6 +43,7 @@ import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
 import com.gregtechceu.gtceu.api.pattern.Predicates;
+import com.gregtechceu.gtceu.api.recipe.DummyCraftingContainer;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeSerializer;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
@@ -59,6 +60,7 @@ import com.gregtechceu.gtceu.common.data.machines.GTMultiMachines;
 import com.gregtechceu.gtceu.common.item.armor.PowerlessJetpack;
 import com.gregtechceu.gtceu.common.machine.multiblock.primitive.PrimitiveFancyUIWorkableMachine;
 import com.gregtechceu.gtceu.common.unification.material.MaterialRegistryManager;
+import com.gregtechceu.gtceu.core.mixins.IngredientAccessor;
 import com.gregtechceu.gtceu.data.recipe.CraftingComponent;
 import com.gregtechceu.gtceu.data.recipe.GTCraftingComponents;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
@@ -81,12 +83,15 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponent
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraftforge.items.ItemStackHandler;
 
 import com.mojang.serialization.DataResult;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
@@ -97,16 +102,17 @@ import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
 import dev.latvian.mods.kubejs.recipe.KubeJSRecipeEventHandler;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipesEventJS;
+import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeComponentFactoryRegistryEvent;
 import dev.latvian.mods.kubejs.recipe.schema.RegisterRecipeSchemasEvent;
 import dev.latvian.mods.kubejs.registry.RegistryInfo;
 import dev.latvian.mods.kubejs.script.BindingsEvent;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import dev.latvian.mods.kubejs.util.ClassFilter;
-import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.rhino.Wrapper;
 import dev.latvian.mods.rhino.mod.util.NBTUtils;
 import dev.latvian.mods.rhino.util.wrap.TypeWrappers;
+import it.unimi.dsi.fastutil.chars.Char2IntMap;
 import it.unimi.dsi.fastutil.chars.Char2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 
@@ -596,12 +602,6 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
     private static void handleGTShaped(GTShapedRecipeSchema.ShapedRecipeJS shaped) {
         if (!shaped.isAddMaterialInfo()) return;
-        // Difficult to deal with ingredient actions, so we just won't support them with decomposition
-        if (shaped.hasIngredientActions()) {
-            ConsoleJS.getCurrent(ConsoleJS.SERVER)
-                    .warnf("Ingredient Actions are not supported with decomposition, check recipe {%s}", shaped.id);
-            return;
-        }
 
         var pattern = shaped.getValue(PATTERN);
         final var tools = ToolHelper.getToolSymbols();
@@ -610,26 +610,42 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
         // Parse Material Info
         Char2IntOpenHashMap inputMap = new Char2IntOpenHashMap(entries.length);
+        Char2IntMap slotMap = new Char2IntOpenHashMap(entries.length);
+        int idx = -1;
         for (String s : pattern) {
             for (char c : s.toCharArray()) {
+                ++idx;
                 if (tools.contains(c)) continue; // Skip tools for decomp
                 inputMap.addTo(c, 1);
+                slotMap.put(c, idx);
             }
         }
         if (inputMap.isEmpty()) return;
+
         var result = shaped.getValue(RESULT);
         ItemStack outItem = result.item;
         int outCount = result.getCount();
         Reference2LongOpenHashMap<Material> materials = new Reference2LongOpenHashMap<>();
+        CraftingContainer cc = new DummyCraftingContainer(new ItemStackHandler(idx + 1));
 
         for (var entry : entries) {
             char c = entry.key();
             int inCount = inputMap.get(c);
             if (inCount == 0) continue;
-            ItemStack[] stacks = entry.value().kjs$asIngredient().getItems();
-            if (stacks.length == 0 || stacks[0].isEmpty()) continue;
-            if (stacks[0].getCraftingRemainingItem() != ItemStack.EMPTY) continue;
-            var item = stacks[0].getItem();
+
+            var ingredient = entry.value().kjs$asIngredient();
+            var values = ((IngredientAccessor) ingredient).getValues();
+            if (values.length == 0 || values[0] instanceof Ingredient.TagValue) continue;
+
+            ItemStack[] stacks = ingredient.getItems();
+            ItemStack stack;
+            if (stacks.length == 0 || (stack = stacks[0]).isEmpty()) continue;
+
+            int slot = slotMap.get(c);
+            cc.setItem(slot, stack);
+            if (!IngredientAction.getRemaining(cc, slot, shaped.getIngredientActions()).isEmpty()) continue;
+
+            var item = stack.getItem();
 
             var info = ItemMaterialData.getMaterialInfo(item);
             if (info != null) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -70,6 +70,8 @@ import com.gregtechceu.gtceu.integration.kjs.helpers.MachineConstructors;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MachineModifiers;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MaterialStackWrapper;
 import com.gregtechceu.gtceu.integration.kjs.recipe.GTRecipeSchema;
+import com.gregtechceu.gtceu.integration.kjs.recipe.GTShapedRecipeSchema;
+import com.gregtechceu.gtceu.integration.kjs.recipe.WrappingRecipeSchemaType;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.ExtendedOutputItem;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 
@@ -78,6 +80,7 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
@@ -88,6 +91,7 @@ import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
 import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
+import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipesEventJS;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeComponentFactoryRegistryEvent;
 import dev.latvian.mods.kubejs.recipe.schema.RegisterRecipeSchemasEvent;
@@ -203,6 +207,9 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         for (var entry : GTRegistries.RECIPE_TYPES.entries()) {
             event.register(entry.getKey(), GTRecipeSchema.SCHEMA);
         }
+        var ns = event.namespace(GTCEu.MOD_ID);
+        ns.put("shaped", new WrappingRecipeSchemaType(ns, GTCEu.id("shaped"),
+                GTShapedRecipeSchema.SCHEMA, RecipeSerializer.SHAPED_RECIPE));
     }
 
     @Override
@@ -449,8 +456,8 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
     public void injectRuntimeRecipes(RecipesEventJS event, RecipeManager manager,
                                      Map<ResourceLocation, Recipe<?>> recipesByName) {
         // (jankily) parse all GT recipes for extra ones to add, modify
-        RecipesEventJS.runInParallel((() -> event.addedRecipes.forEach(recipe -> {
-            if (recipe instanceof GTRecipeSchema.GTRecipeJS gtRecipe) {
+        for (RecipeJS addedRecipe : event.addedRecipes) {
+            if (addedRecipe instanceof GTRecipeSchema.GTRecipeJS gtRecipe) {
                 // get the recipe ID without the leading type path
                 GTRecipeBuilder builder = ((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(gtRecipe.type.id))
                         .recipeBuilder(gtRecipe.idWithoutType());
@@ -532,7 +539,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                 builder.save(builtRecipe -> recipesByName.put(builtRecipe.getId(),
                         GTRecipeSerializer.SERIALIZER.fromJson(builtRecipe.getId(), builtRecipe.serializeRecipe())));
             }
-        })));
+        }
 
         PowerlessJetpack.FUELS.clear();
         // Must run recycling recipes very last

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -1,20 +1,12 @@
 package com.gregtechceu.gtceu.integration.kjs.recipe;
 
-import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
-import com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData;
-import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterial;
-import com.gregtechceu.gtceu.api.data.chemical.material.Material;
-import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
-
-import net.minecraft.world.item.ItemStack;
 
 import dev.latvian.mods.kubejs.item.InputItem;
 import dev.latvian.mods.kubejs.item.OutputItem;
 import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
-import dev.latvian.mods.kubejs.recipe.component.BooleanComponent;
 import dev.latvian.mods.kubejs.recipe.component.ItemComponents;
 import dev.latvian.mods.kubejs.recipe.component.MapRecipeComponent;
 import dev.latvian.mods.kubejs.recipe.component.StringComponent;
@@ -22,9 +14,10 @@ import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.TinyMap;
 import it.unimi.dsi.fastutil.chars.CharArrayList;
+import it.unimi.dsi.fastutil.chars.CharArraySet;
 import it.unimi.dsi.fastutil.chars.CharList;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
+import it.unimi.dsi.fastutil.chars.CharSet;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +25,14 @@ import java.util.Arrays;
 public interface GTShapedRecipeSchema {
 
     class ShapedRecipeJS extends RecipeJS {
+
+        @Getter
+        protected boolean addMaterialInfo = false;
+
+        public ShapedRecipeJS addMaterialInfo() {
+            addMaterialInfo = true;
+            return this;
+        }
 
         // Adapted from KJS's ShapedRecipeSchema#ShapedRecipeJS
         @Override
@@ -48,20 +49,20 @@ public interface GTShapedRecipeSchema {
                 throw new RecipeExceptionJS("Key map is empty!");
             }
 
-            final var symbols = ToolHelper.getToolSymbols();
+            final CharSet tools = ToolHelper.getToolSymbols();
+            CharSet addedTools = new CharArraySet(9);
 
             CharList airs = new CharArrayList(1);
 
             var keyEntries = new ArrayList<>(Arrays.asList(key.entries()));
-            boolean changed = false;
             for (var it = keyEntries.iterator(); it.hasNext();) {
                 var entry = it.next();
+                char entryKey = entry.key();
                 if (entry.value() == null || entry.value().isEmpty()) {
-                    airs.add(entry.key().charValue());
+                    airs.add(entryKey);
                     it.remove();
-                } else if (symbols.contains(entry.key())) {
-                    ConsoleJS.SERVER.warn("Symbol {" + entry.key() + "} set as key in tooled recipe - overriding");
-                    changed = true;
+                } else if (tools.contains(entryKey)) {
+                    ConsoleJS.SERVER.warn("Symbol {" + entryKey + "} set as key in tooled recipe - overriding");
                     it.remove();
                 }
             }
@@ -70,85 +71,27 @@ public interface GTShapedRecipeSchema {
                 for (var it = airs.iterator(); it.hasNext();) {
                     pattern[i] = pattern[i].replace(it.nextChar(), ' ');
                 }
-                for (Character c : pattern[i].toCharArray()) {
-                    if (symbols.contains(c)) {
+                for (char c : pattern[i].toCharArray()) { // Inject tool symbol mappings
+                    if (tools.contains(c) && !addedTools.contains(c)) {
                         var tool = ToolHelper.getToolFromSymbol(c);
                         keyEntries.add(new TinyMap.Entry<>(c, InputItem.of(tool.itemTags.get(0))));
-                        changed = true;
+                        addedTools.add(c);
                     }
                 }
             }
 
-            if (!airs.isEmpty() || changed) {
+            if (!airs.isEmpty() || !addedTools.isEmpty()) {
                 setValue(PATTERN, pattern);
                 setValue(KEY, new TinyMap<>(keyEntries));
             }
-
-            Boolean addInfo = getValue(MATERIAL_INFO);
-            if (addInfo == null || !addInfo) return;
-
-            // Parse Material Info
-            Object2IntOpenHashMap<Character> inputMap = new Object2IntOpenHashMap<>();
-            for (String s : pattern) {
-                for (Character c : s.toCharArray()) {
-                    if (symbols.contains(c)) continue;
-                    inputMap.addTo(c, 1);
-                }
-            }
-            if (inputMap.isEmpty()) return;
-            var result = getValue(RESULT);
-            ItemStack outItem = result.item;
-            int outCount = result.getCount();
-            Reference2LongOpenHashMap<Material> materials = new Reference2LongOpenHashMap<>();
-
-            for (var entry : keyEntries) {
-                Character c = entry.key();
-                int inCount = inputMap.getInt(c);
-                if (inCount == 0) continue;
-                ItemStack[] stacks = entry.value().kjs$asIngredient().getItems();
-                if (stacks.length == 0 || stacks[0].isEmpty()) continue;
-                var item = stacks[0].getItem();
-
-                var info = ItemMaterialData.getMaterialInfo(item);
-                if (info != null) {
-                    for (var ms : info.getMaterials()) {
-                        if (ms.material() instanceof MarkerMaterial) continue;
-                        materials.addTo(ms.material(), (ms.amount() * inCount) / outCount);
-                    }
-                    continue;
-                } else {
-                    ItemMaterialData.UNRESOLVED_ITEM_MATERIAL_INFO.computeIfAbsent(outItem, i -> new ArrayList<>())
-                            .add(stacks[0].copyWithCount(inCount));
-                }
-
-                var matStack = ChemicalHelper.getMaterialStack(item);
-                if (!matStack.isEmpty() && !(matStack.material() instanceof MarkerMaterial)) {
-                    materials.addTo(matStack.material(), (matStack.amount() * inCount) / outCount);
-                }
-
-                var prefix = ChemicalHelper.getPrefix(item);
-                if (!prefix.isEmpty()) {
-                    for (var ms : prefix.secondaryMaterials()) {
-                        materials.addTo(ms.material(), (ms.amount() * inCount) / outCount);
-                    }
-                }
-            }
-
-            ItemMaterialData.registerMaterialInfo(outItem.getItem(), new ItemMaterialInfo(materials));
         }
     }
 
     RecipeKey<OutputItem> RESULT = ItemComponents.OUTPUT.key("result");
     RecipeKey<String[]> PATTERN = StringComponent.NON_EMPTY.asArray().key("pattern");
     RecipeKey<TinyMap<Character, InputItem>> KEY = MapRecipeComponent.ITEM_PATTERN_KEY.key("key");
-    RecipeKey<Boolean> MATERIAL_INFO = BooleanComponent.BOOLEAN.key("gtceu:material_info")
-            .preferred("materialInfo")
-            .optional(Boolean.FALSE)
-            .exclude();
 
-    RecipeSchema SCHEMA = new RecipeSchema(ShapedRecipeJS.class, ShapedRecipeJS::new, RESULT, PATTERN, KEY,
-            MATERIAL_INFO)
+    RecipeSchema SCHEMA = new RecipeSchema(ShapedRecipeJS.class, ShapedRecipeJS::new, RESULT, PATTERN, KEY)
             .constructor(RESULT, PATTERN, KEY)
-            .constructor(RESULT, PATTERN, KEY, MATERIAL_INFO)
             .uniqueOutputId(RESULT);
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -1,13 +1,20 @@
 package com.gregtechceu.gtceu.integration.kjs.recipe;
 
+import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
+import com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData;
+import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterial;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
+
+import net.minecraft.world.item.ItemStack;
 
 import dev.latvian.mods.kubejs.item.InputItem;
 import dev.latvian.mods.kubejs.item.OutputItem;
 import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
-import dev.latvian.mods.kubejs.recipe.RecipeTypeFunction;
+import dev.latvian.mods.kubejs.recipe.component.BooleanComponent;
 import dev.latvian.mods.kubejs.recipe.component.ItemComponents;
 import dev.latvian.mods.kubejs.recipe.component.MapRecipeComponent;
 import dev.latvian.mods.kubejs.recipe.component.StringComponent;
@@ -16,6 +23,8 @@ import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.TinyMap;
 import it.unimi.dsi.fastutil.chars.CharArrayList;
 import it.unimi.dsi.fastutil.chars.CharList;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,33 +48,32 @@ public interface GTShapedRecipeSchema {
                 throw new RecipeExceptionJS("Key map is empty!");
             }
 
-            final var symbols = ToolHelper.getSymbols();
+            final var symbols = ToolHelper.getToolSymbols();
 
             CharList airs = new CharArrayList(1);
 
-            var entries = new ArrayList<>(Arrays.asList(key.entries()));
-            var itr = entries.iterator();
-
-            while (itr.hasNext()) {
-                var entry = itr.next();
+            var keyEntries = new ArrayList<>(Arrays.asList(key.entries()));
+            boolean changed = false;
+            for (var it = keyEntries.iterator(); it.hasNext();) {
+                var entry = it.next();
                 if (entry.value() == null || entry.value().isEmpty()) {
                     airs.add(entry.key().charValue());
-                    itr.remove();
-                } else if (symbols.containsKey(entry.key())) {
+                    it.remove();
+                } else if (symbols.contains(entry.key())) {
                     ConsoleJS.SERVER.warn("Symbol {" + entry.key() + "} set as key in tooled recipe - overriding");
-                    itr.remove();
+                    changed = true;
+                    it.remove();
                 }
             }
 
-            boolean changed = false;
             for (int i = 0; i < pattern.length; i++) {
                 for (var it = airs.iterator(); it.hasNext();) {
                     pattern[i] = pattern[i].replace(it.nextChar(), ' ');
                 }
-                for (var symbolEntry : ToolHelper.getSymbols().entrySet()) {
-                    var c = symbolEntry.getKey();
-                    if (pattern[i].indexOf(c) >= 0) {
-                        entries.add(new TinyMap.Entry<>(c, InputItem.of(symbolEntry.getValue().itemTags.get(0))));
+                for (Character c : pattern[i].toCharArray()) {
+                    if (symbols.contains(c)) {
+                        var tool = ToolHelper.getToolFromSymbol(c);
+                        keyEntries.add(new TinyMap.Entry<>(c, InputItem.of(tool.itemTags.get(0))));
                         changed = true;
                     }
                 }
@@ -73,21 +81,74 @@ public interface GTShapedRecipeSchema {
 
             if (!airs.isEmpty() || changed) {
                 setValue(PATTERN, pattern);
-                setValue(KEY, new TinyMap<>(entries));
+                setValue(KEY, new TinyMap<>(keyEntries));
             }
-        }
 
-        @Override
-        public RecipeTypeFunction getSerializationTypeFunction() {
-            return type.event.vanillaShaped;
+            Boolean addInfo = getValue(MATERIAL_INFO);
+            if (addInfo == null || !addInfo) return;
+
+            // Parse Material Info
+            Object2IntOpenHashMap<Character> inputMap = new Object2IntOpenHashMap<>();
+            for (String s : pattern) {
+                for (Character c : s.toCharArray()) {
+                    if (symbols.contains(c)) continue;
+                    inputMap.addTo(c, 1);
+                }
+            }
+            if (inputMap.isEmpty()) return;
+            var result = getValue(RESULT);
+            ItemStack outItem = result.item;
+            int outCount = result.getCount();
+            Reference2LongOpenHashMap<Material> materials = new Reference2LongOpenHashMap<>();
+
+            for (var entry : keyEntries) {
+                Character c = entry.key();
+                int inCount = inputMap.getInt(c);
+                if (inCount == 0) continue;
+                ItemStack[] stacks = entry.value().kjs$asIngredient().getItems();
+                if (stacks.length == 0 || stacks[0].isEmpty()) continue;
+                var item = stacks[0].getItem();
+
+                var info = ItemMaterialData.getMaterialInfo(item);
+                if (info != null) {
+                    for (var ms : info.getMaterials()) {
+                        if (ms.material() instanceof MarkerMaterial) continue;
+                        materials.addTo(ms.material(), (ms.amount() * inCount) / outCount);
+                    }
+                    continue;
+                } else {
+                    ItemMaterialData.UNRESOLVED_ITEM_MATERIAL_INFO.computeIfAbsent(outItem, i -> new ArrayList<>())
+                            .add(stacks[0].copyWithCount(inCount));
+                }
+
+                var matStack = ChemicalHelper.getMaterialStack(item);
+                if (!matStack.isEmpty() && !(matStack.material() instanceof MarkerMaterial)) {
+                    materials.addTo(matStack.material(), (matStack.amount() * inCount) / outCount);
+                }
+
+                var prefix = ChemicalHelper.getPrefix(item);
+                if (!prefix.isEmpty()) {
+                    for (var ms : prefix.secondaryMaterials()) {
+                        materials.addTo(ms.material(), (ms.amount() * inCount) / outCount);
+                    }
+                }
+            }
+
+            ItemMaterialData.registerMaterialInfo(outItem.getItem(), new ItemMaterialInfo(materials));
         }
     }
 
     RecipeKey<OutputItem> RESULT = ItemComponents.OUTPUT.key("result");
     RecipeKey<String[]> PATTERN = StringComponent.NON_EMPTY.asArray().key("pattern");
     RecipeKey<TinyMap<Character, InputItem>> KEY = MapRecipeComponent.ITEM_PATTERN_KEY.key("key");
+    RecipeKey<Boolean> MATERIAL_INFO = BooleanComponent.BOOLEAN.key("gtceu:material_info")
+            .preferred("materialInfo")
+            .optional(Boolean.FALSE)
+            .exclude();
 
-    RecipeSchema SCHEMA = new RecipeSchema(ShapedRecipeJS.class, ShapedRecipeJS::new, RESULT, PATTERN, KEY)
+    RecipeSchema SCHEMA = new RecipeSchema(ShapedRecipeJS.class, ShapedRecipeJS::new, RESULT, PATTERN, KEY,
+            MATERIAL_INFO)
             .constructor(RESULT, PATTERN, KEY)
+            .constructor(RESULT, PATTERN, KEY, MATERIAL_INFO)
             .uniqueOutputId(RESULT);
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -3,16 +3,12 @@ package com.gregtechceu.gtceu.integration.kjs.recipe;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 
 import dev.latvian.mods.kubejs.item.InputItem;
-import dev.latvian.mods.kubejs.item.OutputItem;
 import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
-import dev.latvian.mods.kubejs.recipe.RecipeKey;
-import dev.latvian.mods.kubejs.recipe.component.ItemComponents;
-import dev.latvian.mods.kubejs.recipe.component.MapRecipeComponent;
-import dev.latvian.mods.kubejs.recipe.component.StringComponent;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.TinyMap;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import it.unimi.dsi.fastutil.chars.CharArrayList;
 import it.unimi.dsi.fastutil.chars.CharArraySet;
 import it.unimi.dsi.fastutil.chars.CharList;
@@ -21,6 +17,10 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.KEY;
+import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.PATTERN;
+import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.RESULT;
 
 public interface GTShapedRecipeSchema {
 
@@ -32,6 +32,11 @@ public interface GTShapedRecipeSchema {
         public ShapedRecipeJS addMaterialInfo() {
             addMaterialInfo = true;
             return this;
+        }
+
+        @HideFromJS
+        public boolean hasIngredientActions() {
+            return recipeIngredientActions != null && !recipeIngredientActions.isEmpty();
         }
 
         // Adapted from KJS's ShapedRecipeSchema#ShapedRecipeJS
@@ -86,10 +91,6 @@ public interface GTShapedRecipeSchema {
             }
         }
     }
-
-    RecipeKey<OutputItem> RESULT = ItemComponents.OUTPUT.key("result");
-    RecipeKey<String[]> PATTERN = StringComponent.NON_EMPTY.asArray().key("pattern");
-    RecipeKey<TinyMap<Character, InputItem>> KEY = MapRecipeComponent.ITEM_PATTERN_KEY.key("key");
 
     RecipeSchema SCHEMA = new RecipeSchema(ShapedRecipeJS.class, ShapedRecipeJS::new, RESULT, PATTERN, KEY)
             .constructor(RESULT, PATTERN, KEY)

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -1,0 +1,93 @@
+package com.gregtechceu.gtceu.integration.kjs.recipe;
+
+import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
+
+import dev.latvian.mods.kubejs.item.InputItem;
+import dev.latvian.mods.kubejs.item.OutputItem;
+import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
+import dev.latvian.mods.kubejs.recipe.RecipeJS;
+import dev.latvian.mods.kubejs.recipe.RecipeKey;
+import dev.latvian.mods.kubejs.recipe.RecipeTypeFunction;
+import dev.latvian.mods.kubejs.recipe.component.ItemComponents;
+import dev.latvian.mods.kubejs.recipe.component.MapRecipeComponent;
+import dev.latvian.mods.kubejs.recipe.component.StringComponent;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import dev.latvian.mods.kubejs.util.ConsoleJS;
+import dev.latvian.mods.kubejs.util.TinyMap;
+import it.unimi.dsi.fastutil.chars.CharArrayList;
+import it.unimi.dsi.fastutil.chars.CharList;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public interface GTShapedRecipeSchema {
+
+    class ShapedRecipeJS extends RecipeJS {
+
+        // Adapted from KJS's ShapedRecipeSchema#ShapedRecipeJS
+        @Override
+        public void afterLoaded() {
+            super.afterLoaded();
+            var pattern = getValue(PATTERN);
+            var key = getValue(KEY);
+
+            if (pattern.length == 0) {
+                throw new RecipeExceptionJS("Pattern is empty!");
+            }
+
+            if (key.isEmpty()) {
+                throw new RecipeExceptionJS("Key map is empty!");
+            }
+
+            final var symbols = ToolHelper.getSymbols();
+
+            CharList airs = new CharArrayList(1);
+
+            var entries = new ArrayList<>(Arrays.asList(key.entries()));
+            var itr = entries.iterator();
+
+            while (itr.hasNext()) {
+                var entry = itr.next();
+                if (entry.value() == null || entry.value().isEmpty()) {
+                    airs.add(entry.key().charValue());
+                    itr.remove();
+                } else if (symbols.containsKey(entry.key())) {
+                    ConsoleJS.SERVER.warn("Symbol {" + entry.key() + "} set as key in tooled recipe - overriding");
+                    itr.remove();
+                }
+            }
+
+            boolean changed = false;
+            for (int i = 0; i < pattern.length; i++) {
+                for (var it = airs.iterator(); it.hasNext();) {
+                    pattern[i] = pattern[i].replace(it.nextChar(), ' ');
+                }
+                for (var symbolEntry : ToolHelper.getSymbols().entrySet()) {
+                    var c = symbolEntry.getKey();
+                    if (pattern[i].indexOf(c) >= 0) {
+                        entries.add(new TinyMap.Entry<>(c, InputItem.of(symbolEntry.getValue().itemTags.get(0))));
+                        changed = true;
+                    }
+                }
+            }
+
+            if (!airs.isEmpty() || changed) {
+                setValue(PATTERN, pattern);
+                setValue(KEY, new TinyMap<>(entries));
+            }
+        }
+
+        @Override
+        public RecipeTypeFunction getSerializationTypeFunction() {
+            return type.event.vanillaShaped;
+        }
+    }
+
+    RecipeKey<OutputItem> RESULT = ItemComponents.OUTPUT.key("result");
+    RecipeKey<String[]> PATTERN = StringComponent.NON_EMPTY.asArray().key("pattern");
+    RecipeKey<TinyMap<Character, InputItem>> KEY = MapRecipeComponent.ITEM_PATTERN_KEY.key("key");
+
+    RecipeSchema SCHEMA = new RecipeSchema(ShapedRecipeJS.class, ShapedRecipeJS::new, RESULT, PATTERN, KEY)
+            .constructor(RESULT, PATTERN, KEY)
+            .uniqueOutputId(RESULT);
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import dev.latvian.mods.kubejs.item.InputItem;
 import dev.latvian.mods.kubejs.recipe.RecipeExceptionJS;
 import dev.latvian.mods.kubejs.recipe.RecipeJS;
+import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
 import dev.latvian.mods.kubejs.util.ConsoleJS;
 import dev.latvian.mods.kubejs.util.TinyMap;
@@ -17,6 +18,8 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.KEY;
 import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.PATTERN;
@@ -35,8 +38,9 @@ public interface GTShapedRecipeSchema {
         }
 
         @HideFromJS
-        public boolean hasIngredientActions() {
-            return recipeIngredientActions != null && !recipeIngredientActions.isEmpty();
+        public List<IngredientAction> getIngredientActions() {
+            if (recipeIngredientActions == null) return Collections.emptyList();
+            return recipeIngredientActions;
         }
 
         // Adapted from KJS's ShapedRecipeSchema#ShapedRecipeJS

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/WrappingRecipeSchemaType.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/WrappingRecipeSchemaType.java
@@ -1,0 +1,19 @@
+package com.gregtechceu.gtceu.integration.kjs.recipe;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+
+import dev.latvian.mods.kubejs.recipe.schema.RecipeNamespace;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeSchemaType;
+
+import java.util.Optional;
+
+public class WrappingRecipeSchemaType extends RecipeSchemaType {
+
+    public WrappingRecipeSchemaType(RecipeNamespace namespace, ResourceLocation id, RecipeSchema schema,
+                                    RecipeSerializer<?> serializer) {
+        super(namespace, id, schema);
+        this.serializer = Optional.of(serializer);
+    }
+}


### PR DESCRIPTION
## What
Adds a new KJS Recipe Schema that allows for the creation of shaped recipes using GT tool symbols as shortcuts. They can be defined like regular KJS shaped recipes.
This allows allows for material decomposition info to be added.

This script, for example:
```js
event.recipes.gtceu.shaped('music_disc_13',
    [' x ',
     'rWf',
     'RRR'],
    { W: 'gtceu:fine_gold_wire',
      R: 'gtceu:rubber_plate' }
).addMaterialInfo()
```
creates the following recipe:
![image](https://github.com/user-attachments/assets/185e027a-a127-46af-aa23-a0ca4a740ff5)
with the proper decomposition:
![image](https://github.com/user-attachments/assets/8b73a3d2-2372-47e3-8143-2f9213de8fd5)
(melting not shown)

## Implementation Details
While this *may* have been able to be done via a mixin to not have to call via `recipes.gtceu` - that would be invasive and also be *completely* backwards incompatible for anyone who happens to have used one of our tool symbols as a key in their shaped recipes.

Also, note that if a key character matching a tool symbol is detected, it will be overriden with the tool.