### PR TITLE
Make all electric items show the charge tooltip

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
@@ -184,9 +184,10 @@ public class ElectricStats implements IInteractionItem, ISubItemHandler, IAddInf
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltipComponents,
                                 TooltipFlag isAdvanced) {
         IElectricItem electricItem = GTCapabilityHelper.getElectricItem(stack);
-        if (electricItem != null) {
-            addCurrentChargeTooltip(tooltipComponents, electricItem.getCharge(), electricItem.getMaxCharge(),
-                    electricItem.getTier(), electricItem.canProvideChargeExternally());
+        if (electricItem == null) return;
+        addCurrentChargeTooltip(tooltipComponents, electricItem.getCharge(), electricItem.getMaxCharge(),
+                electricItem.getTier(), electricItem.canProvideChargeExternally());
+        if (electricItem.canProvideChargeExternally()) {
             tooltipComponents.add(Component.translatable("metaitem.electric.discharge_mode.tooltip"));
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/ElectricStats.java
@@ -184,9 +184,9 @@ public class ElectricStats implements IInteractionItem, ISubItemHandler, IAddInf
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltipComponents,
                                 TooltipFlag isAdvanced) {
         IElectricItem electricItem = GTCapabilityHelper.getElectricItem(stack);
-        if (electricItem != null && electricItem.canProvideChargeExternally()) {
+        if (electricItem != null) {
             addCurrentChargeTooltip(tooltipComponents, electricItem.getCharge(), electricItem.getMaxCharge(),
-                    electricItem.getTier(), true);
+                    electricItem.getTier(), electricItem.canProvideChargeExternally());
             tooltipComponents.add(Component.translatable("metaitem.electric.discharge_mode.tooltip"));
         }
     }


### PR DESCRIPTION
## What
Show electric tool charge

## Additional Information
It was hard to understand how much charge the nano saber had, so I made it so that the charge of the tools was always visible.

![image](https://github.com/user-attachments/assets/11963186-642a-460d-8084-6a35b7d30f26)
![image](https://github.com/user-attachments/assets/3c7da6f9-4606-4ddf-889f-b686d30d5a62)
![image](https://github.com/user-attachments/assets/993dbe3c-4a3a-46ff-a483-f57143cb0a54)
