### PR TITLE
Disable diode/battery buffer output when working is disabled

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -28,7 +28,6 @@ import net.minecraft.core.Direction;
 import net.minecraftforge.energy.IEnergyStorage;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -48,7 +47,6 @@ public class BatteryBufferMachine extends TieredEnergyMachine
 
     @Persisted
     @Getter
-    @Setter
     private boolean isWorkingEnabled;
     @Getter
     private final int inventorySize;
@@ -143,6 +141,12 @@ public class BatteryBufferMachine extends TieredEnergyMachine
     // ****** Battery Logic ******//
     //////////////////////////////////////
 
+    @Override
+    public void setWorkingEnabled(boolean workingEnabled) {
+        isWorkingEnabled = workingEnabled;
+        energyContainer.checkOutputSubscription();
+    }
+
     private List<Object> getNonFullBatteries() {
         List<Object> batteries = new ArrayList<>();
         for (int i = 0; i < batteryInventory.getSlots(); i++) {
@@ -207,6 +211,16 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                     inventorySize * AMPS_PER_BATTERY, GTValues.V[tier], inventorySize);
             this.setSideInputCondition(side -> side != getFrontFacing() && isWorkingEnabled());
             this.setSideOutputCondition(side -> side == getFrontFacing() && isWorkingEnabled());
+        }
+
+        @Override
+        public void checkOutputSubscription() {
+            if (isWorkingEnabled()) {
+                super.checkOutputSubscription();
+            } else if (outputSubs != null) {
+                outputSubs.unsubscribe();
+                outputSubs = null;
+            }
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -214,7 +214,7 @@ public class BatteryBufferMachine extends TieredEnergyMachine
             if (!isWorkingEnabled()) {
                 return;
             }
-            
+
             var outFacing = getFrontFacing();
             var energyContainer = GTCapabilityHelper.getEnergyContainer(getLevel(), getPos().relative(outFacing),
                     outFacing.getOpposite());

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -211,6 +211,10 @@ public class BatteryBufferMachine extends TieredEnergyMachine
 
         @Override
         public void serverTick() {
+            if (!isWorkingEnabled()) {
+                return;
+            }
+            
             var outFacing = getFrontFacing();
             var energyContainer = GTCapabilityHelper.getEnergyContainer(getLevel(), getPos().relative(outFacing),
                     outFacing.getOpposite());

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DiodePartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DiodePartMachine.java
@@ -78,7 +78,7 @@ public class DiodePartMachine extends TieredIOPartMachine {
 
         this.energyContainer.resetBasicInfo(tierVoltage * MAX_AMPS * 2, tierVoltage, amps, tierVoltage, amps);
         this.energyContainer.setSideInputCondition(s -> s != getFrontFacing());
-        this.energyContainer.setSideOutputCondition(s -> s == getFrontFacing());
+        this.energyContainer.setSideOutputCondition(s -> s == getFrontFacing() && isWorkingEnabled());
     }
 
     @Override


### PR DESCRIPTION
## What
Adds isWorkingEnabled check to diodes and battery buffers, to prevent output when working is disabled

## Implementation Details
Since isWorkingEnabled() was already an SideOutputCondition in the battery buffer, this may need some attention, since in game the battery buffers still output energy when working is disabled

## Outcome
Diodes and battery buffers no longer output energy when working is disabled

## Additional Information
N/A

## Potential Compatibility Issues
I don't think this will have compat issues