### PR TITLE
Fixed link on docs home page

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -25,4 +25,4 @@ You can download an offline version of this wiki here:
 ## Want to Contribute?
 
 If you want to contribute to this documentation site, feel free to read the instructions and open a pull request on
-[its GitHub repository](https://github.com/GregTechCEu/GregTech-Modern/tree/1.20.1/docs).
+the [GitHub repository](https://github.com/GregTechCEu/GregTech-Modern/tree/1.20.1/docs).

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -24,5 +24,5 @@ You can download an offline version of this wiki here:
 
 ## Want to Contribute?
 
-If you want to contribute to this documentation site, feel free to open a pull request on
-[its GitHub repository](https://github.com/GregTechCEu/gtceu-modern-docs).
+If you want to contribute to this documentation site, feel free to read the instructions and open a pull request on
+[its GitHub repository](https://github.com/GregTechCEu/GregTech-Modern/tree/1.20.1/docs).

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -23,6 +23,5 @@ You can download an offline version of this wiki here:
 
 
 ## Want to Contribute?
-
-If you want to contribute to this documentation site, feel free to read the instructions and open a pull request on
-the [GitHub repository](https://github.com/GregTechCEu/GregTech-Modern/tree/1.20.1/docs).
+If you want to contribute to this documentation site, feel free to read [the instructions](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/docs/CONTRIBUTING.md) and open a pull request on the [GitHub repository](https://github.com/GregTechCEu/GregTech-Modern).
+```


### PR DESCRIPTION
## What
Corrected the link on the home page to link directly to the docs repository instead of going through an archived repo, added a few words to highlight the instructions
