### PR TITLE
[1.20.1] Update version name for published releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
           files: |
             ./gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar
             ./!(gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)
-          name: 'GregTechCEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
+          name: 'GregTech CEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
           version: 'mc${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
           version-type: ${{ env.VERSION_TYPE }}
           changelog: ${{ inputs.release-body }}
@@ -136,7 +136,7 @@ jobs:
           files: |
             ./gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar
             ./!(gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)
-          name: 'GregTechCEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
+          name: 'GregTech CEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
           version: 'mc${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
           version-type: ${{ env.VERSION_TYPE }}
           changelog: ${{ inputs.release-body }}


### PR DESCRIPTION
## What
Updates the name displayed in curseforge and modrinth for 1.20.1 releases (not the file name, just the website release name)