### PR TITLE
Release Action for Forcing Release Label Type

### DIFF
--- a/.github/workflows/manage-pr-labels.yml
+++ b/.github/workflows/manage-pr-labels.yml
@@ -32,3 +32,11 @@ jobs:
           count: 1
           labels: 'type: feature, type: bugfix, type: refactor, type: translation, ignore changelog'
           exit_type: failure
+      - name: Check for Required Labels # require at least one of these labels
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: 'release: api - X.0.0, release: major - 0.X.0, releasee: Patch - 0.0.X, release: stale'
+          exit_type: failure
+          

--- a/.github/workflows/manage-pr-labels.yml
+++ b/.github/workflows/manage-pr-labels.yml
@@ -25,14 +25,15 @@ jobs:
           labels: 'do not merge'
           exit_type: failure
 
-      - name: Check for Required Labels # require at least one of these labels
+      - name: Check for Required Type Labels # require at least one of these labels
         uses: mheap/github-action-required-labels@v5
         with:
           mode: minimum
           count: 1
           labels: 'type: feature, type: bugfix, type: refactor, type: translation, ignore changelog'
           exit_type: failure
-      - name: Check for Required Labels # require at least one of these labels
+
+      - name: Check for Required Release Label # require exactly one of these labels
         uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly


### PR DESCRIPTION
## What
Requires all PR's to declare explictly what type of release they should go in, this allows us as a team to visibly understand what will be packaged into releases, as well as contest labeling/release type if needed.


Idk what i'm doing i probably broke the action but here's to hoping ig