### PR TITLE
Automatically label issues with version

### DIFF
--- a/.github/ISSUE_TEMPLATE/001-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/001-feature-request.yml
@@ -8,6 +8,15 @@ body:
       label: Cross-mod Integration
       description: "Does this feature involve integration with another mod? If so specify the mod(s). Otherwise, leave this blank."
       placeholder: "Example: Create Mod"
+  - type: dropdown
+    id: mc-version
+    attributes:
+      label: Minecraft Version
+      description: The version of Minecraft you wish this feature was added for.
+      options:
+        - "Both"
+        - "1.20.1 Forge"
+        - "1.21.1 NeoForge"
   - type: textarea
     id: description
     attributes:

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,13 @@
+# syntax - https://github.com/redhat-plumbers-in-action/advanced-issue-labeler#policy
+
+policy:
+  - template: [000-bug-report.yml, 001-feature-request.yml]
+    section:
+      - id: [mc-version]
+        block-list: ['Both', 'Any']
+        label:
+          - name: '1.20'
+            keys: ['1.20.1 Forge']
+
+          - name: '1.21'
+            keys: ['1.21.1 NeoForge']

--- a/.github/workflows/manage-issue-labels.yml
+++ b/.github/workflows/manage-issue-labels.yml
@@ -1,0 +1,32 @@
+# Manages labels on new issues
+name: Issue Labels
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # needed to utilize advanced-issue-labeler
+    strategy:
+      matrix:
+        template: [ 000-bug-report.yml, 001-feature-request.yml ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Set labels based on mc-version field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manage-issue-labels.yml
+++ b/.github/workflows/manage-issue-labels.yml
@@ -3,7 +3,7 @@ name: Issue Labels
 
 on:
   issues:
-    types: [opened, labeled, unlabeled]
+    types: [opened]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What
automatically label new issues with the MC version label

## Implementation Details
used https://github.com/marketplace/actions/advanced-issue-labeler

## Outcome
can find out what mc version an issue is for without having to open it
