### PR TITLE
fix spotless checks always fetching 1.20.1 instead of current main branch

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -23,6 +23,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # do a full checkout instead of a shallow clone of HEAD so spotless's ratchetFrom works
       - name: Setup Build
         uses: ./.github/actions/build_setup
       - name: Get Mod Version
@@ -31,7 +33,6 @@ jobs:
       - name: Version Suffix
         id: suffix
         run: echo "VERSION_SUFFIX=$(echo "${{ github.sha }}" | cut -c 1-7)" >> $GITHUB_ENV
-      - run: git fetch origin 1.20.1
       - name: Build
         run: ./gradlew build
       - name: Publish to Maven

--- a/.github/workflows/format-java.yml
+++ b/.github/workflows/format-java.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # do a full checkout instead of a shallow clone of HEAD so spotless's ratchetFrom works
       - name: Check Path Filter
         uses: dorny/paths-filter@v3
         id: filter
@@ -29,8 +31,6 @@ jobs:
             code:
               - 'src/main/java/**'
               - 'src/test/**'
-      - run: git fetch origin 1.20.1
-        if: steps.filter.outputs.code == 'true'
       - name: Setup Build
         if: steps.filter.outputs.code == 'true'
         uses: ./.github/actions/build_setup


### PR DESCRIPTION
## What
spotless's ratchetFrom argument makes it only check changes from the set branch instead of all code, which speeds it up substantially. The workflow was always fetching the 1.20.1 branch instead of the current "main" (whatever that is), though, which could have resulted in errors. Also it looks neater now

## Implementation Details
used the recommended fix instead of a workaround

## Outcome
now fetches the correct branch