### PR TITLE
Refactor ItemMaterialData#registerMaterialInfoItems to not use var-args

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -1248,7 +1248,7 @@ public class TagPrefix {
     public final void setIgnored(Material material, Supplier<? extends ItemLike>... items) {
         ignoredMaterials.put(material, items);
         if (items.length > 0) {
-            ItemMaterialData.registerMaterialInfoItems(this, material, items);
+            ItemMaterialData.registerMaterialInfoItems(this, material, Arrays.asList(items));
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -1396,7 +1396,7 @@ public class GTBlocks {
                 Supplier<Block> blockSupplier = GTMemoizer.memoizeBlockSupplier(() -> block);
                 MaterialEntry entry = new MaterialEntry(tagPrefix, mat);
                 GTMaterialItems.toUnify.put(entry, blockSupplier);
-                ItemMaterialData.registerMaterialInfoItems(entry, blockSupplier);
+                ItemMaterialData.registerMaterialInfoItem(entry, blockSupplier);
             });
             return builder;
         };

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -2529,7 +2529,7 @@ public class GTItems {
                 Supplier<ItemLike> supplier = GTMemoizer.memoize(() -> item);
                 MaterialEntry entry = new MaterialEntry(tagPrefix, mat);
                 GTMaterialItems.toUnify.put(entry, supplier);
-                ItemMaterialData.registerMaterialInfoItems(entry, supplier);
+                ItemMaterialData.registerMaterialInfoItem(entry, supplier);
             });
             return builder;
         };

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -427,7 +427,7 @@ public class StoneMachineRecipes {
     public static void registerStoneMaterialInfo(@NotNull StoneTypeEntry entry) {
         if (!entry.material.isNull() && entry.stone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.block, entry.material, entry.stone);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.stone);
             }
             if (entry.addStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.stone,
@@ -437,7 +437,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.polishedStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.block, entry.material, entry.polishedStone);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.polishedStone);
             }
             if (entry.addPolishedStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.polishedStone,
@@ -447,7 +447,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.smeltStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.block, entry.material, entry.smeltStone);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.smeltStone);
             }
             if (entry.addSmeltStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.smeltStone,
@@ -457,7 +457,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.chiselStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.block, entry.material, entry.chiselStone);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.chiselStone);
             }
             if (entry.addChiselStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.chiselStone,
@@ -467,7 +467,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.crackedStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.block, entry.material, entry.crackedStone);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.crackedStone);
             }
             if (entry.addCrackedStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.crackedStone,
@@ -477,7 +477,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.slab != null) {
             if (entry.addSlabOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.slab, entry.material, entry.slab);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.slab, entry.material, entry.slab);
             }
             if (entry.addSlabMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.slab,
@@ -487,7 +487,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.stair != null) {
             if (entry.addStairOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.stairs, entry.material, entry.stair);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.stairs, entry.material, entry.stair);
             }
             if (entry.addStairMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.stair,
@@ -497,7 +497,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.wall != null) {
             if (entry.addWallOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(TagPrefix.fence, entry.material, entry.wall);
+                ItemMaterialData.registerMaterialInfoItem(TagPrefix.fence, entry.material, entry.wall);
             }
             if (entry.addWallMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.wall,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -339,12 +339,12 @@ public class WoodMachineRecipes {
     public static void registerWoodMaterialInfo(@NotNull WoodTypeEntry entry) {
         for (var log_ : entry.getLogs()) {
             if (log_ != null && entry.addLogOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(log, entry.material, log_);
+                ItemMaterialData.registerMaterialInfoItem(log, entry.material, log_);
             }
         }
 
         if (entry.addPlanksOreDict) {
-            ItemMaterialData.registerMaterialInfoItems(planks, entry.material, entry.planks);
+            ItemMaterialData.registerMaterialInfoItem(planks, entry.material, entry.planks);
         }
         if (entry.addPlanksMaterialInfo) {
             ItemMaterialData.registerMaterialInfo(entry.planks,
@@ -353,7 +353,7 @@ public class WoodMachineRecipes {
 
         if (entry.door != null) {
             if (entry.addDoorsOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(door, entry.material, entry.door);
+                ItemMaterialData.registerMaterialInfoItem(door, entry.material, entry.door);
             }
             if (entry.addDoorsMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.door, ConfigHolder.INSTANCE.recipes.hardWoodRecipes ?
@@ -365,7 +365,7 @@ public class WoodMachineRecipes {
 
         if (entry.slab != null) {
             if (entry.addSlabsOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(slab, entry.material, entry.slab);
+                ItemMaterialData.registerMaterialInfoItem(slab, entry.material, entry.slab);
             }
             if (entry.addSlabsMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.slab,
@@ -375,7 +375,7 @@ public class WoodMachineRecipes {
 
         if (entry.fence != null) {
             if (entry.addFencesOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(fence, entry.material, entry.fence);
+                ItemMaterialData.registerMaterialInfoItem(fence, entry.material, entry.fence);
             }
             if (entry.addFencesMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.fence,
@@ -385,7 +385,7 @@ public class WoodMachineRecipes {
 
         if (entry.fenceGate != null) {
             if (entry.addFenceGatesOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(fenceGate, entry.material, entry.fenceGate);
+                ItemMaterialData.registerMaterialInfoItem(fenceGate, entry.material, entry.fenceGate);
             }
             if (entry.addFenceGatesMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.fenceGate,
@@ -395,7 +395,7 @@ public class WoodMachineRecipes {
 
         if (entry.stairs != null) {
             if (entry.addStairsOreDict) {
-                ItemMaterialData.registerMaterialInfoItems(stairs, entry.material, entry.stairs);
+                ItemMaterialData.registerMaterialInfoItem(stairs, entry.material, entry.stairs);
             }
             if (entry.addStairsMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.stairs,

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/TagsHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/TagsHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.world.level.material.Fluid;
 
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 
-import static com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData.registerMaterialInfoItems;
+import static com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData.registerMaterialInfoItem;
 import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
 
@@ -38,23 +38,23 @@ public class TagsHandler {
     }
 
     public static void initExtraUnificationEntries() {
-        registerMaterialInfoItems(ingot, Clay, Items.CLAY_BALL);
+        registerMaterialInfoItem(ingot, Clay, Items.CLAY_BALL);
 
-        registerMaterialInfoItems(dye, Color.Black, Items.BLACK_DYE);
-        registerMaterialInfoItems(dye, Color.Red, Items.RED_DYE);
-        registerMaterialInfoItems(dye, Color.Green, Items.GREEN_DYE);
-        registerMaterialInfoItems(dye, Color.Brown, Items.BROWN_DYE);
-        registerMaterialInfoItems(dye, Color.Blue, Items.BLUE_DYE);
-        registerMaterialInfoItems(dye, Color.Purple, Items.PURPLE_DYE);
-        registerMaterialInfoItems(dye, Color.Cyan, Items.CYAN_DYE);
-        registerMaterialInfoItems(dye, Color.LightGray, Items.LIGHT_GRAY_DYE);
-        registerMaterialInfoItems(dye, Color.Gray, Items.GRAY_DYE);
-        registerMaterialInfoItems(dye, Color.Pink, Items.PINK_DYE);
-        registerMaterialInfoItems(dye, Color.Lime, Items.LIME_DYE);
-        registerMaterialInfoItems(dye, Color.Yellow, Items.YELLOW_DYE);
-        registerMaterialInfoItems(dye, Color.LightBlue, Items.LIGHT_BLUE_DYE);
-        registerMaterialInfoItems(dye, Color.Magenta, Items.MAGENTA_DYE);
-        registerMaterialInfoItems(dye, Color.Orange, Items.ORANGE_DYE);
-        registerMaterialInfoItems(dye, Color.White, Items.WHITE_DYE);
+        registerMaterialInfoItem(dye, Color.Black, Items.BLACK_DYE);
+        registerMaterialInfoItem(dye, Color.Red, Items.RED_DYE);
+        registerMaterialInfoItem(dye, Color.Green, Items.GREEN_DYE);
+        registerMaterialInfoItem(dye, Color.Brown, Items.BROWN_DYE);
+        registerMaterialInfoItem(dye, Color.Blue, Items.BLUE_DYE);
+        registerMaterialInfoItem(dye, Color.Purple, Items.PURPLE_DYE);
+        registerMaterialInfoItem(dye, Color.Cyan, Items.CYAN_DYE);
+        registerMaterialInfoItem(dye, Color.LightGray, Items.LIGHT_GRAY_DYE);
+        registerMaterialInfoItem(dye, Color.Gray, Items.GRAY_DYE);
+        registerMaterialInfoItem(dye, Color.Pink, Items.PINK_DYE);
+        registerMaterialInfoItem(dye, Color.Lime, Items.LIME_DYE);
+        registerMaterialInfoItem(dye, Color.Yellow, Items.YELLOW_DYE);
+        registerMaterialInfoItem(dye, Color.LightBlue, Items.LIGHT_BLUE_DYE);
+        registerMaterialInfoItem(dye, Color.Magenta, Items.MAGENTA_DYE);
+        registerMaterialInfoItem(dye, Color.Orange, Items.ORANGE_DYE);
+        registerMaterialInfoItem(dye, Color.White, Items.WHITE_DYE);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/utils/memoization/MemoizedBlockSupplier.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/memoization/MemoizedBlockSupplier.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 /**
  * A variant of the memoized supplier that stores a block explicitly.
  * Use this to save blocks to
- * {@link com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData#registerMaterialInfoItems(MaterialEntry, Supplier[])}}
+ * {@link com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData#registerMaterialInfoItem(MaterialEntry, Supplier)}}
  */
 public class MemoizedBlockSupplier<T extends Block> extends MemoizedSupplier<T> {
 


### PR DESCRIPTION
## What
Removes the var-args methods in favor of single argument methods in `ItemMaterialData`. Effectively nothing made use of this and it means we can also remove the `@SafeVarargs` annotations. Additionally, removes the unused case for `Supplier<? extends ItemLike> instanceof Block` for material info registration.

## Outcome
Small cleanup and removal of some code smells.

## Potential Compatibility Issues
The removal of the varargs is an API change, however it is a modification of already breaking unreleased code.
