### PR TITLE
Add NightVision goggles to head curio slot

### DIFF
--- a/src/main/resources/data/curios/tags/items/head.json
+++ b/src/main/resources/data/curios/tags/items/head.json
@@ -1,5 +1,6 @@
 {
     "values": [
-        "gtceu:face_mask"
+        "gtceu:face_mask",
+        "gtceu:nightvision_goggles"
     ]
 }


### PR DESCRIPTION
## What
Adds NightVision goggles to head curio slot tag so it can be used as a curio