### PR TITLE
implement real XOR chance logic (replaces old, which is renamed FIRST)

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2164,6 +2164,7 @@
   "gtceu.canner": "ɹǝuuɐƆ",
   "gtceu.centrifuge": "ǝbnɟıɹʇuǝƆ",
   "gtceu.chance_logic.and": "ᗡNⱯ",
+  "gtceu.chance_logic.first": "⟘SᴚIℲ",
   "gtceu.chance_logic.none": "ƎNON",
   "gtceu.chance_logic.or": "ᴚO",
   "gtceu.chance_logic.xor": "ᴚOX",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2164,6 +2164,7 @@
   "gtceu.canner": "Canner",
   "gtceu.centrifuge": "Centrifuge",
   "gtceu.chance_logic.and": "AND",
+  "gtceu.chance_logic.first": "FIRST",
   "gtceu.chance_logic.none": "NONE",
   "gtceu.chance_logic.or": "OR",
   "gtceu.chance_logic.xor": "XOR",

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -11,6 +11,7 @@ import net.minecraftforge.fml.ModLoader;
 
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.apache.commons.compress.harmony.pack200.IntList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -164,9 +165,18 @@ public abstract class ChanceLogic {
                                                          int recipeTier, int chanceTier,
                                                          @Nullable Object2IntMap<?> cache, int times) {
             // Have to set up a system where all chances are set to be out of 10000
-            List<Integer> chancesOutOfTenThousand = new java.util.ArrayList<>(chancedEntries.stream()
-                    .map(orig -> (int) (((float) orig.chance / (float) orig.maxChance) * (float) getMaxChancedValue()))
-                    .toList());
+            IntList chances = new IntList();
+
+            for (Content orig : chancedEntries) {
+                if (orig.maxChance == 100) {
+                    chances.add(orig.chance);
+                } else {
+                    chances.add((int) ((orig.chance / (float) orig.maxChance) * getMaxChancedValue()));
+                }
+            }
+
+            int[] chancesOutOfTenThousand = chances.toArray();
+
             int chanceTotal = 0;
             for (int chance : chancesOutOfTenThousand) {
                 chanceTotal += chance;
@@ -175,14 +185,14 @@ public abstract class ChanceLogic {
             // Here, if the newly calculated chances don't add up to 10000, they're renormalized
             if (chanceTotal != getMaxChancedValue()) {
                 int chanceTotalDecremented = getMaxChancedValue();
-                for (int i = 0; i < chancesOutOfTenThousand.size(); i++) {
-                    int newChance = (int) (chancesOutOfTenThousand.get(i) *
+                for (int i = 0; i < chancesOutOfTenThousand.length; i++) {
+                    int newChance = (int) (chancesOutOfTenThousand[i] *
                             ((float) getMaxChancedValue() / (float) chanceTotal));
                     // last chance ends up being set to the remainder in case things don't line up
-                    if (i == chancesOutOfTenThousand.size() - 1) {
-                        chancesOutOfTenThousand.set(i, chanceTotalDecremented);
+                    if (i == chancesOutOfTenThousand.length - 1) {
+                        chancesOutOfTenThousand[i] = chanceTotalDecremented;
                     } else {
-                        chancesOutOfTenThousand.set(i, newChance);
+                        chancesOutOfTenThousand[i] = newChance;
                     }
                     chanceTotalDecremented -= newChance;
                 }
@@ -190,8 +200,8 @@ public abstract class ChanceLogic {
 
             // Finally, generate a new Content list with the changes
             List<Content> normalizedEntries = new ArrayList<>();
-            for (int i = 0; i < chancesOutOfTenThousand.size(); i++) {
-                normalizedEntries.add(new Content(chancedEntries.get(i).content, chancesOutOfTenThousand.get(i),
+            for (int i = 0; i < chancesOutOfTenThousand.length; i++) {
+                normalizedEntries.add(new Content(chancedEntries.get(i).content, chancesOutOfTenThousand[i],
                         getMaxChancedValue(), chancedEntries.get(i).tierChanceBoost));
             }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -115,7 +115,7 @@ public abstract class ChanceLogic {
     /**
      * Chanced Output Logic where only the first ingredient succeeding its roll will be produced
      */
-    public static final ChanceLogic XOR = new ChanceLogic("xor") {
+    public static final ChanceLogic FIRST = new ChanceLogic("first") {
 
         @Override
         public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
@@ -135,6 +135,53 @@ public abstract class ChanceLogic {
                     }
                     updateCachedChance(entry.content, cache, newChance / 2 + cached);
                     if (selected != null) break;
+                }
+                if (selected != null) builder.add(selected);
+            }
+            return builder.build();
+        }
+
+        @Override
+        public @NotNull Component getTranslation() {
+            return Component.translatable("gtceu.chance_logic.first");
+        }
+
+        @Override
+        public String toString() {
+            return "ChanceLogic{FIRST}";
+        }
+    };
+
+    /**
+     * Chanced Output Logic where only one of the ingredients will be output, in a manner weighted to the input chances
+     */
+    public static final ChanceLogic XOR = new ChanceLogic("xor") {
+
+        @Override
+        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction,
+                                                         int recipeTier, int chanceTier,
+                                                         @Nullable Object2IntMap<?> cache, int times) {
+            ImmutableList.Builder<Content> builder = ImmutableList.builder();
+            int maxChance = 0;
+            boolean firstMaxChanceSet = false;
+            for (int i = 0; i < times; ++i) {
+                Content selected = null;
+                for (Content entry : chancedEntries) {
+                    if (!firstMaxChanceSet) {
+                        maxChance = entry.maxChance;
+                        firstMaxChanceSet = true;
+                    }
+                    int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
+                    int cached = getCachedChance(entry, cache);
+                    int chance = newChance + cached;
+                    if (passesChance(chance, maxChance)) {
+                        selected = entry;
+                        newChance -= maxChance;
+                    }
+                    updateCachedChance(entry.content, cache, newChance / 2 + cached);
+                    if (selected != null) break;
+                    maxChance -= newChance;
                 }
                 if (selected != null) builder.add(selected);
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -162,18 +163,44 @@ public abstract class ChanceLogic {
                                                          @NotNull ChanceBoostFunction boostFunction,
                                                          int recipeTier, int chanceTier,
                                                          @Nullable Object2IntMap<?> cache, int times) {
+            // Have to set up a system where all chances are set to be out of 10000
+            List<Integer> chancesOutOfTenThousand = new java.util.ArrayList<>(chancedEntries.stream()
+                    .map(orig -> (int) (((float) orig.chance / (float) orig.maxChance) * (float) getMaxChancedValue()))
+                    .toList());
+            int chanceTotal = 0;
+            for (int chance : chancesOutOfTenThousand) {
+                chanceTotal += chance;
+            }
+
+            // Here, if the newly calculated chances don't add up to 10000, they're renormalized
+            if (chanceTotal != getMaxChancedValue()) {
+                int chanceTotalDecremented = getMaxChancedValue();
+                for (int i = 0; i < chancesOutOfTenThousand.size(); i++) {
+                    int newChance = (int) (chancesOutOfTenThousand.get(i) *
+                            ((float) getMaxChancedValue() / (float) chanceTotal));
+                    // last chance ends up being set to the remainder in case things don't line up
+                    if (i == chancesOutOfTenThousand.size() - 1) {
+                        chancesOutOfTenThousand.set(i, chanceTotalDecremented);
+                    } else {
+                        chancesOutOfTenThousand.set(i, newChance);
+                    }
+                    chanceTotalDecremented -= newChance;
+                }
+            }
+
+            // Finally, generate a new Content list with the changes
+            List<Content> normalizedEntries = new ArrayList<>();
+            for (int i = 0; i < chancesOutOfTenThousand.size(); i++) {
+                normalizedEntries.add(new Content(chancedEntries.get(i).content, chancesOutOfTenThousand.get(i),
+                        getMaxChancedValue(), chancedEntries.get(i).tierChanceBoost));
+            }
+
+            // Use the new, normalized list for the logic
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
-            int maxChance;
-            boolean firstMaxChanceSet;
             for (int i = 0; i < times; ++i) {
                 Content selected = null;
-                maxChance = 0;
-                firstMaxChanceSet = false;
-                for (Content entry : chancedEntries) {
-                    if (!firstMaxChanceSet) {
-                        maxChance = entry.maxChance;
-                        firstMaxChanceSet = true;
-                    }
+                int maxChance = getMaxChancedValue();
+                for (Content entry : normalizedEntries) {
                     int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                     int cached = getCachedChance(entry, cache);
                     int chance = newChance + cached;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -10,8 +10,9 @@ import net.minecraft.network.chat.Component;
 import net.minecraftforge.fml.ModLoader;
 
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
-import org.apache.commons.compress.harmony.pack200.IntList;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -165,17 +166,15 @@ public abstract class ChanceLogic {
                                                          int recipeTier, int chanceTier,
                                                          @Nullable Object2IntMap<?> cache, int times) {
             // Have to set up a system where all chances are set to be out of 10000
-            IntList chances = new IntList();
+            IntList chancesOutOfTenThousand = new IntArrayList();
 
             for (Content orig : chancedEntries) {
-                if (orig.maxChance == 100) {
-                    chances.add(orig.chance);
+                if (orig.maxChance == getMaxChancedValue()) {
+                    chancesOutOfTenThousand.add(orig.chance);
                 } else {
-                    chances.add((int) ((orig.chance / (float) orig.maxChance) * getMaxChancedValue()));
+                    chancesOutOfTenThousand.add((int) ((orig.chance / (float) orig.maxChance) * getMaxChancedValue()));
                 }
             }
-
-            int[] chancesOutOfTenThousand = chances.toArray();
 
             int chanceTotal = 0;
             for (int chance : chancesOutOfTenThousand) {
@@ -185,14 +184,14 @@ public abstract class ChanceLogic {
             // Here, if the newly calculated chances don't add up to 10000, they're renormalized
             if (chanceTotal != getMaxChancedValue()) {
                 int chanceTotalDecremented = getMaxChancedValue();
-                for (int i = 0; i < chancesOutOfTenThousand.length; i++) {
-                    int newChance = (int) (chancesOutOfTenThousand[i] *
+                for (int i = 0; i < chancesOutOfTenThousand.size(); i++) {
+                    int newChance = (int) (chancesOutOfTenThousand.getInt(i) *
                             ((float) getMaxChancedValue() / (float) chanceTotal));
                     // last chance ends up being set to the remainder in case things don't line up
-                    if (i == chancesOutOfTenThousand.length - 1) {
-                        chancesOutOfTenThousand[i] = chanceTotalDecremented;
+                    if (i == chancesOutOfTenThousand.size() - 1) {
+                        chancesOutOfTenThousand.set(i, chanceTotalDecremented);
                     } else {
-                        chancesOutOfTenThousand[i] = newChance;
+                        chancesOutOfTenThousand.set(i, newChance);
                     }
                     chanceTotalDecremented -= newChance;
                 }
@@ -200,8 +199,8 @@ public abstract class ChanceLogic {
 
             // Finally, generate a new Content list with the changes
             List<Content> normalizedEntries = new ArrayList<>();
-            for (int i = 0; i < chancesOutOfTenThousand.length; i++) {
-                normalizedEntries.add(new Content(chancedEntries.get(i).content, chancesOutOfTenThousand[i],
+            for (int i = 0; i < chancesOutOfTenThousand.size(); i++) {
+                normalizedEntries.add(new Content(chancedEntries.get(i).content, chancesOutOfTenThousand.getInt(i),
                         getMaxChancedValue(), chancedEntries.get(i).tierChanceBoost));
             }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -163,10 +163,12 @@ public abstract class ChanceLogic {
                                                          int recipeTier, int chanceTier,
                                                          @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
-            int maxChance = 0;
-            boolean firstMaxChanceSet = false;
+            int maxChance;
+            boolean firstMaxChanceSet;
             for (int i = 0; i < times; ++i) {
                 Content selected = null;
+                maxChance = 0;
+                firstMaxChanceSet = false;
                 for (Content entry : chancedEntries) {
                     if (!firstMaxChanceSet) {
                         maxChance = entry.maxChance;

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1328,6 +1328,7 @@ public class LangHandler {
         provider.add("gtceu.chance_logic.or", "OR");
         provider.add("gtceu.chance_logic.and", "AND");
         provider.add("gtceu.chance_logic.xor", "XOR");
+        provider.add("gtceu.chance_logic.first", "FIRST");
         provider.add("gtceu.chance_logic.none", "NONE");
 
         provider.add("gtceu.gui.content.per_tick", "§aConsumed/Produced Per Tick§r");


### PR DESCRIPTION
## What
Implements true XOR chance logic, otuputting one or the other but never both or neither, weighted to the provided chances.

## Implementation Details
Old XOR logic is renamed to FIRST. This uses successive subtraction of chances from each possible output or input and replaces the name.

## Outcome
New chance logic. Implements #3186.

## Potential Compatibility Issues
Anyone using the old XOR chance logic will need to rename their usage to FIRST.