### PR TITLE
Re-enable remapping on mixin target in LevelMixin

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
@@ -63,7 +63,8 @@ public abstract class LevelMixin implements LevelAccessor {
     @SuppressWarnings("ConstantValue")
     @Inject(method = "markAndNotifyBlock",
             at = @At(value = "INVOKE",
-                     target = "Lnet/minecraft/world/level/Level;blockUpdated(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;)V"),
+                     target = "Lnet/minecraft/world/level/Level;blockUpdated(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;)V",
+                    remap = true),
             remap = false)
     private void gtceu$updateChunkMultiblocks(BlockPos pos, LevelChunk chunk,
                                               BlockState oldState, BlockState newState, int flags, int recursionLeft,

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
@@ -64,7 +64,7 @@ public abstract class LevelMixin implements LevelAccessor {
     @Inject(method = "markAndNotifyBlock",
             at = @At(value = "INVOKE",
                      target = "Lnet/minecraft/world/level/Level;blockUpdated(Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/Block;)V",
-                    remap = true),
+                     remap = true),
             remap = false)
     private void gtceu$updateChunkMultiblocks(BlockPos pos, LevelChunk chunk,
                                               BlockState oldState, BlockState newState, int flags, int recursionLeft,


### PR DESCRIPTION
fixes a CF crash