### PR TITLE
Oil sprout spawn config

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlacements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlacements.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.worldgen.BiomeWeightModifier;
 import com.gregtechceu.gtceu.api.data.worldgen.modifier.BiomePlacement;
 import com.gregtechceu.gtceu.common.worldgen.modifier.RubberTreeChancePlacement;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
 
 import net.minecraft.core.HolderGetter;

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlacements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlacements.java
@@ -59,7 +59,7 @@ public class GTPlacements {
                 BiomeFilter.biome(),
                 HeightRangePlacement.uniform(VerticalAnchor.absolute(-8), VerticalAnchor.top()));
         PlacementUtils.register(ctx, RAW_OIL_SPROUT, featureLookup.getOrThrow(GTConfiguredFeatures.RAW_OIL_SPROUT),
-                RarityFilter.onAverageOnceEvery(64),
+                RarityFilter.onAverageOnceEvery(ConfigHolder.INSTANCE.worldgen.rawOilSproutSpawnChance),
                 InSquarePlacement.spread(),
                 BiomeFilter.biome(),
                 HeightRangePlacement.uniform(VerticalAnchor.absolute(10), VerticalAnchor.absolute(40)));

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -336,6 +336,11 @@ public class ConfigHolder {
         public float rubberTreeSpawnChance = 0.5f;
 
         @Configurable
+        @Configurable.Comment({ "Raw Oil Sprout spawn chance (on average 1 every n chunks)", "Default: 64" })
+        @Configurable.Range(min = 1, max = Integer.MAX_VALUE)
+        public float rawOilSproutSpawnChance = 64;
+
+        @Configurable
         @Configurable.Comment({ "Should all Stone Types drop unique Ore Item Blocks?",
                 "Default: false (meaning only Stone, Netherrack, and Endstone)" })
         public boolean allUniqueStoneTypes = false;

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -338,7 +338,7 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Raw Oil Sprout spawn chance (on average 1 every n chunks)", "Default: 64" })
         @Configurable.Range(min = 1, max = Integer.MAX_VALUE)
-        public float rawOilSproutSpawnChance = 64;
+        public int rawOilSproutSpawnChance = 64;
 
         @Configurable
         @Configurable.Comment({ "Should all Stone Types drop unique Ore Item Blocks?",


### PR DESCRIPTION
## What
This PR adds a configuration property to control the spawn chance of Raw Oil Sprouts during world generation.

## Implementation Details
Introduces a new config value in WorldGenConfigs (via ConfigHolder) to define the spawn chance of Raw Oil Sprouts.
The value represents the number of chunks per spawn (i.e., 1 means every chunk, higher values reduce frequency).
Value constraints:
- Min: 1 (sprout in every chunk)
- Max: Integer.MAX_VALUE
- Default: 64 — matching the original hardcoded value from GTPlacements, which now uses this config instead.

## Outcome
This change allows modpack creators, server admins and players to customize the frequency of Raw Oil Sprouts through config, enabling more flexible world generation.
Closes #2954  