### PR TITLE
Disable default enchantments if enchantedTools is false

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolDefinitionBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolDefinitionBuilder.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.item.tool;
 import com.gregtechceu.gtceu.api.item.tool.aoe.AoESymmetrical;
 import com.gregtechceu.gtceu.api.item.tool.behavior.IToolBehavior;
 
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
@@ -144,7 +145,10 @@ public class ToolDefinitionBuilder {
     }
 
     public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, int level, int growth) {
-        this.defaultEnchantments.put(enchantment, level);
+        if (ConfigHolder.INSTANCE.recipes.enchantedTools) {
+            this.defaultEnchantments.put(enchantment, level);
+        }
+        
         return this;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolDefinitionBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolDefinitionBuilder.java
@@ -2,8 +2,8 @@ package com.gregtechceu.gtceu.api.item.tool;
 
 import com.gregtechceu.gtceu.api.item.tool.aoe.AoESymmetrical;
 import com.gregtechceu.gtceu.api.item.tool.behavior.IToolBehavior;
-
 import com.gregtechceu.gtceu.config.ConfigHolder;
+
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentCategory;
@@ -148,7 +148,7 @@ public class ToolDefinitionBuilder {
         if (ConfigHolder.INSTANCE.recipes.enchantedTools) {
             this.defaultEnchantments.put(enchantment, level);
         }
-        
+
         return this;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolDefinitionBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolDefinitionBuilder.java
@@ -141,10 +141,6 @@ public class ToolDefinitionBuilder {
     }
 
     public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, int level) {
-        return this.defaultEnchantment(enchantment, level, 0);
-    }
-
-    public ToolDefinitionBuilder defaultEnchantment(Enchantment enchantment, int level, int growth) {
         if (ConfigHolder.INSTANCE.recipes.enchantedTools) {
             this.defaultEnchantments.put(enchantment, level);
         }


### PR DESCRIPTION
## What
Any enchantments added via `ToolDefinitionBuilder.defaultEnchantment` would be registered to tools even if enchantedTools was false in config. This PR makes it respect the config

## Implementation Details
Added a check in `ToolDefinitionBuilder.defaultEnchantment` before putting the enchantment in defaultEnchantments. If false, it simply returns the builder

## Outcome
Fixes a bug where butchery knives and damascus steel tools had enchantments regardless of enchantedTools being false

## Potential Compatibility Issues
Pre-existing tools will not have their enchantments removed when worlds upgrade to 1.7.0 (I think)
This may also break some packs' tools, but you were never supposed to use default enchantments with enchanted tools disabled in the first place anyway.