### PR TITLE
Fix default machine pausing behavior

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -424,14 +424,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
         var controllable = GTCapabilityHelper.getControllable(getLevel(), getPos(), gridSide);
         if (controllable == null) return InteractionResult.PASS;
         if (!isRemote()) {
-            if (!playerIn.isShiftKeyDown() || !controllable.isWorkingEnabled()) {
-                controllable.setWorkingEnabled(!controllable.isWorkingEnabled());
-                playerIn.sendSystemMessage(Component.translatable(controllable.isWorkingEnabled() ?
-                        "behaviour.soft_hammer.enabled" : "behaviour.soft_hammer.disabled"));
-            } else {
-                controllable.setSuspendAfterFinish(true);
-                playerIn.sendSystemMessage(Component.translatable("behaviour.soft_hammer.idle_after_cycle"));
-            }
+            controllable.setWorkingEnabled(!controllable.isWorkingEnabled());
         }
         return InteractionResult.sidedSuccess(playerIn.level().isClientSide);
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -131,7 +131,7 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
     //////////////////////////////////////
     @Override
     default boolean isWorkingEnabled() {
-        return getRecipeLogic().isWorkingEnabled();
+        return getRecipeLogic().isWorkingEnabled() && !getRecipeLogic().isSuspendAfterFinish();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -116,6 +116,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
     protected long totalContinuousRunningTime;
     @Persisted
     @Setter
+    @Getter
     protected boolean suspendAfterFinish = false;
     @Getter
     protected final Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches = makeChanceCaches();
@@ -406,7 +407,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
     @Override
     public void setWorkingEnabled(boolean isWorkingAllowed) {
         if (!isWorkingAllowed) {
-            setStatus(Status.SUSPEND);
+            setSuspendAfterFinish(true);
         } else {
             if (lastRecipe != null && duration > 0) {
                 setStatus(Status.WORKING);


### PR DESCRIPTION
## What
removes the old behavior of pausing recipe logic at a specific progress, now when you pause a machine it will try to finish the recipe before suspending, more akin to how GT 5u handles it

## Implementation Details
no more setting status to suspend using the `IControllable#setWorkingEnabled` method, it will instead set the suspend on finish field, also removed the shift behavior for soft mallets as that split is no longer desired

## Outcome
no more power cheesing