### PR TITLE
fix magnetic tools crashing the server when `drops` is immutable

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/ToolEventHandlers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/ToolEventHandlers.java
@@ -36,6 +36,7 @@ import net.minecraftforge.fml.common.Mod;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -135,6 +136,7 @@ public class ToolEventHandlers {
             }
         }
         if (behaviorTag.getBoolean(ToolHelper.RELOCATE_MINED_BLOCKS_KEY)) {
+            drops = new ArrayList<>(drops);
             Iterator<ItemStack> dropItr = drops.iterator();
             while (dropItr.hasNext()) {
                 ItemStack dropStack = dropItr.next();


### PR DESCRIPTION
we already return the list just simply cloning it works :)

fixes #3284
fixes #2826