### PR TITLE
Add API for using custom blocks/items in `TagPrefix`es

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/OreBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/OreBlock.java
@@ -18,9 +18,9 @@ import net.minecraft.world.phys.BlockHitResult;
 
 public class OreBlock extends MaterialBlock {
 
-    public OreBlock(Properties properties, TagPrefix tagPrefix, Material material, boolean registerModel) {
+    public OreBlock(Properties properties, TagPrefix tagPrefix, Material material) {
         super(properties, tagPrefix, material, false);
-        if (registerModel && GTCEu.isClientSide()) {
+        if (GTCEu.isClientSide()) {
             OreBlockRenderer.create(this);
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -4,12 +4,16 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.addon.AddonFinder;
 import com.gregtechceu.gtceu.api.addon.IGTAddon;
+import com.gregtechceu.gtceu.api.block.MaterialBlock;
+import com.gregtechceu.gtceu.api.block.OreBlock;
 import com.gregtechceu.gtceu.api.data.chemical.material.ItemMaterialData;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconType;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
+import com.gregtechceu.gtceu.api.item.MaterialBlockItem;
+import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
@@ -30,6 +34,7 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
@@ -998,8 +1003,17 @@ public class TagPrefix {
     private boolean generateRecycling = false;
     @Setter
     private boolean generateItem;
+    @Getter
+    @Setter
+    private ItemConstructor itemConstructor = TagPrefixItem::new;
     @Setter
     private boolean generateBlock;
+    @Getter
+    @Setter
+    private BlockConstructor blockConstructor = MaterialBlock::new;
+    @Getter
+    @Setter
+    private BlockItemConstructor blockItemConstructor = MaterialBlockItem::new;
     @Getter
     @Setter
     private BlockProperties blockProperties = new BlockProperties(() -> RenderType::translucent,
@@ -1055,6 +1069,7 @@ public class TagPrefix {
                 .materialIconType(MaterialIconType.ore)
                 .miningToolTag(miningToolTag)
                 .unificationEnabled(true)
+                .blockConstructor(OreBlock::new)
                 .generationCondition(hasOreProperty);
     }
 
@@ -1319,5 +1334,23 @@ public class TagPrefix {
     @Override
     public String toString() {
         return name;
+    }
+
+    @FunctionalInterface
+    public interface ItemConstructor {
+
+        Item create(Item.Properties properties, TagPrefix prefix, Material material);
+    }
+
+    @FunctionalInterface
+    public interface BlockConstructor {
+
+        Block create(Block.Properties properties, TagPrefix prefix, Material material);
+    }
+
+    @FunctionalInterface
+    public interface BlockItemConstructor {
+
+        BlockItem create(Block block, Item.Properties properties, TagPrefix prefix, Material material);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/MaterialBlockItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/MaterialBlockItem.java
@@ -2,8 +2,10 @@ package com.gregtechceu.gtceu.api.item;
 
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.block.MaterialBlock;
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.DustProperty;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 
 import com.lowdragmc.lowdraglib.client.renderer.IBlockRendererProvider;
 import com.lowdragmc.lowdraglib.client.renderer.IItemRendererProvider;
@@ -12,9 +14,9 @@ import com.lowdragmc.lowdraglib.client.renderer.IRenderer;
 import net.minecraft.client.color.item.ItemColor;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.block.Block;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -23,20 +25,19 @@ import org.jetbrains.annotations.Nullable;
 
 public class MaterialBlockItem extends BlockItem implements IItemRendererProvider {
 
-    protected MaterialBlockItem(MaterialBlock block, Properties properties) {
-        super(block, properties);
-    }
+    public final TagPrefix tagPrefix;
+    public final Material material;
 
-    public static MaterialBlockItem create(MaterialBlock block, Item.Properties properties) {
-        return new MaterialBlockItem(block, properties);
+    public MaterialBlockItem(Block block, Properties properties, TagPrefix tagPrefix, Material material) {
+        super(block, properties);
+        this.tagPrefix = tagPrefix;
+        this.material = material;
     }
 
     @Override
     public int getBurnTime(ItemStack itemStack, @Nullable RecipeType<?> recipeType) {
         return getItemBurnTime();
     }
-
-    public void onRegister() {}
 
     @Override
     @NotNull
@@ -45,13 +46,8 @@ public class MaterialBlockItem extends BlockItem implements IItemRendererProvide
     }
 
     @OnlyIn(Dist.CLIENT)
-    public static ItemColor tintColor() {
-        return (itemStack, index) -> {
-            if (itemStack.getItem() instanceof MaterialBlockItem materialBlockItem) {
-                return materialBlockItem.getBlock().material.getLayerARGB(index);
-            }
-            return -1;
-        };
+    public static ItemColor tintColor(Material material) {
+        return (itemStack, index) -> material.getLayerARGB(index);
     }
 
     @Nullable
@@ -85,10 +81,10 @@ public class MaterialBlockItem extends BlockItem implements IItemRendererProvide
     }
 
     public int getItemBurnTime() {
-        var material = getBlock().material;
         DustProperty property = material.isNull() ? null : material.getProperty(PropertyKey.DUST);
-        if (property != null)
-            return (int) (property.getBurnTime() * getBlock().tagPrefix.getMaterialAmount(material) / GTValues.M);
+        if (property != null) {
+            return (int) (property.getBurnTime() * tagPrefix.getMaterialAmount(material) / GTValues.M);
+        }
         return -1;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/TagPrefixItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/TagPrefixItem.java
@@ -51,16 +51,9 @@ public class TagPrefixItem extends Item {
         return getItemBurnTime();
     }
 
-    public void onRegister() {}
-
     @OnlyIn(Dist.CLIENT)
-    public static ItemColor tintColor() {
-        return (itemStack, index) -> {
-            if (itemStack.getItem() instanceof TagPrefixItem tagPrefixItem) {
-                return tagPrefixItem.material.getLayerARGB(index);
-            }
-            return -1;
-        };
+    public static ItemColor tintColor(Material material) {
+        return (itemStack, index) -> material.getLayerARGB(index);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.registry.registrate.forge.GTFluidBuilder;
+import com.gregtechceu.gtceu.core.mixins.AbstractRegistrateAccessor;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -28,8 +29,12 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.data.event.GatherDataEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.RegisterEvent;
 import net.minecraftforge.registries.RegistryObject;
 
 import com.tterrag.registrate.Registrate;
@@ -37,6 +42,7 @@ import com.tterrag.registrate.builders.Builder;
 import com.tterrag.registrate.builders.ItemBuilder;
 import com.tterrag.registrate.builders.NoConfigBuilder;
 import com.tterrag.registrate.providers.ProviderType;
+import com.tterrag.registrate.util.OneTimeEventReceiver;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import com.tterrag.registrate.util.entry.RegistryEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
@@ -89,7 +95,22 @@ public class GTRegistrate extends Registrate {
     @Override
     public Registrate registerEventListeners(IEventBus bus) {
         if (!registered.getAndSet(true)) {
-            return super.registerEventListeners(bus);
+            // recreate the super method so we can register the event listener with LOW priority.
+            Consumer<RegisterEvent> onRegister = this::onRegister;
+            Consumer<RegisterEvent> onRegisterLate = this::onRegisterLate;
+            bus.addListener(EventPriority.LOW, onRegister);
+            bus.addListener(EventPriority.LOWEST, onRegisterLate);
+
+            // Fired multiple times when ever tabs need contents rebuilt (changing op tab perms for example)
+            bus.addListener(this::onBuildCreativeModeTabContents);
+            // Register events fire multiple times, so clean them up on common setup
+            OneTimeEventReceiver.addModListener(this, FMLCommonSetupEvent.class, $ -> {
+                OneTimeEventReceiver.unregister(this, onRegister, RegisterEvent.class);
+                OneTimeEventReceiver.unregister(this, onRegisterLate, RegisterEvent.class);
+            });
+            if (((AbstractRegistrateAccessor) this).getDoDatagen().get()) {
+                OneTimeEventReceiver.addModListener(this, GatherDataEvent.class, this::onData);
+            }
         }
         return this;
     }

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.forge;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.block.MaterialBlock;
 import com.gregtechceu.gtceu.api.block.MetaMachineBlock;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IElectricItem;
@@ -17,7 +16,6 @@ import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.item.DrumMachineItem;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
-import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
@@ -71,11 +69,13 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.PotionItem;
 import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
@@ -638,7 +638,7 @@ public class ForgeCommonEventListener {
             event.getMappings(Registries.BLOCK, GTCEu.MOD_ID).forEach(mapping -> {
                 Matcher matcher = idPattern.matcher(mapping.getKey().getPath());
                 if (matcher.matches()) {
-                    BlockEntry<? extends MaterialBlock> block = GTMaterialBlocks.MATERIAL_BLOCKS.get(prefix,
+                    BlockEntry<? extends Block> block = GTMaterialBlocks.MATERIAL_BLOCKS.get(prefix,
                             GTCEuAPI.materialManager.getRegistry(GTCEu.MOD_ID).get(matcher.group(1)));
                     if (block != null && block.isPresent()) {
                         mapping.remap(block.get());
@@ -648,12 +648,12 @@ public class ForgeCommonEventListener {
             event.getMappings(Registries.ITEM, GTCEu.MOD_ID).forEach(mapping -> {
                 Matcher matcher = idPattern.matcher(mapping.getKey().getPath());
                 if (matcher.matches()) {
-                    BlockEntry<? extends MaterialBlock> block = GTMaterialBlocks.MATERIAL_BLOCKS.get(prefix,
+                    BlockEntry<? extends Block> block = GTMaterialBlocks.MATERIAL_BLOCKS.get(prefix,
                             GTCEuAPI.materialManager.getRegistry(GTCEu.MOD_ID).get(matcher.group(1)));
                     if (block != null && block.isPresent()) {
                         mapping.remap(block.asItem());
                     } else {
-                        ItemEntry<? extends TagPrefixItem> item = GTMaterialItems.MATERIAL_ITEMS.get(prefix,
+                        ItemEntry<? extends Item> item = GTMaterialItems.MATERIAL_ITEMS.get(prefix,
                                 GTCEuAPI.materialManager.getRegistry(GTCEu.MOD_ID).get(matcher.group(1)));
                         if (item != null && item.isPresent()) {
                             mapping.remap(item.asItem());


### PR DESCRIPTION
## What
Call `TagPrefix.blockConstructor(ctorCallHere)`, or the same method for items or block items, to override the default logic for intializing the blocks.
Also lowered the register event listener's priority in hopes of that fixing the KJS ore type fiasco

## Implementation Details
Added a few functional interfaces.

## Outcome
it's now supported wow
also hopefully ad astra ore blocks work without any extra fiddling now?