### PR TITLE
Fixes assembly lines finding items wrongly

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
@@ -23,9 +23,7 @@ import lombok.experimental.Accessors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Optional;
+import java.util.*;
 
 public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
 
@@ -74,7 +72,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
                         .map(ItemStack.class::cast)
                         .filter(s -> !s.isEmpty())
                         .findFirst())
-                .dropWhile(Optional::isEmpty)
+                .filter(o -> !(o.isEmpty() || o.get().isEmpty()))
                 .limit(inputsSize)
                 .map(o -> o.orElse(ItemStack.EMPTY))
                 .toList();
@@ -105,7 +103,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
                         .map(FluidStack.class::cast)
                         .filter(f -> !f.isEmpty())
                         .findFirst())
-                .dropWhile(Optional::isEmpty)
+                .filter(o -> !(o.isEmpty() || o.get().isEmpty()))
                 .limit(inputsSize)
                 .map(o -> o.orElse(FluidStack.EMPTY))
                 .toList();


### PR DESCRIPTION
## What
Fixes assembly lines from not running

## Implementation Details
use a filter instead of dropWhile in the streams

## Outcome
asslines run again