### PR TITLE
Fix Capability Max Log Spam

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1472,6 +1472,9 @@ public class GTRecipeBuilder {
                                           boolean isInput,
                                           Map<RecipeCapability<?>, List<Content>> table,
                                           int addedEntries) {
+        var recipeCapabilityMax = isInput ? recipeType.maxInputs : recipeType.maxOutputs;
+        if (!recipeCapabilityMax.containsKey(capability)) return;
+
         int max = isInput ? recipeType.getMaxInputs(capability) : recipeType.getMaxOutputs(capability);
         if (table.getOrDefault(capability, List.of()).size() + addedEntries > max) {
             String io = isInput ? "inputs" : "outputs";

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1475,7 +1475,7 @@ public class GTRecipeBuilder {
         var recipeCapabilityMax = isInput ? recipeType.maxInputs : recipeType.maxOutputs;
         if (!recipeCapabilityMax.containsKey(capability)) return;
 
-        int max = isInput ? recipeType.getMaxInputs(capability) : recipeType.getMaxOutputs(capability);
+        int max = recipeCapabilityMax.getInt(capability);
         if (table.getOrDefault(capability, List.of()).size() + addedEntries > max) {
             String io = isInput ? "inputs" : "outputs";
             GTCEu.LOGGER.warn("Recipe {} is trying to add more {} than its recipe type can support, Max {} {}: {}",


### PR DESCRIPTION
## What
Fixes log spamming from trying to add recipe content to recipe maps that don't have an explicit maximum for those contents, namely EU and CWU introduced in #3293 

## Implementation Details
just check if the maximums exist in the recipe type before trying to see if we exceed them

## Outcome
no more log spam