### PR TITLE
clarify CapeRegistry's javadocs and add a KubeJS event for it

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cosmetics/CapeRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cosmetics/CapeRegistry.java
@@ -1,8 +1,11 @@
 package com.gregtechceu.gtceu.api.cosmetics;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.cosmetics.event.RegisterGTCapesEvent;
 import com.gregtechceu.gtceu.common.network.GTNetwork;
 import com.gregtechceu.gtceu.common.network.packets.SPacketNotifyCapeChange;
+import com.gregtechceu.gtceu.integration.kjs.GTCEuServerEvents;
+import com.gregtechceu.gtceu.integration.kjs.events.RegisterCapesEventJS;
 
 import net.minecraft.nbt.*;
 import net.minecraft.resources.ResourceLocation;
@@ -12,6 +15,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraftforge.common.MinecraftForge;
 
+import dev.latvian.mods.kubejs.script.ScriptType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +43,12 @@ public class CapeRegistry extends SavedData {
     private CapeRegistry() {}
 
     private static void initCapes() {
-        MinecraftForge.EVENT_BUS.post(new RegisterGTCapesEvent());
+        RegisterGTCapesEvent event = new RegisterGTCapesEvent();
+        MinecraftForge.EVENT_BUS.post(event);
+        if (GTCEu.Mods.isKubeJSLoaded()) {
+            KJSCallWrapper.fireKJSEvent(event);
+        }
+
         save();
     }
 
@@ -146,70 +155,74 @@ public class CapeRegistry extends SavedData {
     }
 
     /**
-     * Makes a cape available to the {@code /gtceu cape} command, allowing it to be used in advancements etc.
+     * Registers a cape.
      *
-     * @param id   An identifier for giving the cape with commands etc.
-     * @param cape The ResourceLocation that points to the cape that can be unlocked through the advancement.
+     * @param id      An identifier for the cape
+     * @param texture The full path to the cape's texture in a resource pack
      *
-     * @deprecated use the {@link com.gregtechceu.gtceu.api.cosmetics.event.RegisterGTCapesEvent} event.
+     * @deprecated use the {@link RegisterGTCapesEvent#registerCape(ResourceLocation, ResourceLocation)}.
+     * @see RegisterGTCapesEvent#registerCape(ResourceLocation, ResourceLocation)
      */
     @ApiStatus.Internal
-    public static void registerCape(ResourceLocation id, ResourceLocation cape) {
-        ALL_CAPES.put(id, cape);
+    public static void registerCape(ResourceLocation id, ResourceLocation texture) {
+        ALL_CAPES.put(id, texture);
     }
 
     /**
-     * Adds a cape that will always be unlocked for all players.
+     * Registers a cape that will always be unlocked for all players.
      *
-     * @param id   An identifier for giving the cape with commands etc.
-     * @param cape A ResourceLocation pointing to the cape texture.
+     * @param id      An identifier for the cape
+     * @param texture The full path to the cape's texture in a resource pack
      *
-     * @deprecated use the {@link com.gregtechceu.gtceu.api.cosmetics.event.RegisterGTCapesEvent} event.
+     * @deprecated use {@link RegisterGTCapesEvent#registerFreeCape(ResourceLocation, ResourceLocation)}.
+     * @see RegisterGTCapesEvent#registerFreeCape(ResourceLocation, ResourceLocation)
      */
     @ApiStatus.Internal
-    public static void registerFreeCape(ResourceLocation id, ResourceLocation cape) {
-        registerCape(id, cape);
+    public static void registerFreeCape(ResourceLocation id, ResourceLocation texture) {
+        registerCape(id, texture);
         FREE_CAPES.add(id);
     }
 
     /**
-     * Automatically gives a cape to a player. may be used for a reward etc.
-     * <br>
-     * DOES NOT SAVE AUTOMATICALLY; PLEASE CALL SAVE AFTER THIS FUNCTION IS USED IF THIS DATA IS MEANT TO PERSIST.
+     * Automatically makes a cape available to a player.<br>
+     * <strong>DOES NOT SAVE AUTOMATICALLY;
+     * PLEASE CALL SAVE AFTER THIS FUNCTION IS USED IF THIS DATA IS MEANT TO PERSIST.</strong>
      *
-     * @param owner  The UUID of the player to be given the cape.
-     * @param capeId The ResourceLocation that holds the cape used here.
+     * @param owner The UUID of the player to give the cape to
+     * @param cape  The cape to give
+     * @see #removeCape(UUID, ResourceLocation)
      */
-    public static boolean unlockCape(UUID owner, ResourceLocation capeId) {
+    public static boolean unlockCape(UUID owner, ResourceLocation cape) {
         Set<ResourceLocation> capes = UNLOCKED_CAPES.computeIfAbsent(owner, CapeRegistry::makeSet);
-        if (capes.contains(capeId)) {
+        if (capes.contains(cape)) {
             return false;
         }
-        capes.add(capeId);
+        capes.add(cape);
         UNLOCKED_CAPES.put(owner, capes);
         return true;
     }
 
     /**
-     * Automatically removes a cape from a player
-     * <br>
-     * DOES NOT SAVE AUTOMATICALLY; PLEASE CALL SAVE AFTER THIS FUNCTION IS USED IF THIS DATA IS MEANT TO PERSIST.
+     * Automatically removes a cape from a player.<br>
+     * <strong>DOES NOT SAVE AUTOMATICALLY;
+     * PLEASE CALL SAVE AFTER THIS FUNCTION IS USED IF THIS DATA IS MEANT TO PERSIST.</strong>
      *
-     * @param uuid The UUID of the player to be given the cape.
-     * @param cape The ResourceLocation that holds the cape used here.
+     * @param owner The UUID of the player to take the cape from
+     * @param cape  The cape to take
+     * @see #unlockCape(UUID, ResourceLocation)
      */
-    public static boolean removeCape(UUID uuid, ResourceLocation cape) {
+    public static boolean removeCape(UUID owner, ResourceLocation cape) {
         if (FREE_CAPES.contains(cape)) {
             return false;
         }
-        Set<ResourceLocation> capes = UNLOCKED_CAPES.get(uuid);
+        Set<ResourceLocation> capes = UNLOCKED_CAPES.get(owner);
         if (capes == null || !capes.contains(cape)) {
             return false;
         }
         capes.remove(cape);
-        UNLOCKED_CAPES.put(uuid, capes);
-        if (cape.equals(getPlayerCapeId(uuid))) {
-            setActiveCape(uuid, null);
+        UNLOCKED_CAPES.put(owner, capes);
+        if (cape.equals(getPlayerCapeId(owner))) {
+            setActiveCape(owner, null);
         }
         return true;
     }
@@ -224,18 +237,18 @@ public class CapeRegistry extends SavedData {
     }
 
     /**
-     * Sets the current cape for a player.
+     * Sets a player's current cape.
      *
-     * @param uuid The UUID of the player to be given the cape.
-     * @param cape The ResourceLocation that holds the cape used here. {@code null} to remove cape.
+     * @param player The UUID of the player
+     * @param cape   The cape to set, or {@code null} to remove the current cape.
      */
-    public static boolean setActiveCape(UUID uuid, @Nullable ResourceLocation cape) {
-        Set<ResourceLocation> capes = UNLOCKED_CAPES.get(uuid);
+    public static boolean setActiveCape(UUID player, @Nullable ResourceLocation cape) {
+        Set<ResourceLocation> capes = UNLOCKED_CAPES.get(player);
         if (capes == null || cape != null && !capes.contains(cape)) {
             return false;
         }
-        CURRENT_CAPES.put(uuid, cape);
-        GTNetwork.NETWORK.sendToAll(new SPacketNotifyCapeChange(uuid, cape));
+        CURRENT_CAPES.put(player, cape);
+        GTNetwork.NETWORK.sendToAll(new SPacketNotifyCapeChange(player, cape));
         save();
         return true;
     }
@@ -284,5 +297,12 @@ public class CapeRegistry extends SavedData {
 
     private static Set<ResourceLocation> makeSet(UUID ignored) {
         return new TreeSet<>(SET_COMPARATOR);
+    }
+
+    private static class KJSCallWrapper {
+
+        public static void fireKJSEvent(RegisterGTCapesEvent event) {
+            GTCEuServerEvents.REGISTER_CAPES.post(ScriptType.SERVER, new RegisterCapesEventJS(event));
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/cosmetics/event/RegisterGTCapesEvent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cosmetics/event/RegisterGTCapesEvent.java
@@ -24,26 +24,32 @@ public class RegisterGTCapesEvent extends Event {
     public RegisterGTCapesEvent() {}
 
     /**
-     * Makes a cape available to the {@code /gtceu cape} command, allowing it to be used in advancements etc.
+     * Registers a cape to the cape registry.
      *
-     * @param id      An identifier for giving the cape with commands etc.
-     * @param texture The ResourceLocation that points to the texture of the cape accessible via {@code id}
+     * @param id      An identifier for the cape
+     * @param texture The full path to the cape's texture in a resource pack
      */
     public void registerCape(ResourceLocation id, ResourceLocation texture) {
         CapeRegistry.registerCape(id, texture);
     }
 
     /**
-     * Adds a cape that will always be unlocked for all players.
+     * Registers a cape that will always be unlocked for all players.
      *
-     * @param id      An identifier for giving the cape with commands etc.
-     * @param texture A ResourceLocation pointing to the cape texture.
+     * @param id      An identifier for the cape
+     * @param texture The full path to the cape's texture in a resource pack
      */
     public void registerFreeCape(ResourceLocation id, ResourceLocation texture) {
         CapeRegistry.registerFreeCape(id, texture);
     }
 
-    public void unlockCapeFor(UUID owner, ResourceLocation capeId) {
-        CapeRegistry.unlockCape(owner, capeId);
+    /**
+     * Automatically makes a cape available to a player.
+     *
+     * @param owner The UUID of the player to give the cape to
+     * @param cape  The cape to give
+     */
+    public void unlockCapeFor(UUID owner, ResourceLocation cape) {
+        CapeRegistry.unlockCape(owner, cape);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuServerEvents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuServerEvents.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.integration.kjs.events.GTBedrockOreVeinEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTFluidVeinEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTOreVeinEventJS;
 
+import com.gregtechceu.gtceu.integration.kjs.events.RegisterCapesEventJS;
 import dev.latvian.mods.kubejs.event.EventGroup;
 import dev.latvian.mods.kubejs.event.EventHandler;
 
@@ -14,4 +15,6 @@ public interface GTCEuServerEvents {
     EventHandler ORE_VEIN_MODIFICATION = GROUP.server("oreVeins", () -> GTOreVeinEventJS.class);
     EventHandler BEDROCK_ORE_VEIN_MODIFICATION = GROUP.server("bedrockOreVeins", () -> GTBedrockOreVeinEventJS.class);
     EventHandler FLUID_VEIN_MODIFICATION = GROUP.server("fluidVeins", () -> GTFluidVeinEventJS.class);
+
+    EventHandler REGISTER_CAPES = GROUP.server("registerCapes", () -> RegisterCapesEventJS.class);
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuServerEvents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTCEuServerEvents.java
@@ -3,8 +3,8 @@ package com.gregtechceu.gtceu.integration.kjs;
 import com.gregtechceu.gtceu.integration.kjs.events.GTBedrockOreVeinEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTFluidVeinEventJS;
 import com.gregtechceu.gtceu.integration.kjs.events.GTOreVeinEventJS;
-
 import com.gregtechceu.gtceu.integration.kjs.events.RegisterCapesEventJS;
+
 import dev.latvian.mods.kubejs.event.EventGroup;
 import dev.latvian.mods.kubejs.event.EventHandler;
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -54,6 +54,7 @@ import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder;
+import com.gregtechceu.gtceu.common.cosmetics.GTCapes;
 import com.gregtechceu.gtceu.common.data.*;
 import com.gregtechceu.gtceu.common.data.machines.GCYMMachines;
 import com.gregtechceu.gtceu.common.data.machines.GTMachineUtils;
@@ -326,7 +327,9 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         event.add("GTDikeBlockDefinition", DikeVeinGenerator.DikeBlockDefinition.class);
         event.add("GTOres", GTOres.class);
         event.add("GTWorldGenLayers", WorldGenLayers.class);
-        // MaterialColor stuff, for TagPrefix
+        // Cape related
+        event.add("GTCapes", GTCapes.class);
+        event.add("CapeRegistry", CapeRegistry.class);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.cosmetics.CapeRegistry;
 import com.gregtechceu.gtceu.api.data.DimensionMarker;
 import com.gregtechceu.gtceu.api.data.RotationState;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/events/RegisterCapesEventJS.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/events/RegisterCapesEventJS.java
@@ -1,0 +1,56 @@
+package com.gregtechceu.gtceu.integration.kjs.events;
+
+import com.gregtechceu.gtceu.api.cosmetics.event.RegisterGTCapesEvent;
+
+import net.minecraft.resources.ResourceLocation;
+
+import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.typings.Info;
+import dev.latvian.mods.kubejs.typings.Param;
+
+import java.util.UUID;
+
+@Info("""
+        Invoked when the server is first loaded.
+        """)
+public class RegisterCapesEventJS extends EventJS {
+
+    private final RegisterGTCapesEvent event;
+
+    public RegisterCapesEventJS(RegisterGTCapesEvent event) {
+        this.event = event;
+    }
+
+    @Info(value = """
+            Registers a cape.
+            """,
+          params = {
+                  @Param(name = "id", value = "An identifier for the cape"),
+                  @Param(name = "texture", value = "The full path to the cape's texture in a resource pack")
+          })
+    public void registerCape(ResourceLocation id, ResourceLocation texture) {
+        event.registerCape(id, texture);
+    }
+
+    @Info(value = """
+            Registers a cape that will always be unlocked for all players.
+            """,
+          params = {
+                  @Param(name = "id", value = "An identifier for the cape"),
+                  @Param(name = "texture", value = "The full path to the cape's texture in a resource pack")
+          })
+    public void registerFreeCape(ResourceLocation id, ResourceLocation texture) {
+        event.registerFreeCape(id, texture);
+    }
+
+    @Info(value = """
+            Automatically makes a cape available to a player.
+            """,
+          params = {
+                  @Param(name = "owner", value = "The UUID of the player to give the cape to."),
+                  @Param(name = "capeId", value = "The cape to give")
+          })
+    public void unlockCapeFor(UUID owner, ResourceLocation capeId) {
+        event.unlockCapeFor(owner, capeId);
+    }
+}


### PR DESCRIPTION
## What
Clarify and clean up CapeRegistry's (and related classes') javadocs.
Also added a KubeJS event for it that just mirrors the forge event we post.

## Outcome
the javadocs are understandable now
also easier to register capes to the GT manager with KubeJS