### PR TITLE
Fix right-clicking buttons not working on 1.21

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ButtonWidgetMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ButtonWidgetMixin.java
@@ -1,0 +1,17 @@
+package com.gregtechceu.gtceu.core.mixins.ldlib;
+
+import com.lowdragmc.lowdraglib.gui.widget.ButtonWidget;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(value = ButtonWidget.class, remap = false)
+public class ButtonWidgetMixin {
+
+    // Patch out the button == 0 check by making it 0 == 0
+    @ModifyVariable(method = "mouseClicked", at = @At(value = "LOAD", ordinal = 0), argsOnly = true)
+    private int gtceu$fixButtonRightClick(int button) {
+        return 0;
+    }
+}

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -64,6 +64,7 @@
         "emi.FillRecipePacketMixin",
         "emi.FluidEmiStackMixin",
         "jei.FluidHelperMixin",
+        "ldlib.ButtonWidgetMixin",
         "ldlib.DummyWorldMixin",
         "ldlib.ItemStackPayloadMixin",
         "ldlib.TrackedDummyWorldMixin",


### PR DESCRIPTION
## What
Fixes #3429

## Implementation Details
I can't just update LDLib to fix this, because the mod's been reworked and I do not have the willpower to update everything.

## Outcome
The overclock calculator button also works on 1.21