### PR TITLE
Fix Recipe Runner Error Reporting

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -144,8 +144,9 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
         duration = 0;
         isActive = false;
         lastFailedMatches = null;
-        if (status != Status.SUSPEND)
-            status = Status.IDLE;
+        if (status != Status.SUSPEND) {
+            setStatus(Status.IDLE);
+        }
         updateTickSubscription();
     }
 
@@ -443,7 +444,8 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                 }
             }
             // try it again
-            if (!recipeDirty && !suspendAfterFinish && checkRecipe(lastRecipe).isSuccess()) {
+            var recipeCheck = checkRecipe(lastRecipe);
+            if (!recipeDirty && !suspendAfterFinish && recipeCheck.isSuccess()) {
                 setupRecipe(lastRecipe);
             } else {
                 if (suspendAfterFinish) {
@@ -451,6 +453,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                     suspendAfterFinish = false;
                 } else {
                     setStatus(Status.IDLE);
+                    waitingReason = recipeCheck.reason();
                 }
                 consecutiveRecipes = 0;
                 progress = 0;
@@ -521,7 +524,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
 
     @Override
     public IGuiTexture getFancyTooltipIcon() {
-        if (isWaiting()) {
+        if (waitingReason != null) {
             return GuiTextures.INSUFFICIENT_INPUT;
         }
         return IGuiTexture.EMPTY;
@@ -529,7 +532,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
 
     @Override
     public List<Component> getFancyTooltip() {
-        if (isWaiting() && waitingReason != null) {
+        if (waitingReason != null) {
             return List.of(waitingReason);
         }
         return Collections.emptyList();
@@ -537,7 +540,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
 
     @Override
     public boolean showFancyTooltip() {
-        return isWaiting();
+        return waitingReason != null;
     }
 
     protected Map<RecipeCapability<?>, Object2IntMap<?>> makeChanceCaches() {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -109,9 +109,7 @@ class RecipeRunner {
     }
 
     private RecipeHandlingResult handleContents() {
-        var result = handleContentsInternal(io);
-        if (result.isSuccess()) return result;
-        return handleContentsInternal(IO.BOTH);
+        return handleContentsInternal(io);
     }
 
     private RecipeHandlingResult handleContentsInternal(IO capIO) {


### PR DESCRIPTION
## What
Removes the IO.BOTH check in handleContentsInternal as that never happens(we never have BOTH recipe handlers), correctly reports when IN or OUT fails to resolve
![image](https://github.com/user-attachments/assets/b6e916b1-c689-44fd-95e7-e5e141677e50)


## Implementation Details
_Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed._

## Outcome
You know now why a recipe is failing to run
![image](https://github.com/user-attachments/assets/67e76a1a-c50a-4ca2-96b6-2f0b98572c9f)
![image](https://github.com/user-attachments/assets/a8fc375b-c1c5-4dce-8cbf-c03e8399143c)
![image](https://github.com/user-attachments/assets/e94d2145-6522-4d12-8d6d-b0d56ed7aa82)

## Potential Compatibility Issues
If a recipe fails to restart it correctly reports its missing inputs, idk if we want to keep this? 
In the future once RecipeLogic gets refactored we can also store the capability that failed instead of just the reason component to change the fancy icon (just uses the energy bolt atm for all caps)