### PR TITLE
Fix Multiblock Pattern slot widgets not showing tooltips

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ModularWrapperWidgetMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ModularWrapperWidgetMixin.java
@@ -1,0 +1,19 @@
+package com.gregtechceu.gtceu.core.mixins.ldlib;
+
+import com.lowdragmc.lowdraglib.emi.ModularWrapperWidget;
+import com.lowdragmc.lowdraglib.gui.ingredient.IRecipeIngredientSlot;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+
+@Mixin(value = ModularWrapperWidget.class, remap = false)
+public class ModularWrapperWidgetMixin {
+
+    @WrapOperation(method = "getTooltip(II)Ljava/util/List;",
+                   constant = { @Constant(classValue = IRecipeIngredientSlot.class) })
+    public boolean gtceu$wrapInstanceOf(Object object, Operation<Boolean> original) {
+        return false;
+    }
+}

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -66,6 +66,7 @@
         "emi.FillRecipePacketMixin",
         "emi.FluidEmiStackMixin",
         "jei.FluidHelperMixin",
+        "ldlib.ModularWrapperWidgetMixin",
         "ldlib.SyncUtilsMixin",
         "rei.InputSlotCrafterMixin",
         "rei.RecipeFinderMixin",


### PR DESCRIPTION
## What
This PR adds a (hopefully temporary) workaround to something added in a recent LDLib update. 
In that update, slots in a ModularWrapperWidget would not show their tooltips via the ModularUI if they were a type of slot that could be converted to a recipe viewer slot. However, this does not work well for dynamic slots, like on the Multiblock Preview.

So, the `instanceof` check has been wrapped to always return false, meaning that ModularUI will show the tooltips.