### PR TITLE
Fix Prussian Blue Voiding 75% of Input Chlorine

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/AntidoteRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/AntidoteRecipes.java
@@ -130,7 +130,7 @@ public class AntidoteRecipes {
                 .inputItems(dust, PotassiumFerrocyanide, 51)
                 .inputFluids(Iron3Chloride.getFluid(4000))
                 .outputItems(dust, PrussianBlue, 1)
-                .outputItems(dust, RockSalt, 6)
+                .outputItems(dust, RockSalt, 24)
                 .duration(500).EUt(VA[HV]).save(provider);
     }
 


### PR DESCRIPTION
Prussian Blue recipe used to only yield 6 Rock Salt, which was way less than  it should yield, it now yields 24 rock salt and should be lossless on Chlorine