### PR TITLE
Edit gitattribute text tag to auto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=autolf
+* text=auto
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.


### PR DESCRIPTION
## What
Fix .gitattribute text value

## Outcome
My spotless apply doesn't automatically add \r anymore

## Additional Information
it used to be autolf, but that's not a correct value
see https://discord.com/channels/701354865217110096/1089296351906504835/1388609856847741089