### PR TITLE
Use a tree structure for GTDynamicDataPack

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
@@ -20,13 +20,11 @@ import com.google.common.collect.Sets;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -42,72 +40,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class GTDynamicDataPack implements PackResources {
 
     protected static final ObjectSet<String> SERVER_DOMAINS = new ObjectOpenHashSet<>();
-    protected static final Node ROOT = new Node();
-
-    protected static class Node {
-
-        /**
-         * Holds either a byte[] with the data for a given location, or a map of string -> Node.
-         */
-        Object contents = new Object2ObjectOpenHashMap<>();
-
-        void collectResources(String namespace, String[] pathComponents, int curIndex,
-                              PackResources.ResourceOutput output) {
-            if (curIndex < pathComponents.length) {
-                String component = pathComponents[curIndex];
-
-                Node n = getChild(component);
-                if (n != null) {
-                    n.collectResources(namespace, pathComponents, curIndex + 1, output);
-                }
-            } else {
-                // We reached the desired path. Collect all resources
-                this.outputResources(namespace, String.join("/", pathComponents), output);
-            }
-        }
-
-        private boolean isTerminalNode() {
-            return contents instanceof byte[];
-        }
-
-        @SuppressWarnings("unchecked")
-        private Map<String, Node> getChildren() {
-            if (!(contents instanceof Map<?, ?>)) {
-                throw new IllegalStateException("attempting to get children on a terminal node");
-            }
-            return (Map<String, Node>) contents;
-        }
-
-        void outputResources(String namespace, String path, PackResources.ResourceOutput output) {
-            if (isTerminalNode()) {
-                // This is a terminal node.
-                ResourceLocation location = new ResourceLocation(namespace, path);
-                output.accept(location, this.createIoSupplier());
-            } else {
-                for (var entry : getChildren().entrySet()) {
-                    entry.getValue().outputResources(namespace, path + "/" + entry.getKey(), output);
-                }
-            }
-        }
-
-        IoSupplier<InputStream> createIoSupplier() {
-            if (!isTerminalNode()) {
-                throw new IllegalStateException("Node has no data");
-            }
-            // Capture the byte array here to avoid capturing the whole node in the lambda
-            byte[] byteArray = (byte[]) contents;
-            return () -> new ByteArrayInputStream(byteArray);
-        }
-
-        @Nullable
-        Node getChild(String name) {
-            if (isTerminalNode()) {
-                return null;
-            } else {
-                return getChildren().get(name);
-            }
-        }
-    }
+    protected static final GTDynamicPackContents CONTENTS = new GTDynamicPackContents();
 
     private final String name;
 
@@ -125,16 +58,11 @@ public class GTDynamicDataPack implements PackResources {
     }
 
     public static void clearServer() {
-        ROOT.getChildren().clear();
+        CONTENTS.clearData();
     }
 
     private static void addToData(ResourceLocation location, byte[] bytes) {
-        String[] pathComponents = location.getPath().split("/");
-        Node node = ROOT.getChildren().computeIfAbsent(location.getNamespace(), $ -> new Node());
-        for (String component : pathComponents) {
-            node = node.getChildren().computeIfAbsent(component, $ -> new Node());
-        }
-        node.contents = bytes;
+        CONTENTS.addToData(location, bytes);
     }
 
     public static void addRecipe(FinishedRecipe recipe) {
@@ -184,9 +112,7 @@ public class GTDynamicDataPack implements PackResources {
 
     public static void addAdvancement(ResourceLocation loc, JsonObject obj) {
         ResourceLocation l = getAdvancementLocation(loc);
-        synchronized (ROOT) {
-            addToData(l, obj.toString().getBytes(StandardCharsets.UTF_8));
-        }
+        addToData(l, obj.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Nullable
@@ -198,18 +124,7 @@ public class GTDynamicDataPack implements PackResources {
     @Override
     public IoSupplier<InputStream> getResource(PackType type, ResourceLocation location) {
         if (type == PackType.SERVER_DATA) {
-            Node node = ROOT.getChild(location.getNamespace());
-            String[] pathComponents = location.getPath().split("/");
-            for (String path : pathComponents) {
-                if (node == null) {
-                    return null;
-                }
-                node = node.getChild(path);
-            }
-            if (node == null) {
-                return null;
-            }
-            return node.createIoSupplier();
+            return CONTENTS.getResource(location);
         } else {
             return null;
         }
@@ -218,11 +133,7 @@ public class GTDynamicDataPack implements PackResources {
     @Override
     public void listResources(PackType packType, String namespace, String path, ResourceOutput resourceOutput) {
         if (packType == PackType.SERVER_DATA) {
-            Node base = ROOT.getChild(namespace);
-            if (base == null) {
-                return;
-            }
-            base.collectResources(namespace, path.split("/"), 0, resourceOutput);
+            CONTENTS.listResources(namespace, path, resourceOutput);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicDataPack.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import org.jetbrains.annotations.ApiStatus;
@@ -41,7 +42,72 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class GTDynamicDataPack implements PackResources {
 
     protected static final ObjectSet<String> SERVER_DOMAINS = new ObjectOpenHashSet<>();
-    protected static final Map<ResourceLocation, byte[]> DATA = new HashMap<>();
+    protected static final Node ROOT = new Node();
+
+    protected static class Node {
+
+        /**
+         * Holds either a byte[] with the data for a given location, or a map of string -> Node.
+         */
+        Object contents = new Object2ObjectOpenHashMap<>();
+
+        void collectResources(String namespace, String[] pathComponents, int curIndex,
+                              PackResources.ResourceOutput output) {
+            if (curIndex < pathComponents.length) {
+                String component = pathComponents[curIndex];
+
+                Node n = getChild(component);
+                if (n != null) {
+                    n.collectResources(namespace, pathComponents, curIndex + 1, output);
+                }
+            } else {
+                // We reached the desired path. Collect all resources
+                this.outputResources(namespace, String.join("/", pathComponents), output);
+            }
+        }
+
+        private boolean isTerminalNode() {
+            return contents instanceof byte[];
+        }
+
+        @SuppressWarnings("unchecked")
+        private Map<String, Node> getChildren() {
+            if (!(contents instanceof Map<?, ?>)) {
+                throw new IllegalStateException("attempting to get children on a terminal node");
+            }
+            return (Map<String, Node>) contents;
+        }
+
+        void outputResources(String namespace, String path, PackResources.ResourceOutput output) {
+            if (isTerminalNode()) {
+                // This is a terminal node.
+                ResourceLocation location = new ResourceLocation(namespace, path);
+                output.accept(location, this.createIoSupplier());
+            } else {
+                for (var entry : getChildren().entrySet()) {
+                    entry.getValue().outputResources(namespace, path + "/" + entry.getKey(), output);
+                }
+            }
+        }
+
+        IoSupplier<InputStream> createIoSupplier() {
+            if (!isTerminalNode()) {
+                throw new IllegalStateException("Node has no data");
+            }
+            // Capture the byte array here to avoid capturing the whole node in the lambda
+            byte[] byteArray = (byte[]) contents;
+            return () -> new ByteArrayInputStream(byteArray);
+        }
+
+        @Nullable
+        Node getChild(String name) {
+            if (isTerminalNode()) {
+                return null;
+            } else {
+                return getChildren().get(name);
+            }
+        }
+    }
 
     private final String name;
 
@@ -59,7 +125,16 @@ public class GTDynamicDataPack implements PackResources {
     }
 
     public static void clearServer() {
-        DATA.clear();
+        ROOT.getChildren().clear();
+    }
+
+    private static void addToData(ResourceLocation location, byte[] bytes) {
+        String[] pathComponents = location.getPath().split("/");
+        Node node = ROOT.getChildren().computeIfAbsent(location.getNamespace(), $ -> new Node());
+        for (String component : pathComponents) {
+            node = node.getChildren().computeIfAbsent(component, $ -> new Node());
+        }
+        node.contents = bytes;
     }
 
     public static void addRecipe(FinishedRecipe recipe) {
@@ -69,13 +144,13 @@ public class GTDynamicDataPack implements PackResources {
         if (ConfigHolder.INSTANCE.dev.dumpRecipes) {
             writeJson(recipeId, "recipes", parent, recipeJson);
         }
-        DATA.put(getRecipeLocation(recipeId), recipeJson.toString().getBytes(StandardCharsets.UTF_8));
+        addToData(getRecipeLocation(recipeId), recipeJson.toString().getBytes(StandardCharsets.UTF_8));
         if (recipe.serializeAdvancement() != null) {
             JsonObject advancement = recipe.serializeAdvancement();
             if (ConfigHolder.INSTANCE.dev.dumpRecipes) {
                 writeJson(recipe.getAdvancementId(), "advancements", parent, advancement);
             }
-            DATA.put(getAdvancementLocation(Objects.requireNonNull(recipe.getAdvancementId())),
+            addToData(getAdvancementLocation(Objects.requireNonNull(recipe.getAdvancementId())),
                     advancement.toString().getBytes(StandardCharsets.UTF_8));
         }
     }
@@ -109,8 +184,8 @@ public class GTDynamicDataPack implements PackResources {
 
     public static void addAdvancement(ResourceLocation loc, JsonObject obj) {
         ResourceLocation l = getAdvancementLocation(loc);
-        synchronized (DATA) {
-            DATA.put(l, obj.toString().getBytes(StandardCharsets.UTF_8));
+        synchronized (ROOT) {
+            addToData(l, obj.toString().getBytes(StandardCharsets.UTF_8));
         }
     }
 
@@ -123,10 +198,18 @@ public class GTDynamicDataPack implements PackResources {
     @Override
     public IoSupplier<InputStream> getResource(PackType type, ResourceLocation location) {
         if (type == PackType.SERVER_DATA) {
-            var byteArray = DATA.get(location);
-            if (byteArray != null)
-                return () -> new ByteArrayInputStream(byteArray);
-            else return null;
+            Node node = ROOT.getChild(location.getNamespace());
+            String[] pathComponents = location.getPath().split("/");
+            for (String path : pathComponents) {
+                if (node == null) {
+                    return null;
+                }
+                node = node.getChild(path);
+            }
+            if (node == null) {
+                return null;
+            }
+            return node.createIoSupplier();
         } else {
             return null;
         }
@@ -135,15 +218,11 @@ public class GTDynamicDataPack implements PackResources {
     @Override
     public void listResources(PackType packType, String namespace, String path, ResourceOutput resourceOutput) {
         if (packType == PackType.SERVER_DATA) {
-            if (!path.endsWith("/")) path += "/";
-            final String finalPath = path;
-            DATA.keySet().stream().filter(Objects::nonNull).filter(loc -> loc.getPath().startsWith(finalPath))
-                    .forEach((id) -> {
-                        IoSupplier<InputStream> resource = this.getResource(packType, id);
-                        if (resource != null) {
-                            resourceOutput.accept(id, resource);
-                        }
-                    });
+            Node base = ROOT.getChild(namespace);
+            if (base == null) {
+                return;
+            }
+            base.collectResources(namespace, path.split("/"), 0, resourceOutput);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicPackContents.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/pack/GTDynamicPackContents.java
@@ -1,0 +1,155 @@
+package com.gregtechceu.gtceu.data.pack;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.PackResources;
+import net.minecraft.server.packs.resources.IoSupplier;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Stores contents of a dynamic resource pack in a tree-style format for efficient traversal. This class can safely
+ * be accessed from multiple threads; it implements synchronization internally.
+ *
+ * @author embeddedt
+ */
+public class GTDynamicPackContents {
+
+    private static class Node {
+
+        /**
+         * Holds either a IoSupplier<InputStream> with the data for a given location, or a map of string -> Node.
+         */
+        Object contents = new Object2ObjectOpenHashMap<>();
+
+        void collectResources(String namespace, String[] pathComponents, int curIndex,
+                              PackResources.ResourceOutput output) {
+            if (curIndex < pathComponents.length) {
+                String component = pathComponents[curIndex];
+
+                Node n = getChild(component);
+                if (n != null) {
+                    n.collectResources(namespace, pathComponents, curIndex + 1, output);
+                }
+            } else {
+                // We reached the desired path. Collect all resources
+                this.outputResources(namespace, String.join("/", pathComponents), output);
+            }
+        }
+
+        private boolean isTerminalNode() {
+            return contents instanceof IoSupplier<?>;
+        }
+
+        @SuppressWarnings("unchecked")
+        private Map<String, Node> getChildren() {
+            if (!(contents instanceof Map<?, ?>)) {
+                throw new IllegalStateException("attempting to get children on a terminal node");
+            }
+            return (Map<String, Node>) contents;
+        }
+
+        void outputResources(String namespace, String path, PackResources.ResourceOutput output) {
+            if (isTerminalNode()) {
+                // This is a terminal node.
+                ResourceLocation location = new ResourceLocation(namespace, path);
+                output.accept(location, this.createIoSupplier());
+            } else {
+                for (var entry : getChildren().entrySet()) {
+                    entry.getValue().outputResources(namespace, path + "/" + entry.getKey(), output);
+                }
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        IoSupplier<InputStream> createIoSupplier() {
+            if (!isTerminalNode()) {
+                throw new IllegalStateException("Node has no data");
+            }
+            // Capture the byte array here to avoid capturing the whole node in the lambda
+            return (IoSupplier<InputStream>) contents;
+        }
+
+        @Nullable
+        Node getChild(String name) {
+            if (isTerminalNode()) {
+                return null;
+            } else {
+                return getChildren().get(name);
+            }
+        }
+    }
+
+    private final Node root = new Node();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public void addToData(ResourceLocation location, byte[] bytes) {
+        addToData(location, () -> new ByteArrayInputStream(bytes));
+    }
+
+    public void addToData(ResourceLocation location, IoSupplier<InputStream> supplier) {
+        String[] pathComponents = location.getPath().split("/");
+        var lock = this.lock.writeLock();
+        lock.lock();
+        try {
+            Node node = root.getChildren().computeIfAbsent(location.getNamespace(), $ -> new Node());
+            for (String component : pathComponents) {
+                node = node.getChildren().computeIfAbsent(component, $ -> new Node());
+            }
+            node.contents = supplier;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void clearData() {
+        var lock = this.lock.writeLock();
+        lock.lock();
+        try {
+            root.getChildren().clear();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public IoSupplier<InputStream> getResource(ResourceLocation location) {
+        var lock = this.lock.readLock();
+        lock.lock();
+        try {
+            Node node = this.root.getChild(location.getNamespace());
+            String[] pathComponents = location.getPath().split("/");
+            for (String path : pathComponents) {
+                if (node == null) {
+                    return null;
+                }
+                node = node.getChild(path);
+            }
+            if (node == null) {
+                return null;
+            }
+            return node.createIoSupplier();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void listResources(String namespace, String path, PackResources.ResourceOutput resourceOutput) {
+        var lock = this.lock.readLock();
+        lock.lock();
+        try {
+            Node base = this.root.getChild(namespace);
+            if (base == null) {
+                return;
+            }
+            base.collectResources(namespace, path.split("/"), 0, resourceOutput);
+        } finally {
+            lock.unlock();
+        }
+    }
+}


### PR DESCRIPTION
## What

The primary motivation of this PR is to fix the extremely slow `GTDynamicDataPack#listResources` method, which causes a noticeable slowdown to all resource loading in large packs.

`GTDynamicDataPack` is currently implemented using a simple map from `ResourceLocation` to `byte[]`. This works well for dynamic `PackResources` implementations that only store a few resources. However, it scales poorly when the pack stores many resources, as every `listResources` call must iterate through the entire map and test each resource location against the provided path. This is particularly problematic in large modpacks like ATM9, where there are many resource reload listeners each probing all datapacks for their particular folder. `listResources` must be able to exit early for directories that don't exist to avoid substantial impact to startup performance.

To fix this I've written a custom tree structure that stores the resources inside `GTDynamicDataPack` (essentially mimicking a filesystem structure, but greatly simplified). This eliminates the performance issue described above, as the tree naturally allows early-exiting when a directory along the path doesn't exist, without having to scan all resources within unrelated paths. It should also improve performance for directories that do exist, as the individual paths don't all need to be checked with `startsWith` anymore (the tree naturally takes care of this).

I apologize for the number of lines required to do this. I tried to keep things as simple as possible, while keeping memory usage in mind, but it inevitably takes some code to properly traverse a tree and collect from all nodes inside it. The good news is that no one should need to touch this again once it works.

I don't have specific profiler screenshots handy, but I believe this saves at least a second or two in ATM9, on my very powerful hardware (7700X), so the gains should be more significant on weaker hardware. Moreover, `GTDynamicDataPack` no longer appears in my profiler during resource reloads, whereas the `String.startsWith` call used to be identified as a hotspot.


## Potential Compatibility Issues

There are no changes to the public-facing API of `GTDynamicDataPack`.