### PR TITLE
Fix iTNT dropping itself after being broken

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/block/explosive/GTExplosiveBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/explosive/GTExplosiveBlock.java
@@ -24,11 +24,14 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.storage.loot.LootParams;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.BlockHitResult;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -139,6 +142,18 @@ public abstract class GTExplosiveBlock extends Block {
                 level.removeBlock(pos, false);
             }
         }
+    }
+
+    @Override
+    public List<ItemStack> getDrops(BlockState state, LootParams.Builder params) {
+        if (explodeOnMine) {
+            Entity player = params.getOptionalParameter(LootContextParams.THIS_ENTITY);
+            if (player != null && !player.isShiftKeyDown()) {
+                return Collections.emptyList();
+            }
+        }
+
+        return super.getDrops(state, params);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -691,7 +691,8 @@ public class GTBlocks {
     public static final BlockEntry<IndustrialTNTBlock> INDUSTRIAL_TNT = REGISTRATE
             .block("industrial_tnt", IndustrialTNTBlock::new)
             .lang("Industrial TNT")
-            .properties(p -> p.mapColor(MapColor.FIRE).instabreak().sound(SoundType.GRASS).ignitedByLava())
+            .properties(
+                    p -> p.mapColor(MapColor.FIRE).instabreak().sound(SoundType.GRASS).ignitedByLava().noLootTable())
             .tag(BlockTags.MINEABLE_WITH_AXE)
             .blockstate((ctx, prov) -> prov.simpleBlock(ctx.get(), prov.models().cubeBottomTop(ctx.getName(),
                     GTCEu.id("block/misc/industrial_tnt_side"),

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -691,8 +691,7 @@ public class GTBlocks {
     public static final BlockEntry<IndustrialTNTBlock> INDUSTRIAL_TNT = REGISTRATE
             .block("industrial_tnt", IndustrialTNTBlock::new)
             .lang("Industrial TNT")
-            .properties(
-                    p -> p.mapColor(MapColor.FIRE).instabreak().sound(SoundType.GRASS).ignitedByLava().noLootTable())
+            .properties(p -> p.mapColor(MapColor.FIRE).instabreak().sound(SoundType.GRASS).ignitedByLava())
             .tag(BlockTags.MINEABLE_WITH_AXE)
             .blockstate((ctx, prov) -> prov.simpleBlock(ctx.get(), prov.models().cubeBottomTop(ctx.getName(),
                     GTCEu.id("block/misc/industrial_tnt_side"),


### PR DESCRIPTION
## What
Fixes an issue with iTNT where when breaking it to ignite it, it would drop the iTNT block so you could use it over and over again.

## Implementation Details
Override `getDrops` in `GTExplosiveBlock` so that if the explosive explodes on break and the player is not sneaking, it drops nothing.

## Outcome
No more free explosion mining.

## Additional Information
Discovered in https://discord.com/channels/701354865217110096/1089296351906504835/1388475817289449573