### PR TITLE
Fix first hit on a Quantum Chest always inserting all items

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -282,7 +282,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     }
 
     private static boolean isDoubleHit(UUID uuid) {
-        return (System.currentTimeMillis() - INTERACTION_LOGGER.getOrDefault(uuid, System.currentTimeMillis())) < 300;
+        return (System.currentTimeMillis() - INTERACTION_LOGGER.getLong(uuid)) < 300;
     }
 
     @Override


### PR DESCRIPTION
## What
the double tap logic checked the duration between hits with `(currentMillis - INTERACTION_LOGGER.getOrDefault(player, currentMillis()) < 300`, which results in the first hit always being registered as a double tap.
This PR fixes that.