### PR TITLE
fix KubeJS machine recipes crashing if multiple conditions of different types are added

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -159,7 +159,9 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS addCondition(RecipeCondition condition) {
-            setValue(CONDITIONS, ArrayUtils.add(getValue(CONDITIONS), condition));
+            if (getValue(CONDITIONS) == null) setValue(CONDITIONS, new RecipeCondition[] { condition });
+            else setValue(CONDITIONS, ArrayUtils.add(getValue(CONDITIONS), condition));
+
             save();
             return this;
         }


### PR DESCRIPTION
## What
Fixed a bug where adding, for example, dimension and cleanroom condition to a recipe with KubeJS would make an error.