### PR TITLE
Fix stone blocks requiring a stone pickaxe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialEntry.java
@@ -30,6 +30,10 @@ public record MaterialEntry(@NotNull TagPrefix tagPrefix, @NotNull Material mate
         return this == NULL_ENTRY || material() == GTMaterials.NULL || tagPrefix().isEmpty();
     }
 
+    public boolean isIgnored() {
+        return tagPrefix().isIgnored(material());
+    }
+
     @Override
     public String toString() {
         if (tagPrefix.isEmpty()) {

--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -150,7 +150,7 @@ public class MixinHelpers {
                     tagMap.computeIfAbsent(materialTag.location(), path -> new ArrayList<>()).addAll(entries);
                 }
                 // Add tool tags
-                if (!entry.tagPrefix().miningToolTag().isEmpty()) {
+                if (!entry.isIgnored() && !entry.tagPrefix().miningToolTag().isEmpty()) {
                     tagMap.computeIfAbsent(CustomTags.TOOL_TIERS[material.getBlockHarvestLevel()].location(),
                             path -> new ArrayList<>()).addAll(entries);
                     if (material.hasProperty(PropertyKey.WOOD)) {


### PR DESCRIPTION
## What
The mineability tag addition didn't check if the material entry is ignored before slapping a mineability tag on the block

## Outcome
fixes #3445