### PR TITLE
Sort ME2 stocking busses and hatches by amount

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -199,6 +199,18 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
                 Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
 
         for (Object2LongMap.Entry<AEKey> entry : counter) {
+            AEKey what = entry.getKey();
+            long amount = entry.getLongValue();
+
+            if (amount <= 0) continue;
+            if (!(what instanceof AEItemKey itemKey)) continue;
+
+            long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
+            if (request == 0) continue;
+
+            // Ensure that it is valid to configure with this stack
+            if (autoPullTest != null && !autoPullTest.test(new GenericStack(itemKey, amount))) continue;
+
             if (topItems.size() < CONFIG_SIZE) {
                 topItems.offer(entry);
             } else if (entry.getLongValue() > topItems.peek().getLongValue()) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -38,6 +38,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Comparator;
+import java.util.PriorityQueue;
 import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -179,7 +181,7 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
 
     /**
      * Refresh the configuration list in auto-pull mode.
-     * Sets the config to the first 16 valid items found in the network.
+     * Sets the config to the CONFIG_SIZE items with the highest amount in the ME system.
      */
     private void refreshList() {
         IGrid grid = this.getMainNode().getGrid();
@@ -190,9 +192,27 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
 
         MEStorage networkStorage = grid.getStorageService().getInventory();
         var counter = networkStorage.getAvailableStacks();
-        int index = 0;
+
+        // Use a PriorityQueue to sort the stacks on size, take the first CONFIG_SIZE
+        // biggest stacks.
+        PriorityQueue<Object2LongMap.Entry<AEKey>> topItems = new PriorityQueue<>(
+                Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
+
         for (Object2LongMap.Entry<AEKey> entry : counter) {
-            if (index >= CONFIG_SIZE) break;
+            if (topItems.size() < CONFIG_SIZE) {
+                topItems.offer(entry);
+            } else if (entry.getLongValue() > topItems.peek().getLongValue()) {
+                topItems.poll();
+                topItems.offer(entry);
+            }
+        }
+
+        // Now, topItems is a PQ with CONFIG_SIZE highest amount items in the system.
+        int index;
+        int itemAmount = topItems.size();
+        for (index = 0; index < CONFIG_SIZE; index++) {
+            if (topItems.isEmpty()) break;
+            Object2LongMap.Entry<AEKey> entry = topItems.poll();
             AEKey what = entry.getKey();
             long amount = entry.getLongValue();
 
@@ -205,10 +225,11 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
             // Ensure that it is valid to configure with this stack
             if (autoPullTest != null && !autoPullTest.test(new GenericStack(itemKey, amount))) continue;
 
-            var slot = this.aeItemHandler.getInventory()[index];
+            // Since we want our items to be displayed from highest to lowest, but poll() returns
+            // the lowest first, we fill in the slots starting at itemAmount-1
+            var slot = this.aeItemHandler.getInventory()[itemAmount - index - 1];
             slot.setConfig(new GenericStack(what, 1));
             slot.setStock(new GenericStack(what, request));
-            index++;
         }
 
         aeItemHandler.clearInventory(index);

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -226,17 +226,12 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
         for (index = 0; index < CONFIG_SIZE; index++) {
             if (topItems.isEmpty()) break;
             Object2LongMap.Entry<AEKey> entry = topItems.poll();
+
             AEKey what = entry.getKey();
             long amount = entry.getLongValue();
 
-            if (amount <= 0) continue;
-            if (!(what instanceof AEItemKey itemKey)) continue;
-
+            // If we get here, the item has already been checked by the PQ.
             long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
-            if (request == 0) continue;
-
-            // Ensure that it is valid to configure with this stack
-            if (autoPullTest != null && !autoPullTest.test(new GenericStack(itemKey, amount))) continue;
 
             // Since we want our items to be displayed from highest to lowest, but poll() returns
             // the lowest first, we fill in the slots starting at itemAmount-1

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -200,7 +200,7 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
 
         for (Object2LongMap.Entry<AEKey> entry : counter) {
             long amount = entry.getLongValue();
-            if (!topItems.isEmpty() && amount <= topItems.peek().getLongValue()) continue;
+            if (!topItems.isEmpty() && amount < topItems.peek().getLongValue()) continue;
             AEKey what = entry.getKey();
 
             if (amount <= 0) continue;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -199,8 +199,9 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
                 Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
 
         for (Object2LongMap.Entry<AEKey> entry : counter) {
-            AEKey what = entry.getKey();
             long amount = entry.getLongValue();
+            if (!topItems.isEmpty() && amount <= topItems.peek().getLongValue()) continue;
+            AEKey what = entry.getKey();
 
             if (amount <= 0) continue;
             if (!(what instanceof AEItemKey itemKey)) continue;
@@ -213,7 +214,7 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
 
             if (topItems.size() < CONFIG_SIZE) {
                 topItems.offer(entry);
-            } else if (entry.getLongValue() > topItems.peek().getLongValue()) {
+            } else if (amount > topItems.peek().getLongValue()) {
                 topItems.poll();
                 topItems.offer(entry);
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
@@ -183,7 +183,7 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
 
         for (Object2LongMap.Entry<AEKey> entry : counter) {
             long amount = entry.getLongValue();
-            if (!topFluids.isEmpty() && amount <= topFluids.peek().getLongValue()) continue;
+            if (!topFluids.isEmpty() && amount < topFluids.peek().getLongValue()) continue;
 
             AEKey what = entry.getKey();
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
@@ -39,6 +39,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Comparator;
+import java.util.PriorityQueue;
 import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -173,9 +175,13 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
 
         MEStorage networkStorage = grid.getStorageService().getInventory();
         var counter = networkStorage.getAvailableStacks();
-        int index = 0;
+
+        // Use a PriorityQueue to sort the stacks on size, take the first CONFIG_SIZE
+        // biggest stacks.
+        PriorityQueue<Object2LongMap.Entry<AEKey>> topFluids = new PriorityQueue<>(
+                Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
+
         for (Object2LongMap.Entry<AEKey> entry : counter) {
-            if (index >= CONFIG_SIZE) break;
             AEKey what = entry.getKey();
             long amount = entry.getLongValue();
 
@@ -188,10 +194,37 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
             // Ensure that it is valid to configure with this stack
             if (autoPullTest != null && !autoPullTest.test(new GenericStack(fluidKey, amount))) continue;
 
-            var slot = this.aeFluidHandler.getInventory()[index];
+            if (topFluids.size() < CONFIG_SIZE) {
+                topFluids.offer(entry);
+            } else if (entry.getLongValue() > topFluids.peek().getLongValue()) {
+                topFluids.poll();
+                topFluids.offer(entry);
+            }
+        }
+
+        // Now, topFluids is a PQ with CONFIG_SIZE highest amount fluids in the system.
+        int index;
+        int fluidAmount = topFluids.size();
+        for (index = 0; index < CONFIG_SIZE; index++) {
+            if (topFluids.isEmpty()) break;
+            Object2LongMap.Entry<AEKey> entry = topFluids.poll();
+            AEKey what = entry.getKey();
+            long amount = entry.getLongValue();
+
+            if (amount <= 0) continue;
+            if (!(what instanceof AEFluidKey fluidKey)) continue;
+
+            long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
+            if (request == 0) continue;
+
+            // Ensure that it is valid to configure with this stack
+            if (autoPullTest != null && !autoPullTest.test(new GenericStack(fluidKey, amount))) continue;
+
+            // Since we want our fluids to be displayed from highest to lowest, but poll() returns
+            // the lowest first, we fill in the slots starting at fluidAmount-1
+            var slot = this.aeFluidHandler.getInventory()[fluidAmount - index - 1];
             slot.setConfig(new GenericStack(what, 1));
             slot.setStock(new GenericStack(what, request));
-            index++;
         }
 
         aeFluidHandler.clearInventory(index);

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
@@ -182,8 +182,10 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
                 Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
 
         for (Object2LongMap.Entry<AEKey> entry : counter) {
-            AEKey what = entry.getKey();
             long amount = entry.getLongValue();
+            if (!topFluids.isEmpty() && amount <= topFluids.peek().getLongValue()) continue;
+
+            AEKey what = entry.getKey();
 
             if (amount <= 0) continue;
             if (!(what instanceof AEFluidKey fluidKey)) continue;
@@ -196,7 +198,7 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
 
             if (topFluids.size() < CONFIG_SIZE) {
                 topFluids.offer(entry);
-            } else if (entry.getLongValue() > topFluids.peek().getLongValue()) {
+            } else if (amount > topFluids.peek().getLongValue()) {
                 topFluids.poll();
                 topFluids.offer(entry);
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
@@ -213,14 +213,8 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
             AEKey what = entry.getKey();
             long amount = entry.getLongValue();
 
-            if (amount <= 0) continue;
-            if (!(what instanceof AEFluidKey fluidKey)) continue;
-
+            // If we get here, the fluid has already been checked by the PQ.
             long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
-            if (request == 0) continue;
-
-            // Ensure that it is valid to configure with this stack
-            if (autoPullTest != null && !autoPullTest.test(new GenericStack(fluidKey, amount))) continue;
 
             // Since we want our fluids to be displayed from highest to lowest, but poll() returns
             // the lowest first, we fill in the slots starting at fluidAmount-1


### PR DESCRIPTION
Closes #2995 

## What
Filters the stocking input bus and hatch to contain the 16 largest item/fluid stacks

## Implementation Details
It uses an `PriorityQueue<Object2LongMap.Entry<AEKey>>` to iterate through all items.
This might have severe performance drawbacks? For every entry, it first checks if it's valid with
```java
long amount = entry.getLongValue();
if (!topItems.isEmpty() && amount <= topItems.peek().getLongValue()) continue;

 if (amount <= 0) continue;
if (!(what instanceof AEItemKey itemKey)) continue;

long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
if (request == 0) continue;
```
This might take a lot of time with large nets that have a lot of items and stocking busses?
It only runs every 100 ticks though. Needs more input.

## Additional Information
![image](https://github.com/user-attachments/assets/7e4dfbb7-0c36-4ec9-8ec9-522de98b272a)
![image](https://github.com/user-attachments/assets/2e5a1dff-0fc9-4dec-b6db-7f0c2bd223bd)