### PR TITLE
Fix more decomp related issues

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
@@ -176,7 +176,6 @@ public class ItemMaterialData {
         for (var iter = UNRESOLVED_ITEM_MATERIAL_INFO.entrySet().iterator(); iter.hasNext();) {
             var entry = iter.next();
             var stack = entry.getKey();
-            // var existingMaterialInfo = ITEM_MATERIAL_INFO.get(stack.getItem());
             var existingMaterialInfo = recurseFindMaterialInfo(ITEM_MATERIAL_INFO.get(stack.getItem()), stack);
             if (existingMaterialInfo != null) {
                 RecyclingRecipes.registerRecyclingRecipes(provider, stack.copyWithCount(1),

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
@@ -176,8 +176,8 @@ public class ItemMaterialData {
         for (var iter = UNRESOLVED_ITEM_MATERIAL_INFO.entrySet().iterator(); iter.hasNext();) {
             var entry = iter.next();
             var stack = entry.getKey();
-            var existingMaterialInfo = ITEM_MATERIAL_INFO.get(stack.getItem());
-            recurseFindMaterialInfo(existingMaterialInfo, stack);
+            // var existingMaterialInfo = ITEM_MATERIAL_INFO.get(stack.getItem());
+            var existingMaterialInfo = recurseFindMaterialInfo(ITEM_MATERIAL_INFO.get(stack.getItem()), stack);
             if (existingMaterialInfo != null) {
                 RecyclingRecipes.registerRecyclingRecipes(provider, stack.copyWithCount(1),
                         existingMaterialInfo.getMaterials(), false, null);
@@ -186,12 +186,12 @@ public class ItemMaterialData {
         }
     }
 
-    private static void recurseFindMaterialInfo(ItemMaterialInfo info, ItemStack stack) {
+    private static ItemMaterialInfo recurseFindMaterialInfo(ItemMaterialInfo info, ItemStack stack) {
         // grab material info from each input
         for (var input : UNRESOLVED_ITEM_MATERIAL_INFO.get(stack)) {
             // recurse if its nested inputs, not yet resolved
             if (UNRESOLVED_ITEM_MATERIAL_INFO.containsKey(input)) {
-                recurseFindMaterialInfo(info, input);
+                info = recurseFindMaterialInfo(info, input);
             } else {
                 // add the info from an item that is resolved (or not in the map to begin with)
                 var singularMatInfo = getMaterialInfo(input.getItem());
@@ -211,5 +211,6 @@ public class ItemMaterialData {
                 }
             }
         }
+        return info;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
@@ -173,29 +173,43 @@ public class ItemMaterialData {
 
     @ApiStatus.Internal
     public static void resolveItemMaterialInfos(Consumer<FinishedRecipe> provider) {
-        for (var entry : UNRESOLVED_ITEM_MATERIAL_INFO.entrySet()) {
-            List<MaterialStack> stacks = new ArrayList<>();
+        for (var iter = UNRESOLVED_ITEM_MATERIAL_INFO.entrySet().iterator(); iter.hasNext();) {
+            var entry = iter.next();
             var stack = entry.getKey();
-            int outputCount = stack.getCount();
-            for (var input : entry.getValue()) {
-                var matStack = getMaterialInfo(input.getItem());
+            var existingMaterialInfo = ITEM_MATERIAL_INFO.get(stack.getItem());
+            recurseFindMaterialInfo(existingMaterialInfo, stack);
+            if (existingMaterialInfo != null) {
+                RecyclingRecipes.registerRecyclingRecipes(provider, stack.copyWithCount(1),
+                        existingMaterialInfo.getMaterials(), false, null);
+            }
+            iter.remove();
+        }
+    }
+
+    private static void recurseFindMaterialInfo(ItemMaterialInfo info, ItemStack stack) {
+        // grab material info from each input
+        for (var input : UNRESOLVED_ITEM_MATERIAL_INFO.get(stack)) {
+            // recurse if its nested inputs, not yet resolved
+            if (UNRESOLVED_ITEM_MATERIAL_INFO.containsKey(input)) {
+                recurseFindMaterialInfo(info, input);
+            } else {
+                // add the info from an item that is resolved (or not in the map to begin with)
+                var singularMatInfo = getMaterialInfo(input.getItem());
                 int inputCount = input.getCount();
-                if (matStack != null) {
-                    matStack.getMaterials()
-                            .forEach(ms -> stacks.add(ms.multiply(inputCount).divide(outputCount)));
+                int outputCount = stack.getCount();
+                if (singularMatInfo != null) { // if that material info exists
+                    List<MaterialStack> stackList = new ArrayList<>();
+                    for (var matStack : singularMatInfo.getMaterials()) {
+                        stackList.add(matStack.multiply(inputCount).divide(outputCount));
+                    }
+                    if (info == null) { // if the info isn't set initialize it
+                        info = new ItemMaterialInfo(stackList);
+                        ITEM_MATERIAL_INFO.put(stack.getItem(), info);
+                    } else { // otherwise, add to it
+                        info.addMaterialStacks(stackList);
+                    }
                 }
             }
-            if (stacks.isEmpty()) continue;
-            var matInfo = ITEM_MATERIAL_INFO.get(stack.getItem());
-            if (matInfo == null) {
-                matInfo = new ItemMaterialInfo(stacks);
-                ITEM_MATERIAL_INFO.put(stack.getItem(), matInfo);
-            } else {
-                matInfo.addMaterialStacks(stacks);
-            }
-            RecyclingRecipes.registerRecyclingRecipes(provider, entry.getKey().copyWithCount(1),
-                    matInfo.getMaterials(), false, null);
         }
-        UNRESOLVED_ITEM_MATERIAL_INFO.clear();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -370,14 +370,19 @@ public class GTRecipeBuilder {
             return this;
         } else {
             var matInfo = ItemMaterialData.getMaterialInfo(input.getItem());
+            var unresolvedMatInfo = ItemMaterialData.UNRESOLVED_ITEM_MATERIAL_INFO.get(input);
             if (chance == maxChance && chance != 0) {
+                if (unresolvedMatInfo != null) {
+                    tempItemStacks.add(input);
+                }
                 if (matInfo != null) {
                     for (var matStack : matInfo.getMaterials()) {
                         tempItemMaterialStacks.add(matStack.multiply(input.getCount()));
                     }
-                } else {
+                } else if (unresolvedMatInfo == null) {
                     tempItemStacks.add(input);
                 }
+
             }
         }
         return input(ItemRecipeCapability.CAP, SizedIngredient.create(input));


### PR DESCRIPTION
## What
turns out you need to recursively check stuff in the map when resolving the information
fixes #3365
for real this time

## Implementation Details
stripping out and cleaning up the resolve method and making it recursive to find every material

## Outcome
more correct decomp

## Additional Information
in #3365, the reason that power transformers are broken is because there are 2 separate recipes