### PR TITLE
Remove Extruder Mold (Long Rod)

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -4007,7 +4007,6 @@
   "item.gtceu.lime_dye_spray_can": ")ǝɯıꞀ( uɐƆ ʎɐɹdS",
   "item.gtceu.lime_glass_lens": ")ǝɯıꞀ( suǝꞀ ssɐן⅁",
   "item.gtceu.liquid_fuel_jetpack": "ʞɔɐdʇǝſ ןǝnℲ pınbıꞀ",
-  "item.gtceu.long_rod_extruder_mold": ")poᴚ buoꞀ( pןoW ɹǝpnɹʇxƎ",
   "item.gtceu.long_treated_wood_rod": "ʞɔıʇS pooM pǝʇɐǝɹ⟘ buoꞀ",
   "item.gtceu.long_wood_rod": "ʞɔıʇS pooM buoꞀ",
   "item.gtceu.lpic_chip": "dıɥƆ ƆIԀꞀ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -4007,7 +4007,6 @@
   "item.gtceu.lime_dye_spray_can": "Spray Can (Lime)",
   "item.gtceu.lime_glass_lens": "Glass Lens (Lime)",
   "item.gtceu.liquid_fuel_jetpack": "Liquid Fuel Jetpack",
-  "item.gtceu.long_rod_extruder_mold": "Extruder Mold (Long Rod)",
   "item.gtceu.long_treated_wood_rod": "Long Treated Wood Stick",
   "item.gtceu.long_wood_rod": "Long Wood Stick",
   "item.gtceu.lpic_chip": "LPIC Chip",

--- a/src/generated/resources/assets/gtceu/models/item/long_rod_extruder_mold.json
+++ b/src/generated/resources/assets/gtceu/models/item/long_rod_extruder_mold.json
@@ -1,6 +1,0 @@
-{
-  "parent": "minecraft:item/generated",
-  "textures": {
-    "layer0": "gtceu:item/long_rod_extruder_mold"
-  }
-}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -210,7 +210,6 @@ public class GTItems {
     public static ItemEntry<Item> SHAPE_EXTRUDER_BOTTLE;
     public static ItemEntry<Item> SHAPE_EXTRUDER_FOIL;
     public static ItemEntry<Item> SHAPE_EXTRUDER_GEAR_SMALL;
-    public static ItemEntry<Item> SHAPE_EXTRUDER_ROD_LONG;
     public static ItemEntry<Item> SHAPE_EXTRUDER_ROTOR;
 
     static {
@@ -281,10 +280,6 @@ public class GTItems {
                 .register();
         SHAPE_EXTRUDERS[24] = SHAPE_EXTRUDER_GEAR_SMALL = REGISTRATE.item("small_gear_extruder_mold", Item::new)
                 .lang("Extruder Mold (Small Gear)")
-                .onRegister(materialInfo(new ItemMaterialInfo(new MaterialStack(GTMaterials.Steel, GTValues.M * 4))))
-                .register();
-        SHAPE_EXTRUDERS[25] = SHAPE_EXTRUDER_ROD_LONG = REGISTRATE.item("long_rod_extruder_mold", Item::new)
-                .lang("Extruder Mold (Long Rod)")
                 .onRegister(materialInfo(new ItemMaterialInfo(new MaterialStack(GTMaterials.Steel, GTValues.M * 4))))
                 .register();
         SHAPE_EXTRUDERS[26] = SHAPE_EXTRUDER_ROTOR = REGISTRATE.item("rotor_extruder_mold", Item::new)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PartsRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PartsRecipeHandler.java
@@ -569,26 +569,6 @@ public final class PartsRecipeHandler {
                 .duration((int) Math.max(material.getMass(), 1L))
                 .EUt(16)
                 .save(provider);
-
-        if (material.hasProperty(PropertyKey.INGOT)) {
-            EXTRUDER_RECIPES.recipeBuilder("extrude_" + material.getName() + "_ingot_to_long_rod")
-                    .inputItems(ingot, material)
-                    .notConsumable(GTItems.SHAPE_EXTRUDER_ROD_LONG)
-                    .outputItems(stack)
-                    .duration((int) Math.max(material.getMass(), 1L))
-                    .EUt(64)
-                    .save(provider);
-
-            if (material.hasFlag(NO_SMASHING)) {
-                EXTRUDER_RECIPES.recipeBuilder("extrude_" + material.getName() + "_dust_to_long_rod")
-                        .inputItems(dust, material)
-                        .notConsumable(GTItems.SHAPE_EXTRUDER_ROD_LONG)
-                        .outputItems(stack)
-                        .duration((int) Math.max(material.getMass(), 1L))
-                        .EUt(64)
-                        .save(provider);
-            }
-        }
     }
 
     private static void processTurbine(@NotNull Consumer<FinishedRecipe> provider, @NotNull Material material) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CraftingRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CraftingRecipeLoader.java
@@ -200,8 +200,6 @@ public class CraftingRecipeLoader {
                 " S ", "   ", 'S', SHAPE_EXTRUDER_ROD.asStack());
         VanillaRecipeHelper.addStrictShapedRecipe(provider, "shape_extruder_rod", SHAPE_EXTRUDER_ROD.asStack(), "   ",
                 " Sx", "   ", 'S', SHAPE_EMPTY.asStack());
-        VanillaRecipeHelper.addStrictShapedRecipe(provider, "shape_extruder_rod_long",
-                SHAPE_EXTRUDER_ROD_LONG.asStack(), "  x", " S ", "   ", 'S', SHAPE_EXTRUDER_ROD.asStack());
         VanillaRecipeHelper.addStrictShapedRecipe(provider, "shape_extruder_plate", SHAPE_EXTRUDER_PLATE.asStack(),
                 "x  ", " S ", "   ", 'S', SHAPE_EXTRUDER_FOIL.asStack());
         VanillaRecipeHelper.addStrictShapedRecipe(provider, "shape_extruder_gear_small",


### PR DESCRIPTION
## What
Removes the Extruder mold for Long Rods

## Outcome
- Enforces the usage of the Forge Hammer to create long rods, this adds to variety in material processing
- Makes the Extruder less of an end-all-be-all solution to material processing, which currently contributes to stale and boring gameplay

## Additional Information
This was discussed on discord and most devs I talked to were in favour of this change

## Potential Compatibility Issues
People need to change their setups slightly, they lose the mold