### PR TITLE
Fix distinct state of buffers and proxies

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -301,6 +301,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
 
         Map<RecipeHandlerGroup, List<RecipeHandlerList>> handlerGroups = new HashMap<>();
         for (var handler : handlerLists) {
+            if (!handler.hasCapability(ItemRecipeCapability.CAP)) continue;
             addToRecipeHandlerMap(handler.getGroup(), handler, handlerGroups);
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/InternalSlotRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/InternalSlotRecipeHandler.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.integration.ae2.machine.trait;
 
 import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableRecipeHandlerTrait;
+import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerGroupDistinctness;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
@@ -43,6 +44,7 @@ public final class InternalSlotRecipeHandler {
             fluidRecipeHandler = new SlotFluidRecipeHandler(buffer, slot, idx);
             addHandlers(buffer.getCircuitInventory(), buffer.getShareInventory(), buffer.getShareTank(),
                     itemRecipeHandler, fluidRecipeHandler);
+            this.setGroup(RecipeHandlerGroupDistinctness.BUS_DISTINCT);
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/ProxySlotRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/ProxySlotRecipeHandler.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.trait.IRecipeHandlerTrait;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableRecipeHandlerTrait;
+import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerGroupDistinctness;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
@@ -65,6 +66,7 @@ public final class ProxySlotRecipeHandler {
             sharedFluid = new ProxyFluidRecipeHandler(machine);
             slotFluid = new ProxyFluidRecipeHandler(machine);
             addHandlers(circuit, sharedItem, slotItem, sharedFluid, slotFluid);
+            this.setGroup(RecipeHandlerGroupDistinctness.BUS_DISTINCT);
         }
 
         public void setBuffer(MEPatternBufferPartMachine buffer, SlotRHL slotRHL) {


### PR DESCRIPTION
## What
proxy and buffer handlers aren't given the right group (distinct) and therefore try to proxy check with eachother

## Implementation Details
I have added it to both places that override isDistinct now
![image](https://github.com/user-attachments/assets/d35baa51-a215-481d-b9e5-414c364b77bf)


## Outcome
Recipes shouldn't try to check with the catalysts in 2 buffers/proxies anymore and cause 20MS/t on one controller :clueless: