### PR TITLE
restrict pipe connection from neighbor

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/LaserPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/LaserPipeBlockEntity.java
@@ -164,7 +164,7 @@ public class LaserPipeBlockEntity extends PipeBlockEntity<LaserPipeType, LaserPi
 
     @Override
     public void setConnection(Direction side, boolean connected, boolean fromNeighbor) {
-        if (!getLevel().isClientSide && connected && !fromNeighbor) {
+        if (!getLevel().isClientSide && connected) {
             int connections = getConnections();
             // block connection if any side other than the requested side and its opposite side are already connected.
             connections &= ~(1 << side.ordinal());


### PR DESCRIPTION
## What
Laser pipes used to ignore "fromNeighbor" connections when doing their straightness check, which means you can connect pipes at a 90 degree angle by putting down 2 pipes and then placing them in the center, like so
https://github.com/user-attachments/assets/b52705e6-6f25-4c5d-964f-5997ed5fb4dc


## Outcome
Now, fromNeighbor connections don't get to skip the checks
https://github.com/user-attachments/assets/4fbedfd1-dd50-453c-90e3-9539e10a5db5

