### PR TITLE
New Key Mapping API

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/armor/IArmorLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/armor/IArmorLogic.java
@@ -96,4 +96,8 @@ public interface IArmorLogic {
     default float getHeatResistance() {
         return 1.0f;
     }
+
+    default void onEquip(Player player) {}
+
+    default void onUnequip(Player player) {}
 }

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -34,6 +34,7 @@ import com.gregtechceu.gtceu.integration.map.layer.Layers;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.FluidRenderLayer;
 import com.gregtechceu.gtceu.integration.map.layer.builtin.OreRenderLayer;
 import com.gregtechceu.gtceu.utils.input.KeyBind;
+import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
 
 import net.minecraft.client.model.BoatModel;
 import net.minecraft.client.model.ChestBoatModel;
@@ -108,6 +109,7 @@ public class ClientProxy extends CommonProxy {
     @SubscribeEvent
     public void registerKeyBindings(RegisterKeyMappingsEvent event) {
         KeyBind.onRegisterKeyBinds(event);
+        SyncedKeyMapping.onRegisterKeyBinds(event);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -52,7 +52,7 @@ import com.gregtechceu.gtceu.integration.kjs.events.MaterialModificationEventJS;
 import com.gregtechceu.gtceu.integration.map.WaypointManager;
 import com.gregtechceu.gtceu.integration.top.forge.TheOneProbePluginImpl;
 import com.gregtechceu.gtceu.utils.input.KeyBind;
-import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
+import com.gregtechceu.gtceu.utils.input.SyncedKeyMappings;
 
 import com.lowdragmc.lowdraglib.gui.factory.UIFactory;
 
@@ -187,7 +187,7 @@ public class CommonProxy {
         GTFeatures.register();
         CustomBlockRotations.init();
         KeyBind.init();
-        SyncedKeyMapping.init();
+        SyncedKeyMappings.init();
         MachineOwner.init();
 
         FusionReactorMachine.registerFusionTier(GTValues.LuV, " (MKI)");

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -52,6 +52,7 @@ import com.gregtechceu.gtceu.integration.kjs.events.MaterialModificationEventJS;
 import com.gregtechceu.gtceu.integration.map.WaypointManager;
 import com.gregtechceu.gtceu.integration.top.forge.TheOneProbePluginImpl;
 import com.gregtechceu.gtceu.utils.input.KeyBind;
+import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
 
 import com.lowdragmc.lowdraglib.gui.factory.UIFactory;
 
@@ -186,6 +187,7 @@ public class CommonProxy {
         GTFeatures.register();
         CustomBlockRotations.init();
         KeyBind.init();
+        SyncedKeyMapping.init();
         MachineOwner.init();
 
         FusionReactorMachine.registerFusionTier(GTValues.LuV, " (MKI)");

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/NightvisionGoggles.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/NightvisionGoggles.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.item.armor.ArmorLogicSuite;
 import com.gregtechceu.gtceu.api.item.armor.ArmorUtils;
 import com.gregtechceu.gtceu.utils.input.IKeyPressedListener;
 import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
+import com.gregtechceu.gtceu.utils.input.SyncedKeyMappings;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -34,13 +35,13 @@ public class NightvisionGoggles extends ArmorLogicSuite implements IKeyPressedLi
     @Override
     public void onEquip(Player player) {
         if (!(player instanceof ServerPlayer serverPlayer)) return;
-        SyncedKeyMapping.ARMOR_MODE_SWITCH.registerPlayerListener(serverPlayer, this);
+        SyncedKeyMappings.ARMOR_MODE_SWITCH.registerPlayerListener(serverPlayer, this);
     }
 
     @Override
     public void onUnequip(Player player) {
         if (!(player instanceof ServerPlayer serverPlayer)) return;
-        SyncedKeyMapping.ARMOR_MODE_SWITCH.removePlayerListener(serverPlayer, this);
+        SyncedKeyMappings.ARMOR_MODE_SWITCH.removePlayerListener(serverPlayer, this);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/NightvisionGoggles.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/NightvisionGoggles.java
@@ -5,11 +5,13 @@ import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IElectricItem;
 import com.gregtechceu.gtceu.api.item.armor.ArmorLogicSuite;
 import com.gregtechceu.gtceu.api.item.armor.ArmorUtils;
-import com.gregtechceu.gtceu.utils.input.KeyBind;
+import com.gregtechceu.gtceu.utils.input.IKeyPressedListener;
+import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
@@ -23,10 +25,48 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class NightvisionGoggles extends ArmorLogicSuite {
+public class NightvisionGoggles extends ArmorLogicSuite implements IKeyPressedListener {
 
     public NightvisionGoggles(int energyPerUse, long capacity, int voltageTier, ArmorItem.Type slot) {
         super(energyPerUse, capacity, voltageTier, slot);
+    }
+
+    @Override
+    public void onEquip(Player player) {
+        if (!(player instanceof ServerPlayer serverPlayer)) return;
+        SyncedKeyMapping.ARMOR_MODE_SWITCH.registerPlayerListener(serverPlayer, this);
+    }
+
+    @Override
+    public void onUnequip(Player player) {
+        if (!(player instanceof ServerPlayer serverPlayer)) return;
+        SyncedKeyMapping.ARMOR_MODE_SWITCH.removePlayerListener(serverPlayer, this);
+    }
+
+    @Override
+    public void onKeyPressed(ServerPlayer player, SyncedKeyMapping keyPressed, boolean isDown) {
+        if (!isDown) return; // Only handle when key is pressed, not released
+        toggleNightVision(player);
+    }
+
+    private void toggleNightVision(Player player) {
+        ItemStack itemStack = player.getItemBySlot(EquipmentSlot.HEAD);
+        if (itemStack.isEmpty()) return;
+        IElectricItem item = GTCapabilityHelper.getElectricItem(itemStack);
+        if (item == null) return;
+
+        CompoundTag data = itemStack.getOrCreateTag();
+        boolean nightVision = data.contains("nightVision") && data.getBoolean("nightVision");
+
+        nightVision = !nightVision;
+        if (item.getCharge() < ArmorUtils.MIN_NIGHTVISION_CHARGE) {
+            nightVision = false;
+            player.displayClientMessage(Component.translatable("metaarmor.nms.nightvision.error"), true);
+        } else {
+            player.displayClientMessage(Component
+                    .translatable("metaarmor.nms.nightvision." + (nightVision ? "enabled" : "disabled")), true);
+        }
+        data.putBoolean("nightVision", nightVision);
     }
 
     @Override
@@ -36,24 +76,10 @@ public class NightvisionGoggles extends ArmorLogicSuite {
             return;
         }
         CompoundTag data = itemStack.getOrCreateTag();
-        byte toggleTimer = data.contains("toggleTimer") ? data.getByte("toggleTimer") : 0;
         int nightVisionTimer = data.contains("nightVisionTimer") ? data.getInt("nightVisionTimer") :
                 ArmorUtils.NIGHTVISION_DURATION;
         if (type == ArmorItem.Type.HELMET) {
-            boolean nightVision = data.contains("nightVision") && data.getBoolean("nightVision");
-            if (toggleTimer == 0 && KeyBind.ARMOR_MODE_SWITCH.isKeyDown(player)) {
-                nightVision = !nightVision;
-                toggleTimer = 5;
-                if (item.getCharge() < ArmorUtils.MIN_NIGHTVISION_CHARGE) {
-                    nightVision = false;
-                    player.displayClientMessage(Component.translatable("metaarmor.nms.nightvision.error"), true);
-                } else {
-                    player.displayClientMessage(Component
-                            .translatable("metaarmor.nms.nightvision." + (nightVision ? "enabled" : "disabled")), true);
-                }
-            }
-
-            if (nightVision) {
+            if (data.contains("nightVision") && data.getBoolean("nightVision")) {
                 player.removeEffect(MobEffects.BLINDNESS);
                 if (nightVisionTimer <= ArmorUtils.NIGHT_VISION_RESET) {
                     nightVisionTimer = ArmorUtils.NIGHTVISION_DURATION;
@@ -65,23 +91,10 @@ public class NightvisionGoggles extends ArmorLogicSuite {
             } else {
                 player.removeEffect(MobEffects.NIGHT_VISION);
             }
-            data.putBoolean("nightVision", nightVision);
-
         }
 
         if (nightVisionTimer > 0) nightVisionTimer--;
-        if (toggleTimer > 0) toggleTimer--;
-
         data.putInt("nightVisionTimer", nightVisionTimer);
-        data.putByte("toggleTimer", toggleTimer);
-    }
-
-    public static void disableNightVision(@NotNull Level world, Player player, boolean sendMsg) {
-        if (!world.isClientSide) {
-            player.removeEffect(MobEffects.NIGHT_VISION);
-            if (sendMsg)
-                player.displayClientMessage(Component.translatable("metaarmor.message.nightvision.disabled"), true);
-        }
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/NightvisionGoggles.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/NightvisionGoggles.java
@@ -7,7 +7,6 @@ import com.gregtechceu.gtceu.api.item.armor.ArmorLogicSuite;
 import com.gregtechceu.gtceu.api.item.armor.ArmorUtils;
 import com.gregtechceu.gtceu.utils.input.IKeyPressedListener;
 import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
-import com.gregtechceu.gtceu.utils.input.SyncedKeyMappings;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
@@ -35,13 +34,11 @@ public class NightvisionGoggles extends ArmorLogicSuite implements IKeyPressedLi
     @Override
     public void onEquip(Player player) {
         if (!(player instanceof ServerPlayer serverPlayer)) return;
-        SyncedKeyMappings.ARMOR_MODE_SWITCH.registerPlayerListener(serverPlayer, this);
     }
 
     @Override
     public void onUnequip(Player player) {
         if (!(player instanceof ServerPlayer serverPlayer)) return;
-        SyncedKeyMappings.ARMOR_MODE_SWITCH.removePlayerListener(serverPlayer, this);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/network/GTNetwork.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/GTNetwork.java
@@ -79,6 +79,8 @@ public class GTNetwork {
 
     public static void init() {
         register(CPacketKeysPressed.class, CPacketKeysPressed::new, NetworkDirection.PLAY_TO_SERVER);
+        register(CPacketKeyDown.class, CPacketKeyDown::new, NetworkDirection.PLAY_TO_SERVER);
+
         register(SPacketSyncOreVeins.class, SPacketSyncOreVeins::new, NetworkDirection.PLAY_TO_CLIENT);
         register(SPacketSyncFluidVeins.class, SPacketSyncFluidVeins::new, NetworkDirection.PLAY_TO_CLIENT);
         register(SPacketSyncBedrockOreVeins.class, SPacketSyncBedrockOreVeins::new, NetworkDirection.PLAY_TO_CLIENT);

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeyDown.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeyDown.java
@@ -40,7 +40,7 @@ public class CPacketKeyDown implements GTNetwork.INetPacket {
     public void execute(NetworkEvent.Context context) {
         if (context.getSender() != null) {
             for (var entry : updateKeys.int2BooleanEntrySet()) {
-                SyncedKeyMapping keyMapping = SyncedKeyMapping.VALUES[entry.getIntKey()];
+                SyncedKeyMapping keyMapping = SyncedKeyMapping.getFromSyncId(entry.getIntKey());
                 keyMapping.serverActivate(entry.getBooleanValue(), context.getSender());
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeyDown.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeyDown.java
@@ -1,0 +1,48 @@
+package com.gregtechceu.gtceu.common.network.packets;
+
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.utils.input.SyncedKeyMapping;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import it.unimi.dsi.fastutil.ints.Int2BooleanMap;
+import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class CPacketKeyDown implements GTNetwork.INetPacket {
+
+    private Int2BooleanMap updateKeys;
+
+    public CPacketKeyDown(Int2BooleanMap updateKeys) {
+        this.updateKeys = updateKeys;
+    }
+
+    public CPacketKeyDown(FriendlyByteBuf buf) {
+        this.updateKeys = new Int2BooleanOpenHashMap();
+        int size = buf.readInt();
+        for (int i = 0; i < size; i++) {
+            updateKeys.put(buf.readInt(), buf.readBoolean());
+        }
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeInt(updateKeys.size());
+        for (var entry : updateKeys.int2BooleanEntrySet()) {
+            buf.writeInt(entry.getIntKey());
+            buf.writeBoolean(entry.getBooleanValue());
+        }
+    }
+
+    @Override
+    public void execute(NetworkEvent.Context context) {
+        if (context.getSender() != null) {
+            for (var entry : updateKeys.int2BooleanEntrySet()) {
+                SyncedKeyMapping keyMapping = SyncedKeyMapping.VALUES[entry.getIntKey()];
+                keyMapping.serverActivate(entry.getBooleanValue(), context.getSender());
+            }
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeyDown.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeyDown.java
@@ -8,12 +8,10 @@ import net.minecraftforge.network.NetworkEvent;
 
 import it.unimi.dsi.fastutil.ints.Int2BooleanMap;
 import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
 public class CPacketKeyDown implements GTNetwork.INetPacket {
 
-    private Int2BooleanMap updateKeys;
+    private final Int2BooleanMap updateKeys;
 
     public CPacketKeyDown(Int2BooleanMap updateKeys) {
         this.updateKeys = updateKeys;

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeysPressed.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/CPacketKeysPressed.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@Deprecated
 @SuppressWarnings("unchecked")
 @NoArgsConstructor
 public class CPacketKeysPressed implements GTNetwork.INetPacket {

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -447,6 +447,19 @@ public class ForgeCommonEventListener {
     }
 
     @SubscribeEvent
+    public static void onEquipmentChange(LivingEquipmentChangeEvent event) {
+        if (!event.getSlot().isArmor()) return;
+        if (!(event.getEntity() instanceof Player player)) return;
+
+        if (!event.getFrom().isEmpty() && event.getFrom().getItem() instanceof ArmorComponentItem armor) {
+            armor.getArmorLogic().onUnequip(player);
+        }
+        if (!event.getTo().isEmpty() && event.getTo().getItem() instanceof ArmorComponentItem armor) {
+            armor.getArmorLogic().onEquip(player);
+        }
+    }
+
+    @SubscribeEvent
     public static void remapIds(MissingMappingsEvent event) {
         event.getMappings(Registries.BLOCK, GTCEu.MOD_ID).forEach(mapping -> {
             if (mapping.getKey().equals(GTCEu.id("tungstensteel_coil_block"))) {

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/IKeyPressedListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/IKeyPressedListener.java
@@ -1,0 +1,15 @@
+package com.gregtechceu.gtceu.utils.input;
+
+import net.minecraft.server.level.ServerPlayer;
+
+@FunctionalInterface
+public interface IKeyPressedListener {
+
+    /**
+     * Called <strong>server-side only</strong> when a player presses a specified keybinding.
+     *
+     * @param player     The player who pressed the key.
+     * @param keyPressed The key the player pressed.
+     */
+    void onKeyPressed(ServerPlayer player, SyncedKeyMapping keyPressed, boolean isDown);
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/KeyBind.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/KeyBind.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.booleans.BooleanBooleanMutablePair;
 import java.util.*;
 import java.util.function.Supplier;
 
+@Deprecated
 @Mod.EventBusSubscriber(modid = GTCEu.MOD_ID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public enum KeyBind {
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
@@ -1,0 +1,205 @@
+package com.gregtechceu.gtceu.utils.input;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.common.network.packets.CPacketKeyDown;
+
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.settings.IKeyConflictContext;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import it.unimi.dsi.fastutil.ints.Int2BooleanMap;
+import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
+
+public enum SyncedKeyMapping {
+
+    ARMOR_MODE_SWITCH("gtceu.key.armor_mode_switch", KeyConflictContext.IN_GAME, InputConstants.KEY_M)
+
+    ;
+
+    public static final SyncedKeyMapping[] VALUES = values();
+
+    @OnlyIn(Dist.CLIENT)
+    private KeyMapping keyMapping;
+    @OnlyIn(Dist.CLIENT)
+    private int keyCode;
+    @OnlyIn(Dist.CLIENT)
+    private boolean isKeyDown;
+
+    private static final Int2BooleanMap updatingKeyDown = new Int2BooleanOpenHashMap();
+
+    private final WeakHashMap<ServerPlayer, Boolean> serverMapping = new WeakHashMap<>();
+    private final WeakHashMap<ServerPlayer, Set<IKeyPressedListener>> playerListeners = new WeakHashMap<>();
+    private final Set<IKeyPressedListener> globalListeners = Collections.newSetFromMap(new WeakHashMap<>());
+
+    public static void init() {
+        if (GTCEu.isClientSide()) {
+            MinecraftForge.EVENT_BUS.register(SyncedKeyMapping.class);
+        }
+    }
+
+    /**
+     * Create a SyncedKeyMapping wrapper around a Minecraft {@link KeyMapping}.
+     *
+     * @param mcKeyMapping Doubly-wrapped supplier around a keymapping from
+     *                     {@link net.minecraft.client.Options Minecraft.getInstance().options}.
+     */
+    SyncedKeyMapping(Supplier<Supplier<KeyMapping>> mcKeyMapping) {
+        if (GTCEu.isClientSide()) {
+            this.keyMapping = mcKeyMapping.get().get();
+        }
+    }
+
+    /**
+     * Create a new SyncdKeyMapping for a specified key code.
+     *
+     * @param keyCode The key code.
+     */
+    SyncedKeyMapping(int keyCode) {
+        if (GTCEu.isClientSide()) {
+            this.keyCode = keyCode;
+        }
+    }
+
+    /**
+     * Create a new SyncedKeyMapping with server held and pressed syncing to server.<br>
+     * Will automatically create a keymapping entry in the MC options page.
+     *
+     * @param nameKey Translation key for the keymapping name.
+     * @param ctx     Conflict context for the keymapping options category.
+     * @param keyCode The key code, from {@link InputConstants}.
+     */
+    SyncedKeyMapping(String nameKey, IKeyConflictContext ctx, int keyCode) {
+        if (GTCEu.isClientSide()) {
+            this.keyMapping = (KeyMapping) createKeyMapping(nameKey, ctx, keyCode);
+        }
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private Object createKeyMapping(String nameKey, IKeyConflictContext ctx, int keyCode) {
+        return new KeyMapping(nameKey, ctx, InputConstants.Type.KEYSYM, keyCode, GTCEu.NAME);
+    }
+
+    /**
+     * Check if a player is currently holding down this key.
+     *
+     * @param player The player to check.
+     *
+     * @return If the key is held.
+     */
+    public boolean isKeyDown(Player player) {
+        if (player.level().isClientSide) {
+            if (keyMapping != null) {
+                return keyMapping.isDown();
+            }
+            long id = Minecraft.getInstance().getWindow().getWindow();
+            return InputConstants.isKeyDown(id, keyCode);
+        }
+        Boolean isKeyDown = serverMapping.get((ServerPlayer) player);
+        return isKeyDown != null ? isKeyDown : false;
+    }
+
+    /**
+     * Registers an {@link IKeyPressedListener} to this key, which will have its {@link IKeyPressedListener#onKeyPressed
+     * onKeyPressed} method called when the provided player presses this key.
+     *
+     * @param player   The player who owns this listener.
+     * @param listener The handler for the key clicked event.
+     */
+    public SyncedKeyMapping registerPlayerListener(ServerPlayer player, IKeyPressedListener listener) {
+        Set<IKeyPressedListener> listenerSet = playerListeners
+                .computeIfAbsent(player, $ -> Collections.newSetFromMap(new WeakHashMap<>()));
+        listenerSet.add(listener);
+        return this;
+    }
+
+    /**
+     * Remove a player's listener on this keymapping for a provided player.
+     *
+     * @param player   The player who owns this listener.
+     * @param listener The handler for the key clicked event.
+     */
+    public void removePlayerListener(ServerPlayer player, IKeyPressedListener listener) {
+        Set<IKeyPressedListener> listenerSet = playerListeners.get(player);
+        if (listenerSet != null) {
+            listenerSet.remove(listener);
+        }
+    }
+
+    /**
+     * Registers an {@link IKeyPressedListener} to this key, which will have its {@link IKeyPressedListener#onKeyPressed
+     * onKeyPressed} method called when any player presses this key.
+     *
+     * @param listener The handler for the key clicked event.
+     */
+    public SyncedKeyMapping registerGlobalListener(IKeyPressedListener listener) {
+        globalListeners.add(listener);
+        return this;
+    }
+
+    /**
+     * Remove a global listener on this keybinding.
+     *
+     * @param listener The handler for the key clicked event.
+     */
+    public void removeGlobalListener(IKeyPressedListener listener) {
+        globalListeners.remove(listener);
+    }
+
+    @SubscribeEvent
+    @OnlyIn(Dist.CLIENT)
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase == TickEvent.Phase.START) {
+            updatingKeyDown.clear();
+            for (var keyMapping : VALUES) {
+                boolean previousKeyDown = keyMapping.isKeyDown;
+
+                if (keyMapping.keyMapping != null) {
+                    keyMapping.isKeyDown = keyMapping.keyMapping.isDown();
+                } else {
+                    long id = Minecraft.getInstance().getWindow().getWindow();
+                    keyMapping.isKeyDown = InputConstants.isKeyDown(id, keyMapping.keyCode);
+                }
+
+                if (previousKeyDown != keyMapping.isKeyDown) {
+                    updatingKeyDown.put(keyMapping.ordinal(), keyMapping.isKeyDown);
+                }
+            }
+            if (!updatingKeyDown.isEmpty()) {
+                GTNetwork.sendToServer(new CPacketKeyDown(updatingKeyDown));
+            }
+        }
+    }
+
+    @ApiStatus.Internal
+    public void serverActivate(boolean keyDown, ServerPlayer player) {
+        this.serverMapping.put(player, keyDown);
+
+        // Player listeners
+        Set<IKeyPressedListener> listenerSet = playerListeners.get(player);
+        if (listenerSet != null && !listenerSet.isEmpty()) {
+            for (IKeyPressedListener listener : listenerSet) {
+                listener.onKeyPressed(player, this, keyDown);
+            }
+        }
+        // Global listeners
+        for (IKeyPressedListener listener : globalListeners) {
+            listener.onKeyPressed(player, this, keyDown);
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
@@ -10,6 +10,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.client.settings.IKeyConflictContext;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -132,6 +133,16 @@ public final class SyncedKeyMapping {
                 .computeIfAbsent(player, $ -> Collections.newSetFromMap(new WeakHashMap<>()));
         listenerSet.add(listener);
         return this;
+    }
+
+    public static void onRegisterKeyBinds(RegisterKeyMappingsEvent event) {
+        for (SyncedKeyMapping value : KEYMAPPINGS.values()) {
+            if (value.keyMapping != null) {
+                event.register(value.keyMapping);
+            }
+            // no need to register keycode only keybinds?
+            // dont think they would show up in the binds menu
+        }
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
@@ -66,7 +66,7 @@ public enum SyncedKeyMapping {
     }
 
     /**
-     * Create a new SyncdKeyMapping for a specified key code.
+     * Create a new SyncedKeyMapping for a specified key code.
      *
      * @param keyCode The key code.
      */

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMapping.java
@@ -11,14 +11,14 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.settings.IKeyConflictContext;
-import net.minecraftforge.client.settings.KeyConflictContext;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import it.unimi.dsi.fastutil.ints.Int2BooleanMap;
 import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Collections;
@@ -26,13 +26,10 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.function.Supplier;
 
-public enum SyncedKeyMapping {
+public final class SyncedKeyMapping {
 
-    ARMOR_MODE_SWITCH("gtceu.key.armor_mode_switch", KeyConflictContext.IN_GAME, InputConstants.KEY_M)
-
-    ;
-
-    public static final SyncedKeyMapping[] VALUES = values();
+    private static final Int2ObjectMap<SyncedKeyMapping> KEYMAPPINGS = new Int2ObjectOpenHashMap<>();
+    private static int syncIndex = 0;
 
     @OnlyIn(Dist.CLIENT)
     private KeyMapping keyMapping;
@@ -47,10 +44,25 @@ public enum SyncedKeyMapping {
     private final WeakHashMap<ServerPlayer, Set<IKeyPressedListener>> playerListeners = new WeakHashMap<>();
     private final Set<IKeyPressedListener> globalListeners = Collections.newSetFromMap(new WeakHashMap<>());
 
-    public static void init() {
+    private SyncedKeyMapping(Supplier<Supplier<KeyMapping>> mcKeyMapping) {
         if (GTCEu.isClientSide()) {
-            MinecraftForge.EVENT_BUS.register(SyncedKeyMapping.class);
+            this.keyMapping = mcKeyMapping.get().get();
         }
+        KEYMAPPINGS.put(syncIndex++, this);
+    }
+
+    private SyncedKeyMapping(int keyCode) {
+        if (GTCEu.isClientSide()) {
+            this.keyCode = keyCode;
+        }
+        KEYMAPPINGS.put(syncIndex++, this);
+    }
+
+    private SyncedKeyMapping(String nameKey, IKeyConflictContext ctx, int keyCode) {
+        if (GTCEu.isClientSide()) {
+            this.keyMapping = (KeyMapping) createKeyMapping(nameKey, ctx, keyCode);
+        }
+        KEYMAPPINGS.put(syncIndex++, this);
     }
 
     /**
@@ -59,10 +71,8 @@ public enum SyncedKeyMapping {
      * @param mcKeyMapping Doubly-wrapped supplier around a keymapping from
      *                     {@link net.minecraft.client.Options Minecraft.getInstance().options}.
      */
-    SyncedKeyMapping(Supplier<Supplier<KeyMapping>> mcKeyMapping) {
-        if (GTCEu.isClientSide()) {
-            this.keyMapping = mcKeyMapping.get().get();
-        }
+    public static SyncedKeyMapping createFromMC(Supplier<Supplier<KeyMapping>> mcKeyMapping) {
+        return new SyncedKeyMapping(mcKeyMapping);
     }
 
     /**
@@ -70,10 +80,8 @@ public enum SyncedKeyMapping {
      *
      * @param keyCode The key code.
      */
-    SyncedKeyMapping(int keyCode) {
-        if (GTCEu.isClientSide()) {
-            this.keyCode = keyCode;
-        }
+    public static SyncedKeyMapping create(int keyCode) {
+        return new SyncedKeyMapping(keyCode);
     }
 
     /**
@@ -84,10 +92,8 @@ public enum SyncedKeyMapping {
      * @param ctx     Conflict context for the keymapping options category.
      * @param keyCode The key code, from {@link InputConstants}.
      */
-    SyncedKeyMapping(String nameKey, IKeyConflictContext ctx, int keyCode) {
-        if (GTCEu.isClientSide()) {
-            this.keyMapping = (KeyMapping) createKeyMapping(nameKey, ctx, keyCode);
-        }
+    public static SyncedKeyMapping createConfigurable(String nameKey, IKeyConflictContext ctx, int keyCode) {
+        return new SyncedKeyMapping(nameKey, ctx, keyCode);
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -166,7 +172,8 @@ public enum SyncedKeyMapping {
     public static void onClientTick(TickEvent.ClientTickEvent event) {
         if (event.phase == TickEvent.Phase.START) {
             updatingKeyDown.clear();
-            for (var keyMapping : VALUES) {
+            for (var entry : KEYMAPPINGS.int2ObjectEntrySet()) {
+                SyncedKeyMapping keyMapping = entry.getValue();
                 boolean previousKeyDown = keyMapping.isKeyDown;
 
                 if (keyMapping.keyMapping != null) {
@@ -177,7 +184,7 @@ public enum SyncedKeyMapping {
                 }
 
                 if (previousKeyDown != keyMapping.isKeyDown) {
-                    updatingKeyDown.put(keyMapping.ordinal(), keyMapping.isKeyDown);
+                    updatingKeyDown.put(entry.getIntKey(), keyMapping.isKeyDown);
                 }
             }
             if (!updatingKeyDown.isEmpty()) {
@@ -201,5 +208,10 @@ public enum SyncedKeyMapping {
         for (IKeyPressedListener listener : globalListeners) {
             listener.onKeyPressed(player, this, keyDown);
         }
+    }
+
+    @ApiStatus.Internal
+    public static SyncedKeyMapping getFromSyncId(int id) {
+        return KEYMAPPINGS.get(id);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappingEvent.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappingEvent.java
@@ -1,0 +1,16 @@
+package com.gregtechceu.gtceu.utils.input;
+
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
+
+/**
+ * Event to register {@link SyncedKeyMapping}s in.
+ * <br>
+ * Event is fired on the mod bus.
+ */
+public class SyncedKeyMappingEvent extends Event implements IModBusEvent {
+
+    public SyncedKeyMappingEvent() {
+        super();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
@@ -2,13 +2,11 @@ package com.gregtechceu.gtceu.utils.input;
 
 import com.gregtechceu.gtceu.GTCEu;
 
-import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.ModLoader;
 
-import com.mojang.blaze3d.platform.InputConstants;
-
 public class SyncedKeyMappings {
+
     public static void init() {
         if (GTCEu.isClientSide()) {
             MinecraftForge.EVENT_BUS.register(SyncedKeyMapping.class);

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
@@ -11,7 +11,8 @@ import com.mojang.blaze3d.platform.InputConstants;
 public class SyncedKeyMappings {
 
     public static final SyncedKeyMapping ARMOR_MODE_SWITCH = SyncedKeyMapping
-            .createConfigurable("gtceu.key.armor_mode_switch", KeyConflictContext.IN_GAME, InputConstants.KEY_M);
+            .createConfigurable("gtceu.key.armor_mode_switch_synctest", KeyConflictContext.IN_GAME,
+                    InputConstants.KEY_M);
 
     public static void init() {
         if (GTCEu.isClientSide()) {

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
@@ -1,0 +1,22 @@
+package com.gregtechceu.gtceu.utils.input;
+
+import com.gregtechceu.gtceu.GTCEu;
+
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.ModLoader;
+
+import com.mojang.blaze3d.platform.InputConstants;
+
+public class SyncedKeyMappings {
+
+    public static final SyncedKeyMapping ARMOR_MODE_SWITCH = SyncedKeyMapping
+            .createConfigurable("gtceu.key.armor_mode_switch", KeyConflictContext.IN_GAME, InputConstants.KEY_M);
+
+    public static void init() {
+        if (GTCEu.isClientSide()) {
+            MinecraftForge.EVENT_BUS.register(SyncedKeyMapping.class);
+        }
+        ModLoader.get().postEvent(new SyncedKeyMappingEvent());
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/input/SyncedKeyMappings.java
@@ -9,11 +9,6 @@ import net.minecraftforge.fml.ModLoader;
 import com.mojang.blaze3d.platform.InputConstants;
 
 public class SyncedKeyMappings {
-
-    public static final SyncedKeyMapping ARMOR_MODE_SWITCH = SyncedKeyMapping
-            .createConfigurable("gtceu.key.armor_mode_switch_synctest", KeyConflictContext.IN_GAME,
-                    InputConstants.KEY_M);
-
     public static void init() {
         if (GTCEu.isClientSide()) {
             MinecraftForge.EVENT_BUS.register(SyncedKeyMapping.class);


### PR DESCRIPTION
## What
Creates a new KeyMapping API able to handle server-synchronized keybinds without issues like armor have with the "toggle timer" concept.

## Implementation Details
Adds a new Key Mapping system for server-synced key presses, with 3 main ways of checking:
- `keyMapping.isKeyDown()`
  - Similar to before, checks the current state of the key
- `keyMapping.registerPlayerListener()`
  - Player-based listener function that will be called when the state of this key changes for the specified player
  - Detects both on-key press and on-key release
  - Example use case: register the listener when an armor item is equipped, remove when unequipped
- `keyMapping.registerGlobalListener()`
  - Global listener function that will be called when the state of this key changes for ANY player
  - Similar to the above
  - Example use case: register the listener on key mapping creation, handle the action for the provided player (this was used in GTNH's [Backhand](https://github.com/GTNewHorizons/Backhand/blob/master/src/main/java/xonin/backhand/CommonProxy.java) mod to good effect)

## Outcome
Better key mapping handling

## Additional Information
Inspired by the work done for the 1.12.2 armor system [here](https://github.com/GregTechCEu/GregTech/tree/sb-armor-rewrite/src/main/java/gregtech/api/util/input)
And its later refinement in GTNHLib [here](https://github.com/GTNewHorizons/GTNHLib/pull/104)

Additionally this includes a proof of concept implementation for Nightvision Goggles to allow for testing this PR in reviews. However I think this commit should be moved to its own PR once the underlying API is reviewed and ready for merge

## Potential Compatibility Issues
While things are still being ported, key mapping options will be duplicated in the controls section. This should be a priority for porting for the 7.1.0 release
