### PR TITLE
Fix Coke Oven Hatches getting stuck after Coke Oven gets backfilled

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/CokeOvenHatch.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/CokeOvenHatch.java
@@ -84,6 +84,7 @@ public class CokeOvenHatch extends MultiblockPartMachine {
             inputInventory.setProxy(cokeOven.importItems);
             outputInventory.setProxy(cokeOven.exportItems);
             tank.setProxy(cokeOven.exportFluids);
+            this.updateAutoIOSubscription();
         }
     }
 


### PR DESCRIPTION
## What
This PR fixes Coke Oven hatches not pushing items or fluids out of the hatches upon a world reload without a recipe finishing and updating the auto IO

## Implementation Details
Upon addition to the multiblock, subscribe the autoIO to tick, instead of waiting for a change notification to occur

## Outcome
Coke ovens no longer clog after getting backfilled