### PR TITLE
Fix various divide by zero errors in material class

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -433,9 +433,11 @@ public class Material implements Comparable<Material> {
             return Math.max(1, 43);
         long totalProtons = 0, totalAmount = 0;
         for (MaterialStack material : materialInfo.componentList) {
+            if (material.isEmpty()) continue;
             totalAmount += material.amount();
             totalProtons += material.amount() * material.material().getProtons();
         }
+        if (totalAmount == 0) return 0;
         return totalProtons / totalAmount;
     }
 
@@ -446,22 +448,26 @@ public class Material implements Comparable<Material> {
             return 55;
         long totalNeutrons = 0, totalAmount = 0;
         for (MaterialStack material : materialInfo.componentList) {
+            if (material.isEmpty()) continue;
             totalAmount += material.amount();
             totalNeutrons += material.amount() * material.material().getNeutrons();
         }
+        if (totalAmount == 0) return 0;
         return totalNeutrons / totalAmount;
     }
 
     public long getMass() {
         if (materialInfo.element != null)
             return materialInfo.element.mass();
-        if (materialInfo.componentList.size() == 0)
+        if (materialInfo.componentList.isEmpty())
             return 98;
         long totalMass = 0, totalAmount = 0;
         for (MaterialStack material : materialInfo.componentList) {
+            if (material.isEmpty()) continue;
             totalAmount += material.amount();
             totalMass += material.amount() * material.material().getMass();
         }
+        if (totalAmount == 0) return 0;
         return totalMass / totalAmount;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialStack.java
@@ -50,7 +50,7 @@ public record MaterialStack(@NotNull Material material, long amount) {
     @Override
     public String toString() {
         String string = "";
-        if (material.getChemicalFormula().isEmpty()) {
+        if (material.getChemicalFormula() == null || material.getChemicalFormula().isEmpty()) {
             string += "?";
         } else if (material.getMaterialComponents().size() > 1) {
             string += '(' + material.getChemicalFormula() + ')';

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialStack.java
@@ -50,6 +50,7 @@ public record MaterialStack(@NotNull Material material, long amount) {
     @Override
     public String toString() {
         String string = "";
+        if (this.isEmpty()) return "";
         if (material.getChemicalFormula() == null || material.getChemicalFormula().isEmpty()) {
             string += "?";
         } else if (material.getMaterialComponents().size() > 1) {


### PR DESCRIPTION
## What
fix potential divide by zero errors in getProtons, getMass and getNeutrons

## Implementation Details
empty mat stack check and 0 count check

## Outcome
no more div by zero if you have null material components
