### PR TITLE
Bump GTM version from 1.7.0 to 7.0.0 for next Major Update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.caching = true
 # Mod Info
 mod_id = gtceu
 mod_name = GregTech
-mod_version = 1.7.0
+mod_version = 7.0.0
 mod_description = GregTech CE Unofficial, ported from 1.12.2
 mod_license = LGPL-3.0 license
 mod_url = https://github.com/GregTechCEu/GregTech-Modern/


### PR DESCRIPTION
## What
Migrates us away from the old 1.X.X versioning to better match our update workflows -
We have received complaints about it being difficult to tell when we are doing major API cleanups, we are actively trying to remove libraries and old code we do not believe is stable or something we should rely on.
Ideally this change will make it easier for pack organizations and devs across the board to understand out intentions.

To generally summarize what each number will relate to.

## X.0.0 - Breaking Changes 
(API Refactors, General Deprecation or Modification of many methods - we will document and provide migration primers for these updates.)

## 0.Y.0 - Feature Additions 
(May be balance or content breaking, anything that doesn't require massive API rewrites should be here, consider these releases as potentially requiring minor patches for modpack devs)

## 0.0.Z - Minor Patches 
(Non-Breaking Bug-fixes, emergency crash fixes, generally making the game functional and less buggy.)


## X.Y.Z-SNAPSHOT-[Hash]

This is the most up to date build supplied on the maven at all times, it contains all merged code from `1.20.1` or `1.21.1` respectively. This is **DANGEROUS** to use unless you know seriously what you are doing, feel free to reach out to us in our discord in #modern-addons if you need help with migrating new changes or have questions about new code base additions.

## Additional Notes

We *plan* to never have any world-breaking changes, so the first number will generally indicate a new API breaking update which requires addon / packdev intervention at a larger scale than the 2nd and 3rd numbers.

Please refer addon/pack devs to this PR if they have questions regarding our version numbering in the future!