### PR TITLE
Fix KJS recipe types' slot overlays not working

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -28,8 +28,6 @@ import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.item.crafting.SmeltingRecipe;
 
-import it.unimi.dsi.fastutil.bytes.Byte2ObjectArrayMap;
-import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
 import it.unimi.dsi.fastutil.objects.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -57,8 +57,6 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
     @Getter
     @Setter
     private GTRecipeTypeUI recipeUI = new GTRecipeTypeUI(this);
-    @Getter
-    private final Byte2ObjectMap<IGuiTexture> slotOverlays = new Byte2ObjectArrayMap<>();
     @Setter
     @Getter
     private GTRecipeType smallRecipeMap;
@@ -85,7 +83,6 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
     private final GTRecipeCategory category;
     @Getter
     private final Map<GTRecipeCategory, Set<GTRecipe>> categoryMap = new Object2ObjectOpenHashMap<>();
-    private CompoundTag customUICache;
     @Getter
     private final GTRecipeLookup lookup = new GTRecipeLookup(this);
     @Setter

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
@@ -12,9 +12,6 @@ import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ProgressTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceTexture;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
-import com.lowdragmc.lowdraglib.utils.Position;
-import com.lowdragmc.lowdraglib.utils.Rect;
-import com.lowdragmc.lowdraglib.utils.Size;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+@SuppressWarnings("unused")
 public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
 
     public transient String name, category;
@@ -36,8 +37,6 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
     private ProgressTexture progressBarTexture;
     private SteamTexture steamProgressBarTexture;
     private ProgressTexture.FillDirection steamMoveType;
-    private transient IGuiTexture specialTexture;
-    private transient Rect specialTexturePosition;
     private transient final Byte2ObjectMap<IGuiTexture> slotOverlays;
     @Nullable
     protected SoundEntry sound;
@@ -95,13 +94,6 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         if (io == IO.OUT || io == IO.BOTH) {
             maxOutputs.put(cap, max);
         }
-        return this;
-    }
-
-    @Deprecated
-    public GTRecipeTypeBuilder setSpecialTexture(int x, int y, int width, int height, IGuiTexture area) {
-        this.specialTexturePosition = Rect.of(new Position(x, y), new Size(width, height));
-        this.specialTexture = area;
         return this;
     }
 
@@ -163,7 +155,7 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         var type = GTRecipeTypes.register(name, category);
         type.maxInputs.putAll(maxInputs);
         type.maxOutputs.putAll(maxOutputs);
-        type.getSlotOverlays().putAll(slotOverlays);
+        type.getRecipeUI().getSlotOverlays().putAll(slotOverlays);
         type.getRecipeUI().setProgressBarTexture(progressBarTexture);
         type.getRecipeUI().setSteamProgressBarTexture(steamProgressBarTexture);
         type.getRecipeUI().setSteamMoveType(steamMoveType);


### PR DESCRIPTION
## What
Switch slot overlay map from `GTRecipeType#slotOverlays` to `GTRecipeTypeUI#slotOverlays`
Patch by @screret, only thing I did was make the PR lol

## Implementation
Removed `GTRecipeTypeBuilder#setSpecialTexture`