### PR TITLE
Refactor item decorators to item decorators instead of using a mixin

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
@@ -270,9 +270,8 @@ public class ElectricStats implements IInteractionItem, ISubItemHandler, IAddInf
     public boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
         var electricItem = GTCapabilityHelper.getElectricItem(stack);
         if (electricItem != null) {
-            ToolChargeBarRenderer.renderElectricBar(guiGraphics, electricItem.getCharge(), electricItem.getMaxCharge(),
-                    xOffset, yOffset, stack.isBarVisible());
-            return true;
+            return ToolChargeBarRenderer.renderElectricBar(guiGraphics, electricItem.getCharge(),
+                    electricItem.getMaxCharge(), xOffset, yOffset, stack.isBarVisible());
         }
         return false;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
@@ -8,12 +8,15 @@ import com.gregtechceu.gtceu.api.capability.compat.FeCompat;
 import com.gregtechceu.gtceu.api.capability.forge.GTCapability;
 import com.gregtechceu.gtceu.api.item.capability.ElectricItem;
 import com.gregtechceu.gtceu.api.item.component.forge.IComponentCapability;
+import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
@@ -41,7 +44,7 @@ import java.time.Instant;
 import java.util.List;
 
 public class ElectricStats implements IInteractionItem, ISubItemHandler, IAddInformation, IItemLifeCycle,
-                           IComponentCapability {
+                           IComponentCapability, IItemDecoratorComponent {
 
     public static final ElectricStats EMPTY = ElectricStats.create(0, 0, false, false);
 
@@ -261,5 +264,16 @@ public class ElectricStats implements IInteractionItem, ISubItemHandler, IAddInf
 
     public static ElectricStats createBattery(long maxCharge, int tier, boolean rechargeable) {
         return ElectricStats.create(maxCharge, tier, rechargeable, true);
+    }
+
+    @Override
+    public boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
+        var electricItem = GTCapabilityHelper.getElectricItem(stack);
+        if (electricItem != null) {
+            ToolChargeBarRenderer.renderElectricBar(guiGraphics, electricItem.getCharge(), electricItem.getMaxCharge(),
+                    xOffset, yOffset, stack.isBarVisible());
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/IDurabilityBar.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/IDurabilityBar.java
@@ -1,5 +1,9 @@
 package com.gregtechceu.gtceu.api.item.component;
 
+import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
+
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
 
@@ -11,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
  * @date 2023/2/22
  * @implNote IDurabilityBar
  */
-public interface IDurabilityBar extends IItemComponent {
+public interface IDurabilityBar extends IItemDecoratorComponent {
 
     default int getBarWidth(ItemStack stack) {
         return Math.round(getDurabilityForDisplay(stack) * 13);
@@ -59,5 +63,10 @@ public interface IDurabilityBar extends IItemComponent {
      */
     default boolean showFullBar(ItemStack itemStack) {
         return true;
+    }
+
+    @Override
+    default boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
+        return ToolChargeBarRenderer.renderDurabilityBar(guiGraphics, stack, this, xOffset, yOffset);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/IItemDecoratorComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/IItemDecoratorComponent.java
@@ -1,0 +1,5 @@
+package com.gregtechceu.gtceu.api.item.component;
+
+import net.minecraftforge.client.IItemDecorator;
+
+public interface IItemDecoratorComponent extends IItemComponent, IItemDecorator {}

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -5,10 +5,15 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
+import com.gregtechceu.gtceu.api.item.IComponentItem;
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.api.item.LampBlockItem;
 import com.gregtechceu.gtceu.client.particle.HazardParticle;
 import com.gregtechceu.gtceu.client.particle.MufflerParticle;
 import com.gregtechceu.gtceu.client.renderer.entity.GTBoatRenderer;
 import com.gregtechceu.gtceu.client.renderer.entity.GTExplosiveRenderer;
+import com.gregtechceu.gtceu.client.renderer.item.decorator.GTItemBarRenderer;
+import com.gregtechceu.gtceu.client.renderer.item.decorator.GTLampItemOverlayRenderer;
 import com.gregtechceu.gtceu.common.CommonProxy;
 import com.gregtechceu.gtceu.common.data.GTBlockEntities;
 import com.gregtechceu.gtceu.common.data.GTEntityTypes;
@@ -30,13 +35,12 @@ import net.minecraft.client.renderer.blockentity.HangingSignRenderer;
 import net.minecraft.client.renderer.blockentity.SignRenderer;
 import net.minecraft.client.renderer.entity.ThrownItemRenderer;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
 import net.minecraftforge.client.ForgeHooksClient;
-import net.minecraftforge.client.event.EntityRenderersEvent;
-import net.minecraftforge.client.event.RegisterGuiOverlaysEvent;
-import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
-import net.minecraftforge.client.event.RegisterParticleProvidersEvent;
+import net.minecraftforge.client.event.*;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -81,6 +85,18 @@ public class ClientProxy extends CommonProxy {
             ForgeHooksClient.registerLayerDefinition(GTBoatRenderer.getBoatModelName(type), BoatModel::createBodyModel);
             ForgeHooksClient.registerLayerDefinition(GTBoatRenderer.getChestBoatModelName(type),
                     ChestBoatModel::createBodyModel);
+        }
+    }
+
+    @SubscribeEvent
+    public void onRegisterItemDecorations(RegisterItemDecorationsEvent event) {
+        for (Item item : ForgeRegistries.ITEMS) {
+            if (item instanceof IGTTool || item instanceof IComponentItem) {
+                event.register(item, GTItemBarRenderer.INSTANCE);
+            }
+            if (item instanceof LampBlockItem) {
+                event.register(item, GTLampItemOverlayRenderer.INSTANCE);
+            }
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -12,8 +12,9 @@ import com.gregtechceu.gtceu.client.particle.HazardParticle;
 import com.gregtechceu.gtceu.client.particle.MufflerParticle;
 import com.gregtechceu.gtceu.client.renderer.entity.GTBoatRenderer;
 import com.gregtechceu.gtceu.client.renderer.entity.GTExplosiveRenderer;
-import com.gregtechceu.gtceu.client.renderer.item.decorator.GTItemBarRenderer;
+import com.gregtechceu.gtceu.client.renderer.item.decorator.GTComponentItemDecorator;
 import com.gregtechceu.gtceu.client.renderer.item.decorator.GTLampItemOverlayRenderer;
+import com.gregtechceu.gtceu.client.renderer.item.decorator.GTToolBarRenderer;
 import com.gregtechceu.gtceu.common.CommonProxy;
 import com.gregtechceu.gtceu.common.data.GTBlockEntities;
 import com.gregtechceu.gtceu.common.data.GTEntityTypes;
@@ -91,8 +92,11 @@ public class ClientProxy extends CommonProxy {
     @SubscribeEvent
     public void onRegisterItemDecorations(RegisterItemDecorationsEvent event) {
         for (Item item : ForgeRegistries.ITEMS) {
-            if (item instanceof IGTTool || item instanceof IComponentItem) {
-                event.register(item, GTItemBarRenderer.INSTANCE);
+            if (item instanceof IComponentItem) {
+                event.register(item, GTComponentItemDecorator.INSTANCE);
+            }
+            if (item instanceof IGTTool) {
+                event.register(item, GTToolBarRenderer.INSTANCE);
             }
             if (item instanceof LampBlockItem) {
                 event.register(item, GTLampItemOverlayRenderer.INSTANCE);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
@@ -1,11 +1,7 @@
 package com.gregtechceu.gtceu.client.renderer.item;
 
-import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
-import com.gregtechceu.gtceu.api.capability.IElectricItem;
-import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.api.item.component.IDurabilityBar;
-import com.gregtechceu.gtceu.api.item.component.IItemComponent;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.client.util.DrawUtil;
 
@@ -52,8 +48,7 @@ public final class ToolChargeBarRenderer {
         boolean renderedDurability = false;
         CompoundTag tag = stack.getOrCreateTag();
         if (!tag.getBoolean(ToolHelper.UNBREAKABLE_KEY)) {
-            renderedDurability = renderDurabilityBar(graphics, stack.getBarWidth(), xPosition,
-                    yPosition);
+            renderedDurability = renderDurabilityBar(graphics, stack.getBarWidth(), xPosition, yPosition);
         }
         if (tool.isElectric()) {
             renderElectricBar(graphics, tool.getCharge(stack), tool.getMaxCharge(stack), xPosition, yPosition,
@@ -61,28 +56,8 @@ public final class ToolChargeBarRenderer {
         }
     }
 
-    public static void renderBarsItem(GuiGraphics graphics, IComponentItem item, ItemStack stack, int xPosition,
-                                      int yPosition) {
-        boolean renderedDurability = false;
-        IDurabilityBar bar = null;
-        for (IItemComponent component : item.getComponents()) {
-            if (component instanceof IDurabilityBar durabilityBar) {
-                bar = durabilityBar;
-            }
-        }
-        if (bar != null) {
-            renderedDurability = renderDurabilityBar(graphics, stack, bar, xPosition, yPosition);
-        }
-
-        IElectricItem electricItem = GTCapabilityHelper.getElectricItem(stack);
-        if (electricItem != null) {
-            renderElectricBar(graphics, electricItem.getCharge(), electricItem.getMaxCharge(), xPosition, yPosition,
-                    renderedDurability);
-        }
-    }
-
-    private static void renderElectricBar(GuiGraphics graphics, long charge, long maxCharge, int xPosition,
-                                          int yPosition, boolean renderedDurability) {
+    public static void renderElectricBar(GuiGraphics graphics, long charge, long maxCharge, int xPosition,
+                                         int yPosition, boolean renderedDurability) {
         if (charge > 0 && maxCharge > 0) {
             int level = Math.round(charge * 13.0F / maxCharge);
             render(graphics, level, xPosition, yPosition, renderedDurability ? 2 : 0, true, colorBarLeftEnergy,
@@ -90,8 +65,8 @@ public final class ToolChargeBarRenderer {
         }
     }
 
-    private static boolean renderDurabilityBar(GuiGraphics graphics, ItemStack stack, IDurabilityBar manager,
-                                               int xPosition, int yPosition) {
+    public static boolean renderDurabilityBar(GuiGraphics graphics, ItemStack stack, IDurabilityBar manager,
+                                              int xPosition, int yPosition) {
         float level = manager.getDurabilityForDisplay(stack);
         if (level == 0.0 && !manager.showEmptyBar(stack)) return false;
         if (level == 1.0 && !manager.showFullBar(stack)) return false;

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
@@ -56,13 +56,15 @@ public final class ToolChargeBarRenderer {
         }
     }
 
-    public static void renderElectricBar(GuiGraphics graphics, long charge, long maxCharge, int xPosition,
-                                         int yPosition, boolean renderedDurability) {
+    public static boolean renderElectricBar(GuiGraphics graphics, long charge, long maxCharge, int xPosition,
+                                            int yPosition, boolean renderedDurability) {
         if (charge > 0 && maxCharge > 0) {
             int level = Math.round(charge * 13.0F / maxCharge);
             render(graphics, level, xPosition, yPosition, renderedDurability ? 2 : 0, true, colorBarLeftEnergy,
                     colorBarRightEnergy, true);
+            return true;
         }
+        return false;
     }
 
     public static boolean renderDurabilityBar(GuiGraphics graphics, ItemStack stack, IDurabilityBar manager,

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTComponentItemDecorator.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTComponentItemDecorator.java
@@ -1,0 +1,29 @@
+package com.gregtechceu.gtceu.client.renderer.item.decorator;
+
+import com.gregtechceu.gtceu.api.item.IComponentItem;
+import com.gregtechceu.gtceu.api.item.component.IItemDecoratorComponent;
+
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.client.IItemDecorator;
+
+public final class GTComponentItemDecorator implements IItemDecorator {
+
+    public static final GTComponentItemDecorator INSTANCE = new GTComponentItemDecorator();
+
+    private GTComponentItemDecorator() {}
+
+    @Override
+    public boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
+        if (stack.getItem() instanceof IComponentItem componentItem) {
+            for (var component : componentItem.getComponents()) {
+                if (component instanceof IItemDecoratorComponent itemDecoratorComponent) {
+                    itemDecoratorComponent.render(guiGraphics, font, stack, xOffset, yOffset);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTComponentItemDecorator.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTComponentItemDecorator.java
@@ -17,12 +17,13 @@ public final class GTComponentItemDecorator implements IItemDecorator {
     @Override
     public boolean render(GuiGraphics guiGraphics, Font font, ItemStack stack, int xOffset, int yOffset) {
         if (stack.getItem() instanceof IComponentItem componentItem) {
+            var retVal = false;
             for (var component : componentItem.getComponents()) {
                 if (component instanceof IItemDecoratorComponent itemDecoratorComponent) {
-                    itemDecoratorComponent.render(guiGraphics, font, stack, xOffset, yOffset);
+                    retVal |= itemDecoratorComponent.render(guiGraphics, font, stack, xOffset, yOffset);
                 }
             }
-            return true;
+            return retVal;
         }
         return false;
     }

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTItemBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTItemBarRenderer.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.client.renderer.item.decorator;
 
-import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
@@ -18,13 +17,10 @@ public class GTItemBarRenderer implements IItemDecorator {
 
     @Override
     public boolean render(@NotNull GuiGraphics guiGraphics, @NotNull Font font, ItemStack stack, int x, int y) {
-        GTCEu.LOGGER.info("Rendering item bar decorator");
         if (stack.getItem() instanceof IGTTool toolItem) {
-            GTCEu.LOGGER.info("Rendering tool bar decorator");
             ToolChargeBarRenderer.renderBarsTool(guiGraphics, toolItem, stack, x, y);
             return true;
         } else if (stack.getItem() instanceof IComponentItem componentItem) {
-            GTCEu.LOGGER.info("Rendering component item bar decorator");
             ToolChargeBarRenderer.renderBarsItem(guiGraphics, componentItem, stack, x, y);
             return true;
         }

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTItemBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTItemBarRenderer.java
@@ -1,0 +1,33 @@
+package com.gregtechceu.gtceu.client.renderer.item.decorator;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.item.IComponentItem;
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
+
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.client.IItemDecorator;
+
+import org.jetbrains.annotations.NotNull;
+
+public class GTItemBarRenderer implements IItemDecorator {
+
+    public static final GTItemBarRenderer INSTANCE = new GTItemBarRenderer();
+
+    @Override
+    public boolean render(@NotNull GuiGraphics guiGraphics, @NotNull Font font, ItemStack stack, int x, int y) {
+        GTCEu.LOGGER.info("Rendering item bar decorator");
+        if (stack.getItem() instanceof IGTTool toolItem) {
+            GTCEu.LOGGER.info("Rendering tool bar decorator");
+            ToolChargeBarRenderer.renderBarsTool(guiGraphics, toolItem, stack, x, y);
+            return true;
+        } else if (stack.getItem() instanceof IComponentItem componentItem) {
+            GTCEu.LOGGER.info("Rendering component item bar decorator");
+            ToolChargeBarRenderer.renderBarsItem(guiGraphics, componentItem, stack, x, y);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTLampItemOverlayRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTLampItemOverlayRenderer.java
@@ -1,11 +1,13 @@
-package com.gregtechceu.gtceu.client.renderer.item;
+package com.gregtechceu.gtceu.client.renderer.item.decorator;
 
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 
+import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.IItemDecorator;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
@@ -13,9 +15,11 @@ import static com.gregtechceu.gtceu.common.block.LampBlock.isBloomEnabled;
 import static com.gregtechceu.gtceu.common.block.LampBlock.isLightEnabled;
 
 @OnlyIn(Dist.CLIENT)
-public class LampItemOverlayRenderer {
+public class GTLampItemOverlayRenderer implements IItemDecorator {
 
-    private LampItemOverlayRenderer() {}
+    public static final GTLampItemOverlayRenderer INSTANCE = new GTLampItemOverlayRenderer();
+
+    private GTLampItemOverlayRenderer() {}
 
     public static OverlayType getOverlayType(boolean light, boolean bloom) {
         if (light) {
@@ -25,13 +29,13 @@ public class LampItemOverlayRenderer {
         }
     }
 
-    public static void renderOverlay(GuiGraphics graphics, ItemStack stack, int xPosition,
-                                     int yPosition) {
+    @Override
+    public boolean render(GuiGraphics graphics, Font font, ItemStack stack, int xPosition, int yPosition) {
         if (stack.hasTag()) {
-            var tag = stack.getTag();
+            var tag = stack.getOrCreateTag();
             var overlayType = getOverlayType(isLightEnabled(tag), isBloomEnabled(tag));
             if (overlayType == OverlayType.NONE) {
-                return;
+                return true;
             }
 
             RenderSystem.disableDepthTest();
@@ -43,7 +47,9 @@ public class LampItemOverlayRenderer {
                 GuiTextures.LAMP_NO_LIGHT.draw(graphics, 0, 0, xPosition, yPosition, 16, 16);
             }
             RenderSystem.enableDepthTest();
+            return true;
         }
+        return false;
     }
 
     public enum OverlayType {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTToolBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/decorator/GTToolBarRenderer.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.client.renderer.item.decorator;
 
-import com.gregtechceu.gtceu.api.item.IComponentItem;
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
 
@@ -11,19 +10,16 @@ import net.minecraftforge.client.IItemDecorator;
 
 import org.jetbrains.annotations.NotNull;
 
-public class GTItemBarRenderer implements IItemDecorator {
+public class GTToolBarRenderer implements IItemDecorator {
 
-    public static final GTItemBarRenderer INSTANCE = new GTItemBarRenderer();
+    public static final GTToolBarRenderer INSTANCE = new GTToolBarRenderer();
 
     @Override
     public boolean render(@NotNull GuiGraphics guiGraphics, @NotNull Font font, ItemStack stack, int x, int y) {
-        if (stack.getItem() instanceof IGTTool toolItem) {
-            ToolChargeBarRenderer.renderBarsTool(guiGraphics, toolItem, stack, x, y);
-            return true;
-        } else if (stack.getItem() instanceof IComponentItem componentItem) {
-            ToolChargeBarRenderer.renderBarsItem(guiGraphics, componentItem, stack, x, y);
+        if (stack.getItem() instanceof IGTTool gtTool) {
+            ToolChargeBarRenderer.renderBarsTool(guiGraphics, gtTool, stack, x, y);
             return true;
         }
-        return false;
+        return true;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/GuiGraphicsMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/GuiGraphicsMixin.java
@@ -1,16 +1,10 @@
 package com.gregtechceu.gtceu.core.mixins;
 
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
-import com.gregtechceu.gtceu.api.item.IComponentItem;
-import com.gregtechceu.gtceu.api.item.IGTTool;
-import com.gregtechceu.gtceu.api.item.LampBlockItem;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
-import com.gregtechceu.gtceu.client.renderer.item.LampItemOverlayRenderer;
-import com.gregtechceu.gtceu.client.renderer.item.ToolChargeBarRenderer;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
-import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.entity.LivingEntity;
@@ -39,25 +33,6 @@ public class GuiGraphicsMixin {
     private void renderItem(@Nullable LivingEntity entity, @Nullable Level level, ItemStack stack, int x, int y,
                             int seed, int guiOffset) {
         throw new AssertionError();
-    }
-
-    @Inject(
-            method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V",
-            at = @At(
-                     value = "FIELD",
-                     target = "Lnet/minecraft/client/gui/GuiGraphics;minecraft:Lnet/minecraft/client/Minecraft;",
-                     shift = At.Shift.BEFORE,
-                     ordinal = 0))
-    private void gtceu$renderCustomItemDecorations(Font font, ItemStack stack, int x, int y, String text,
-                                                   CallbackInfo ci) {
-        GuiGraphics self = (GuiGraphics) (Object) this;
-        if (stack.getItem() instanceof IGTTool toolItem) {
-            ToolChargeBarRenderer.renderBarsTool(self, toolItem, stack, x, y);
-        } else if (stack.getItem() instanceof IComponentItem componentItem) {
-            ToolChargeBarRenderer.renderBarsItem(self, componentItem, stack, x, y);
-        } else if (stack.getItem() instanceof LampBlockItem) {
-            LampItemOverlayRenderer.renderOverlay(self, stack, x, y);
-        }
     }
 
     @Inject(method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;IIII)V",


### PR DESCRIPTION
## What
Moves the lamp item overlays and item bar renderers to item decorators and removes the mixin that used to handle them.
Introduces the ability to attach item decorator components to component items.

## Implementation Details
Uses a forge event and removes the mixin.

## Potential Compatibility Issues
Anyone using an item decorator for a component item/tool/lamp will need to account for this change since I think only 1 decorator is used per item.