### PR TITLE
Add "Washed by "Liquid" tag for filtering

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.FluidProperty;
+import com.gregtechceu.gtceu.api.data.chemical.material.properties.OreProperty;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
@@ -23,6 +24,7 @@ import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.BlockBehaviourAccessor;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -72,9 +74,18 @@ public class MixinHelpers {
                     for (TagKey<Item> materialTag : materialTags) {
                         List<TagLoader.EntryWithSource> tags = new ArrayList<>();
                         itemLikes.forEach(item -> tags.add(new TagLoader.EntryWithSource(
-                                TagEntry.element(BuiltInRegistries.ITEM.getKey(item.get().asItem())),
+                                TagEntry.element(BuiltInRegistries.ITEM.getKey(item.get())),
                                 GTValues.CUSTOM_TAG_SOURCE)));
-                        tagMap.computeIfAbsent(materialTag.location(), path -> new ArrayList<>()).addAll(tags);
+                        tagMap.merge(materialTag.location(), tags, GTUtil::mergeLists);
+                    }
+                        if (entry.tagPrefix() == TagPrefix.crushed && material.hasProperty(PropertyKey.ORE)) {
+                        OreProperty ore = material.getProperty(PropertyKey.ORE);
+                        ResourceLocation tag = GTCEu.id("washed_in/" + ore.getWashedIn().getFirst().getName());
+                        List<TagLoader.EntryWithSource> tags = new ArrayList<>();
+                        itemLikes.forEach(item -> tags.add(new TagLoader.EntryWithSource(
+                        TagEntry.element(BuiltInRegistries.ITEM.getKey(item.get())),
+                        GTValues.CUSTOM_TAG_SOURCE)));
+                        tagMap.merge(tag, tags, GTUtil::mergeLists);
                     }
 
                 }

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -50,10 +50,7 @@ import org.lwjgl.glfw.GLFW;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import static com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey.HAZARD;
@@ -301,7 +298,10 @@ public class GTUtil {
     public static <T> int getRandomItem(List<? extends Entry<Integer, T>> randomList, int size) {
         return getRandomItem(GTValues.RNG, randomList, size);
     }
-
+    public static <T> List<T> mergeLists(@NotNull List<T> first, @NotNull List<? extends T> second) {
+        first.addAll(second);
+        return first;
+    }
     @SuppressWarnings("unchecked")
     public static <T, R> Class<T> getActualTypeParameter(Class<? extends R> thisClass, int index) {
         Type type = thisClass.getGenericSuperclass();


### PR DESCRIPTION
screret provided the code, I'm just pushing the feature and I proposed the idea. Thanks to her.

## What
This PR adds a new dynamic tag to crushed ore, to indicate if they can be washed by Mercury or another liquid. This can be useful for tag filters to create more robust processing queues.

## Implementation Details
Add another function to the dynamic tag.