### PR TITLE
Memoize biome holderset supplier to work around vanilla concurrency bug

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OreVeinUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OreVeinUtil.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 
+import com.google.common.base.Suppliers;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
@@ -119,9 +120,9 @@ public class OreVeinUtil {
 
         RegistryOps<JsonElement> registryOps = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
         JsonElement codecInput = resolveBiomeCodecInput(biomes);
-        return () -> RegistryCodecs.homogeneousList(Registries.BIOME)
+        return Suppliers.memoize(() -> RegistryCodecs.homogeneousList(Registries.BIOME)
                 .parse(registryOps, codecInput)
-                .getOrThrow(false, GTCEu.LOGGER::error);
+                .getOrThrow(false, GTCEu.LOGGER::error));
     }
 
     private static JsonElement resolveBiomeCodecInput(List<String> biomes) {


### PR DESCRIPTION
The following crash has been observed to occur during world generation sometimes:

```
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap.computeIfAbsent(HashMap.java:1229) ~[?:?] {re:mixin}
        at net.minecraft.resources.RegistryOps$1.m_254838_(RegistryOps.java:25) ~[server-1.20.1-20230612.114412-srg.jar%23511!/:?] {re:classloading,pl:connector_pre_launch:A}
        at net.minecraft.resources.RegistryOps.m_255006_(RegistryOps.java:54) ~[server-1.20.1-20230612.114412-srg.jar%23511!/:?] {re:classloading,pl:connector_pre_launch:A,re:mixin,pl:connector_pre_launch:A}
        at net.minecraft.resources.HolderSetCodec.decode(HolderSetCodec.java:55) ~[server-1.20.1-20230612.114412-srg.jar%23511!/:?] {re:classloading,pl:connector_pre_launch:A}
        at com.mojang.serialization.Decoder.parse(Decoder.java:18) ~[datafixerupper-6.0.8.jar%2377!/:?] {re:mixin}
        at com.gregtechceu.gtceu.api.data.worldgen.ores.OreVeinUtil.lambda$resolveBiomes$0(OreVeinUtil.java:123) ~[gtceu-1.20.1-1.6.4.jar%23395!/:?] {re:classloading}
        at com.gregtechceu.gtceu.api.data.worldgen.WorldGeneratorUtils$WorldOreVeinCache.lambda$getEntry$2(WorldGeneratorUtils.java:70) ~[gtceu-1.20.1-1.6.4.jar%23395!/:?] {re:classloading}
```

This is ultimately a vanilla bug, as the `RegistryOps` object should be safe to use from multiple threads (vanilla is also known to [rely on this](https://github.com/PaperMC/Folia/commit/051ec0dd65b34549f6c0cac064abea1dc74c5420)). To work around it we can just memoize the supplier, which will ensure it's only called exactly once and may potentially also be a speedup since the biome list won't need to be decoded many times. This should be safe as long as `resolveBiomes` is called again when datapacks are reloaded.