### PR TITLE
Fix armor charging causing a crash if the offhand item is switched repeatedly

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/ArmorUtils.java
@@ -104,7 +104,7 @@ public class ArmorUtils {
         }
 
         if (isPossibleToCharge(offHand) && offHandItem.getTier() <= tier) {
-            inventorySlotMap.add(Pair.of(player.getInventory().offhand, IntList.of(0)));
+            inventorySlotMap.add(Pair.of(player.getInventory().offhand, new IntArrayList(new int[] { 0 })));
         }
 
         return inventorySlotMap;

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
@@ -26,7 +26,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.ints.IntList;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -105,49 +104,35 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                 // Charge all inventory slots
                 for (int i = 0; i < inventoryIndexMap.size(); i++) {
                     Pair<NonNullList<ItemStack>, IntList> inventoryMap = inventoryIndexMap.get(i);
-                    NonNullList<ItemStack> itemList = inventoryMap.getFirst();
-                    IntList slots = inventoryMap.getSecond();
+                    var inventoryIterator = inventoryMap.getSecond().iterator();
+                    while (inventoryIterator.hasNext()) {
+                        int slot = inventoryIterator.nextInt();
+                        IElectricItem chargable = GTCapabilityHelper.getElectricItem(inventoryMap.getFirst().get(slot));
 
-                    // Ensure slots list is mutable
-                    if (!(slots instanceof IntArrayList)) {
-                        slots = new IntArrayList(slots);
-                        inventoryIndexMap.set(i, Pair.of(itemList, slots));
-                    }
+                        // Safety check the null, it should not actually happen. Also don't try and charge itself
+                        if (chargable == null || chargable == cont) {
+                            inventoryIterator.remove();
+                            continue;
+                        }
 
-                    slots.removeIf(slot -> {
-                        ItemStack stack = itemList.get(slot);
-                        IElectricItem chargable = GTCapabilityHelper.getElectricItem(stack);
-                        return chargable == null || chargable == cont;
-                    });
-
-
-                    // Now do the charging
-                    for (int j = 0; j < slots.size(); j++) {
-                        int slot = slots.getInt(j);
-                        IElectricItem chargable = GTCapabilityHelper.getElectricItem(itemList.get(slot));
                         long attemptedChargeAmount = chargable.getTransferLimit() * 10;
 
-                        if (chargable.getCharge() < chargable.getMaxCharge() &&
-                            cont.canUse(attemptedChargeAmount) &&
-                            timer % 10 == 0) {
-
+                        // Accounts for tick differences when charging items
+                        if (chargable.getCharge() < chargable.getMaxCharge() && cont.canUse(attemptedChargeAmount) &&
+                                timer % 10 == 0) {
                             long delta = chargable.charge(attemptedChargeAmount, cont.getTier(), true, false);
                             if (delta > 0) {
                                 cont.discharge(delta, cont.getTier(), true, false, false);
                             }
-
                             if (chargable.getCharge() == chargable.getMaxCharge()) {
-                                slots.removeInt(j);
-                                j--; // Decrement index to account for removed element
+                                inventoryIterator.remove();
                             }
-
                             player.inventoryMenu.sendAllDataToRemote();
                         }
                     }
 
-                    if (slots.isEmpty()) inventoryIndexMap.remove(inventoryMap);
+                    if (inventoryMap.getSecond().isEmpty()) inventoryIndexMap.remove(inventoryMap);
                 }
-
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
@@ -26,6 +26,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -104,35 +105,48 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                 // Charge all inventory slots
                 for (int i = 0; i < inventoryIndexMap.size(); i++) {
                     Pair<NonNullList<ItemStack>, IntList> inventoryMap = inventoryIndexMap.get(i);
-                    var inventoryIterator = inventoryMap.getSecond().iterator();
-                    while (inventoryIterator.hasNext()) {
-                        int slot = inventoryIterator.nextInt();
-                        IElectricItem chargable = GTCapabilityHelper.getElectricItem(inventoryMap.getFirst().get(slot));
+                    NonNullList<ItemStack> itemList = inventoryMap.getFirst();
+                    IntList slots = inventoryMap.getSecond();
 
-                        // Safety check the null, it should not actually happen. Also don't try and charge itself
-                        if (chargable == null || chargable == cont) {
-                            inventoryIterator.remove();
-                            continue;
-                        }
+                    // Remove invalid or self-referencing electric items
+                IntList safeSlots = new IntArrayList(slots);  // copy to mutable list
 
+                safeSlots.removeIf(slot -> {
+                    ItemStack stack = itemList.get(slot);
+                    IElectricItem chargable = GTCapabilityHelper.getElectricItem(stack);
+                    return chargable == null || chargable == cont;      
+                });
+
+                inventoryIndexMap.set(i, Pair.of(itemList, safeSlots)); // replace with mutable, updated list
+
+
+                  // Now do the charging
+                    for (int j = 0; j < safeSlots.size(); j++) {
+                        int slot = safeSlots.getInt(j);
+                        IElectricItem chargable = GTCapabilityHelper.getElectricItem(itemList.get(slot));
                         long attemptedChargeAmount = chargable.getTransferLimit() * 10;
 
-                        // Accounts for tick differences when charging items
-                        if (chargable.getCharge() < chargable.getMaxCharge() && cont.canUse(attemptedChargeAmount) &&
-                                timer % 10 == 0) {
+                        if (chargable.getCharge() < chargable.getMaxCharge() &&
+                            cont.canUse(attemptedChargeAmount) &&
+                            timer % 10 == 0) {
+
                             long delta = chargable.charge(attemptedChargeAmount, cont.getTier(), true, false);
                             if (delta > 0) {
                                 cont.discharge(delta, cont.getTier(), true, false, false);
                             }
+
                             if (chargable.getCharge() == chargable.getMaxCharge()) {
-                                inventoryIterator.remove();
+                                safeSlots.removeInt(j);
+                                j--; // Decrement index to account for removed element
                             }
+
                             player.inventoryMenu.sendAllDataToRemote();
                         }
                     }
 
-                    if (inventoryMap.getSecond().isEmpty()) inventoryIndexMap.remove(inventoryMap);
+                    if (safeSlots.isEmpty()) inventoryIndexMap.remove(inventoryMap);
                 }
+
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/AdvancedNanoMuscleSuite.java
@@ -108,21 +108,22 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                     NonNullList<ItemStack> itemList = inventoryMap.getFirst();
                     IntList slots = inventoryMap.getSecond();
 
-                    // Remove invalid or self-referencing electric items
-                IntList safeSlots = new IntArrayList(slots);  // copy to mutable list
+                    // Ensure slots list is mutable
+                    if (!(slots instanceof IntArrayList)) {
+                        slots = new IntArrayList(slots);
+                        inventoryIndexMap.set(i, Pair.of(itemList, slots));
+                    }
 
-                safeSlots.removeIf(slot -> {
-                    ItemStack stack = itemList.get(slot);
-                    IElectricItem chargable = GTCapabilityHelper.getElectricItem(stack);
-                    return chargable == null || chargable == cont;      
-                });
-
-                inventoryIndexMap.set(i, Pair.of(itemList, safeSlots)); // replace with mutable, updated list
+                    slots.removeIf(slot -> {
+                        ItemStack stack = itemList.get(slot);
+                        IElectricItem chargable = GTCapabilityHelper.getElectricItem(stack);
+                        return chargable == null || chargable == cont;
+                    });
 
 
-                  // Now do the charging
-                    for (int j = 0; j < safeSlots.size(); j++) {
-                        int slot = safeSlots.getInt(j);
+                    // Now do the charging
+                    for (int j = 0; j < slots.size(); j++) {
+                        int slot = slots.getInt(j);
                         IElectricItem chargable = GTCapabilityHelper.getElectricItem(itemList.get(slot));
                         long attemptedChargeAmount = chargable.getTransferLimit() * 10;
 
@@ -136,7 +137,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                             }
 
                             if (chargable.getCharge() == chargable.getMaxCharge()) {
-                                safeSlots.removeInt(j);
+                                slots.removeInt(j);
                                 j--; // Decrement index to account for removed element
                             }
 
@@ -144,7 +145,7 @@ public class AdvancedNanoMuscleSuite extends NanoMuscleSuite implements IJetpack
                         }
                     }
 
-                    if (safeSlots.isEmpty()) inventoryIndexMap.remove(inventoryMap);
+                    if (slots.isEmpty()) inventoryIndexMap.remove(inventoryMap);
                 }
 
             }


### PR DESCRIPTION
## What
Fixes a crash caused by UnsupportedOperationException, which occurs when attempting to use removeIf on an immutable IntList.
This error happens consistently during certain inventory actions, such as swapping batteries to the offhand while the suit is actively charging items.

## Implementation Details
The crash originated from modifying a fastutil.IntList, which in some cases is an immutable singleton (IntLists.Singleton), causing removeIf to throw an exception.

Instead of mutating the original list in-place, the list is now copied into a mutable IntArrayList.
Filtering is applied to the copied list, and the cleaned version is set back into the inventory tracking map.

## Outcome
Close #3321 

## Additional Information

My java skill is terrible, and i hope there are not many mistakes, if any.

## Potential Compatibility Issues
hopefully none