### PR TITLE
Refactor torch placement behaviour to check if offhand is empty

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/TorchPlaceBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/TorchPlaceBehavior.java
@@ -39,6 +39,10 @@ public class TorchPlaceBehavior implements IToolBehavior {
         ItemStack stack = player.getItemInHand(hand);
         CompoundTag behaviourTag = ToolHelper.getBehaviorsTag(stack);
 
+        if (!context.getPlayer().getOffhandItem().isEmpty()) {
+            return InteractionResult.PASS;
+        }
+
         if (!behaviourTag.getBoolean(TORCH_PLACING_KEY)) {
             return InteractionResult.PASS;
         }


### PR DESCRIPTION
## What
Mining hammers don't respect existing offhand items when performing their torch placing behavior. This PR adds an early exit for if the off hand is not empty

## Implementation Details
While this works for all items, there is an edge case in that items without any right click behaviors (eg. iron ingot, as opposed to food, shields, blocks, etc.) cancel out the torch placement behavior from happening. If someone knows a way around this, lmk please