### PR TITLE
Revert `MachineBuilder#machine` being made final

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -91,7 +91,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     protected final TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory;
 
     protected final Function<ResourceLocation, DEFINITION> definition;
-    protected final Function<IMachineBlockEntity, MetaMachine> machine;
+    protected Function<IMachineBlockEntity, MetaMachine> machine;
     @Nullable
     @Getter
     @Setter
@@ -389,6 +389,11 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
 
     public MachineBuilder<DEFINITION> clearModelProperties() {
         this.modelProperties.clear();
+        return this;
+    }
+
+    public MachineBuilder<DEFINITION> machine(Function<IMachineBlockEntity, MetaMachine> newMachine) {
+        this.machine = newMachine;
         return this;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -91,6 +91,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     protected final TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory;
 
     protected final Function<ResourceLocation, DEFINITION> definition;
+    @Setter
     protected Function<IMachineBlockEntity, MetaMachine> machine;
     @Nullable
     @Getter
@@ -389,11 +390,6 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
 
     public MachineBuilder<DEFINITION> clearModelProperties() {
         this.modelProperties.clear();
-        return this;
-    }
-
-    public MachineBuilder<DEFINITION> machine(Function<IMachineBlockEntity, MetaMachine> newMachine) {
-        this.machine = newMachine;
         return this;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.data.RotationState;
 import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.item.MetaMachineItem;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
@@ -112,6 +113,11 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     public MultiblockMachineBuilder recoveryStacks(Supplier<ItemStack[]> stacks) {
         this.recoveryItems.add(stacks);
         return this;
+    }
+
+    @Override
+    public MultiblockMachineBuilder machine(Function<IMachineBlockEntity, MetaMachine> metaMachine) {
+        return (MultiblockMachineBuilder) super.machine(metaMachine);
     }
 
     @Override


### PR DESCRIPTION
## What
Re-adds an old method that makes registering a kjs machine with a custom machine class easier.

## Implementation Details
Makes the field 'machine' in MachineBuilder not final anymore, but that shouldn't really change much.

## Outcome
makes kjs machines with custom classes easier (or indeed, possible)
