### PR TITLE
Fix night vision flickering

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorUtils.java
@@ -39,7 +39,8 @@ public class ArmorUtils {
 
     public static final int MIN_NIGHTVISION_CHARGE = 4;
     public static final int NIGHTVISION_DURATION = 20 * 20; // 20 seconds
-    public static final int NIGHT_VISION_RESET = 12 * 20; // Flashing starts at 10 seconds, need a second to reset as well
+    // Flashing starts at 10 seconds + two second buffer to prevent flicker
+    public static final int NIGHT_VISION_RESET = 12 * 20;
 
     /**
      * Check is possible to charge item

--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorUtils.java
@@ -39,7 +39,7 @@ public class ArmorUtils {
 
     public static final int MIN_NIGHTVISION_CHARGE = 4;
     public static final int NIGHTVISION_DURATION = 20 * 20; // 20 seconds
-    public static final int NIGHT_VISION_RESET = 11 * 20; // 11 seconds is before the flashing
+    public static final int NIGHT_VISION_RESET = 12 * 20; // Flashing starts at 10 seconds, need a second to reset as well
 
     /**
      * Check is possible to charge item


### PR DESCRIPTION
## What
Fixes night vision flickering with night vision goggles, nanomuscle suite, and quarktech suite

## Implementation Details
Previously, `ArmorUtils#NIGHT_VISION_RESET` was 11 seconds. Flickering starts at 10 seconds, but the one second buffer does not reset the timer in time before it happens. This PR changes it to be 12 seconds instead 

## Potential Compatibility Issues
None methinks