### PR TITLE
Fix issues with StoneTypeEntry and variant ores

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
@@ -183,7 +183,7 @@ public class ChemicalHelper {
             // Resolve all the lazy suppliers once, rather than on each request. This avoids O(n) lookup performance
             // for unification entries.
             for (var entry : ITEM_MATERIAL_ENTRY) {
-                ITEM_MATERIAL_ENTRY_COLLECTED.put(entry.getFirst().get(), entry.getSecond());
+                ITEM_MATERIAL_ENTRY_COLLECTED.put(entry.getFirst().get().asItem(), entry.getSecond());
             }
             ITEM_MATERIAL_ENTRY.clear();
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -1248,7 +1248,7 @@ public class TagPrefix {
     public final void setIgnored(Material material, Supplier<? extends ItemLike>... items) {
         ignoredMaterials.put(material, items);
         if (items.length > 0) {
-            ItemMaterialData.registerMaterialInfoItems(this, material, Arrays.asList(items));
+            ItemMaterialData.registerMaterialEntries(Arrays.asList(items), this, material);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -1396,7 +1396,7 @@ public class GTBlocks {
                 Supplier<Block> blockSupplier = GTMemoizer.memoizeBlockSupplier(() -> block);
                 MaterialEntry entry = new MaterialEntry(tagPrefix, mat);
                 GTMaterialItems.toUnify.put(entry, blockSupplier);
-                ItemMaterialData.registerMaterialInfoItem(entry, blockSupplier);
+                ItemMaterialData.registerMaterialEntry(blockSupplier, entry);
             });
             return builder;
         };

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -2529,7 +2529,7 @@ public class GTItems {
                 Supplier<ItemLike> supplier = GTMemoizer.memoize(() -> item);
                 MaterialEntry entry = new MaterialEntry(tagPrefix, mat);
                 GTMaterialItems.toUnify.put(entry, supplier);
-                ItemMaterialData.registerMaterialInfoItem(entry, supplier);
+                ItemMaterialData.registerMaterialEntry(supplier, entry);
             });
             return builder;
         };

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/MaterialInfoLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/MaterialInfoLoader.java
@@ -75,7 +75,8 @@ public class MaterialInfoLoader {
         ItemMaterialData.registerMaterialInfo(Blocks.SNOW,
                 new ItemMaterialInfo(new MaterialStack(GTMaterials.Water, M)));
 
-        ItemMaterialData.registerMaterialInfo(Blocks.ICE, new ItemMaterialInfo(new MaterialStack(GTMaterials.Ice, M)));
+        ItemMaterialData.registerMaterialInfo(Blocks.ICE,
+                new ItemMaterialInfo(new MaterialStack(GTMaterials.Ice, M)));
 
         ItemMaterialData.registerMaterialInfo(Items.BOOK,
                 new ItemMaterialInfo(new MaterialStack(GTMaterials.Paper, M * 3)));

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -305,8 +305,7 @@ public class VanillaRecipeHelper {
         builder.save(provider);
 
         if (setMaterialInfoData) {
-            ItemMaterialData.registerMaterialInfo(result.getItem(),
-                    getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialData.registerMaterialInfo(result.getItem(), getRecyclingIngredients(result.getCount(), recipe));
         }
     }
 
@@ -396,8 +395,7 @@ public class VanillaRecipeHelper {
         builder.save(provider);
 
         if (setMaterialInfoData) {
-            ItemMaterialData.registerMaterialInfo(result.getItem(),
-                    getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialData.registerMaterialInfo(result.getItem(), getRecyclingIngredients(result.getCount(), recipe));
         }
     }
 
@@ -468,8 +466,7 @@ public class VanillaRecipeHelper {
         builder.save(provider);
 
         if (setMaterialInfoData) {
-            ItemMaterialData.registerMaterialInfo(result.getItem(),
-                    getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialData.registerMaterialInfo(result.getItem(), getRecyclingIngredients(result.getCount(), recipe));
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -305,7 +305,8 @@ public class VanillaRecipeHelper {
         builder.save(provider);
 
         if (setMaterialInfoData) {
-            ItemMaterialData.registerMaterialInfo(result.getItem(), getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialData.registerMaterialInfo(result.getItem(),
+                    getRecyclingIngredients(result.getCount(), recipe));
         }
     }
 
@@ -395,7 +396,8 @@ public class VanillaRecipeHelper {
         builder.save(provider);
 
         if (setMaterialInfoData) {
-            ItemMaterialData.registerMaterialInfo(result.getItem(), getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialData.registerMaterialInfo(result.getItem(),
+                    getRecyclingIngredients(result.getCount(), recipe));
         }
     }
 
@@ -466,7 +468,8 @@ public class VanillaRecipeHelper {
         builder.save(provider);
 
         if (setMaterialInfoData) {
-            ItemMaterialData.registerMaterialInfo(result.getItem(), getRecyclingIngredients(result.getCount(), recipe));
+            ItemMaterialData.registerMaterialInfo(result.getItem(),
+                    getRecyclingIngredients(result.getCount(), recipe));
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -427,7 +427,7 @@ public class StoneMachineRecipes {
     public static void registerStoneMaterialInfo(@NotNull StoneTypeEntry entry) {
         if (!entry.material.isNull() && entry.stone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.stone);
+                ItemMaterialData.registerMaterialEntry(entry.stone, TagPrefix.block, entry.material);
             }
             if (entry.addStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.stone,
@@ -437,7 +437,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.polishedStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.polishedStone);
+                ItemMaterialData.registerMaterialEntry(entry.polishedStone, TagPrefix.block, entry.material);
             }
             if (entry.addPolishedStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.polishedStone,
@@ -447,7 +447,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.smeltStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.smeltStone);
+                ItemMaterialData.registerMaterialEntry(entry.smeltStone, TagPrefix.block, entry.material);
             }
             if (entry.addSmeltStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.smeltStone,
@@ -457,7 +457,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.chiselStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.chiselStone);
+                ItemMaterialData.registerMaterialEntry(entry.chiselStone, TagPrefix.block, entry.material);
             }
             if (entry.addChiselStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.chiselStone,
@@ -467,7 +467,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.crackedStone != null) {
             if (entry.addStoneOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.block, entry.material, entry.crackedStone);
+                ItemMaterialData.registerMaterialEntry(entry.crackedStone, TagPrefix.block, entry.material);
             }
             if (entry.addCrackedStoneMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.crackedStone,
@@ -477,7 +477,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.slab != null) {
             if (entry.addSlabOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.slab, entry.material, entry.slab);
+                ItemMaterialData.registerMaterialEntry(entry.slab, TagPrefix.slab, entry.material);
             }
             if (entry.addSlabMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.slab,
@@ -487,7 +487,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.stair != null) {
             if (entry.addStairOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.stairs, entry.material, entry.stair);
+                ItemMaterialData.registerMaterialEntry(entry.stair, TagPrefix.stairs, entry.material);
             }
             if (entry.addStairMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.stair,
@@ -497,7 +497,7 @@ public class StoneMachineRecipes {
 
         if (!entry.material.isNull() && entry.wall != null) {
             if (entry.addWallOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(TagPrefix.fence, entry.material, entry.wall);
+                ItemMaterialData.registerMaterialEntry(entry.wall, TagPrefix.fence, entry.material);
             }
             if (entry.addWallMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.wall,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -339,12 +339,12 @@ public class WoodMachineRecipes {
     public static void registerWoodMaterialInfo(@NotNull WoodTypeEntry entry) {
         for (var log_ : entry.getLogs()) {
             if (log_ != null && entry.addLogOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(log, entry.material, log_);
+                ItemMaterialData.registerMaterialEntry(log_, log, entry.material);
             }
         }
 
         if (entry.addPlanksOreDict) {
-            ItemMaterialData.registerMaterialInfoItem(planks, entry.material, entry.planks);
+            ItemMaterialData.registerMaterialEntry(entry.planks, planks, entry.material);
         }
         if (entry.addPlanksMaterialInfo) {
             ItemMaterialData.registerMaterialInfo(entry.planks,
@@ -353,7 +353,7 @@ public class WoodMachineRecipes {
 
         if (entry.door != null) {
             if (entry.addDoorsOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(door, entry.material, entry.door);
+                ItemMaterialData.registerMaterialEntry(entry.door, door, entry.material);
             }
             if (entry.addDoorsMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.door, ConfigHolder.INSTANCE.recipes.hardWoodRecipes ?
@@ -365,7 +365,7 @@ public class WoodMachineRecipes {
 
         if (entry.slab != null) {
             if (entry.addSlabsOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(slab, entry.material, entry.slab);
+                ItemMaterialData.registerMaterialEntry(entry.slab, slab, entry.material);
             }
             if (entry.addSlabsMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.slab,
@@ -375,7 +375,7 @@ public class WoodMachineRecipes {
 
         if (entry.fence != null) {
             if (entry.addFencesOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(fence, entry.material, entry.fence);
+                ItemMaterialData.registerMaterialEntry(entry.fence, fence, entry.material);
             }
             if (entry.addFencesMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.fence,
@@ -385,7 +385,7 @@ public class WoodMachineRecipes {
 
         if (entry.fenceGate != null) {
             if (entry.addFenceGatesOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(fenceGate, entry.material, entry.fenceGate);
+                ItemMaterialData.registerMaterialEntry(entry.fenceGate, fenceGate, entry.material);
             }
             if (entry.addFenceGatesMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.fenceGate,
@@ -395,7 +395,7 @@ public class WoodMachineRecipes {
 
         if (entry.stairs != null) {
             if (entry.addStairsOreDict) {
-                ItemMaterialData.registerMaterialInfoItem(stairs, entry.material, entry.stairs);
+                ItemMaterialData.registerMaterialEntry(entry.stairs, stairs, entry.material);
             }
             if (entry.addStairsMaterialInfo) {
                 ItemMaterialData.registerMaterialInfo(entry.stairs,

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/TagsHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/TagsHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.world.level.material.Fluid;
 
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 
-import static com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData.registerMaterialInfoItem;
+import static com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData.registerMaterialEntry;
 import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.*;
 import static com.gregtechceu.gtceu.common.data.GTMaterials.*;
 
@@ -38,23 +38,23 @@ public class TagsHandler {
     }
 
     public static void initExtraUnificationEntries() {
-        registerMaterialInfoItem(ingot, Clay, Items.CLAY_BALL);
+        registerMaterialEntry(Items.CLAY_BALL, ingot, Clay);
 
-        registerMaterialInfoItem(dye, Color.Black, Items.BLACK_DYE);
-        registerMaterialInfoItem(dye, Color.Red, Items.RED_DYE);
-        registerMaterialInfoItem(dye, Color.Green, Items.GREEN_DYE);
-        registerMaterialInfoItem(dye, Color.Brown, Items.BROWN_DYE);
-        registerMaterialInfoItem(dye, Color.Blue, Items.BLUE_DYE);
-        registerMaterialInfoItem(dye, Color.Purple, Items.PURPLE_DYE);
-        registerMaterialInfoItem(dye, Color.Cyan, Items.CYAN_DYE);
-        registerMaterialInfoItem(dye, Color.LightGray, Items.LIGHT_GRAY_DYE);
-        registerMaterialInfoItem(dye, Color.Gray, Items.GRAY_DYE);
-        registerMaterialInfoItem(dye, Color.Pink, Items.PINK_DYE);
-        registerMaterialInfoItem(dye, Color.Lime, Items.LIME_DYE);
-        registerMaterialInfoItem(dye, Color.Yellow, Items.YELLOW_DYE);
-        registerMaterialInfoItem(dye, Color.LightBlue, Items.LIGHT_BLUE_DYE);
-        registerMaterialInfoItem(dye, Color.Magenta, Items.MAGENTA_DYE);
-        registerMaterialInfoItem(dye, Color.Orange, Items.ORANGE_DYE);
-        registerMaterialInfoItem(dye, Color.White, Items.WHITE_DYE);
+        registerMaterialEntry(Items.BLACK_DYE, dye, Color.Black);
+        registerMaterialEntry(Items.RED_DYE, dye, Color.Red);
+        registerMaterialEntry(Items.GREEN_DYE, dye, Color.Green);
+        registerMaterialEntry(Items.BROWN_DYE, dye, Color.Brown);
+        registerMaterialEntry(Items.BLUE_DYE, dye, Color.Blue);
+        registerMaterialEntry(Items.PURPLE_DYE, dye, Color.Purple);
+        registerMaterialEntry(Items.CYAN_DYE, dye, Color.Cyan);
+        registerMaterialEntry(Items.LIGHT_GRAY_DYE, dye, Color.LightGray);
+        registerMaterialEntry(Items.GRAY_DYE, dye, Color.Gray);
+        registerMaterialEntry(Items.PINK_DYE, dye, Color.Pink);
+        registerMaterialEntry(Items.LIME_DYE, dye, Color.Lime);
+        registerMaterialEntry(Items.YELLOW_DYE, dye, Color.Yellow);
+        registerMaterialEntry(Items.LIGHT_BLUE_DYE, dye, Color.LightBlue);
+        registerMaterialEntry(Items.MAGENTA_DYE, dye, Color.Magenta);
+        registerMaterialEntry(Items.ORANGE_DYE, dye, Color.Orange);
+        registerMaterialEntry(Items.WHITE_DYE, dye, Color.White);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/utils/memoization/MemoizedBlockSupplier.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/memoization/MemoizedBlockSupplier.java
@@ -9,7 +9,7 @@ import java.util.function.Supplier;
 /**
  * A variant of the memoized supplier that stores a block explicitly.
  * Use this to save blocks to
- * {@link com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData#registerMaterialInfoItem(MaterialEntry, Supplier)}}
+ * {@link com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData#registerMaterialEntry(Supplier, MaterialEntry)}}
  */
 public class MemoizedBlockSupplier<T extends Block> extends MemoizedSupplier<T> {
 


### PR DESCRIPTION
## What
Fix small regressions from #2591 and #3057:
- Fix variant (i.e., non-stone) ores not having maceration recipes
- Fix stone types not having decomposition recipes

Also rename some methods in `ItemMaterialData` and change parameter order to be more descriptive

## Outcome
Onion fix