### PR TITLE
Fix turbines not being put into creative tab

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/TurbineRotorBehaviour.java
@@ -33,7 +33,7 @@ public class TurbineRotorBehaviour implements IMaterialPartItem, ISubItemHandler
     public void fillItemCategory(Item item, CreativeModeTab category, NonNullList<ItemStack> items) {
         for (Material material : GTCEuAPI.materialManager.getRegisteredMaterials()) {
             if (!material.shouldGenerateRecipesFor(turbineBlade) || !material.hasProperty(PropertyKey.INGOT)) {
-                return;
+                continue;
             }
 
             var rotorStack = new ItemStack(item);


### PR DESCRIPTION
## What
Fixes small issue from #2616, where the loop over materials was terminated early, leading to turbines not being added to the creative menu.