### PR TITLE
refactor material builder api to allow for custom tags

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -591,8 +591,8 @@ public class Material implements Comparable<Material> {
             flags = new MaterialFlags();
         }
 
-        public Builder customTags(String path, Boolean isVanilla) {
-            this.itemTags.add(TagUtil.createItemTag(path, isVanilla));
+        public Builder customTags(TagKey<Item> key) {
+            this.itemTags.add(TagUtil.createItemTag( key.location().getPath()));
             return this;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -83,6 +83,13 @@ public class Material implements Comparable<Material> {
      */
     private String chemicalFormula;
 
+    /**
+     * Material specific tags
+     */
+    @Setter
+    @Getter
+    private List<TagKey<Item>> itemTags = new ArrayList<>();
+
     private String calculateChemicalFormula() {
         if (chemicalFormula != null) return this.chemicalFormula;
         if (materialInfo.element != null) {
@@ -550,6 +557,8 @@ public class Material implements Comparable<Material> {
         private final MaterialProperties properties;
         private final MaterialFlags flags;
         private Set<TagPrefix> ignoredTagPrefixes = null;
+        @Getter
+        private List<TagKey<Item>> itemTags = new ArrayList<>();
 
         private String formula = null;
 
@@ -580,6 +589,11 @@ public class Material implements Comparable<Material> {
             materialInfo = new MaterialInfo(resourceLocation);
             properties = new MaterialProperties();
             flags = new MaterialFlags();
+        }
+
+        public Builder customTags(String path, Boolean isVanilla) {
+            this.itemTags.add(TagUtil.createItemTag(path, isVanilla));
+            return this;
         }
 
         /*
@@ -1282,6 +1296,10 @@ public class Material implements Comparable<Material> {
             }
 
             var mat = new Material(materialInfo, properties, flags);
+            if (!itemTags.isEmpty()) {
+
+                mat.setItemTags(itemTags);
+            }
             if (formula != null) {
                 mat.setFormula(formula);
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -592,7 +592,7 @@ public class Material implements Comparable<Material> {
         }
 
         public Builder customTags(TagKey<Item> key) {
-            this.itemTags.add(TagUtil.createItemTag( key.location().getPath()));
+            this.itemTags.add(key);
             return this;
         }
 
@@ -1297,7 +1297,6 @@ public class Material implements Comparable<Material> {
 
             var mat = new Material(materialInfo, properties, flags);
             if (!itemTags.isEmpty()) {
-
                 mat.setItemTags(itemTags);
             }
             if (formula != null) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -557,8 +557,8 @@ public class Material implements Comparable<Material> {
         private final MaterialProperties properties;
         private final MaterialFlags flags;
         private Set<TagPrefix> ignoredTagPrefixes = null;
-        @Getter
-        private List<TagKey<Item>> itemTags = new ArrayList<>();
+
+        private final List<TagKey<Item>> itemTags = new ArrayList<>();
 
         private String formula = null;
 

--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -72,8 +72,11 @@ public class MixinHelpers {
                 if (material.isNull()) return;
                 var entries = itemLikes.stream().map(MixinHelpers::makeItemEntry).collect(toArrayList());
 
-                var materialTags = entry.tagPrefix().getAllItemTags(material);
-                for (TagKey<Item> materialTag : materialTags) {
+                var prefixTagKeys = entry.tagPrefix().getAllItemTags(material);
+                for (TagKey<Item> prefixTag : prefixTagKeys) {
+                    tagMap.computeIfAbsent(prefixTag.location(), path -> new ArrayList<>()).addAll(entries);
+                }
+                for (TagKey<Item> materialTag : material.getItemTags()) {
                     tagMap.computeIfAbsent(materialTag.location(), path -> new ArrayList<>()).addAll(entries);
                 }
 


### PR DESCRIPTION
adds an api for custom tags in the material builder that can be applied
to use it
in your material just use .customTags(tag name, vanilla tag)
adds a second iteration in generateGTDynamic items that may slow down the tag loader