### PR TITLE
Fix Pyrolyse Oven double tooltip

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -315,8 +315,7 @@ public class GTMultiMachines {
             })
             .workableCasingRenderer(GTCEu.id("block/casings/voltage/ulv/side"),
                     GTCEu.id("block/multiblock/pyrolyse_oven"))
-            .tooltips(Component.translatable("gtceu.machine.pyrolyse_oven.tooltip"),
-                    Component.translatable("gtceu.machine.pyrolyse_oven.tooltip.1"))
+            .tooltips(Component.translatable("gtceu.machine.pyrolyse_oven.tooltip.1"))
             .additionalDisplay((controller, components) -> {
                 if (controller instanceof CoilWorkableElectricMultiblockMachine coilMachine && controller.isFormed()) {
                     components.add(Component.translatable("gtceu.multiblock.pyrolyse_oven.speed",


### PR DESCRIPTION
## What
Pyro oven had double tooltip
![image](https://github.com/user-attachments/assets/376557f4-6776-461e-ad15-3e7e7fc8ab36)

## Outcome
It no longer does 

## Additional Information
did you know you can hook underwater for extra speed?