### PR TITLE
fix my Mistake in checking what a client thread is.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/GTCEu.java
+++ b/src/main/java/com/gregtechceu/gtceu/GTCEu.java
@@ -15,7 +15,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.FMLPaths;
-import net.minecraftforge.fml.util.thread.EffectiveSide;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
 import dev.emi.emi.config.EmiConfig;
@@ -117,11 +116,14 @@ public class GTCEu {
      * @return if the current thread is the client thread
      */
     public static boolean isClientThread() {
-        return isClientSide() && EffectiveSide.get().isClient();
+        return isClientSide() && Minecraft.getInstance().isSameThread();
     }
 
     /**
-     * @return if the FML environment is a client
+     * @return if the game is the <strong>PHYSICAL</strong> client, e.g. not a dedicated server.
+     * @apiNote Do not use this to check if you're currently on the server thread for side-specific actions!
+     * It does <strong>NOT</strong> work for that. Use {@link #isClientThread()} instead.
+     * @see #isClientThread()
      */
     public static boolean isClientSide() {
         return FMLEnvironment.dist.isClient();

--- a/src/main/java/com/gregtechceu/gtceu/GTCEu.java
+++ b/src/main/java/com/gregtechceu/gtceu/GTCEu.java
@@ -122,7 +122,7 @@ public class GTCEu {
     /**
      * @return if the game is the <strong>PHYSICAL</strong> client, e.g. not a dedicated server.
      * @apiNote Do not use this to check if you're currently on the server thread for side-specific actions!
-     * It does <strong>NOT</strong> work for that. Use {@link #isClientThread()} instead.
+     *          It does <strong>NOT</strong> work for that. Use {@link #isClientThread()} instead.
      * @see #isClientThread()
      */
     public static boolean isClientSide() {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/VeinedVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/VeinedVeinGenerator.java
@@ -7,7 +7,6 @@ import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.VeinGenerator;
 import com.gregtechceu.gtceu.api.data.worldgen.ores.OreBlockPlacer;
 import com.gregtechceu.gtceu.api.data.worldgen.ores.OreVeinUtil;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTFeatures;
 import com.gregtechceu.gtceu.utils.GTUtil;
 import com.gregtechceu.gtceu.utils.WeightedEntry;
@@ -117,7 +116,7 @@ public class VeinedVeinGenerator extends VeinGenerator {
                                                   BlockPos origin) {
         Map<BlockPos, OreBlockPlacer> generatedBlocks = new Object2ObjectOpenHashMap<>();
 
-        Registry<? extends DensityFunction> densityFunctions = GTRegistries.builtinRegistry()
+        Registry<? extends DensityFunction> densityFunctions = level.registryAccess()
                 .registry(Registries.DENSITY_FUNCTION).get();
 
         RandomState randomState = level.getLevel().getChunkSource().randomState();

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -250,10 +250,11 @@ public class ForgeCommonEventListener {
 
     @SubscribeEvent
     public static void registerReloadListeners(AddReloadListenerEvent event) {
+        GTRegistries.updateFrozenRegistry(event.getRegistryAccess());
+
         event.addListener(new GTOreLoader());
         event.addListener(new BedrockFluidLoader());
         event.addListener(new BedrockOreLoader());
-        GTRegistries.updateFrozenRegistry(event.getRegistryAccess());
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Turns out worldgen workers aren't explicitly server threads, and as such default to being client threads.

Also fixed the ore loaders using old registry data (oops!)