### PR TITLE
Fix partSorter being wrong on certain directions

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/util/RelativeDirection.java
@@ -169,12 +169,12 @@ public enum RelativeDirection implements StringRepresentable {
 
         // Determined by Direction.Axis + Direction.AxisDirection
         return switch (sorterDirection) {
-            case UP -> Comparator.comparingInt(pos -> -pos.getY());
-            case DOWN -> Comparator.comparingInt(BlockPos::getY);
-            case EAST -> Comparator.comparingInt(pos -> -pos.getX());
-            case WEST -> Comparator.comparingInt(BlockPos::getX);
+            case UP -> Comparator.comparingInt(BlockPos::getY);
+            case DOWN -> Comparator.comparingInt(pos -> -pos.getY());
             case NORTH -> Comparator.comparingInt(pos -> -pos.getZ());
+            case EAST -> Comparator.comparingInt(BlockPos::getX);
             case SOUTH -> Comparator.comparingInt(BlockPos::getZ);
+            case WEST -> Comparator.comparingInt(pos -> -pos.getX());
         };
     }
 


### PR DESCRIPTION
## What
fixes #3480 

## Implementation Details
The sorting direction for east west up and down were just backwards :p

## Outcome
assembly lines can work again