### PR TITLE
Fix recipe naming

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/AcidRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/AcidRecipes.java
@@ -101,7 +101,7 @@ public class AcidRecipes {
                 .outputFluids(NitricOxide.getFluid(1000))
                 .duration(240).EUt(VA[LV]).save(provider);
 
-        CHEMICAL_RECIPES.recipeBuilder("nitric_oxide_from_dioxide_2")
+        CHEMICAL_RECIPES.recipeBuilder("nitric_acid_from_dioxide_2")
                 .circuitMeta(3)
                 .inputFluids(Water.getFluid(1000))
                 .inputFluids(Oxygen.getFluid(1000))


### PR DESCRIPTION
## What
Changes the recipe with name: `nitric_oxide_from_dioxide_2` to `nitric_acid_from_dioxide_2`, since the recipe does not contain nitric_oxide. 

## Outcome
Recipe name will be more descriptive of the outputs.

## Potential Compatibility Issues
Custom code referencing this recipe by its name could break.