### PR TITLE
Fix Material Decomp being wrong for some recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
@@ -176,12 +176,13 @@ public class ItemMaterialData {
         for (var entry : UNRESOLVED_ITEM_MATERIAL_INFO.entrySet()) {
             List<MaterialStack> stacks = new ArrayList<>();
             var stack = entry.getKey();
-            var count = stack.getCount();
+            int outputCount = stack.getCount();
             for (var input : entry.getValue()) {
                 var matStack = getMaterialInfo(input.getItem());
+                int inputCount = input.getCount();
                 if (matStack != null) {
                     matStack.getMaterials()
-                            .forEach(ms -> stacks.add(new MaterialStack(ms.material(), ms.amount() / count)));
+                            .forEach(ms -> stacks.add(ms.multiply(inputCount).divide(outputCount)));
                 }
             }
             if (stacks.isEmpty()) continue;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialStack.java
@@ -28,6 +28,10 @@ public record MaterialStack(@NotNull Material material, long amount) {
         return new MaterialStack(material, this.amount * amount);
     }
 
+    public MaterialStack divide(long amount) {
+        return new MaterialStack(material, this.amount / amount);
+    }
+
     public static MaterialStack fromString(CharSequence str) {
         String trimmed = str.toString().trim();
         String copy = trimmed;


### PR DESCRIPTION
## What
Fixes #3365 

## Implementation Details
use the input item stacks count when determining the material stack amounts for unresolved material information

## Outcome
first load decomp will not be wrong now