### PR TITLE
fix KJS machine recipes erroring if user added multiple recipe conditions of different types

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -1062,7 +1062,7 @@ public interface GTRecipeSchema {
     RecipeKey<Long> DURATION = TimeComponent.TICKS.key("duration").optional(100L);
     RecipeKey<CompoundTag> DATA = GTRecipeComponents.TAG.key("data").optional((CompoundTag) null);
     RecipeKey<RecipeCondition[]> CONDITIONS = GTRecipeComponents.RECIPE_CONDITION.asArray().key("recipeConditions")
-            .defaultOptional();
+            .optional(new RecipeCondition[0]);
     RecipeKey<ResourceLocation> CATEGORY = GTRecipeComponents.RESOURCE_LOCATION.key("category").defaultOptional();
 
     RecipeKey<CapabilityMap> ALL_INPUTS = GTRecipeComponents.IN.key("inputs").defaultOptional();


### PR DESCRIPTION
## What
fix this teeny tiny oopsie :3

## Implementation Details
turns out I used ArrayUtils.add wrong.
fixed by setting a default value that's not null.

## Outcome
no more weird wacky error that I think only one person ever got

## Additional Information
![image](https://github.com/user-attachments/assets/e7d07d5c-d695-4851-835b-b40fe31d1948)

## Potential Compatibility Issues
fixes one!!