### PR TITLE
Remove machete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'idea'
     id 'maven-publish'
     alias libs.plugins.modDevGradle
-    alias libs.plugins.machete // automatic jar compressing on build
     //alias libs.plugins.shadow
     alias libs.plugins.spotless
     alias libs.plugins.lombok
@@ -92,14 +91,6 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
     options.compilerArgs << "-Xlint:-removal"
     options.compilerArgs << "-Aquiet=true" // Suppress mixin notes
-}
-
-machete {
-    // disable machete locally for faster builds
-    enabled = false
-    // Only optimize reobf jars
-    ignoredTasks.addAll("jar", "slimJar")
-    additionalTasks.addAll("reobfJar", "reobfSlimJar")
 }
 
 lombok {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ parchment = "2023.09.03" # https://parchmentmc.org/docs/getting-started
 shadow = "8.3.5"
 spotless = "7.0.2"
 modDevGradle = "2.0.86"
-machete = "2.0.1"
 lombok = "8.11"
 jetbrains-annotations = "26.0.1"
 mixin = "0.8.7"
@@ -21,5 +20,4 @@ mixin                   = { module = "org.spongepowered:mixin", version.ref = "m
 modDevGradle            = { id = "net.neoforged.moddev.legacyforge", version.ref = "modDevGradle" }
 shadow                  = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless                = { id = "com.diffplug.spotless", version.ref = "spotless" }
-machete                 = { id = "io.github.p03w.machete", version.ref = "machete" }
 lombok                  = { id = "io.freefair.lombok", version.ref = "lombok" }


### PR DESCRIPTION
## What
Removes machete since it has caused problems with releases and is deprecated as of June 11, 2023 (https://github.com/SilverAndro/Machete)