### PR TITLE
Fix missing maxDamage override in armorcomponent

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorComponentItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorComponentItem.java
@@ -119,6 +119,11 @@ public class ArmorComponentItem extends ArmorItem implements IComponentItem {
     }
 
     @Override
+    public int getMaxDamage(ItemStack stack) {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
     public <T extends LivingEntity> int damageItem(ItemStack stack, int amount, T entity, Consumer<T> onBroken) {
         return armorLogic.damageArmor(entity, stack, entity.getLastDamageSource(), amount, this.getEquipmentSlot());
     }


### PR DESCRIPTION
## What
In https://github.com/GregTechCEu/GregTech-Modern/pull/3205, a bug was introduced that meant getMaxDamage was 0 on ArmorComponentItems
Shooting an arrow at yourself while wearing any armor immediately breaks it

## Outcome
see https://discord.com/channels/701354865217110096/1089296351906504835/1384280384195526916
Now shooting an arrow at yourself doesn't break it.