### PR TITLE
Fix dependency cycle error

### DIFF
--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -89,10 +89,3 @@ mandatory = false
 versionRange = "[${jade_version},)"
 ordering = "NONE"
 side = "BOTH"
-
-[[dependencies.${mod_id}]]
-modId = "modernfix"
-mandatory = false
-versionRange = "[${modernfix_version},)"
-ordering = "BEFORE"
-side = "BOTH"


### PR DESCRIPTION
## What
Removed the explicit ModernFix dependency.

## Outcome
No more cryptic error with (older versions of) ModernFix and JEI installed
