### PR TITLE
Nerf naphtha combustion duration to 6 ticks from 10

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -93,7 +93,7 @@ public class FuelRecipes {
         // diesel generator fuels
         COMBUSTION_GENERATOR_FUELS.recipeBuilder("naphtha")
                 .inputFluids(Naphtha.getFluid(1))
-                .duration(10)
+                .duration(6)
                 .EUt(-V[LV])
                 .save(provider);
 


### PR DESCRIPTION
## What
Nerfs the combustion duration for naphtha down from 10 ticks to 6 ticks. This is currently the value Cosmic Frontiers uses, and there has already been some discussion about nerfing its use as a combustion fuel. This just implements that.

## Implementation Details
Changes the recipe builder definition for naphtha as a combustion fuel. The value can of course be changed to something else, but it should probably be to less than what it is currently, which is a full two-thirds the power of diesel.

## Outcome
Naphtha is now worse as a fuel.
