### PR TITLE
fix parallel limiting counting all inventories as distinct

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -292,6 +292,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
             if (invMultiplier == limit) return limit;
             maxMultiplier = Math.max(maxMultiplier, invMultiplier);
         }
+
         return maxMultiplier;
     }
 
@@ -314,24 +315,26 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
         // Handle distinct groups first, adding an inventory based on their contents individually.
         for (RecipeHandlerList handlerList : distinctHandlerLists) {
             var handlers = handlerList.getCapability(ItemRecipeCapability.CAP);
+            Object2IntOpenCustomHashMap<ItemStack> distinctInv = new Object2IntOpenCustomHashMap<>(strat);
+
             for (IRecipeHandler<?> handler : handlers) {
-                Object2IntOpenCustomHashMap<ItemStack> distinctInv = new Object2IntOpenCustomHashMap<>(strat);
                 for (var content : handler.getContents()) {
                     if (content instanceof ItemStack stack && !stack.isEmpty()) {
                         distinctInv.addTo(stack, stack.getCount());
                     }
                 }
-                if (!distinctInv.isEmpty()) invs.add(distinctInv);
             }
+            if (!distinctInv.isEmpty()) invs.add(distinctInv);
         }
 
-        // Then handle other groups. The logic of undyed busses belonging to
+        // Then handle other groups. The logic of undyed buses belonging to
         // everything has already been taken care of by addToRecipeMap()
         for (Map.Entry<RecipeHandlerGroup, List<RecipeHandlerList>> handlerListEntry : handlerGroups.entrySet()) {
-            if (RecipeHandlerGroupDistinctness.BUS_DISTINCT == handlerListEntry.getKey()) continue;
+            if (handlerListEntry.getKey() == RecipeHandlerGroupDistinctness.BUS_DISTINCT) continue;
+
+            Object2IntOpenCustomHashMap<ItemStack> inventory = new Object2IntOpenCustomHashMap<>(strat);
             for (RecipeHandlerList handlerList : handlerListEntry.getValue()) {
                 var handlers = handlerList.getCapability(ItemRecipeCapability.CAP);
-                Object2IntOpenCustomHashMap<ItemStack> inventory = new Object2IntOpenCustomHashMap<>(strat);
                 for (var handler : handlers) {
                     for (var content : handler.getContents()) {
                         if (content instanceof ItemStack stack && !stack.isEmpty()) {
@@ -339,8 +342,8 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                         }
                     }
                 }
-                if (!inventory.isEmpty()) invs.add(inventory);
             }
+            if (!inventory.isEmpty()) invs.add(inventory);
         }
 
         return invs;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -150,7 +150,8 @@ class RecipeRunner {
 
         // Check the others
         for (Map.Entry<RecipeHandlerGroup, List<RecipeHandlerList>> handlerListEntry : handlerGroups.entrySet()) {
-            if (RecipeHandlerGroupDistinctness.BUS_DISTINCT == handlerListEntry.getKey()) continue;
+            if (handlerListEntry.getKey() == RecipeHandlerGroupDistinctness.BUS_DISTINCT) continue;
+
             // List to keep track of the remaining items for this RecipeHandlerGroup
             Map<RecipeCapability<?>, List<Object>> copiedRecipeContents = searchRecipeContents;
             boolean found = false;


### PR DESCRIPTION
## What
fixes #3389

## Implementation Details
moved the map init outside the handler loop(s)

## Outcome
Parallelizing recipes that have their contents in multiple handlers works now