### PR TITLE
Fix transformer recipes + move some to assembler only

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -258,8 +258,7 @@ public class ElementMaterials {
                 .liquid(new FluidBuilder().temperature(1099))
                 .color(0x20FFFF).secondaryColor(0x429393).iconSet(METALLIC)
                 .appendFlags(STD_METAL, GENERATE_LONG_ROD, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL,
-                        GENERATE_FOIL,
-                        GENERATE_FRAME)
+                        GENERATE_FOIL, GENERATE_FRAME)
                 .element(GTElements.Eu)
                 .cableProperties(V[UHV], 2, 32)
                 .fluidPipeProperties(7750, 300, true)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/ElementMaterials.java
@@ -257,7 +257,8 @@ public class ElementMaterials {
                 .ingot()
                 .liquid(new FluidBuilder().temperature(1099))
                 .color(0x20FFFF).secondaryColor(0x429393).iconSet(METALLIC)
-                .appendFlags(STD_METAL, GENERATE_LONG_ROD, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_FOIL,
+                .appendFlags(STD_METAL, GENERATE_LONG_ROD, GENERATE_FINE_WIRE, GENERATE_SPRING, GENERATE_SPRING_SMALL,
+                        GENERATE_FOIL,
                         GENERATE_FRAME)
                 .element(GTElements.Eu)
                 .cableProperties(V[UHV], 2, 32)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
@@ -102,7 +102,8 @@ public class HigherDegreeMaterials {
                 .ingot(0)
                 .liquid(new FluidBuilder().temperature(1400))
                 .color(0xc55252).secondaryColor(0xC80000).iconSet(METALLIC)
-                .appendFlags(STD_METAL, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW, DISABLE_DECOMPOSITION)
+                .appendFlags(STD_METAL, GENERATE_FINE_WIRE, GENERATE_BOLT_SCREW, GENERATE_SPRING_SMALL,
+                        DISABLE_DECOMPOSITION)
                 .components(Copper, 1, Redstone, 4)
                 .cableProperties(GTValues.V[0], 1, 0)
                 .buildAndRegister();

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
@@ -865,24 +865,8 @@ public class MetaTileEntityLoader {
 
         registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.ULV, GTValues.MV), " CC",
                 "TH ", " CC", 'C', CABLE, 'T', CABLE_TIER_UP, 'H', HULL);
-        registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.MV, GTValues.UHV), "WCC",
+        registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.MV, GTValues.IV), "WCC",
                 "TH ", "WCC", 'W', POWER_COMPONENT, 'C', CABLE, 'T', CABLE_TIER_UP, 'H', HULL);
-        registerMachineRecipe(provider,
-                ArrayUtils.subarray(GTMachines.HI_AMP_TRANSFORMER_2A, GTValues.ULV, GTValues.MV), " CC", "TH ", " CC",
-                'C', CABLE_DOUBLE, 'T', CABLE_TIER_UP_DOUBLE, 'H', HULL);
-        registerMachineRecipe(provider,
-                ArrayUtils.subarray(GTMachines.HI_AMP_TRANSFORMER_2A, GTValues.MV, GTValues.UHV), "WCC", "TH ", "WCC",
-                'W', POWER_COMPONENT, 'C', CABLE_DOUBLE, 'T', CABLE_TIER_UP_DOUBLE, 'H', HULL);
-        registerMachineRecipe(provider,
-                ArrayUtils.subarray(GTMachines.HI_AMP_TRANSFORMER_4A, GTValues.ULV, GTValues.MV), " CC", "TH ", " CC",
-                'C', CABLE_QUAD, 'T', CABLE_TIER_UP_QUAD, 'H', HULL);
-        registerMachineRecipe(provider,
-                ArrayUtils.subarray(GTMachines.HI_AMP_TRANSFORMER_4A, GTValues.MV, GTValues.UHV), "WCC", "TH ", "WCC",
-                'W', POWER_COMPONENT, 'C', CABLE_QUAD, 'T', CABLE_TIER_UP_QUAD, 'H', HULL);
-        registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.POWER_TRANSFORMER, GTValues.ULV, GTValues.MV),
-                " CC", "TH ", " CC", 'C', CABLE_HEX, 'T', CABLE_TIER_UP_HEX, 'H', HULL);
-        registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.POWER_TRANSFORMER, GTValues.MV, GTValues.UHV),
-                "WCC", "TH ", "WCC", 'W', POWER_COMPONENT, 'C', CABLE_HEX, 'T', CABLE_TIER_UP_HEX, 'H', HULL);
 
         registerMachineRecipe(provider, GTMachines.BATTERY_BUFFER_4, "WTW", "WMW", 'M', HULL, 'W', WIRE_QUAD, 'T',
                 Tags.Items.CHESTS_WOODEN);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
@@ -863,10 +863,11 @@ public class MetaTileEntityLoader {
         registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.DIODE, GTValues.LuV, GTMachines.DIODE.length),
                 "CDC", "DHD", "PDP", 'H', HULL, 'D', GTItems.ADVANCED_SMD_DIODE, 'P', PLATE, 'C', CABLE_QUAD);
 
-        registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.ULV, GTValues.MV), " CC",
-                "TH ", " CC", 'C', CABLE, 'T', CABLE_TIER_UP, 'H', HULL);
-        registerMachineRecipe(provider, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.MV, GTValues.IV), "WCC",
-                "TH ", "WCC", 'W', POWER_COMPONENT, 'C', CABLE, 'T', CABLE_TIER_UP, 'H', HULL);
+        // Decomposition info handled by the assembler recipe
+        registerMachineRecipe(provider, false, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.ULV, GTValues.MV),
+                " CC", "TH ", " CC", 'C', CABLE, 'T', CABLE_TIER_UP, 'H', HULL);
+        registerMachineRecipe(provider, false, ArrayUtils.subarray(GTMachines.TRANSFORMER, GTValues.MV, GTValues.IV),
+                "WCC", "TH ", "WCC", 'W', POWER_COMPONENT, 'C', CABLE, 'T', CABLE_TIER_UP, 'H', HULL);
 
         registerMachineRecipe(provider, GTMachines.BATTERY_BUFFER_4, "WTW", "WMW", 'M', HULL, 'W', WIRE_QUAD, 'T',
                 Tags.Items.CHESTS_WOODEN);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
@@ -324,7 +324,8 @@ public class MetaTileEntityMachineRecipeLoader {
                     .outputItems(transformer)
                     // Lower-tier recipes faster because they have crafting table equivalents
                     .duration(tier < IV ? 20 : 100)
-                    .EUt(tier < GTValues.IV ? VA[LV] : VA[tier]);
+                    .EUt(tier < GTValues.IV ? VA[LV] : VA[tier])
+                    .addMaterialInfo(true);
 
             if (tier >= MV) {
                 b.inputItems(GTCraftingComponents.POWER_COMPONENT.get(tier), 2);
@@ -340,12 +341,13 @@ public class MetaTileEntityMachineRecipeLoader {
             if (hiAmp == null || lowAmp == null) continue;
 
             GTRecipeBuilder b = ASSEMBLER_RECIPES
-                    .recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "hi_amp_2a_transformer")
+                    .recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "_hi_amp_2a_transformer")
                     .inputItems(lowAmp)
                     .inputItems(GTCraftingComponents.CABLE_TIER_UP_DOUBLE.get(tier))
                     .inputItems(GTCraftingComponents.CABLE_DOUBLE.get(tier), 4)
                     .outputItems(hiAmp)
-                    .duration(100).EUt(VA[tier]);
+                    .duration(100).EUt(VA[tier])
+                    .addMaterialInfo(true);
 
             if (tier >= MV) {
                 b.inputItems(GTCraftingComponents.POWER_COMPONENT.get(tier), 2);
@@ -361,12 +363,13 @@ public class MetaTileEntityMachineRecipeLoader {
             if (hiAmp == null || lowAmp == null) continue;
 
             GTRecipeBuilder b = ASSEMBLER_RECIPES
-                    .recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "hi_amp_4a_transformer")
+                    .recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "_hi_amp_4a_transformer")
                     .inputItems(lowAmp)
                     .inputItems(GTCraftingComponents.CABLE_TIER_UP_QUAD.get(tier))
                     .inputItems(GTCraftingComponents.CABLE_QUAD.get(tier), 4)
                     .outputItems(hiAmp)
-                    .duration(100).EUt(VA[tier]);
+                    .duration(100).EUt(VA[tier])
+                    .addMaterialInfo(true);
 
             if (tier >= MV) {
                 b.inputItems(GTCraftingComponents.POWER_COMPONENT.get(tier), 2);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityMachineRecipeLoader.java
@@ -10,6 +10,7 @@ import com.gregtechceu.gtceu.common.data.machines.GTMultiMachines;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
 import com.gregtechceu.gtceu.data.recipe.GTCraftingComponents;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
+import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.world.item.ItemStack;
@@ -310,6 +311,69 @@ public class MetaTileEntityMachineRecipeLoader {
                         .CWUt(128)
                         .EUt(VA[UV]))
                 .duration(1000).EUt(VA[UHV]).save(provider);
+
+        // Transformers
+        for (int tier = 0; tier < TRANSFORMER.length; tier++) {
+            var transformer = TRANSFORMER[tier];
+            if (transformer == null) continue;
+
+            GTRecipeBuilder b = ASSEMBLER_RECIPES.recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "_transformer")
+                    .inputItems(GTCraftingComponents.HULL.get(tier))
+                    .inputItems(GTCraftingComponents.CABLE_TIER_UP.get(tier))
+                    .inputItems(GTCraftingComponents.CABLE.get(tier), 4)
+                    .outputItems(transformer)
+                    // Lower-tier recipes faster because they have crafting table equivalents
+                    .duration(tier < IV ? 20 : 100)
+                    .EUt(tier < GTValues.IV ? VA[LV] : VA[tier]);
+
+            if (tier >= MV) {
+                b.inputItems(GTCraftingComponents.POWER_COMPONENT.get(tier), 2);
+            }
+
+            b.save(provider);
+        }
+
+        // Hi-Amp (2x) Transformers
+        for (int tier = 0; tier < TRANSFORMER.length; tier++) {
+            var hiAmp = HI_AMP_TRANSFORMER_2A[tier];
+            var lowAmp = TRANSFORMER[tier];
+            if (hiAmp == null || lowAmp == null) continue;
+
+            GTRecipeBuilder b = ASSEMBLER_RECIPES
+                    .recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "hi_amp_2a_transformer")
+                    .inputItems(lowAmp)
+                    .inputItems(GTCraftingComponents.CABLE_TIER_UP_DOUBLE.get(tier))
+                    .inputItems(GTCraftingComponents.CABLE_DOUBLE.get(tier), 4)
+                    .outputItems(hiAmp)
+                    .duration(100).EUt(VA[tier]);
+
+            if (tier >= MV) {
+                b.inputItems(GTCraftingComponents.POWER_COMPONENT.get(tier), 2);
+            }
+
+            b.save(provider);
+        }
+
+        // Hi-Amp (4x) Transformers
+        for (int tier = 0; tier < TRANSFORMER.length; tier++) {
+            var hiAmp = HI_AMP_TRANSFORMER_4A[tier];
+            var lowAmp = TRANSFORMER[tier];
+            if (hiAmp == null || lowAmp == null) continue;
+
+            GTRecipeBuilder b = ASSEMBLER_RECIPES
+                    .recipeBuilder(VN[tier].toLowerCase(Locale.ROOT) + "hi_amp_4a_transformer")
+                    .inputItems(lowAmp)
+                    .inputItems(GTCraftingComponents.CABLE_TIER_UP_QUAD.get(tier))
+                    .inputItems(GTCraftingComponents.CABLE_QUAD.get(tier), 4)
+                    .outputItems(hiAmp)
+                    .duration(100).EUt(VA[tier]);
+
+            if (tier >= MV) {
+                b.inputItems(GTCraftingComponents.POWER_COMPONENT.get(tier), 2);
+            }
+
+            b.save(provider);
+        }
 
         // Power Transformers
         for (int tier = 0; tier < POWER_TRANSFORMER.length; tier++) {


### PR DESCRIPTION
## What
Fixes inconsistencies with the Transformer (+2a +4a +power) recipes

## Implementation Details
- Fixes missing Small Red Alloy Spring (ULV Power Transformer)
- Fixes missing Small Europium Spring (UHV Power Transformer)
- Moves IV+ Transformers to assembler-only
- Moves Hi-Amp 2A and 4A Transformers to assembler-only (and tweaks their recipes to use a Transformer over a Hull, partially because I think this makes more sense due to the Power Transformer recipe, but also to avoid conflict chance with more `Hull + X` recipes in assembler)

## Outcome
Transformer recipes better!

## Additional Information
This is a first attempt, discussion will be needed (@Ghostipedia)