### PR TITLE
Fix ModernFix dynamic resources compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,6 +42,7 @@ dependencies {
     modCompileOnly(forge.shimmer)
     modCompileOnly(forge.embeddium)
     modCompileOnly(forge.oculus)
+    modCompileOnly(forge.modernfix)
 
     // Teams
     modCompileOnly(forge.ftblibrary)
@@ -69,6 +70,7 @@ dependencies {
     modLocalRuntime(forge.jade)
     modLocalRuntime(forge.ae2)
     modLocalRuntime(forge.spark)
+    modLocalRuntime(forge.modernfix)
 
     // Runtime Recipe Viewers - uncomment whichever one you want to use //
     modLocalRuntime(forge.emi)

--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -27,6 +27,7 @@ ccTweaked = "1.114.3"
 jade = "11.6.3"
 embeddium = "0.3.31+mc1.20.1"
 oculus = "1.20.1-1.8.0"
+modernfix = "DdUByV9S" # 5.24.1+mc1.20.1
 
 ## cursemaven ##
 worldStripper = "4578579"
@@ -81,6 +82,7 @@ ftbchunks           = { module = "dev.ftb.mods:ftb-chunks-forge", version.ref = 
 jade                = { module = "maven.modrinth:jade", version.ref = "jade" }
 embeddium           = { module = "maven.modrinth:embeddium", version.ref = "embeddium" }
 oculus              = { module = "maven.modrinth:oculus", version.ref = "oculus" }
+modernfix           = { module = "maven.modrinth:modernfix", version.ref = "modernfix" }
 
 
 cc-tweaked-core-api   = { module = "cc.tweaked:cc-tweaked-1.20.1-core-api", version.ref = "ccTweaked" }

--- a/gradle/scripts/resources.gradle
+++ b/gradle/scripts/resources.gradle
@@ -46,6 +46,7 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
             emi_version         : forge.versions.emi.get(),
             top_version         : forge.versions.theoneprobe.get(),
             jade_version        : forge.versions.jade.get(),
+            modernfix_version   : forge.versions.modernfix.get(),
             mod_license         : mod_license,
             mod_name            : mod_name,
             mod_description     : mod_description,

--- a/src/main/java/com/gregtechceu/gtceu/GTCEu.java
+++ b/src/main/java/com/gregtechceu/gtceu/GTCEu.java
@@ -190,6 +190,10 @@ public class GTCEu {
             return isModLoaded(GTValues.MODID_SHIMMER);
         }
 
+        public static boolean isModernFixLoaded() {
+            return isModLoaded(GTValues.MODID_MODERNFIX);
+        }
+
         public static boolean isJAVDLoaded() {
             return isModLoaded(GTValues.MODID_JAVD);
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -119,6 +119,7 @@ public class GTValues {
             MODID_CURIOS = "curios",
             MODID_AE2WTLIB = "ae2wtlib",
             MODID_SHIMMER = "shimmer",
+            MODID_MODERNFIX = "modernfix",
             MODID_JOURNEYMAP = "journeymap",
             MODID_XAEROS_MINIMAP = "xaerominimap",
             MODID_XAEROS_WORLDMAP = "xaeroworldmap",

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -33,7 +33,6 @@ import com.gregtechceu.gtceu.integration.map.ftbchunks.FTBChunksPlugin;
 import com.gregtechceu.gtceu.integration.map.layer.Layers;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.FluidRenderLayer;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.OreRenderLayer;
-import com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration;
 import com.gregtechceu.gtceu.utils.input.KeyBind;
 
 import net.minecraft.client.model.BoatModel;

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -33,6 +33,7 @@ import com.gregtechceu.gtceu.integration.map.ftbchunks.FTBChunksPlugin;
 import com.gregtechceu.gtceu.integration.map.layer.Layers;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.FluidRenderLayer;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.OreRenderLayer;
+import com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration;
 import com.gregtechceu.gtceu.utils.input.KeyBind;
 
 import net.minecraft.client.model.BoatModel;

--- a/src/main/java/com/gregtechceu/gtceu/client/model/PipeModel.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/PipeModel.java
@@ -136,13 +136,13 @@ public class PipeModel {
         }
 
         if (!isRestrictorInitialized) {
-            ModelUtils.registerAtlasStitchedEventListener(InventoryMenu.BLOCK_ATLAS, event -> {
+            ModelUtils.registerAtlasStitchedEventListener(false, InventoryMenu.BLOCK_ATLAS, event -> {
                 initializeRestrictor(event.getAtlas()::getSprite);
             });
 
             isRestrictorInitialized = true;
         }
-        ModelUtils.registerAtlasStitchedEventListener(InventoryMenu.BLOCK_ATLAS, event -> {
+        ModelUtils.registerAtlasStitchedEventListener(false, InventoryMenu.BLOCK_ATLAS, event -> {
             TextureAtlas atlas = event.getAtlas();
 
             sideSprite = atlas.getSprite(sideTexture.get());

--- a/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModel.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModel.java
@@ -15,7 +15,6 @@ import com.gregtechceu.gtceu.client.model.TextureOverrideModel;
 import com.gregtechceu.gtceu.client.model.machine.multipart.MultiPartBakedModel;
 import com.gregtechceu.gtceu.client.renderer.cover.ICoverableRenderer;
 import com.gregtechceu.gtceu.client.renderer.machine.DynamicRender;
-import com.gregtechceu.gtceu.client.util.ModelUtils;
 import com.gregtechceu.gtceu.client.util.StaticFaceBakery;
 import com.gregtechceu.gtceu.common.data.models.GTModels;
 

--- a/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModel.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModel.java
@@ -74,7 +74,6 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
     private static @Nullable TextureAtlasSprite fluidOutputOverlaySprite;
     private static @Nullable TextureAtlasSprite itemOutputOverlaySprite;
     private static @Nullable TextureAtlasSprite blankSprite;
-    private static boolean overlaysInitialized = false;
 
     public static final Map<String, List<String>> TEXTURE_REMAPS = Util.make(new HashMap<>(), map -> {
         var all = List.of("all");
@@ -133,22 +132,13 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
         for (DynamicRender<?, ?> render : this.dynamicRenders) {
             render.setParent(this);
         }
+    }
 
-        if (!overlaysInitialized) {
-            ModelUtils.registerAtlasStitchedEventListener(InventoryMenu.BLOCK_ATLAS, event -> {
-                spriteCapturer.getCapturedMaterials().clear();
-
-                TextureAtlas atlas = event.getAtlas();
-
-                pipeOverlaySprite = atlas.getSprite(PIPE_OVERLAY);
-                fluidOutputOverlaySprite = atlas.getSprite(FLUID_OUTPUT_OVERLAY);
-                itemOutputOverlaySprite = atlas.getSprite(ITEM_OUTPUT_OVERLAY);
-                blankSprite = atlas.getSprite(GTModels.BLANK_TEXTURE);
-
-                ICoverableRenderer.initSprites(atlas::getSprite);
-            });
-            overlaysInitialized = true;
-        }
+    public static void initSprites(TextureAtlas atlas) {
+        pipeOverlaySprite = atlas.getSprite(PIPE_OVERLAY);
+        fluidOutputOverlaySprite = atlas.getSprite(FLUID_OUTPUT_OVERLAY);
+        itemOutputOverlaySprite = atlas.getSprite(ITEM_OUTPUT_OVERLAY);
+        blankSprite = atlas.getSprite(GTModels.BLANK_TEXTURE);
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/ICoverableRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/ICoverableRenderer.java
@@ -8,10 +8,10 @@ import com.lowdragmc.lowdraglib.client.bakedpipeline.FaceQuad;
 
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.phys.AABB;
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.function.Function;
 
 public interface ICoverableRenderer {
 
@@ -31,8 +30,8 @@ public interface ICoverableRenderer {
     TextureAtlasSprite[] COVER_BACK_PLATE = new TextureAtlasSprite[1];
 
     @OnlyIn(Dist.CLIENT)
-    static void initSprites(Function<ResourceLocation, TextureAtlasSprite> atlas) {
-        COVER_BACK_PLATE[0] = atlas.apply(GTCEu.id("block/material_sets/dull/wire_side"));
+    static void initSprites(TextureAtlas atlas) {
+        COVER_BACK_PLATE[0] = atlas.getSprite(GTCEu.id("block/material_sets/dull/wire_side"));
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/IOCoverRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/IOCoverRenderer.java
@@ -46,7 +46,7 @@ public class IOCoverRenderer implements ICoverRenderer {
                            @Nullable ResourceLocation invertedOverlay,
                            @Nullable ResourceLocation emissiveOverlay,
                            @Nullable ResourceLocation invertedEmissiveOverlay) {
-        ModelUtils.registerAtlasStitchedEventListener(InventoryMenu.BLOCK_ATLAS, event -> {
+        ModelUtils.registerAtlasStitchedEventListener(false, InventoryMenu.BLOCK_ATLAS, event -> {
             var atlas = event.getAtlas();
 
             if (overlay != null) {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/SimpleCoverRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/SimpleCoverRenderer.java
@@ -34,7 +34,7 @@ public class SimpleCoverRenderer implements ICoverRenderer {
     }
 
     public SimpleCoverRenderer(ResourceLocation texture, ResourceLocation emissiveTexture) {
-        ModelUtils.registerAtlasStitchedEventListener(InventoryMenu.BLOCK_ATLAS, event -> {
+        ModelUtils.registerAtlasStitchedEventListener(false, InventoryMenu.BLOCK_ATLAS, event -> {
             var atlas = event.getAtlas();
 
             sprite = atlas.getSprite(texture);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/BoilerMultiPartRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/BoilerMultiPartRender.java
@@ -71,7 +71,7 @@ public class BoilerMultiPartRender extends DynamicRender<LargeBoilerMachine, Boi
         this.fireboxActive = fireboxActive;
 
         this.casing = casing;
-        ModelUtils.registerBakeEventListener(event -> {
+        ModelUtils.registerBakeEventListener(true, event -> {
             this.fireboxIdleModel = event.getModels().get(BlockModelShaper.stateToModelLocation(this.fireboxIdle));
             this.fireboxActiveModel = event.getModels().get(BlockModelShaper.stateToModelLocation(this.fireboxActive));
             this.casingModel = event.getModels().get(BlockModelShaper.stateToModelLocation(this.casing));

--- a/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.client.util;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.client.model.machine.MachineModel;
+import com.gregtechceu.gtceu.client.renderer.cover.ICoverableRenderer;
 import com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration;
 
 import com.lowdragmc.lowdraglib.client.model.custommodel.CustomBakedModel;
@@ -9,21 +10,27 @@ import com.lowdragmc.lowdraglib.client.model.custommodel.CustomBakedModel;
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.resources.model.*;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ModelEvent;
+import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +41,7 @@ public class ModelUtils {
 
     private ModelUtils() {}
 
-    private static final List<AssetEventListener<?>> EVENT_LISTENERS = new ArrayList<>();
+    private static final List<EventListenerHolder> EVENT_LISTENERS = new ArrayList<>();
 
     public static List<BakedQuad> getBakedModelQuads(BakedModel model, BlockAndTintGetter level, BlockPos pos,
                                                      BlockState state, Direction side, RandomSource rand) {
@@ -55,34 +62,52 @@ public class ModelUtils {
         return property.getName() + ": " + valueString;
     }
 
-    public static void registerAtlasStitchedEventListener(AssetEventListener.AtlasStitched listener) {
-        EVENT_LISTENERS.add(listener);
+    public static void registerAtlasStitchedEventListener(AssetEventListener.AtlasStitched listener,
+                                                          boolean removeOnReload) {
+        EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
     }
 
-    public static void registerAtlasStitchedEventListener(final ResourceLocation atlasLocation,
+    public static void registerAtlasStitchedEventListener(boolean removeOnReload, final ResourceLocation atlasLocation,
                                                           final AssetEventListener.AtlasStitched listener) {
-        EVENT_LISTENERS.add((AssetEventListener.AtlasStitched) event -> {
+        registerAtlasStitchedEventListener(event -> {
             if (event.getAtlas().location().equals(atlasLocation)) {
                 listener.accept(event);
+            }
+        }, removeOnReload);
+    }
+
+    public static void registerBakeEventListener(boolean removeOnReload, AssetEventListener.ModifyBakingResult listener) {
+        EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
+    }
+
+    public static void registerAddModelsEventListener(AssetEventListener.RegisterAdditional listener,
+                                                      boolean removeOnReload) {
+        EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public static void registerReloadListener(RegisterClientReloadListenersEvent event) {
+        event.registerReloadListener(new ResourceManagerReloadListener() {
+            @Override
+            public void onResourceManagerReload(@NotNull ResourceManager resourceManager) {
+                EVENT_LISTENERS.removeIf(EventListenerHolder::removeOnReload);
             }
         });
     }
 
-    public static void registerBakeEventListener(AssetEventListener.ModifyBakingResult listener) {
-        EVENT_LISTENERS.add(listener);
-    }
-
-    public static void registerAddModelsEventListener(AssetEventListener.RegisterAdditional listener) {
-        EVENT_LISTENERS.add(listener);
-    }
-
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "deprecation" })
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onAtlasStitched(TextureStitchEvent.Post event) {
+        TextureAtlas atlas = event.getAtlas();
+        if (atlas.location() == TextureAtlas.LOCATION_BLOCKS) {
+            MachineModel.initSprites(atlas);
+            ICoverableRenderer.initSprites(atlas);
+        }
+
         for (var listener : EVENT_LISTENERS) {
-            Class<?> eventClass = listener.eventClass();
+            Class<?> eventClass = listener.listener.eventClass();
             if (eventClass != null && eventClass.isInstance(event)) {
-                ((AssetEventListener<TextureStitchEvent.Post>) listener).accept(event);
+                ((AssetEventListener<TextureStitchEvent.Post>) listener.listener).accept(event);
             }
         }
     }
@@ -91,9 +116,9 @@ public class ModelUtils {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onModifyBakingResult(ModelEvent.ModifyBakingResult event) {
         for (var listener : EVENT_LISTENERS) {
-            Class<?> eventClass = listener.eventClass();
+            Class<?> eventClass = listener.listener.eventClass();
             if (eventClass != null && eventClass.isInstance(event)) {
-                ((AssetEventListener<ModelEvent.ModifyBakingResult>) listener).accept(event);
+                ((AssetEventListener<ModelEvent.ModifyBakingResult>) listener.listener).accept(event);
             }
         }
 
@@ -117,10 +142,12 @@ public class ModelUtils {
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onRegisterAdditional(ModelEvent.RegisterAdditional event) {
         for (var listener : EVENT_LISTENERS) {
-            Class<?> eventClass = listener.eventClass();
+            Class<?> eventClass = listener.listener.eventClass();
             if (eventClass != null && eventClass.isInstance(event)) {
-                ((AssetEventListener<ModelEvent.RegisterAdditional>) listener).accept(event);
+                ((AssetEventListener<ModelEvent.RegisterAdditional>) listener.listener).accept(event);
             }
         }
     }
+
+    private record EventListenerHolder(AssetEventListener<?> listener, boolean removeOnReload) {}
 }

--- a/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
@@ -76,7 +76,8 @@ public class ModelUtils {
         }, removeOnReload);
     }
 
-    public static void registerBakeEventListener(boolean removeOnReload, AssetEventListener.ModifyBakingResult listener) {
+    public static void registerBakeEventListener(boolean removeOnReload,
+                                                 AssetEventListener.ModifyBakingResult listener) {
         EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
     }
 
@@ -88,6 +89,7 @@ public class ModelUtils {
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void registerReloadListener(RegisterClientReloadListenersEvent event) {
         event.registerReloadListener(new ResourceManagerReloadListener() {
+
             @Override
             public void onResourceManagerReload(@NotNull ResourceManager resourceManager) {
                 EVENT_LISTENERS.removeIf(EventListenerHolder::removeOnReload);

--- a/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
@@ -62,18 +62,18 @@ public class ModelUtils {
         return property.getName() + ": " + valueString;
     }
 
-    public static void registerAtlasStitchedEventListener(AssetEventListener.AtlasStitched listener,
-                                                          boolean removeOnReload) {
+    public static void registerAtlasStitchedEventListener(boolean removeOnReload,
+                                                          AssetEventListener.AtlasStitched listener) {
         EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
     }
 
     public static void registerAtlasStitchedEventListener(boolean removeOnReload, final ResourceLocation atlasLocation,
                                                           final AssetEventListener.AtlasStitched listener) {
-        registerAtlasStitchedEventListener(event -> {
+        registerAtlasStitchedEventListener(removeOnReload, event -> {
             if (event.getAtlas().location().equals(atlasLocation)) {
                 listener.accept(event);
             }
-        }, removeOnReload);
+        });
     }
 
     public static void registerBakeEventListener(boolean removeOnReload,
@@ -81,8 +81,8 @@ public class ModelUtils {
         EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
     }
 
-    public static void registerAddModelsEventListener(AssetEventListener.RegisterAdditional listener,
-                                                      boolean removeOnReload) {
+    public static void registerAddModelsEventListener(boolean removeOnReload,
+                                                      AssetEventListener.RegisterAdditional listener) {
         EVENT_LISTENERS.add(new EventListenerHolder(listener, removeOnReload));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/ModelUtils.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.client.util;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.client.model.machine.MachineModel;
+import com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration;
 
 import com.lowdragmc.lowdraglib.client.model.custommodel.CustomBakedModel;
 
@@ -89,8 +90,18 @@ public class ModelUtils {
     @SuppressWarnings("unchecked")
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onModifyBakingResult(ModelEvent.ModifyBakingResult event) {
-        // Unwrap all machine models from the LDLib CTM models so we don't need to be as aggressive with mixins.
-        // Also, the caching they have stops our models from updating properly.
+        for (var listener : EVENT_LISTENERS) {
+            Class<?> eventClass = listener.eventClass();
+            if (eventClass != null && eventClass.isInstance(event)) {
+                ((AssetEventListener<ModelEvent.ModifyBakingResult>) listener).accept(event);
+            }
+        }
+
+        // don't process the CTM model unwrapping here if modernfix dynamic resources is enabled
+        if (GTCEu.Mods.isModernFixLoaded() && GTModernFixIntegration.isDynamicResourcesEnabled()) return;
+
+        // Unwrap all machine models from LDLib CTM models so we don't need to be as aggressive with mixins
+        // Also, the caching they have stops our models from updating properly
         for (var entry : event.getModels().entrySet()) {
             BakedModel model = entry.getValue();
             if (!(model instanceof CustomBakedModel ctmModel)) {
@@ -98,13 +109,6 @@ public class ModelUtils {
             }
             if (ctmModel.getParent() instanceof MachineModel machine) {
                 entry.setValue(machine);
-            }
-        }
-
-        for (var listener : EVENT_LISTENERS) {
-            Class<?> eventClass = listener.eventClass();
-            if (eventClass != null && eventClass.isInstance(event)) {
-                ((AssetEventListener<ModelEvent.ModifyBakingResult>) listener).accept(event);
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/ModelManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/ModelManagerMixin.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.client.renderer.item.TagPrefixItemRenderer;
 import com.gregtechceu.gtceu.client.renderer.item.ToolItemRenderer;
 import com.gregtechceu.gtceu.common.data.models.GTModels;
 import com.gregtechceu.gtceu.integration.kjs.GregTechKubeJSPlugin;
+import com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration;
 
 import net.minecraft.client.resources.model.ModelManager;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
@@ -46,6 +47,9 @@ public abstract class ModelManagerMixin {
 
         if (GTCEu.Mods.isKubeJSLoaded()) {
             GregTechKubeJSPlugin.generateMachineBlockModels();
+        }
+        if (GTCEu.Mods.isModernFixLoaded()) {
+            GTModernFixIntegration.setAsLast();
         }
         GTCEu.LOGGER.info("GregTech Model loading took {}ms", System.currentTimeMillis() - startTime);
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/modernfix/GTModernFixIntegration.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/modernfix/GTModernFixIntegration.java
@@ -9,6 +9,7 @@ import net.minecraft.client.resources.model.*;
 import net.minecraft.resources.ResourceLocation;
 
 import lombok.Getter;
+import org.embeddedt.modernfix.ModernFixClient;
 import org.embeddedt.modernfix.api.entrypoint.ModernFixClientIntegration;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -16,11 +17,23 @@ import java.util.function.Function;
 
 public class GTModernFixIntegration implements ModernFixClientIntegration {
 
+    private static GTModernFixIntegration INSTANCE = null;
     @Getter
     private static boolean dynamicResourcesEnabled = false;
 
     @ApiStatus.Internal
-    public GTModernFixIntegration() {}
+    public GTModernFixIntegration() {
+        INSTANCE = this;
+    }
+
+    public static void setAsLast() {
+        if (INSTANCE != null) {
+            ModernFixClient.CLIENT_INTEGRATIONS.remove(INSTANCE);
+        } else {
+            INSTANCE = new GTModernFixIntegration();
+        }
+        ModernFixClient.CLIENT_INTEGRATIONS.add(INSTANCE);
+    }
 
     @Override
     public void onDynamicResourcesStatusChange(boolean enabled) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/modernfix/GTModernFixIntegration.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/modernfix/GTModernFixIntegration.java
@@ -1,0 +1,42 @@
+package com.gregtechceu.gtceu.integration.modernfix;
+
+import com.gregtechceu.gtceu.client.model.machine.MachineModel;
+
+import com.lowdragmc.lowdraglib.client.model.custommodel.CustomBakedModel;
+
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.*;
+import net.minecraft.resources.ResourceLocation;
+
+import lombok.Getter;
+import org.embeddedt.modernfix.api.entrypoint.ModernFixClientIntegration;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.function.Function;
+
+public class GTModernFixIntegration implements ModernFixClientIntegration {
+
+    @Getter
+    private static boolean dynamicResourcesEnabled = false;
+
+    @ApiStatus.Internal
+    public GTModernFixIntegration() {}
+
+    @Override
+    public void onDynamicResourcesStatusChange(boolean enabled) {
+        dynamicResourcesEnabled = enabled;
+    }
+
+    @Override
+    public BakedModel onBakedModelLoad(ResourceLocation location, UnbakedModel baseModel,
+                                       BakedModel originalModel, ModelState state, ModelBakery bakery,
+                                       Function<Material, TextureAtlasSprite> textureGetter) {
+        if (originalModel instanceof CustomBakedModel ctmModel) {
+            // Unwrap all machine models from LDLib CTM models so we don't need to be as aggressive with mixins
+            if (ctmModel.getParent() instanceof MachineModel machineModel) {
+                return machineModel;
+            }
+        }
+        return originalModel;
+    }
+}

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -12,6 +12,7 @@ description = "${mod_description}"
 logoFile = "icon.png"
 displayURL = "${mod_url}"
 credits = "GregoriusT, Mr_Touchyou, Zerrens for making GregTech and textures, the GT5u authors and maintainers for providing the original code, and the community."
+
 [mods."modernfix:integration"]
 client_entrypoint = "com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration"
 
@@ -87,4 +88,11 @@ modId = "jade"
 mandatory = false
 versionRange = "[${jade_version},)"
 ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.${mod_id}]]
+modId = "modernfix"
+mandatory = false
+versionRange = "[${modernfix_version},)"
+ordering = "BEFORE"
 side = "BOTH"

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -12,6 +12,8 @@ description = "${mod_description}"
 logoFile = "icon.png"
 displayURL = "${mod_url}"
 credits = "GregoriusT, Mr_Touchyou, Zerrens for making GregTech and textures, the GT5u authors and maintainers for providing the original code, and the community."
+[mods."modernfix:integration"]
+client_entrypoint = "com.gregtechceu.gtceu.integration.modernfix.GTModernFixIntegration"
 
 [[dependencies.${mod_id}]]
 modId = "forge"


### PR DESCRIPTION
## What
Added ModernFix as a dependency and made the event listener not run if dynamic resources are installed so ModernFix can process them properly

## Implementation Details
I had to force our client integration instance to be the last one in ModernFix's list, as otherwise it'd run before LDLib's and do nothing.

## Outcome
no more pipe model logspam
machine CTM works with dynamic resources enabled