### PR TITLE
Rebalance flint tools

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -394,7 +394,7 @@ public class SecondDegreeMaterials {
                 .color(0xc7c7c7).secondaryColor(0x212121).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
-                .toolStats(ToolProperty.Builder.of(0F, 0F, 64, 1)
+                .toolStats(ToolProperty.Builder.of(0.0F, 0.0F, 64, 1)
                         .types(GTToolType.MORTAR, GTToolType.KNIFE, GTToolType.AXE, GTToolType.PICKAXE, GTToolType.HOE,
                                 GTToolType.SWORD, GTToolType.SHOVEL)
                         .enchantability(5).ignoreCraftingTools()

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -394,7 +394,7 @@ public class SecondDegreeMaterials {
                 .color(0xc7c7c7).secondaryColor(0x212121).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
-                .toolStats(ToolProperty.Builder.of(1.0F, 1.0F, 64, 1)
+                .toolStats(ToolProperty.Builder.of(0F, 0F, 64, 1)
                         .types(GTToolType.MORTAR, GTToolType.KNIFE, GTToolType.AXE, GTToolType.PICKAXE, GTToolType.HOE,
                                 GTToolType.SWORD, GTToolType.SHOVEL)
                         .enchantability(5).ignoreCraftingTools()

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -394,11 +394,11 @@ public class SecondDegreeMaterials {
                 .color(0xc7c7c7).secondaryColor(0x212121).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
-                .toolStats(ToolProperty.Builder.of(1.5F, 1.0F, 64, 2)
+                .toolStats(ToolProperty.Builder.of(1.0F, 1.0F, 64, 1)
                         .types(GTToolType.MORTAR, GTToolType.KNIFE, GTToolType.AXE, GTToolType.PICKAXE, GTToolType.HOE,
                                 GTToolType.SWORD, GTToolType.SHOVEL)
                         .enchantability(5).ignoreCraftingTools()
-                        .enchantment(Enchantments.FIRE_ASPECT, 2).build())
+                        .enchantment(Enchantments.FIRE_ASPECT, 1).build())
                 .buildAndRegister();
 
         Air = new Material.Builder(GTCEu.id("air"))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -394,7 +394,7 @@ public class SecondDegreeMaterials {
                 .color(0xc7c7c7).secondaryColor(0x212121).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(SiliconDioxide, 1)
-                .toolStats(ToolProperty.Builder.of(0.0F, 0.0F, 64, 1)
+                .toolStats(ToolProperty.Builder.of(0.0F, 1.0F, 64, 1)
                         .types(GTToolType.MORTAR, GTToolType.KNIFE, GTToolType.AXE, GTToolType.PICKAXE, GTToolType.HOE,
                                 GTToolType.SWORD, GTToolType.SHOVEL)
                         .enchantability(5).ignoreCraftingTools()


### PR DESCRIPTION
## What
Flint tools incorrectly had the stas of iron tools (including harvest level). This PR reduces its stats to that of vanilla stone tools, and reduces its innate Fire Aspect II to Fire Aspect I

## Potential Compatibility Issues
None, hopefully. Pre-existing flint tools will retain their old stats