### PR TITLE
Fix the multiblock preview page Z-fighting on most multiblocks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
@@ -213,7 +213,8 @@ public class PatternPreviewWidget extends WidgetGroup {
         Stream<BlockPos> stream = pattern.blockMap.keySet().stream()
                 .filter(pos -> layer == -1 || layer + pattern.minY == pos.getY());
         if (pattern.controllerBase.isFormed()) {
-            LongSet modelDisabled = pattern.controllerBase.getMultiblockState().getMatchContext().getOrDefault("renderMask",
+            LongSet modelDisabled = pattern.controllerBase.getMultiblockState().getMatchContext().getOrDefault(
+                    "renderMask",
                     LongSets.EMPTY_SET);
             if (!modelDisabled.isEmpty()) {
                 stream = stream.filter(pos -> !modelDisabled.contains(pos.asLong()));

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
@@ -31,6 +31,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -62,7 +63,8 @@ public class PatternPreviewWidget extends WidgetGroup {
 
     private boolean isLoaded;
     private static TrackedDummyWorld LEVEL;
-    private static BlockPos LAST_POS = new BlockPos(0, 50, 0);
+    private static final int REGION_SIZE = 512;
+    private static int LAST_OFFSET_INDEX = 0;
     private static final Map<MultiblockMachineDefinition, MBPattern[]> CACHE = new HashMap<>();
     private final SceneWidget sceneWidget;
     private final DraggableScrollableWidgetGroup scrollableWidgetGroup;
@@ -211,18 +213,13 @@ public class PatternPreviewWidget extends WidgetGroup {
         Stream<BlockPos> stream = pattern.blockMap.keySet().stream()
                 .filter(pos -> layer == -1 || layer + pattern.minY == pos.getY());
         if (pattern.controllerBase.isFormed()) {
-            LongSet set = pattern.controllerBase.getMultiblockState().getMatchContext().getOrDefault("renderMask",
+            LongSet modelDisabled = pattern.controllerBase.getMultiblockState().getMatchContext().getOrDefault("renderMask",
                     LongSets.EMPTY_SET);
-            Set<BlockPos> modelDisabled = set.stream().map(BlockPos::of).collect(Collectors.toSet());
             if (!modelDisabled.isEmpty()) {
-                sceneWidget.setRenderedCore(
-                        stream.filter(pos -> !modelDisabled.contains(pos)).collect(Collectors.toList()), null);
-            } else {
-                sceneWidget.setRenderedCore(stream.toList(), null);
+                stream = stream.filter(pos -> !modelDisabled.contains(pos.asLong()));
             }
-        } else {
-            sceneWidget.setRenderedCore(stream.toList(), null);
         }
+        sceneWidget.setRenderedCore(stream.toList(), null);
     }
 
     public static PatternPreviewWidget getPatternWidget(MultiblockMachineDefinition controllerDefinition) {
@@ -306,10 +303,43 @@ public class PatternPreviewWidget extends WidgetGroup {
         }
     }
 
-    public static BlockPos locateNextRegion(int range) {
-        BlockPos pos = LAST_POS;
-        LAST_POS = LAST_POS.offset(range, 0, range);
-        return pos;
+    /**
+     * Finds the next section of the dummy preview level to place a multiblock at in a spiral pattern.
+     * <p>
+     * This results in positions that are considerably closer to the world origin than
+     * the one it replaces, which did {@code prevPos.offset(500, 0, 500)},
+     * which results in absurdly high offsets for the later multiblocks.
+     * </p>
+     * The regions being closer to {@code (0,0)} means that Z-fighting should be less likely,
+     * since floating point inaccuracies won't be as large of a factor.
+     *
+     * @return the area to place the current multiblock at
+     */
+    public static BlockPos locateNextRegion() {
+        int currentIndex = LAST_OFFSET_INDEX++;
+
+        // Origin coordinates scaled back to the offset value, from global
+        int x = 0, z = 0;
+        if (currentIndex > 0) {
+            int v = (int) (Mth.sqrt(currentIndex + 0.25f) - 0.5f);
+            int nextV = v + 1;
+            int spiralBaseIndex = v * nextV;
+            // this is 1 or -1 depending on if v is odd or even
+            int flipFlop = (v & 1) * 2 - 1;
+
+            int offset = flipFlop * nextV / 2;
+            x += offset;
+            z += offset;
+
+            int cornerIndex = spiralBaseIndex + nextV;
+            if (currentIndex < cornerIndex) {
+                x -= flipFlop * (currentIndex - spiralBaseIndex + 1);
+            } else {
+                x -= flipFlop * nextV;
+                z -= flipFlop * (currentIndex - cornerIndex + 1);
+            }
+        }
+        return new BlockPos(x * REGION_SIZE, 50, z * REGION_SIZE);
     }
 
     @Override
@@ -335,7 +365,7 @@ public class PatternPreviewWidget extends WidgetGroup {
     private MBPattern initializePattern(MultiblockShapeInfo shapeInfo, HashSet<ItemStackKey> blockDrops) {
         Map<BlockPos, BlockInfo> blockMap = new HashMap<>();
         IMultiController controllerBase = null;
-        BlockPos multiPos = locateNextRegion(500);
+        BlockPos multiPos = locateNextRegion();
 
         BlockInfo[][][] blocks = shapeInfo.getBlocks();
         for (int x = 0; x < blocks.length; x++) {
@@ -379,21 +409,19 @@ public class PatternPreviewWidget extends WidgetGroup {
                 controllerBase);
     }
 
-    private void loadControllerFormed(Collection<BlockPos> poses, IMultiController controllerBase) {
+    private void loadControllerFormed(Collection<BlockPos> positions, IMultiController controllerBase) {
         BlockPattern pattern = controllerBase.getPattern();
         if (pattern != null && pattern.checkPatternAt(controllerBase.getMultiblockState(), true)) {
             controllerBase.onStructureFormed();
         }
         if (controllerBase.isFormed()) {
-            LongSet set = controllerBase.getMultiblockState().getMatchContext().getOrDefault("renderMask",
+            LongSet modelDisabled = controllerBase.getMultiblockState().getMatchContext().getOrDefault("renderMask",
                     LongSets.EMPTY_SET);
-            Set<BlockPos> modelDisabled = set.stream().map(BlockPos::of).collect(Collectors.toSet());
             if (!modelDisabled.isEmpty()) {
-                sceneWidget.setRenderedCore(
-                        poses.stream().filter(pos -> !modelDisabled.contains(pos)).collect(Collectors.toList()), null);
-            } else {
-                sceneWidget.setRenderedCore(poses, null);
+                positions = new HashSet<>(positions);
+                positions.removeIf(pos -> modelDisabled.contains(pos.asLong()));
             }
+            sceneWidget.setRenderedCore(positions, null);
         } else {
             GTCEu.LOGGER.warn("Pattern formed checking failed: {}", controllerBase.self().getDefinition());
         }
@@ -403,7 +431,7 @@ public class PatternPreviewWidget extends WidgetGroup {
         Map<ItemStackKey, PartInfo> partsMap = new Object2ObjectOpenHashMap<>();
         for (Map.Entry<BlockPos, BlockInfo> entry : blocks.entrySet()) {
             BlockPos pos = entry.getKey();
-            BlockState blockState = ((Level) PatternPreviewWidget.LEVEL).getBlockState(pos);
+            BlockState blockState = PatternPreviewWidget.LEVEL.getBlockState(pos);
             ItemStack itemStack = blockState.getBlock().getCloneItemStack(PatternPreviewWidget.LEVEL, pos, blockState);
 
             if (itemStack.isEmpty() && !blockState.getFluidState().isEmpty()) {
@@ -446,7 +474,7 @@ public class PatternPreviewWidget extends WidgetGroup {
         }
     }
 
-    private static class MBPattern {
+    public static class MBPattern {
 
         @NotNull
         final List<List<ItemStack>> parts;


### PR DESCRIPTION
## What
Fix the multiblock preview Z-fighting on basically all multiblocks past the 10th one in the list.

## Implementation Details
Previously, the preview page simply offset the multiblock by `500, 0, 500` relative to the previous one, which gave later multiblocks very large offsets in the dummy world.
This PR changes that method to offset them in a spiral pattern starting from `0, 0` instead.

I also cleaned up most of the warnings in the class.

## Outcome
No more Z-fighting. Except on models whose offsets are too small, but even those were barely noticeable in my testing.

## Additional Information
Thanks stack overflow 👍 