### PR TITLE
Fix adding recipes with KubeJS not working

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/material/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/material/ChemicalHelper.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.common.crafting.SizedIngredient;
 
 import com.mojang.datafixers.util.Pair;
 import org.jetbrains.annotations.NotNull;
@@ -54,10 +55,19 @@ public class ChemicalHelper {
                 return ItemMaterialData.getMaterialInfo(items.get(0));
             }
         } else if (object instanceof Ingredient ing) {
+            if (!ing.isCustom()) {
+                for (Ingredient.Value value : ing.getValues()) {
+                    if (value instanceof Ingredient.TagValue) {
+                        return null;
+                    }
+                }
+            }
             for (var stack : ing.getItems()) {
                 var ms = ItemMaterialData.getMaterialInfo(stack.getItem());
                 if (ms != null) return ms;
             }
+        } else if (object instanceof SizedIngredient ing) {
+            return getMaterialInfo(ing.ingredient());
         }
         return null;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTKubeJSPlugin.java
@@ -116,6 +116,7 @@ import dev.latvian.mods.kubejs.event.EventGroupRegistry;
 import dev.latvian.mods.kubejs.plugin.ClassFilter;
 import dev.latvian.mods.kubejs.plugin.KubeJSPlugin;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeComponentFactoryRegistry;
+import dev.latvian.mods.kubejs.recipe.schema.RecipeFactoryRegistry;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchemaRegistry;
 import dev.latvian.mods.kubejs.registry.BuilderTypeRegistry;
 import dev.latvian.mods.kubejs.registry.RegistryObjectStorage;
@@ -252,6 +253,12 @@ public class GTKubeJSPlugin implements KubeJSPlugin {
             event.register(id, GTRecipeSchema.SCHEMA);
         }
         event.namespace(GTCEu.MOD_ID).register("shaped", GTShapedRecipeSchema.SCHEMA);
+    }
+
+    @Override
+    public void registerRecipeFactories(RecipeFactoryRegistry registry) {
+        registry.register(GTRecipeSchema.RECIPE_FACTORY);
+        registry.register(GTShapedRecipeSchema.RECIPE_FACTORY);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -24,7 +24,6 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.CapabilityMapComp
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceKey;
@@ -46,9 +45,9 @@ import dev.latvian.mods.kubejs.recipe.KubeRecipe;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.component.ComponentRole;
 import dev.latvian.mods.kubejs.recipe.component.TimeComponent;
+import dev.latvian.mods.kubejs.recipe.schema.KubeRecipeFactory;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeConstructor;
 import dev.latvian.mods.kubejs.recipe.schema.RecipeSchema;
-import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.util.KubeResourceLocation;
 import dev.latvian.mods.kubejs.util.TickDuration;
 import dev.latvian.mods.rhino.util.HideFromJS;
@@ -90,6 +89,8 @@ public interface GTRecipeSchema {
         public boolean fluidMaterialInfo = false;
         public boolean removeMaterialInfo = false;
 
+        public GTKubeRecipe() {}
+
         @HideFromJS
         @Override
         public GTKubeRecipe id(KubeResourceLocation _id) {
@@ -103,36 +104,29 @@ public interface GTRecipeSchema {
         }
 
         public <T> GTKubeRecipe input(RecipeCapability<T> capability, Object... obj) {
-            CapabilityMap map = getValue(perTick ? ALL_TICK_INPUTS : ALL_INPUTS);
-            if (map != null) {
-                for (Object object : obj) {
-                    map.add(capability, new Content(object, chance, maxChance, tierChanceBoost));
-                }
+            var key = perTick ? ALL_TICK_INPUTS : ALL_INPUTS;
+            if (getValue(key) == null) setValue(key, new CapabilityMap());
+            CapabilityMap map = getValue(key);
+            for (Object object : obj) {
+                map.add(capability, new Content(object, chance, maxChance, tierChanceBoost));
             }
             save();
             return this;
         }
 
         public <T> GTKubeRecipe output(RecipeCapability<T> capability, Object... obj) {
-            CapabilityMap map = getValue(perTick ? ALL_TICK_OUTPUTS : ALL_OUTPUTS);
-            if (map != null) {
-                var recipeType = BuiltInRegistries.RECIPE_TYPE.get(this.type.id);
-                if (recipeType instanceof GTRecipeType gtType &&
-                        map.get(capability) != null &&
-                        map.get(capability).size() + obj.length > gtType.getMaxOutputs(capability)) {
-                    ConsoleJS.SERVER.warn(String.format(
-                            "Trying to add more outputs than RecipeType can support, id: %s, Max %s%sOutputs: %s",
-                            id, (perTick ? "Tick " : ""), capability.name, gtType.getMaxOutputs(capability)));
-                }
-                for (Object object : obj) {
-                    map.add(capability, new Content(object, chance, maxChance, tierChanceBoost));
-                }
+            var key = perTick ? ALL_TICK_INPUTS : ALL_INPUTS;
+            if (getValue(key) == null) setValue(key, new CapabilityMap());
+            CapabilityMap map = getValue(key);
+            for (Object object : obj) {
+                map.add(capability, new Content(object, chance, maxChance, tierChanceBoost));
             }
             save();
             return this;
         }
 
         public GTKubeRecipe addCondition(RecipeCondition<?> condition) {
+            if (getValue(CONDITIONS) == null) setValue(CONDITIONS, new ArrayList<>());
             getValue(CONDITIONS).add(condition);
             save();
             return this;
@@ -864,18 +858,20 @@ public interface GTRecipeSchema {
         }
     }
 
+    KubeRecipeFactory RECIPE_FACTORY = new KubeRecipeFactory(GTCEu.id("machine"), GTKubeRecipe.class, GTKubeRecipe::new);
+
     // spotless:off
     RecipeKey<ResourceLocation> ID = GTRecipeComponents.RESOURCE_LOCATION.key("id", ComponentRole.OTHER);
     RecipeKey<TickDuration> DURATION = TimeComponent.TICKS.key("duration", ComponentRole.OTHER).optional(new TickDuration(100));
-    RecipeKey<CompoundTag> DATA = GTRecipeComponents.TAG.key("data", ComponentRole.OTHER).optional(new CompoundTag());
-    RecipeKey<List<RecipeCondition<?>>> CONDITIONS = GTRecipeComponents.RECIPE_CONDITION.asList().key("recipeConditions", ComponentRole.OTHER).optional(new ArrayList<>());
+    RecipeKey<CompoundTag> DATA = GTRecipeComponents.TAG.key("data", ComponentRole.OTHER).optional(r -> new CompoundTag());
+    RecipeKey<List<RecipeCondition<?>>> CONDITIONS = GTRecipeComponents.RECIPE_CONDITION.asList().key("recipeConditions", ComponentRole.OTHER).defaultOptional();
     RecipeKey<ResourceLocation> CATEGORY = GTRecipeComponents.RESOURCE_LOCATION.key("category", ComponentRole.OTHER).defaultOptional();
 
-    RecipeKey<CapabilityMap> ALL_INPUTS = CapabilityMapComponent.INSTANCE.key("inputs", ComponentRole.INPUT).optional(new CapabilityMap());
-    RecipeKey<CapabilityMap> ALL_TICK_INPUTS = CapabilityMapComponent.INSTANCE.key("tickInputs", ComponentRole.INPUT).optional(new CapabilityMap());
+    RecipeKey<CapabilityMap> ALL_INPUTS = CapabilityMapComponent.INSTANCE.key("inputs", ComponentRole.INPUT).defaultOptional();
+    RecipeKey<CapabilityMap> ALL_TICK_INPUTS = CapabilityMapComponent.INSTANCE.key("tickInputs", ComponentRole.INPUT).defaultOptional();
 
-    RecipeKey<CapabilityMap> ALL_OUTPUTS = CapabilityMapComponent.INSTANCE.key("outputs", ComponentRole.OUTPUT).optional(new CapabilityMap());
-    RecipeKey<CapabilityMap> ALL_TICK_OUTPUTS = CapabilityMapComponent.INSTANCE.key("tickOutputs", ComponentRole.OUTPUT).optional(new CapabilityMap());
+    RecipeKey<CapabilityMap> ALL_OUTPUTS = CapabilityMapComponent.INSTANCE.key("outputs", ComponentRole.OUTPUT).defaultOptional();
+    RecipeKey<CapabilityMap> ALL_TICK_OUTPUTS = CapabilityMapComponent.INSTANCE.key("tickOutputs", ComponentRole.OUTPUT).defaultOptional();
 
     RecipeKey<Map<RecipeCapability<?>, ChanceLogic>> INPUT_CHANCE_LOGICS = GTRecipeComponents.CHANCE_LOGIC_MAP
             .key("inputChanceLogics", ComponentRole.OTHER).defaultOptional();
@@ -889,9 +885,10 @@ public interface GTRecipeSchema {
     RecipeSchema SCHEMA = new RecipeSchema(DURATION, DATA, CONDITIONS,
             ALL_INPUTS, ALL_TICK_INPUTS, ALL_OUTPUTS, ALL_TICK_OUTPUTS,
             INPUT_CHANCE_LOGICS, OUTPUT_CHANCE_LOGICS, TICK_INPUT_CHANCE_LOGICS, TICK_OUTPUT_CHANCE_LOGICS, CATEGORY)
+            .factory(RECIPE_FACTORY)
             .constructor(new IDRecipeConstructor())
             .constructor(new RecipeConstructor())
             .constructor(DURATION, CONDITIONS, ALL_INPUTS, ALL_OUTPUTS, ALL_TICK_INPUTS, ALL_TICK_OUTPUTS)
-            .uniqueIds(List.of(ALL_OUTPUTS, ALL_TICK_OUTPUTS));
+            .uniqueIds(List.of(ALL_INPUTS, ALL_OUTPUTS, ALL_TICK_INPUTS, ALL_TICK_OUTPUTS));
     // spotless:on
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -858,9 +858,9 @@ public interface GTRecipeSchema {
         }
     }
 
+    // spotless:off
     KubeRecipeFactory RECIPE_FACTORY = new KubeRecipeFactory(GTCEu.id("machine"), GTKubeRecipe.class, GTKubeRecipe::new);
 
-    // spotless:off
     RecipeKey<ResourceLocation> ID = GTRecipeComponents.RESOURCE_LOCATION.key("id", ComponentRole.OTHER);
     RecipeKey<TickDuration> DURATION = TimeComponent.TICKS.key("duration", ComponentRole.OTHER).optional(new TickDuration(100));
     RecipeKey<CompoundTag> DATA = GTRecipeComponents.TAG.key("data", ComponentRole.OTHER).optional(r -> new CompoundTag());

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -117,21 +117,20 @@ public interface GTShapedRecipeSchema {
         }
     }
 
+    // spotless:off
     KubeRecipeFactory RECIPE_FACTORY = new KubeRecipeFactory(GTCEu.id("shaped"), ShapedKubeRecipe.class, ShapedKubeRecipe::new);
 
     RecipeKey<ItemStack> RESULT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
     RecipeKey<List<String>> PATTERN = StringGridComponent.STRING_GRID.otherKey("pattern");
-    RecipeKey<TinyMap<Character, Ingredient>> KEY = IngredientComponent.INGREDIENT
-            .asPatternKey().inputKey("key");
-    RecipeKey<Boolean> MIRROR = BooleanComponent.BOOLEAN.otherKey(KubeJSCraftingRecipe.MIRROR_KEY)
-            .optional(true).exclude()
+    RecipeKey<TinyMap<Character, Ingredient>> KEY = IngredientComponent.INGREDIENT.asPatternKey().inputKey("key");
+    RecipeKey<Boolean> MIRROR = BooleanComponent.BOOLEAN.otherKey(KubeJSCraftingRecipe.MIRROR_KEY).optional(true).exclude()
             .functionNames(List.of("kjsMirror"));
-    RecipeKey<Boolean> SHRINK = BooleanComponent.BOOLEAN.otherKey("kubejs:shrink")
-            .optional(true).exclude()
+    RecipeKey<Boolean> SHRINK = BooleanComponent.BOOLEAN.otherKey("kubejs:shrink").optional(true).exclude()
             .functionNames(List.of("kjsShrink"));
     RecipeKey<CraftingBookCategory> CATEGORY = BookCategoryComponent.CRAFTING_BOOK_CATEGORY.otherKey("category")
             .optional(CraftingBookCategory.MISC)
             .functionNames(List.of("kjsShrink"));
+    // spotless:on
 
     RecipeSchema SCHEMA = new RecipeSchema(RESULT, PATTERN, KEY, MIRROR, SHRINK, CATEGORY)
             .factory(RECIPE_FACTORY)

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTShapedRecipeSchema.java
@@ -117,6 +117,8 @@ public interface GTShapedRecipeSchema {
         }
     }
 
+    KubeRecipeFactory RECIPE_FACTORY = new KubeRecipeFactory(GTCEu.id("shaped"), ShapedKubeRecipe.class, ShapedKubeRecipe::new);
+
     RecipeKey<ItemStack> RESULT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
     RecipeKey<List<String>> PATTERN = StringGridComponent.STRING_GRID.otherKey("pattern");
     RecipeKey<TinyMap<Character, Ingredient>> KEY = IngredientComponent.INGREDIENT
@@ -132,7 +134,7 @@ public interface GTShapedRecipeSchema {
             .functionNames(List.of("kjsShrink"));
 
     RecipeSchema SCHEMA = new RecipeSchema(RESULT, PATTERN, KEY, MIRROR, SHRINK, CATEGORY)
-            .factory(new KubeRecipeFactory(GTCEu.id("shaped"), ShapedKubeRecipe.class, ShapedKubeRecipe::new))
+            .factory(RECIPE_FACTORY)
             .constructor(RESULT, PATTERN, KEY)
             .uniqueId(RESULT)
             .typeOverride(KubeJS.id("shaped"))


### PR DESCRIPTION
## What
Fixes the missing recipe factory required to initialize GT machine recipes properly
also fixes some *very* invalid defaults that came from minor changes in KubeJS between MC versions

## Outcome
KubeJS integration actually works now