### PR TITLE
remove unnecessary nbt clearing from custom item fluid handlers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/misc/forge/FilteredFluidHandlerItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/forge/FilteredFluidHandlerItemStack.java
@@ -23,26 +23,6 @@ public class FilteredFluidHandlerItemStack extends FluidHandlerItemStack {
     }
 
     @Override
-    public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
-        FluidStack drained = super.drain(resource, action);
-        this.removeTagWhenEmpty(action);
-        return drained;
-    }
-
-    @Override
-    public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
-        FluidStack drained = super.drain(maxDrain, action);
-        this.removeTagWhenEmpty(action);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(FluidAction action) {
-        if (getFluid() == FluidStack.EMPTY && action.execute()) {
-            this.container.setTag(null);
-        }
-    }
-
-    @Override
     public boolean canFillFluidType(FluidStack fluid) {
         return filter.test(fluid);
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/forge/SimpleThermalFluidHandlerItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/forge/SimpleThermalFluidHandlerItemStack.java
@@ -3,18 +3,23 @@ package com.gregtechceu.gtceu.api.misc.forge;
 import com.gregtechceu.gtceu.api.capability.IThermalFluidHandlerItemStack;
 
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStackSimple;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStackSimple
                                                 implements IThermalFluidHandlerItemStack {
 
-    public final int maxFluidTemperature;
+    @Getter
+    private final int maxFluidTemperature;
+    @Getter
     private final boolean gasProof;
+    @Getter
     private final boolean acidProof;
+    @Getter
     private final boolean cryoProof;
+    @Getter
     private final boolean plasmaProof;
 
     public SimpleThermalFluidHandlerItemStack(@NotNull ItemStack container, int capacity, int maxFluidTemperature,
@@ -26,50 +31,5 @@ public class SimpleThermalFluidHandlerItemStack extends FluidHandlerItemStackSim
         this.acidProof = acidProof;
         this.cryoProof = cryoProof;
         this.plasmaProof = plasmaProof;
-    }
-
-    @Override
-    public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
-        FluidStack drained = super.drain(resource, action);
-        this.removeTagWhenEmpty(action);
-        return drained;
-    }
-
-    @Override
-    public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
-        FluidStack drained = super.drain(maxDrain, action);
-        this.removeTagWhenEmpty(action);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(FluidAction action) {
-        if (getFluid() == FluidStack.EMPTY && action.execute()) {
-            this.container.setTag(null);
-        }
-    }
-
-    @Override
-    public int getMaxFluidTemperature() {
-        return maxFluidTemperature;
-    }
-
-    @Override
-    public boolean isGasProof() {
-        return gasProof;
-    }
-
-    @Override
-    public boolean isAcidProof() {
-        return acidProof;
-    }
-
-    @Override
-    public boolean isCryoProof() {
-        return cryoProof;
-    }
-
-    @Override
-    public boolean isPlasmaProof() {
-        return plasmaProof;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/forge/ThermalFluidHandlerItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/forge/ThermalFluidHandlerItemStack.java
@@ -6,14 +6,20 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.templates.FluidHandlerItemStack;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 public class ThermalFluidHandlerItemStack extends FluidHandlerItemStack implements IThermalFluidHandlerItemStack {
 
+    @Getter
     private final int maxFluidTemperature;
+    @Getter
     private final boolean gasProof;
+    @Getter
     private final boolean acidProof;
+    @Getter
     private final boolean cryoProof;
+    @Getter
     private final boolean plasmaProof;
 
     /**
@@ -31,52 +37,7 @@ public class ThermalFluidHandlerItemStack extends FluidHandlerItemStack implemen
     }
 
     @Override
-    public @NotNull FluidStack drain(FluidStack resource, FluidAction action) {
-        FluidStack drained = super.drain(resource, action);
-        this.removeTagWhenEmpty(action);
-        return drained;
-    }
-
-    @Override
-    public @NotNull FluidStack drain(int maxDrain, FluidAction action) {
-        FluidStack drained = super.drain(maxDrain, action);
-        this.removeTagWhenEmpty(action);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(FluidAction action) {
-        if (getFluid() == FluidStack.EMPTY && action.execute()) {
-            this.container.setTag(null);
-        }
-    }
-
-    @Override
     public boolean canFillFluidType(FluidStack fluid) {
         return IThermalFluidHandlerItemStack.super.canFillFluidType(fluid);
-    }
-
-    @Override
-    public int getMaxFluidTemperature() {
-        return maxFluidTemperature;
-    }
-
-    @Override
-    public boolean isGasProof() {
-        return gasProof;
-    }
-
-    @Override
-    public boolean isAcidProof() {
-        return acidProof;
-    }
-
-    @Override
-    public boolean isCryoProof() {
-        return cryoProof;
-    }
-
-    @Override
-    public boolean isPlasmaProof() {
-        return plasmaProof;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/ItemFluidContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ItemFluidContainer.java
@@ -15,9 +15,7 @@ public class ItemFluidContainer implements IRecipeRemainder {
             var drained = handler.drain(FluidType.BUCKET_VOLUME, FluidAction.SIMULATE);
             if (drained.getAmount() != FluidType.BUCKET_VOLUME) return ItemStack.EMPTY;
             handler.drain(FluidType.BUCKET_VOLUME, FluidAction.EXECUTE);
-            var copy = handler.getContainer();
-            copy.setTag(null);
-            return copy;
+            return handler.getContainer();
         }).orElse(itemStack);
     }
 }


### PR DESCRIPTION
## What
Forge's handlers already remove the correct tag when empty, we don't need to delete all the NBT.
All these overrides would've done is delete someone else's NBT tags that we don't have anything to do with.

## Outcome
removed a possible issue (IDK if anyone ever got this to happen but better to be safe than sorry)