### PR TITLE
Fix Minecraft blaming GT if neoforge encountered a mod loading error before registration events.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ModelManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ModelManagerMixin.java
@@ -13,6 +13,7 @@ import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
 
+import net.neoforged.fml.ModLoader;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -29,6 +30,11 @@ public abstract class ModelManagerMixin {
                                          ResourceManager resourceManager, ProfilerFiller preparationsProfiler,
                                          ProfilerFiller reloadProfiler, Executor backgroundExecutor,
                                          Executor gameExecutor, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+        if (ModLoader.hasErrors()) {
+            GTCEu.LOGGER.warn("GregTech Model loading CANCELLED because loading errors have been encountered");
+            return;
+        }
+
         long startTime = System.currentTimeMillis();
         // turns out these do have to be init in here after all, as they check for asset existence. whoops.
         MaterialBlockRenderer.reinitModels();

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ModelManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ModelManagerMixin.java
@@ -12,8 +12,8 @@ import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
-
 import net.neoforged.fml.ModLoader;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -422,7 +422,7 @@ public interface GTRecipeSchema {
             } catch (NumberFormatException e) {
                 throw new KubeRuntimeException(String.format(
                         "Fraction or number was not parsed correctly! Expected format is \"1/3\" or \"1000\". Actual: \"%s\".",
-                        fraction, e));
+                        fraction), e);
             }
 
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
@@ -704,13 +704,12 @@ public interface GTRecipeSchema {
             if (!ConfigHolder.INSTANCE.machines.enableResearch) return false;
             if (researchEntry == null) {
                 throw new KubeRuntimeException(
-                        String.format("Assembly Line Research Entry cannot be empty.", new IllegalArgumentException()));
+                        "Assembly Line Research Entry cannot be empty.", new IllegalArgumentException());
             }
 
             if (!generatingRecipes) {
                 throw new KubeRuntimeException(
-                        String.format("Cannot generate recipes when using researchWithoutRecipe()",
-                                new IllegalArgumentException()));
+                       "Cannot generate recipes when using researchWithoutRecipe()", new IllegalArgumentException());
             }
 
             if (getValue(CONDITIONS) == null) setValue(CONDITIONS, List.of());

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -709,7 +709,7 @@ public interface GTRecipeSchema {
 
             if (!generatingRecipes) {
                 throw new KubeRuntimeException(
-                       "Cannot generate recipes when using researchWithoutRecipe()", new IllegalArgumentException());
+                        "Cannot generate recipes when using researchWithoutRecipe()", new IllegalArgumentException());
             }
 
             if (getValue(CONDITIONS) == null) setValue(CONDITIONS, List.of());


### PR DESCRIPTION
## What
fix the error that blames GT about all possible mod initialization crashes
also fixed some invalid `String.format` usage in KJS logging

## Implementation Details
added a state check and a little printout :)

## Outcome