### PR TITLE
clean up RelativeDirection and rename its methods to be more consistent with vanilla

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -192,7 +192,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                     }
                 }
                 if (isEqual) continue;
-                //@formatter:off
+                // spotless:off
                 if (ingredient instanceof IntCircuitIngredient) {
                     list.add(0, ingredient);
                 } else if (ingredient instanceof SizedIngredient sized &&
@@ -204,7 +204,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                 } else {
                     list.add(ingredient);
                 }
-                //@formatter:on
+                // spotless:on
             } else if (item instanceof ItemStack stack) {
                 boolean isEqual = false;
                 for (Object obj : list) {
@@ -511,7 +511,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                     GTRecipeWidget.setConsumedChance(content,
                             recipe.getChanceLogicForCapability(this, io, isTickSlot(index, io, recipe)),
                             tooltips, recipeTier, chanceTier, recipeType.getChanceFunction());
-                    //@formatter:off
+                    // spotless:off
                     if (this.of(content.content) instanceof IntProviderIngredient ingredient) {
                         IntProvider countProvider = ingredient.getCountProvider();
                         tooltips.add(Component.translatable("gtceu.gui.content.count_range",
@@ -524,7 +524,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                                 countProvider.getMinValue(), countProvider.getMaxValue())
                                 .withStyle(ChatFormatting.GOLD));
                     }
-                    //@formatter:on
+                    // spotless:on
                     if (isTickSlot(index, io, recipe)) {
                         tooltips.add(Component.translatable("gtceu.gui.content.per_tick"));
                     }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
@@ -16,6 +16,7 @@ import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 
 import com.mojang.serialization.Codec;
 import io.netty.buffer.Unpooled;
@@ -99,8 +100,12 @@ public abstract class RecipeCapability<T> {
         return "%s_%s_%s".formatted(name, io.name().toLowerCase(Locale.ROOT), index);
     }
 
-    public Component getName() {
+    public MutableComponent getName() {
         return Component.translatable("recipe.capability.%s.name".formatted(name));
+    }
+
+    public MutableComponent getColoredName() {
+        return getName().withStyle(style -> style.withColor(this.color));
     }
 
     public boolean isRecipeSearchFilter() {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MultiblockMachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MultiblockMachineDefinition.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.machine;
 
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.pattern.BlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
 
@@ -20,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class MultiblockMachineDefinition extends MachineDefinition {
@@ -47,7 +49,7 @@ public class MultiblockMachineDefinition extends MachineDefinition {
     private Supplier<ItemStack[]> recoveryItems;
     @Setter
     @Getter
-    private Comparator<IMultiPart> partSorter;
+    private Function<MultiblockControllerMachine, Comparator<IMultiPart>> partSorter;
     @Getter
     @Setter
     private TriFunction<IMultiController, IMultiPart, Direction, BlockState> partAppearance;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiController.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMultiController.java
@@ -21,6 +21,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
@@ -175,6 +176,10 @@ public interface IMultiController extends IMachineFeature, IInteractedMachine {
             return self().getDefinition().getPartAppearance().apply(this, part, side);
         }
         return null;
+    }
+
+    default Comparator<IMultiPart> getPartSorter() {
+        return self().getDefinition().getPartSorter().apply(self());
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
@@ -179,7 +179,7 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
                 this.parts.add(part);
             }
         }
-        this.parts.sort(getDefinition().getPartSorter());
+        this.parts.sort(getPartSorter());
         for (var part : parts) {
             if (part instanceof IParallelHatch pHatch) {
                 parallelHatch = pHatch;

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
@@ -547,7 +547,7 @@ public class BlockPattern {
         if (facing == Direction.UP || facing == Direction.DOWN) {
             Direction of = facing == Direction.DOWN ? upwardsFacing : upwardsFacing.getOpposite();
             for (int i = 0; i < 3; i++) {
-                switch (structureDir[i].getActualFacing(of)) {
+                switch (structureDir[i].getActualDirection(of)) {
                     case UP -> c1[1] = c0[i];
                     case DOWN -> c1[1] = -c0[i];
                     case WEST -> c1[0] = -c0[i];
@@ -577,7 +577,7 @@ public class BlockPattern {
             }
         } else {
             for (int i = 0; i < 3; i++) {
-                switch (structureDir[i].getActualFacing(facing)) {
+                switch (structureDir[i].getActualDirection(facing)) {
                     case UP -> c1[1] = c0[i];
                     case DOWN -> c1[1] = -c0[i];
                     case WEST -> c1[0] = -c0[i];

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
@@ -35,6 +35,17 @@ public enum RelativeDirection {
         return this.axis == dir.axis;
     }
 
+    public RelativeDirection getOpposite() {
+        return switch (this) {
+            case UP -> DOWN;
+            case DOWN -> UP;
+            case LEFT -> RIGHT;
+            case RIGHT -> LEFT;
+            case FRONT -> BACK;
+            case BACK -> FRONT;
+        };
+    }
+
     public Vec3i applyVec3i(Direction facing) {
         return getActualFacing(facing).getNormal();
     }
@@ -195,5 +206,66 @@ public enum RelativeDirection {
         oZ += relForward.getStepZ() * forwardOffset;
 
         return pos.offset(oX, oY, oZ);
+    }
+
+    public static Direction getActualDirection(Direction original, Direction current, Direction direction) {
+        return findRelativeOf(original, current).getActualDirection(direction);
+    }
+
+    /**
+     * Finds the relative rotation between {@code base} and {@code relative}.
+     * <br>
+     * If {@code base} is vertical (e.g. {@link Direction#UP UP} or {@link Direction#DOWN DOWN}),
+     * the rotation is calculated with {@link Direction#NORTH NORTH} as the "forward" direction.
+     * 
+     * @param base     the direction to offset
+     * @param relative the direction to offset by
+     * @return The relative rotation between {@code base} and {@code relative}
+     */
+    public static RelativeDirection findRelativeOf(Direction base, Direction relative) {
+        return findRelativeOf(base, relative, Direction.NORTH);
+    }
+
+    /**
+     * Finds the relative rotation between {@code base} and {@code relative}.
+     * <br>
+     * If {@code base} is vertical (e.g. {@link Direction#UP UP} or {@link Direction#DOWN DOWN}),
+     * the rotation is calculated with {@code forward} as the "forward" direction.
+     * 
+     * @param base     the direction to relative
+     * @param relative the direction to relative by
+     * @param forward  the direction to use as "forward"
+     */
+    public static RelativeDirection findRelativeOf(Direction base, Direction relative, Direction forward) {
+        // Check simple cases first
+        if (base == relative) return RelativeDirection.FRONT;
+        if (base.getOpposite() == relative) return RelativeDirection.BACK;
+
+        if (base.getAxis().isHorizontal()) { // base is one of N,S,W,E
+            if (relative == Direction.UP) return RelativeDirection.UP;
+            else if (relative == Direction.DOWN) return RelativeDirection.DOWN;
+            else if (base.getCounterClockWise() == relative) return RelativeDirection.LEFT;
+            else return RelativeDirection.RIGHT; // base.getClockWise() == relative
+        } else { // base is UP or DOWN
+            if (forward.getAxis() == Direction.Axis.Y) {
+                throw new IllegalStateException("forward must be a horizontal direction! is %s".formatted(forward));
+            }
+            Direction globalLeft = forward.getCounterClockWise();
+            Direction globalRight = forward.getClockWise();
+            Direction globalBack = forward.getOpposite();
+
+            if (relative == globalLeft) {
+                return RelativeDirection.LEFT;
+            } else if (relative == globalRight) {
+                return RelativeDirection.RIGHT;
+            } else { // relative is NORTH or SOUTH (assuming forward is NORTH)
+                RelativeDirection dir;
+                if (relative == globalBack) dir = RelativeDirection.UP;
+                else dir = RelativeDirection.DOWN; // relative == NORTH
+
+                if (base == Direction.DOWN) dir = dir.getOpposite();
+                return dir;
+            }
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
@@ -4,35 +4,42 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 
-import java.util.function.Function;
-import java.util.function.ToIntFunction;
+import org.jetbrains.annotations.ApiStatus;
 
-/**
- * Relative direction when facing horizontally
- */
+import java.util.Comparator;
+import java.util.function.UnaryOperator;
+
 public enum RelativeDirection {
 
-    UP(f -> Direction.UP, Direction.Axis.Y),
-    DOWN(f -> Direction.DOWN, Direction.Axis.Y),
-    LEFT(Direction::getCounterClockWise, Direction.Axis.X),
-    RIGHT(Direction::getClockWise, Direction.Axis.X),
-    FRONT(Function.identity(), Direction.Axis.Z),
-    BACK(Direction::getOpposite, Direction.Axis.Z);
+    UP(dir -> dir.getAxis() == Direction.Axis.Y ? Direction.NORTH : Direction.UP, Direction.UP),
+    DOWN(dir -> dir.getAxis() == Direction.Axis.Y ? Direction.SOUTH : Direction.DOWN, Direction.DOWN),
+    LEFT(dir -> {
+        if (dir == Direction.UP) return Direction.EAST;
+        else if (dir == Direction.DOWN) return Direction.WEST;
+        else return dir.getCounterClockWise();
+    }, Direction.WEST),
+    RIGHT(dir -> {
+        if (dir == Direction.UP) return Direction.WEST;
+        else if (dir == Direction.DOWN) return Direction.EAST;
+        else return dir.getClockWise();
+    }, Direction.EAST),
+    FRONT(UnaryOperator.identity(), Direction.NORTH),
+    BACK(Direction::getOpposite, Direction.SOUTH);
 
-    final Function<Direction, Direction> actualFacing;
-    public final Direction.Axis axis;
+    private final UnaryOperator<Direction> actualDirection;
+    /**
+     * Equivalent global direction to this relative direction
+     * with {@link Direction#NORTH NORTH} as the "forward" direction.
+     */
+    public final Direction equivalentGlobal;
 
-    RelativeDirection(Function<Direction, Direction> actualFacing, Direction.Axis axis) {
-        this.actualFacing = actualFacing;
-        this.axis = axis;
+    RelativeDirection(UnaryOperator<Direction> actualDirection, Direction equivalentGlobal) {
+        this.actualDirection = actualDirection;
+        this.equivalentGlobal = equivalentGlobal;
     }
 
-    public Direction getActualFacing(Direction facing) {
-        return getRelativeFacing(facing, Direction.NORTH, false);
-    }
-
-    public boolean isSameAxis(RelativeDirection dir) {
-        return this.axis == dir.axis;
+    public Direction getActualDirection(Direction direction) {
+        return actualDirection.apply(direction);
     }
 
     public RelativeDirection getOpposite() {
@@ -47,81 +54,88 @@ public enum RelativeDirection {
     }
 
     public Vec3i applyVec3i(Direction facing) {
-        return getActualFacing(facing).getNormal();
+        return getActualDirection(facing).getNormal();
     }
 
+    /**
+     * @deprecated Renamed to {@link RelativeDirection#getRelative(Direction, Direction, boolean) getRelative}.
+     */
+    @ApiStatus.ScheduledForRemoval(inVersion = "8.0.0")
+    @Deprecated(since = "7.0.0", forRemoval = true)
     public Direction getRelativeFacing(Direction frontFacing, Direction upwardsFacing, boolean isFlipped) {
-        Direction.Axis frontAxis = frontFacing.getAxis();
+        return getRelative(frontFacing, upwardsFacing, isFlipped);
+    }
+
+    public Direction getRelative(Direction frontDir, Direction upwardsDir, boolean isFlipped) {
+        Direction.Axis frontAxis = frontDir.getAxis();
         return switch (this) {
             case UP -> {
                 if (frontAxis == Direction.Axis.Y) {
                     // same direction as upwards facing
-                    yield upwardsFacing;
+                    yield upwardsDir;
                 } else {
                     // transform the upwards facing into a real facing
-                    yield switch (upwardsFacing) {
+                    yield switch (upwardsDir) {
                         case NORTH -> Direction.UP;
                         case SOUTH -> Direction.DOWN;
-                        case EAST -> frontFacing.getCounterClockWise();
-                        default -> frontFacing.getClockWise(); // WEST
+                        case EAST -> frontDir.getCounterClockWise();
+                        default -> frontDir.getClockWise(); // WEST
                     };
                 }
             }
             case DOWN -> {
                 if (frontAxis == Direction.Axis.Y) {
                     // opposite direction as upwards facing
-                    yield upwardsFacing.getOpposite();
+                    yield upwardsDir.getOpposite();
                 } else {
                     // transform the upwards facing into a real facing
-                    yield switch (upwardsFacing) {
+                    yield switch (upwardsDir) {
                         case NORTH -> Direction.DOWN;
                         case SOUTH -> Direction.UP;
-                        case EAST -> frontFacing.getClockWise();
-                        default -> frontFacing.getCounterClockWise(); // WEST
+                        case EAST -> frontDir.getClockWise();
+                        default -> frontDir.getCounterClockWise(); // WEST
                     };
                 }
             }
             case LEFT -> {
-                Direction facing;
+                Direction direction;
                 if (frontAxis == Direction.Axis.Y) {
-                    facing = frontFacing.getStepY() > 0 ? upwardsFacing.getClockWise() :
-                            upwardsFacing.getCounterClockWise();
+                    direction = frontDir.getStepY() > 0 ? upwardsDir.getClockWise() : upwardsDir.getCounterClockWise();
                 } else {
-                    facing = switch (upwardsFacing) {
-                        case NORTH -> frontFacing.getCounterClockWise();
-                        case SOUTH -> frontFacing.getClockWise();
+                    direction = switch (upwardsDir) {
+                        case NORTH -> frontDir.getCounterClockWise();
+                        case SOUTH -> frontDir.getClockWise();
                         case EAST -> Direction.DOWN;
                         default -> Direction.UP; // WEST
                     };
                 }
-                yield isFlipped ? facing.getOpposite() : facing;
+                yield isFlipped ? direction.getOpposite() : direction;
             }
             case RIGHT -> {
-                Direction facing;
+                Direction direction;
                 if (frontAxis == Direction.Axis.Y) {
-                    facing = frontFacing.getStepY() > 0 ? upwardsFacing.getCounterClockWise() :
-                            upwardsFacing.getClockWise();
+                    direction = frontDir.getStepY() > 0 ? upwardsDir.getCounterClockWise() : upwardsDir.getClockWise();
                 } else {
-                    facing = switch (upwardsFacing) {
-                        case NORTH -> frontFacing.getClockWise();
-                        case SOUTH -> frontFacing.getCounterClockWise();
+                    direction = switch (upwardsDir) {
+                        case NORTH -> frontDir.getClockWise();
+                        case SOUTH -> frontDir.getCounterClockWise();
                         case EAST -> Direction.UP;
                         default -> Direction.DOWN; // WEST
                     };
                 }
                 // invert if flipped
-                yield isFlipped ? facing.getOpposite() : facing;
+                yield isFlipped ? direction.getOpposite() : direction;
             }
             // same direction as front facing, upwards facing doesn't matter
-            case FRONT -> frontFacing;
+            case FRONT -> frontDir;
             // opposite direction as front facing, upwards facing doesn't matter
-            case BACK -> frontFacing.getOpposite();
+            case BACK -> frontDir.getOpposite();
         };
     }
 
-    public Comparator<BlockPos> getSorter(Direction frontFacing, Direction upwardsFacing, boolean isFlipped) {
+    public Comparator<BlockPos> getSorter(Direction frontDir, Direction upwardsDir, boolean isFlipped) {
         // get the direction to go in for the part sorter
-        Direction sorterDirection = getRelativeFacing(frontFacing, upwardsFacing, isFlipped);
+        Direction sorterDirection = getRelative(frontDir, upwardsDir, isFlipped);
 
         // Determined by Direction.Axis + Direction.AxisDirection
         return switch (sorterDirection) {
@@ -139,43 +153,42 @@ public enum RelativeDirection {
      *
      * @return Returns the new upwards facing.
      */
-    public static Direction simulateAxisRotation(Direction newFrontFacing, Direction oldFrontFacing,
-                                                 Direction upwardsFacing) {
-        if (newFrontFacing == oldFrontFacing) return upwardsFacing;
+    public static Direction simulateAxisRotation(Direction newFrontDir, Direction oldFrontDir, Direction upwardsDir) {
+        if (newFrontDir == oldFrontDir) return upwardsDir;
 
-        Direction.Axis newAxis = newFrontFacing.getAxis();
-        Direction.Axis oldAxis = oldFrontFacing.getAxis();
+        Direction.Axis newAxis = newFrontDir.getAxis();
+        Direction.Axis oldAxis = oldFrontDir.getAxis();
 
         if (newAxis != Direction.Axis.Y && oldAxis != Direction.Axis.Y) {
             // no change needed
-            return upwardsFacing;
+            return upwardsDir;
         } else if (newAxis == Direction.Axis.Y && oldAxis != Direction.Axis.Y) {
             // going from horizontal to vertical axis
-            Direction newUpwardsFacing = switch (upwardsFacing) {
-                case NORTH -> oldFrontFacing.getOpposite();
-                case SOUTH -> oldFrontFacing;
-                case EAST -> oldFrontFacing.getCounterClockWise();
-                default -> oldFrontFacing.getClockWise(); // WEST
+            Direction newUpwardsDir = switch (upwardsDir) {
+                case NORTH -> oldFrontDir.getOpposite();
+                case SOUTH -> oldFrontDir;
+                case EAST -> oldFrontDir.getCounterClockWise();
+                default -> oldFrontDir.getClockWise(); // WEST
             };
-            return newFrontFacing == Direction.DOWN && upwardsFacing.getAxis() == Direction.Axis.Z ?
-                    newUpwardsFacing.getOpposite() : newUpwardsFacing;
+            return newFrontDir == Direction.DOWN && upwardsDir.getAxis() == Direction.Axis.Z ?
+                    newUpwardsDir.getOpposite() : newUpwardsDir;
         } else if (newAxis != Direction.Axis.Y) {
             // going from vertical to horizontal axis
-            Direction newUpwardsFacing;
-            if (upwardsFacing == newFrontFacing.getOpposite()) {
-                newUpwardsFacing = Direction.NORTH;
-            } else if (upwardsFacing == newFrontFacing) {
-                newUpwardsFacing = Direction.SOUTH;
-            } else if (upwardsFacing == newFrontFacing.getClockWise()) {
-                newUpwardsFacing = Direction.WEST;
+            Direction newUpwardsDir;
+            if (upwardsDir == newFrontDir) {
+                newUpwardsDir = Direction.SOUTH;
+            } else if (upwardsDir == newFrontDir.getOpposite()) {
+                newUpwardsDir = Direction.NORTH;
+            } else if (upwardsDir == newFrontDir.getClockWise()) {
+                newUpwardsDir = Direction.WEST;
             } else { // getCounterClockWise
-                newUpwardsFacing = Direction.EAST;
+                newUpwardsDir = Direction.EAST;
             }
-            return oldFrontFacing == Direction.DOWN && newUpwardsFacing.getAxis() == Direction.Axis.Z ?
-                    newUpwardsFacing.getOpposite() : newUpwardsFacing;
+            return oldFrontDir == Direction.DOWN && newUpwardsDir.getAxis() == Direction.Axis.Z ?
+                    newUpwardsDir.getOpposite() : newUpwardsDir;
         } else {
             // was on vertical axis and still is. Must have flipped from up to down or vice versa
-            return upwardsFacing.getOpposite();
+            return upwardsDir.getOpposite();
         }
     }
 
@@ -183,24 +196,24 @@ public enum RelativeDirection {
      * Offset a BlockPos relatively in any direction by any amount. Pass negative values to offset down, right or
      * backwards.
      */
-    public static BlockPos offsetPos(BlockPos pos, Direction frontFacing, Direction upwardsFacing, boolean isFlipped,
+    public static BlockPos offsetPos(BlockPos pos, Direction frontDir, Direction upwardsDir, boolean isFlipped,
                                      int upOffset, int leftOffset, int forwardOffset) {
         if (upOffset == 0 && leftOffset == 0 && forwardOffset == 0) {
             return pos;
         }
 
         int oX = 0, oY = 0, oZ = 0;
-        final Direction relUp = UP.getRelativeFacing(frontFacing, upwardsFacing, isFlipped);
+        final Direction relUp = UP.getRelative(frontDir, upwardsDir, isFlipped);
         oX += relUp.getStepX() * upOffset;
         oY += relUp.getStepY() * upOffset;
         oZ += relUp.getStepZ() * upOffset;
 
-        final Direction relLeft = LEFT.getRelativeFacing(frontFacing, upwardsFacing, isFlipped);
+        final Direction relLeft = LEFT.getRelative(frontDir, upwardsDir, isFlipped);
         oX += relLeft.getStepX() * leftOffset;
         oY += relLeft.getStepY() * leftOffset;
         oZ += relLeft.getStepZ() * leftOffset;
 
-        final Direction relForward = FRONT.getRelativeFacing(frontFacing, upwardsFacing, isFlipped);
+        final Direction relForward = FRONT.getRelative(frontDir, upwardsDir, isFlipped);
         oX += relForward.getStepX() * forwardOffset;
         oY += relForward.getStepY() * forwardOffset;
         oZ += relForward.getStepZ() * forwardOffset;
@@ -232,9 +245,10 @@ public enum RelativeDirection {
      * If {@code base} is vertical (e.g. {@link Direction#UP UP} or {@link Direction#DOWN DOWN}),
      * the rotation is calculated with {@code forward} as the "forward" direction.
      * 
-     * @param base     the direction to relative
-     * @param relative the direction to relative by
+     * @param base     the direction to offset
+     * @param relative the direction to offset by
      * @param forward  the direction to use as "forward"
+     * @return The relative rotation between {@code base} and {@code relative}
      */
     public static RelativeDirection findRelativeOf(Direction base, Direction relative, Direction forward) {
         // Check simple cases first
@@ -244,8 +258,8 @@ public enum RelativeDirection {
         if (base.getAxis().isHorizontal()) { // base is one of N,S,W,E
             if (relative == Direction.UP) return RelativeDirection.UP;
             else if (relative == Direction.DOWN) return RelativeDirection.DOWN;
-            else if (base.getCounterClockWise() == relative) return RelativeDirection.LEFT;
-            else return RelativeDirection.RIGHT; // base.getClockWise() == relative
+            else if (relative == base.getCounterClockWise()) return RelativeDirection.LEFT;
+            else return RelativeDirection.RIGHT; // getClockWise
         } else { // base is UP or DOWN
             if (forward.getAxis() == Direction.Axis.Y) {
                 throw new IllegalStateException("forward must be a horizontal direction! is %s".formatted(forward));

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
@@ -119,18 +119,18 @@ public enum RelativeDirection {
         };
     }
 
-    public ToIntFunction<BlockPos> getSorter(Direction frontFacing, Direction upwardsFacing, boolean isFlipped) {
+    public Comparator<BlockPos> getSorter(Direction frontFacing, Direction upwardsFacing, boolean isFlipped) {
         // get the direction to go in for the part sorter
         Direction sorterDirection = getRelativeFacing(frontFacing, upwardsFacing, isFlipped);
 
         // Determined by Direction.Axis + Direction.AxisDirection
         return switch (sorterDirection) {
-            case UP -> BlockPos::getY;
-            case DOWN -> pos -> -pos.getY();
-            case EAST -> BlockPos::getX;
-            case WEST -> pos -> -pos.getX();
-            case NORTH -> pos -> -pos.getZ();
-            case SOUTH -> BlockPos::getZ;
+            case UP -> Comparator.comparingInt(BlockPos::getY);
+            case DOWN -> Comparator.comparingInt(pos -> -pos.getY());
+            case EAST -> Comparator.comparingInt(BlockPos::getX);
+            case WEST -> Comparator.comparingInt(pos -> -pos.getX());
+            case NORTH -> Comparator.comparingInt(BlockPos::getZ);
+            case SOUTH -> Comparator.comparingInt(pos -> -pos.getZ());
         };
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -188,7 +188,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
     }
 
     private static Codec<GTRecipe> makeCodec(boolean isKubeLoaded) {
-        // @formatter:off
+        // spotless:off
         if (!isKubeLoaded) {
             return RecordCodecBuilder.create(instance -> instance.group(
                             GTRegistries.RECIPE_TYPES.codec().fieldOf("type").forGetter(val -> val.recipeType),
@@ -237,7 +237,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory))
                     .apply(instance, GTRecipe::new));
         }
-        // @formatter:on
+        // spotless:on
     }
 
     public static class KJSCallWrapper {

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -298,6 +298,7 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     public MultiblockMachineBuilder conditionalTooltip(Component component, boolean condition) {
         if (condition)
             tooltips(component);
+        return this;
     }
 
     @Tolerate

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -49,6 +49,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.experimental.Tolerate;
 import org.apache.commons.lang3.function.TriFunction;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,7 +75,7 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     private boolean allowFlip = true;
     private final List<Supplier<ItemStack[]>> recoveryItems = new ArrayList<>();
     @Setter
-    private Comparator<IMultiPart> partSorter = (a, b) -> 0;
+    private Function<MultiblockControllerMachine, Comparator<IMultiPart>> partSorter = (c) -> (a, b) -> 0;
     @Setter
     private TriFunction<IMultiController, IMultiPart, Direction, BlockState> partAppearance;
     @Getter
@@ -297,6 +298,11 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     public MultiblockMachineBuilder conditionalTooltip(Component component, boolean condition) {
         if (condition)
             tooltips(component);
+    }
+
+    @Tolerate
+    public MultiblockMachineBuilder partSorter(Comparator<IMultiPart> sorter) {
+        this.partSorter = $ -> sorter;
         return this;
     }
 
@@ -403,7 +409,7 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
             definition.setRecoveryItems(
                     () -> recoveryItems.stream().map(Supplier::get).flatMap(Arrays::stream).toArray(ItemStack[]::new));
         }
-        definition.setPartSorter(partSorter);
+        definition.setPartSorter(GTMemoizer.memoizeFunctionWeakIdent(partSorter));
         if (partAppearance == null) {
             partAppearance = (controller, part, side) -> definition.getAppearance().get();
         }

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/FusionReactorRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/FusionReactorRenderer.java
@@ -69,8 +69,8 @@ public class FusionReactorRenderer extends WorkableCasingMachineRenderer {
         var front = machine.getFrontFacing();
         var upwards = machine.getUpwardsFacing();
         var flipped = machine.isFlipped();
-        var back = RelativeDirection.BACK.getRelativeFacing(front, upwards, flipped);
-        var axis = RelativeDirection.UP.getRelativeFacing(front, upwards, flipped).getAxis();
+        var back = RelativeDirection.BACK.getRelative(front, upwards, flipped);
+        var axis = RelativeDirection.UP.getRelative(front, upwards, flipped).getAxis();
         var r = Mth.lerp(lerpFactor, red(lastColor), 255) / 255f;
         var g = Mth.lerp(lerpFactor, green(lastColor), 255) / 255f;
         var b = Mth.lerp(lerpFactor, blue(lastColor), 255) / 255f;

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/HPCAPartRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/HPCAPartRenderer.java
@@ -91,7 +91,7 @@ public class HPCAPartRenderer extends TieredHullMachineRenderer {
                 // Always render this outwards in the HPCA, in case it is not placed outwards in structure.
                 // Check for HPCA specifically since these components could potentially be used in other multiblocks.
                 if (controller instanceof HPCAMachine hpca) {
-                    facing = RelativeDirection.RIGHT.getRelativeFacing(hpca.getFrontFacing(), hpca.getUpwardsFacing(),
+                    facing = RelativeDirection.RIGHT.getRelative(hpca.getFrontFacing(), hpca.getUpwardsFacing(),
                             hpca.isFlipped());
                 }
                 facing = ModelFactory.modelFacing(frontFacing, facing);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/LargeBoilerRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/LargeBoilerRenderer.java
@@ -48,7 +48,7 @@ public class LargeBoilerRenderer extends WorkableCasingMachineRenderer implement
         var multiState = GTMatrixUtils.createRotationState(multiFront, Direction.NORTH);
         var multiFacing = ModelFactory.modelFacing(side, multiFront);
         var flipped = machine.self().isFlipped();
-        var relativeDown = RelativeDirection.DOWN.getRelativeFacing(multiFront, multiUpward, flipped);
+        var relativeDown = RelativeDirection.DOWN.getRelative(multiFront, multiUpward, flipped);
         // the rest of the owl
         if (machine.self().getPos().relative(relativeDown).get(relativeDown.getAxis()) !=
                 part.self().getPos().get(relativeDown.getAxis())) {
@@ -59,7 +59,7 @@ public class LargeBoilerRenderer extends WorkableCasingMachineRenderer implement
         if (side == relativeDown) {
             quads.add(
                     StaticFaceBakery.bakeFace(multiFacing, ModelFactory.getBlockSprite(firebox.bottom()), multiState));
-        } else if (side == RelativeDirection.UP.getRelativeFacing(multiFacing, multiUpward, flipped)) {
+        } else if (side == RelativeDirection.UP.getRelative(multiFacing, multiUpward, flipped)) {
             quads.add(StaticFaceBakery.bakeFace(multiFacing, ModelFactory.getBlockSprite(firebox.top()), multiState));
         } else {
             quads.add(StaticFaceBakery.bakeFace(multiFacing, ModelFactory.getBlockSprite(firebox.side()), multiState));

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/PrimitiveBlastFurnaceRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/PrimitiveBlastFurnaceRenderer.java
@@ -55,9 +55,9 @@ public class PrimitiveBlastFurnaceRenderer extends WorkableCasingMachineRenderer
                 pose.translate(opposite.getStepX(), opposite.getStepY(), opposite.getStepZ());
 
                 var consumer = buffer.getBuffer(RenderTypeHelper.getEntityRenderType(lavaRenderType, true));
-                var up = RelativeDirection.UP.getRelativeFacing(pbf.getFrontFacing(), pbf.getUpwardsFacing(),
+                var up = RelativeDirection.UP.getRelative(pbf.getFrontFacing(), pbf.getUpwardsFacing(),
                         pbf.isFlipped());
-                if (up != Direction.UP && up != Direction.DOWN) up = up.getOpposite();
+                if (up.getAxis() != Direction.Axis.Y) up = up.getOpposite();
 
                 fluidBlockRenderer.drawFace(up, pose, consumer, Fluids.LAVA.getSource(),
                         RenderUtil.FluidTextureType.STILL, combinedOverlay, combinedLight);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeChemicalBathRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeChemicalBathRenderer.java
@@ -80,7 +80,7 @@ public class LargeChemicalBathRenderer extends WorkableCasingMachineRenderer {
                 var fluidRenderType = ItemBlockRenderTypes.getRenderLayer(cachedFluid.defaultFluidState());
                 var consumer = buffer.getBuffer(RenderTypeHelper.getEntityRenderType(fluidRenderType, false));
 
-                var up = RelativeDirection.UP.getRelativeFacing(lcb.getFrontFacing(), lcb.getUpwardsFacing(),
+                var up = RelativeDirection.UP.getRelative(lcb.getFrontFacing(), lcb.getUpwardsFacing(),
                         lcb.isFlipped());
                 if (up.getAxis() != Direction.Axis.Y) up = up.getOpposite();
                 fluidBlockRenderer.drawPlane(up, lcb.getFluidBlockOffsets(), pose, consumer, cachedFluid,

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeMixerRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/gcym/LargeMixerRenderer.java
@@ -80,7 +80,7 @@ public class LargeMixerRenderer extends WorkableCasingMachineRenderer {
                 var fluidRenderType = ItemBlockRenderTypes.getRenderLayer(cachedFluid.defaultFluidState());
                 var consumer = buffer.getBuffer(RenderTypeHelper.getEntityRenderType(fluidRenderType, false));
 
-                var up = RelativeDirection.UP.getRelativeFacing(lm.getFrontFacing(), lm.getUpwardsFacing(),
+                var up = RelativeDirection.UP.getRelative(lm.getFrontFacing(), lm.getUpwardsFacing(),
                         lm.isFlipped());
                 if (up != Direction.UP && up != Direction.DOWN) up = up.getOpposite();
                 fluidBlockRenderer.drawPlane(up, lm.getFluidBlockOffsets(), pose, consumer, cachedFluid,

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCYMMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCYMMachines.java
@@ -703,7 +703,8 @@ public class GCYMMachines {
                 }
                 return shapeInfos;
             })
-            .partSorter(Comparator.comparingInt(a -> a.self().getPos().getY()))
+            .allowExtendedFacing(false)
+            .partSorter(Comparator.comparingInt(p -> p.self().getPos().getY()))
             .workableCasingRenderer(GTCEu.id("block/casings/gcym/watertight_casing"),
                     GTCEu.id("block/multiblock/gcym/large_distillery"))
             .register();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -494,7 +494,7 @@ public class GTMultiMachines {
                 return shapeInfos;
             })
             .allowExtendedFacing(false)
-            .partSorter(Comparator.comparingInt(a -> a.self().getPos().getY()))
+            .partSorter(Comparator.comparingInt(p -> p.self().getPos().getY()))
             .workableCasingRenderer(GTCEu.id("block/casings/solid/machine_casing_clean_stainless_steel"),
                     GTCEu.id("block/multiblock/distillation_tower"))
             .register();
@@ -551,6 +551,7 @@ public class GTMultiMachines {
                     .where('D', dataHatchPredicate(blocks(CASING_GRATE.get())))
                     .where('#', Predicates.any())
                     .build())
+            .partSorter(AssemblyLineMachine::partSorter)
             .workableCasingRenderer(GTCEu.id("block/casings/solid/machine_casing_solid_steel"),
                     GTCEu.id("block/multiblock/assembly_line"))
             .register();

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/MetaMachineConfigCopyBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/MetaMachineConfigCopyBehaviour.java
@@ -1,18 +1,25 @@
 package com.gregtechceu.gtceu.common.item.tool.behavior;
 
-import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
 import com.gregtechceu.gtceu.api.item.component.IInteractionItem;
+import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputFluid;
 import com.gregtechceu.gtceu.api.machine.feature.IAutoOutputItem;
 import com.gregtechceu.gtceu.api.machine.feature.IMufflableMachine;
+import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.machine.owner.MachineOwner;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NumericTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -24,11 +31,16 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 
+import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
+import joptsimple.internal.Strings;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInformation {
+
+    public static final String NONE_DIRECTION = "null";
 
     public static final String CONFIG_DATA = "config_data";
     public static final String ORIGINAL_FRONT = "front";
@@ -39,57 +51,48 @@ public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInf
     public static final String INPUT_FROM_OUTPUT_SIDE = "in_from_out";
     public static final String MUFFLED = "muffled";
 
-    public static int directionToInt(@Nullable Direction direction) {
-        return direction == null ? 0 : direction.ordinal() + 1;
+    public static final Component ENABLED = Component.translatable("cover.voiding.label.enabled")
+            .withStyle(ChatFormatting.GREEN);
+    public static final Component DISABLED = Component.translatable("cover.voiding.label.disabled")
+            .withStyle(ChatFormatting.RED);
+
+    public static final Component[] DIRECTION_TOOLTIPS = {
+            Component.translatable("gtceu.direction.tooltip.up").withStyle(ChatFormatting.YELLOW),
+            Component.translatable("gtceu.direction.tooltip.down").withStyle(ChatFormatting.YELLOW),
+            Component.translatable("gtceu.direction.tooltip.left").withStyle(ChatFormatting.YELLOW),
+            Component.translatable("gtceu.direction.tooltip.right").withStyle(ChatFormatting.YELLOW),
+            Component.translatable("gtceu.direction.tooltip.front").withStyle(ChatFormatting.YELLOW),
+            Component.translatable("gtceu.direction.tooltip.back").withStyle(ChatFormatting.YELLOW),
+    };
+
+    public static String directionToString(@Nullable Direction direction) {
+        if (direction == null) return NONE_DIRECTION;
+        return direction.getSerializedName();
     }
 
-    public static Direction intToDirection(int ordinal) {
-        return ordinal <= 0 || ordinal > Direction.values().length ? null : Direction.values()[ordinal - 1];
+    public static @Nullable Direction tagToDirection(@Nullable Tag tag) {
+        if (tag instanceof StringTag string) {
+            String name = string.getAsString();
+            if (Strings.isNullOrEmpty(name) || NONE_DIRECTION.equalsIgnoreCase(name)) return null;
+            return Direction.byName(name);
+        } else if (tag instanceof NumericTag number) {
+            // backwards compatibility
+            int ordinal = number.getAsInt();
+            return ordinal <= 0 || ordinal > Direction.values().length ? null : Direction.values()[ordinal - 1];
+        }
+        return null;
     }
 
     public static Component relativeDirectionComponent(Direction origFront, Direction origDirection) {
-        if (origFront == origDirection) {
-            return Component.translatable("gtceu.direction.tooltip.front").withStyle(ChatFormatting.YELLOW);
-        }
-        if (Direction.UP == origDirection) {
-            return Component.translatable("gtceu.direction.tooltip.up").withStyle(ChatFormatting.YELLOW);
-        }
-        if (Direction.DOWN == origDirection) {
-            return Component.translatable("gtceu.direction.tooltip.down").withStyle(ChatFormatting.YELLOW);
-        }
-        var face = origFront;
-        int i;
-        for (i = 0; i < 3; i++) {
-            face = face.getClockWise();
-            if (face == origDirection) break;
-        }
-        return switch (i) {
-            case 0 -> Component.translatable("gtceu.direction.tooltip.right").withStyle(ChatFormatting.YELLOW);
-            case 1 -> Component.translatable("gtceu.direction.tooltip.back").withStyle(ChatFormatting.YELLOW);
-            case 2 -> Component.translatable("gtceu.direction.tooltip.left").withStyle(ChatFormatting.YELLOW);
-            default -> Component.literal("");
-        };
-    }
-
-    public static Direction getRelativeDirection(Direction originalFront, Direction currentFacing, Direction face) {
-        if ((currentFacing == null || originalFront == null) || (currentFacing == originalFront) ||
-                (face == Direction.UP || face == Direction.DOWN))
-            return face;
-
-        Direction newFace = originalFront;
-        int i;
-        for (i = 0; i < 4 && newFace != currentFacing; i++) newFace = newFace.getClockWise();
-
-        newFace = face;
-        for (int j = 0; j < i; j++) newFace = newFace.getClockWise();
-        return newFace;
+        RelativeDirection relative = RelativeDirection.findRelativeOf(origFront, origDirection);
+        return DIRECTION_TOOLTIPS[relative.ordinal()];
     }
 
     @Override
     public InteractionResultHolder<ItemStack> use(Item item, Level level, Player player, InteractionHand usedHand) {
         var stack = player.getItemInHand(usedHand);
         if (player.isShiftKeyDown()) {
-            stack.setTag(null);
+            stack.removeTagKey(CONFIG_DATA);
             return InteractionResultHolder.success(stack);
         }
         return IInteractionItem.super.use(item, level, player, usedHand);
@@ -97,39 +100,35 @@ public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInf
 
     @Override
     public InteractionResult onItemUseFirst(ItemStack stack, UseOnContext context) {
-        if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof MetaMachineBlockEntity blockEntity) {
+        // spotless:off
+        if (context.getLevel().getBlockEntity(context.getClickedPos()) instanceof IMachineBlockEntity blockEntity) {
             var machine = blockEntity.getMetaMachine();
             if (!MachineOwner.canOpenOwnerMachine(context.getPlayer(), machine)) {
                 return InteractionResult.FAIL;
             }
-            if (context.isSecondaryUseActive())
+            if (context.isSecondaryUseActive()) {
                 return handleCopy(stack, machine);
-            else if (stack.hasTag() && stack.getTag().contains(CONFIG_DATA))
+            } else if (stack.getTagElement(CONFIG_DATA) != null) {
                 return handlePaste(stack, machine);
-        } else
-            if (context.isSecondaryUseActive() && context.getLevel().getBlockState(context.getClickedPos()).isAir()) {
-                stack.setTag(null);
-                return InteractionResult.SUCCESS;
             }
+        } else if (context.isSecondaryUseActive() && context.getLevel().getBlockState(context.getClickedPos()).isAir()) {
+            stack.removeTagKey(CONFIG_DATA);
+            return InteractionResult.SUCCESS;
+        }
+        // spotless:on
         return InteractionResult.SUCCESS;
     }
 
     public static InteractionResult handleCopy(ItemStack stack, MetaMachine machine) {
         CompoundTag configData = new CompoundTag();
-        configData.putInt(ORIGINAL_FRONT, directionToInt(machine.getFrontFacing()));
+        configData.putString(ORIGINAL_FRONT, directionToString(machine.getFrontFacing()));
         if (machine instanceof IAutoOutputItem autoOutputItem && autoOutputItem.getOutputFacingItems() != null) {
-            CompoundTag itemTag = new CompoundTag();
-            itemTag.putInt(DIRECTION, directionToInt(autoOutputItem.getOutputFacingItems()));
-            itemTag.putBoolean(AUTO, autoOutputItem.isAutoOutputItems());
-            itemTag.putBoolean(INPUT_FROM_OUTPUT_SIDE, autoOutputItem.isAllowInputFromOutputSideItems());
-            configData.put(ITEM_CONFIG, itemTag);
+            configData.put(ITEM_CONFIG, copyOutputConfig(autoOutputItem.getOutputFacingItems(),
+                    autoOutputItem.isAutoOutputItems(), autoOutputItem.isAllowInputFromOutputSideItems()));
         }
         if (machine instanceof IAutoOutputFluid autoOutputFluid && autoOutputFluid.getOutputFacingFluids() != null) {
-            CompoundTag fluidTag = new CompoundTag();
-            fluidTag.putInt(DIRECTION, directionToInt(autoOutputFluid.getOutputFacingFluids()));
-            fluidTag.putBoolean(AUTO, autoOutputFluid.isAutoOutputFluids());
-            fluidTag.putBoolean(INPUT_FROM_OUTPUT_SIDE, autoOutputFluid.isAllowInputFromOutputSideFluids());
-            configData.put(FLUID_CONFIG, fluidTag);
+            configData.put(FLUID_CONFIG, copyOutputConfig(autoOutputFluid.getOutputFacingFluids(),
+                    autoOutputFluid.isAutoOutputFluids(), autoOutputFluid.isAllowInputFromOutputSideFluids()));
         }
         if (machine instanceof IMufflableMachine mufflableMachine) {
             configData.putBoolean(MUFFLED, mufflableMachine.isMuffled());
@@ -141,23 +140,18 @@ public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInf
     }
 
     public static InteractionResult handlePaste(ItemStack stack, MetaMachine machine) {
-        if (!stack.hasTag() || !stack.getTag().contains(CONFIG_DATA)) return InteractionResult.PASS;
-        CompoundTag root = stack.getOrCreateTag();
-        CompoundTag configData = root.getCompound(CONFIG_DATA);
-        Direction originalFront = intToDirection(configData.getInt(ORIGINAL_FRONT));
+        CompoundTag configData = stack.getTagElement(CONFIG_DATA);
+        if (configData == null) return InteractionResult.PASS;
+        Direction originalFront = tagToDirection(configData.get(ORIGINAL_FRONT));
         if (configData.contains(ITEM_CONFIG) && machine instanceof IAutoOutputItem autoOutputItem) {
-            CompoundTag itemData = configData.getCompound(ITEM_CONFIG);
-            autoOutputItem.setOutputFacingItems(getRelativeDirection(originalFront, machine.getFrontFacing(),
-                    intToDirection(itemData.getInt(DIRECTION))));
-            autoOutputItem.setAutoOutputItems(itemData.getBoolean(AUTO));
-            autoOutputItem.setAllowInputFromOutputSideItems(itemData.getBoolean(INPUT_FROM_OUTPUT_SIDE));
+            pasteOutputConfig(originalFront, machine.getFrontFacing(), configData.getCompound(ITEM_CONFIG),
+                    autoOutputItem::setOutputFacingItems, autoOutputItem::setAutoOutputItems,
+                    autoOutputItem::setAllowInputFromOutputSideItems);
         }
         if (configData.contains(FLUID_CONFIG) && machine instanceof IAutoOutputFluid autoOutputFluid) {
-            CompoundTag fluidData = configData.getCompound(FLUID_CONFIG);
-            autoOutputFluid.setOutputFacingFluids(getRelativeDirection(originalFront, machine.getFrontFacing(),
-                    intToDirection(fluidData.getInt(DIRECTION))));
-            autoOutputFluid.setAutoOutputFluids(fluidData.getBoolean(AUTO));
-            autoOutputFluid.setAllowInputFromOutputSideFluids(fluidData.getBoolean(INPUT_FROM_OUTPUT_SIDE));
+            pasteOutputConfig(originalFront, machine.getFrontFacing(), configData.getCompound(FLUID_CONFIG),
+                    autoOutputFluid::setOutputFacingFluids, autoOutputFluid::setAutoOutputFluids,
+                    autoOutputFluid::setAllowInputFromOutputSideFluids);
         }
         if (configData.contains(MUFFLED) && machine instanceof IMufflableMachine mufflableMachine) {
             mufflableMachine.setMuffled(configData.getBoolean(MUFFLED));
@@ -170,54 +164,53 @@ public class MetaMachineConfigCopyBehaviour implements IInteractionItem, IAddInf
                                 TooltipFlag isAdvanced) {
         tooltipComponents.add(Component.translatable("behaviour.meta.machine.config.copy.tooltip"));
         tooltipComponents.add(Component.translatable("behaviour.meta.machine.config.paste.tooltip"));
-        if (!stack.hasTag()) return;
+        CompoundTag data = stack.getTagElement(CONFIG_DATA);
+        if (data == null) return;
         if (Screen.hasShiftDown()) {
-            tooltipComponents.add(Component.literal(""));
-            var tag = stack.getOrCreateTag();
-            if (tag.contains(CONFIG_DATA)) {
-                var data = tag.getCompound(CONFIG_DATA);
-                var enabledComponent = Component.translatable("cover.voiding.label.enabled")
-                        .withStyle(ChatFormatting.GREEN);
-                var disabledComponent = Component.translatable("cover.voiding.label.disabled")
-                        .withStyle(ChatFormatting.RED);
-                if (data.contains(ORIGINAL_FRONT)) {
-                    var origFront = intToDirection(data.getInt(ORIGINAL_FRONT));
-                    if (data.contains(ITEM_CONFIG)) {
-                        var itemData = data.getCompound(ITEM_CONFIG);
-                        var itemComponent = Component.translatable("recipe.capability.item.name")
-                                .withStyle(ChatFormatting.GOLD);
-                        tooltipComponents.add(Component.translatable("behaviour.setting.output.direction.tooltip",
-                                itemComponent,
-                                relativeDirectionComponent(origFront, intToDirection(itemData.getInt(DIRECTION)))));
-                        tooltipComponents
-                                .add(Component.translatable("behaviour.setting.item_auto_output.tooltip", itemComponent,
-                                        (itemData.getBoolean(AUTO) ? enabledComponent : disabledComponent)));
-                        tooltipComponents.add(Component.translatable(
-                                "behaviour.setting.allow.input.from.output.tooltip", itemComponent,
-                                (itemData.getBoolean(INPUT_FROM_OUTPUT_SIDE) ? enabledComponent : disabledComponent)));
-                    }
-                    if (data.contains(FLUID_CONFIG)) {
-                        var fluidData = data.getCompound(FLUID_CONFIG);
-                        var fluidComponent = Component.translatable("recipe.capability.fluid.name")
-                                .withStyle(ChatFormatting.BLUE);
-                        tooltipComponents.add(Component.translatable("behaviour.setting.output.direction.tooltip",
-                                fluidComponent,
-                                relativeDirectionComponent(origFront, intToDirection(fluidData.getInt(DIRECTION)))));
-                        tooltipComponents.add(
-                                Component.translatable("behaviour.setting.item_auto_output.tooltip", fluidComponent,
-                                        (fluidData.getBoolean(AUTO) ? enabledComponent : disabledComponent)));
-                        tooltipComponents.add(Component.translatable(
-                                "behaviour.setting.allow.input.from.output.tooltip", fluidComponent,
-                                (fluidData.getBoolean(INPUT_FROM_OUTPUT_SIDE) ? enabledComponent : disabledComponent)));
-                    }
+            tooltipComponents.add(CommonComponents.EMPTY);
+            if (data.contains(ORIGINAL_FRONT)) {
+                var origFront = tagToDirection(data.get(ORIGINAL_FRONT));
+                for (RecipeCapability<?> cap : GTRegistries.RECIPE_CAPABILITIES) {
+                    if (!data.contains(cap.name)) continue;
+                    var configData = data.getCompound(cap.name);
+                    var component = cap.getColoredName();
+                    addConfigTypeTooltips(tooltipComponents, component, configData, origFront);
                 }
-                if (data.contains(MUFFLED)) {
-                    tooltipComponents.add(Component.translatable("behaviour.setting.muffled.tooltip",
-                            data.getBoolean(MUFFLED) ? enabledComponent : disabledComponent));
-                }
+            }
+            if (data.contains(MUFFLED)) {
+                tooltipComponents.add(Component.translatable("behaviour.setting.muffled.tooltip",
+                        data.getBoolean(MUFFLED) ? ENABLED : DISABLED));
             }
         } else {
             tooltipComponents.add(Component.translatable("item.toggle.advanced.info.tooltip"));
         }
+    }
+
+    private static void addConfigTypeTooltips(List<Component> tooltip, Component baseComponent,
+                                              CompoundTag data, Direction origFront) {
+        tooltip.add(Component.translatable("behaviour.setting.output.direction.tooltip",
+                baseComponent, relativeDirectionComponent(origFront, tagToDirection(data.get(DIRECTION)))));
+        tooltip.add(Component.translatable("behaviour.setting.item_auto_output.tooltip", baseComponent,
+                data.getBoolean(AUTO) ? ENABLED : DISABLED));
+        tooltip.add(Component.translatable("behaviour.setting.allow.input.from.output.tooltip", baseComponent,
+                data.getBoolean(INPUT_FROM_OUTPUT_SIDE) ? ENABLED : DISABLED));
+    }
+
+    private static CompoundTag copyOutputConfig(Direction outputSide, boolean autoOutput,
+                                                boolean allowInputFromOutputSide) {
+        CompoundTag tag = new CompoundTag();
+        tag.putString(DIRECTION, directionToString(outputSide));
+        tag.putBoolean(AUTO, autoOutput);
+        tag.putBoolean(INPUT_FROM_OUTPUT_SIDE, allowInputFromOutputSide);
+        return tag;
+    }
+
+    private static void pasteOutputConfig(Direction originalFront, Direction currentFront, CompoundTag data,
+                                          Consumer<Direction> outputSide, BooleanConsumer autoOutput,
+                                          BooleanConsumer allowInputFromOutputSide) {
+        outputSide.accept(RelativeDirection.getActualDirection(originalFront, currentFront,
+                tagToDirection(data.get(DIRECTION))));
+        autoOutput.accept(data.getBoolean(AUTO));
+        allowInputFromOutputSide.accept(data.getBoolean(INPUT_FROM_OUTPUT_SIDE));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
@@ -5,6 +5,8 @@ import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.IRecipeHandler;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -13,7 +15,6 @@ import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.fluids.FluidStack;
@@ -26,7 +27,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
-import java.util.function.ToIntFunction;
 
 public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
 
@@ -57,15 +57,9 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
         return checkFluidInputs(recipe);
     }
 
-    @Override
-    public void onStructureFormed() {
-        getDefinition()
-                .setPartSorter(Comparator.comparingInt(it -> multiblockPartSorter().applyAsInt(it.self().getPos())));
-        super.onStructureFormed();
-    }
-
-    private ToIntFunction<BlockPos> multiblockPartSorter() {
-        return RelativeDirection.RIGHT.getSorter(getFrontFacing(), getUpwardsFacing(), isFlipped());
+    public static Comparator<IMultiPart> partSorter(MultiblockControllerMachine mc) {
+        return Comparator.comparing(p -> p.self().getPos(),
+                RelativeDirection.RIGHT.getSorter(mc.getFrontFacing(), mc.getUpwardsFacing(), mc.isFlipped()));
     }
 
     private boolean checkItemInputs(@NotNull GTRecipe recipe) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
@@ -75,8 +75,6 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
 
     @Override
     public void onStructureFormed() {
-        getDefinition().setPartSorter(Comparator.comparingInt(p -> p.self().getPos().getY()));
-        getDefinition().setAllowExtendedFacing(false);
         super.onStructureFormed();
         final int startY = getPos().getY() + yOffset;
         List<IMultiPart> parts = getParts().stream()

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/gcym/LargeChemicalBathMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/gcym/LargeChemicalBathMachine.java
@@ -54,7 +54,7 @@ public class LargeChemicalBathMachine extends WorkableElectricMultiblockMachine 
     }
 
     protected void saveOffsets() {
-        Direction up = RelativeDirection.UP.getRelativeFacing(getFrontFacing(), getUpwardsFacing(), isFlipped());
+        Direction up = RelativeDirection.UP.getRelative(getFrontFacing(), getUpwardsFacing(), isFlipped());
         Direction back = getFrontFacing().getOpposite();
         Direction clockWise;
         Direction counterClockWise;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/gcym/LargeMixerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/gcym/LargeMixerMachine.java
@@ -54,7 +54,7 @@ public class LargeMixerMachine extends WorkableElectricMultiblockMachine {
     }
 
     protected void saveOffsets() {
-        Direction up = RelativeDirection.UP.getRelativeFacing(getFrontFacing(), getUpwardsFacing(), isFlipped());
+        Direction up = RelativeDirection.UP.getRelative(getFrontFacing(), getUpwardsFacing(), isFlipped());
         Direction back = getFrontFacing().getOpposite();
         Direction clockWise;
         Direction counterClockWise;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -714,7 +714,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
 
         public void tryGatherClientComponents(Level world, BlockPos pos, Direction frontFacing,
                                               Direction upwardsFacing, boolean flip) {
-            Direction relativeUp = RelativeDirection.UP.getRelativeFacing(frontFacing, upwardsFacing, flip);
+            Direction relativeUp = RelativeDirection.UP.getRelative(frontFacing, upwardsFacing, flip);
 
             if (components.isEmpty()) {
                 BlockPos testPos = pos

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveBlastFurnaceMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveBlastFurnaceMachine.java
@@ -83,7 +83,7 @@ public class PrimitiveBlastFurnaceMachine extends PrimitiveWorkableMachine imple
             float yPos = facing.getStepY() * 0.76F + pos.getY() + 0.25F;
             float zPos = facing.getStepZ() * 0.76F + pos.getZ() + 0.5F;
 
-            var up = RelativeDirection.UP.getRelativeFacing(getFrontFacing(), getUpwardsFacing(), isFlipped());
+            var up = RelativeDirection.UP.getRelative(getFrontFacing(), getUpwardsFacing(), isFlipped());
             var sign = up.getAxisDirection().getStep();
             var shouldX = up.getAxis() == Direction.Axis.X;
             var shouldY = up.getAxis() == Direction.Axis.Y;

--- a/src/main/java/com/gregtechceu/gtceu/utils/memoization/ConcurrentWeakIdentityHashMap.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/memoization/ConcurrentWeakIdentityHashMap.java
@@ -1,0 +1,235 @@
+package com.gregtechceu.gtceu.utils.memoization;
+
+import org.jetbrains.annotations.NotNullByDefault;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Serial;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@NotNullByDefault
+public class ConcurrentWeakIdentityHashMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {
+
+    private final ConcurrentMap<Key<K>, V> map;
+    private final ReferenceQueue<K> queue = new ReferenceQueue<>();
+    private transient @Nullable Set<Map.Entry<K, V>> entrySet;
+
+    public ConcurrentWeakIdentityHashMap(int initialCapacity) {
+        this.map = new ConcurrentHashMap<>(initialCapacity);
+    }
+
+    public ConcurrentWeakIdentityHashMap() {
+        this.map = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public @Nullable V get(Object key) {
+        purgeKeys();
+        return map.get(new Key<>(key, null));
+    }
+
+    @Override
+    public @Nullable V put(K key, V value) {
+        purgeKeys();
+        return map.put(new Key<>(key, queue), value);
+    }
+
+    @Override
+    public int size() {
+        purgeKeys();
+        return map.size();
+    }
+
+    @SuppressWarnings({ "ReassignedVariable", "SuspiciousMethodCalls" })
+    private void purgeKeys() {
+        Reference<? extends K> reference;
+        while ((reference = queue.poll()) != null) {
+            map.remove(reference);
+        }
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        Set<Map.Entry<K, V>> entrySet = this.entrySet;
+        return entrySet == null ? this.entrySet = new EntrySet() : entrySet;
+    }
+
+    @Override
+    public @Nullable V putIfAbsent(K key, V value) {
+        purgeKeys();
+        return map.putIfAbsent(new Key<>(key, queue), value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return map.remove(new Key<>(key, null));
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        purgeKeys();
+        return map.remove(new Key<>(key, null), value);
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        purgeKeys();
+        return map.replace(new Key<>(key, null), oldValue, newValue);
+    }
+
+    @Override
+    public @Nullable V replace(K key, V value) {
+        purgeKeys();
+        return map.replace(new Key<>(key, null), value);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        purgeKeys();
+        return map.containsKey(new Key<>(key, null));
+    }
+
+    @SuppressWarnings("StatementWithEmptyBody")
+    @Override
+    public void clear() {
+        while (queue.poll() != null);
+        map.clear();
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        purgeKeys();
+        return map.containsValue(value);
+    }
+
+    private static class Key<T> extends WeakReference<T> {
+
+        private final int hash;
+
+        Key(T t, @Nullable ReferenceQueue<T> queue) {
+            super(t, queue);
+            hash = System.identityHashCode(Objects.requireNonNull(t));
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj == this || obj instanceof Key<?> key && key.get() == this.get();
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+
+    private class Iter implements Iterator<Map.Entry<K, V>> {
+
+        private final Iterator<Map.Entry<Key<K>, V>> it;
+        private @Nullable Map.Entry<K, V> nextValue;
+
+        Iter(Iterator<Map.Entry<Key<K>, V>> it) {
+            this.it = it;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (nextValue != null) {
+                return true;
+            }
+            while (it.hasNext()) {
+                Map.Entry<Key<K>, V> entry = it.next();
+                K key = entry.getKey().get();
+                if (key != null) {
+                    nextValue = new Entry(key, entry.getValue());
+                    return true;
+                } else {
+                    it.remove();
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public @Nullable Map.Entry<K, V> next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            Map.Entry<K, V> entry = nextValue;
+            nextValue = null;
+            return entry;
+        }
+
+        @Override
+        public void remove() {
+            it.remove();
+            nextValue = null;
+        }
+    }
+
+    private class EntrySet extends AbstractSet<Map.Entry<K, V>> {
+
+        @Override
+        public Iterator<Map.Entry<K, V>> iterator() {
+            return new Iter(map.entrySet().iterator());
+        }
+
+        @Override
+        public int size() {
+            return ConcurrentWeakIdentityHashMap.this.size();
+        }
+
+        @Override
+        public void clear() {
+            ConcurrentWeakIdentityHashMap.this.clear();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            if (!(o instanceof Map.Entry<?, ?> e)) {
+                return false;
+            }
+            return ConcurrentWeakIdentityHashMap.this.get(e.getKey()) == e.getValue();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            if (!(o instanceof Map.Entry<?, ?> e)) {
+                return false;
+            }
+            return ConcurrentWeakIdentityHashMap.this.remove(e.getKey(), e.getValue());
+        }
+    }
+
+    private class Entry extends AbstractMap.SimpleEntry<K, V> {
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        Entry(K key, V value) {
+            super(key, value);
+        }
+
+        @Override
+        public V setValue(V value) {
+            ConcurrentWeakIdentityHashMap.this.put(getKey(), value);
+            return super.setValue(value);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Map.Entry<?, ?> e) {
+                return getKey() == e.getKey() && getValue() == e.getValue();
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(getKey()) ^ System.identityHashCode(getValue());
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/memoization/GTMemoizer.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/memoization/GTMemoizer.java
@@ -2,6 +2,8 @@ package com.gregtechceu.gtceu.utils.memoization;
 
 import net.minecraft.world.level.block.Block;
 
+import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class GTMemoizer {
@@ -19,5 +21,20 @@ public class GTMemoizer {
 
     public static <T extends Block> MemoizedBlockSupplier<T> memoizeBlockSupplier(Supplier<T> delegate) {
         return new MemoizedBlockSupplier<>(delegate);
+    }
+
+    public static <T, R> Function<T, R> memoizeFunctionWeakIdent(final Function<T, R> memoFunction) {
+        return new Function<>() {
+
+            private final Map<T, R> cache = new ConcurrentWeakIdentityHashMap<>();
+
+            public R apply(T key) {
+                return this.cache.computeIfAbsent(key, memoFunction);
+            }
+
+            public String toString() {
+                return "memoizeFunctionWeakIdent/1[function=" + memoFunction + ", size=" + this.cache.size() + "]";
+            }
+        };
     }
 }


### PR DESCRIPTION
## What
- Cleaned up `RelativeDirection` and the code using it directly
- Made Assembly Lines and Distillation towers not override the definition's part sorter every time they form
- Made `MetaMachineConfigCopyBehaviour` not repeat itself constantly
- Added some new utility methods to `RelativeDirection`
- Also touched up some other stuff _relating_ to the matter

## Implementation Details
- added `IMultiController#getPartSorter` so it can be overridden if necessary
- changed `MultiblockMachineDefinition#partSorter` to be a `fn(contoller) -> comparator<part>` so it can use the controller's state as extra information
  - this is cached via a new memoization function in `GTMemoizer` using `ConcurrentWeakIdentityHashMap`.
- renamed `RelativeDirection#getActualFacing` to `getActualDirection` (the old method still exists, but is deprecated for removal)
- renamed `RelativeDirection#getRelativeFacing` to `getRelative` (the old method still exists, but is deprecated for removal)
- changed `RelativeDirection#getSorter`'s type to `Comparator<BlockPos>`
- added an utility method to `RelativeDirection` for finding the relative direction between two directions

## Outcome
cleaner code in RelativeDirection & co.

## Additional Information
Do tell me if I should make `MetaMachineConfigCopyBehaviour` NOT print out the *actual* relative facing if you find that confusing, as currently it will rotate the direction correctly in all axes, which could result in "above" not actually being up if the machine is facing up or down.

## Potential Compatibility Issues
addons using `RelativeDirection#getSorter` will break, but everything else should work like before.