### PR TITLE
Make thorium and magnesite ores obtainable again

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -177,7 +177,7 @@ public class GTOres {
             .dikeVeinGenerator(generator -> generator
                     .withBlock(new DikeBlockDefinition(Beryllium, 3, 5, 30))
                     .withBlock(new DikeBlockDefinition(Emerald, 2, 5, 19))
-                    .withBlock(new DikeBlockDefinition(Emerald, 2, 16, 30)))
+                    .withBlock(new DikeBlockDefinition(Thorium, 1, 16, 30)))
             .surfaceIndicatorGenerator(indicator -> indicator
                     .surfaceRock(Beryllium)
                     .placement(SurfaceIndicatorGenerator.IndicatorPlacement.ABOVE)));
@@ -659,7 +659,7 @@ public class GTOres {
             .layeredVeinGenerator(generator -> generator
                     .withLayerPattern(() -> GTLayerPattern.builder(OVERWORLD_RULES)
                             .layer(l -> l.weight(3).mat(Bentonite).size(2, 4))
-                            .layer(l -> l.weight(2).mat(Magnetite).size(1, 1))
+                            .layer(l -> l.weight(2).mat(Magnesite).size(1, 1))
                             .layer(l -> l.weight(2).mat(Olivine).size(1, 1))
                             .layer(l -> l.weight(1).mat(GlauconiteSand).size(1, 1))
                             .build()))


### PR DESCRIPTION
## What
Magnesite and thorium ores were previously unobtainable even though they are obtainable in 1.12 GTCEu. 

## Implementation Details
Modifed thorium ore's weight to 1 based on an older revision.

## Outcome
Magnesite and thorium ores now generate in olivine and beryllium veins respectively.

Closes #3222 