### PR TITLE
Fix overlay being backwards on certain orientations

### DIFF
--- a/src/generated/resources/assets/gtceu/blockstates/active_transformer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/active_transformer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/active_transformer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/active_transformer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/active_transformer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/active_transformer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/active_transformer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/active_transformer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/active_transformer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/active_transformer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/active_transformer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/active_transformer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/active_transformer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/alloy_blast_smelter.json
+++ b/src/generated/resources/assets/gtceu/blockstates/alloy_blast_smelter.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/alloy_blast_smelter"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/alloy_blast_smelter"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/alloy_blast_smelter"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/alloy_blast_smelter",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/assembly_line.json
+++ b/src/generated/resources/assets/gtceu/blockstates/assembly_line.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/assembly_line",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/assembly_line",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/assembly_line"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/assembly_line"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/assembly_line"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/assembly_line",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/assembly_line",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/assembly_line",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/assembly_line",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/assembly_line",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/assembly_line",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/coke_oven.json
+++ b/src/generated/resources/assets/gtceu/blockstates/coke_oven.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/coke_oven",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/coke_oven",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/coke_oven"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/coke_oven"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/coke_oven"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/coke_oven",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/coke_oven",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/coke_oven",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/coke_oven",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/coke_oven",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/coke_oven",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/cracker.json
+++ b/src/generated/resources/assets/gtceu/blockstates/cracker.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/cracker",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/cracker",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/cracker"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/cracker"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/cracker"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/cracker",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/cracker",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/cracker",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/cracker",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/cracker",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/cracker",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/creative_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/creative_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/creative_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/creative_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/creative_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/creative_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/creative_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/creative_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/data_bank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/data_bank.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/data_bank",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/data_bank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/data_bank"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/data_bank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/data_bank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/data_bank",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/data_bank",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/data_bank",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/data_bank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/electric_blast_furnace.json
+++ b/src/generated/resources/assets/gtceu/blockstates/electric_blast_furnace.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/electric_blast_furnace"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/electric_blast_furnace"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/electric_blast_furnace"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/electric_blast_furnace",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/ev_bedrock_ore_miner.json
+++ b/src/generated/resources/assets/gtceu/blockstates/ev_bedrock_ore_miner.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/ev_bedrock_ore_miner"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_bedrock_ore_miner",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/ev_fluid_drilling_rig.json
+++ b/src/generated/resources/assets/gtceu/blockstates/ev_fluid_drilling_rig.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/ev_fluid_drilling_rig"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_fluid_drilling_rig",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/ev_large_miner.json
+++ b/src/generated/resources/assets/gtceu/blockstates/ev_large_miner.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_large_miner",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_large_miner",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_large_miner"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/ev_large_miner"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_large_miner"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_large_miner",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_large_miner",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_large_miner",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_large_miner",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/ev_super_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/ev_super_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/ev_super_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/ev_super_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/ev_super_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/ev_super_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/ev_super_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/ev_super_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/extreme_combustion_engine.json
+++ b/src/generated/resources/assets/gtceu/blockstates/extreme_combustion_engine.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/extreme_combustion_engine"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/extreme_combustion_engine"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/extreme_combustion_engine"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/extreme_combustion_engine",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/gas_large_turbine.json
+++ b/src/generated/resources/assets/gtceu/blockstates/gas_large_turbine.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/gas_large_turbine",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/gas_large_turbine",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/gas_large_turbine"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/gas_large_turbine"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/gas_large_turbine"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/gas_large_turbine",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/gas_large_turbine",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/gas_large_turbine",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/gas_large_turbine",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/gas_large_turbine",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/gas_large_turbine",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/high_performance_computation_array.json
+++ b/src/generated/resources/assets/gtceu/blockstates/high_performance_computation_array.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/high_performance_computation_array",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/high_performance_computation_array",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/high_performance_computation_array"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/high_performance_computation_array"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/high_performance_computation_array"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/high_performance_computation_array",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/high_performance_computation_array",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/high_performance_computation_array",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/high_performance_computation_array",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/hv_bedrock_ore_miner.json
+++ b/src/generated/resources/assets/gtceu/blockstates/hv_bedrock_ore_miner.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/hv_bedrock_ore_miner"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_bedrock_ore_miner",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/hv_fluid_drilling_rig.json
+++ b/src/generated/resources/assets/gtceu/blockstates/hv_fluid_drilling_rig.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/hv_fluid_drilling_rig"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_fluid_drilling_rig",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/hv_super_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/hv_super_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/hv_super_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/hv_super_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/hv_super_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/hv_super_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/hv_super_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/hv_super_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/implosion_compressor.json
+++ b/src/generated/resources/assets/gtceu/blockstates/implosion_compressor.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/implosion_compressor",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/implosion_compressor",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/implosion_compressor"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/implosion_compressor"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/implosion_compressor"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/implosion_compressor",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/implosion_compressor",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/implosion_compressor",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/implosion_compressor",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/implosion_compressor",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/implosion_compressor",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/iv_large_miner.json
+++ b/src/generated/resources/assets/gtceu/blockstates/iv_large_miner.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_large_miner",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_large_miner",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_large_miner"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/iv_large_miner"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_large_miner"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_large_miner",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_large_miner",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_large_miner",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_large_miner",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/iv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/iv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/iv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/iv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/iv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/iv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/iv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_arc_smelter.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_arc_smelter.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_arc_smelter",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_arc_smelter",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_arc_smelter"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_arc_smelter"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_arc_smelter"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_arc_smelter",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_arc_smelter",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_arc_smelter",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_arc_smelter",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_arc_smelter",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_arc_smelter",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_assembler.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_assembler.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_assembler",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_assembler",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_assembler"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_assembler"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_assembler"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_assembler",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_assembler",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_assembler",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_assembler",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_assembler",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_assembler",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_autoclave.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_autoclave.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_autoclave",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_autoclave",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_autoclave"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_autoclave"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_autoclave"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_autoclave",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_autoclave",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_autoclave",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_autoclave",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_autoclave",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_autoclave",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_brewer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_brewer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_brewer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_brewer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_brewer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_brewer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_brewer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_brewer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_brewer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_brewer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_brewer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_brewer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_brewer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_centrifuge.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_centrifuge.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_centrifuge",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_centrifuge",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_centrifuge"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_centrifuge"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_centrifuge"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_centrifuge",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_centrifuge",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_centrifuge",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_centrifuge",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_centrifuge",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_centrifuge",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_chemical_bath.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_chemical_bath.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_bath",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_bath",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_bath"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_chemical_bath"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_bath"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_bath",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_bath",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_bath",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_bath",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_bath",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_bath",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_chemical_reactor.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_chemical_reactor.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_reactor"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_chemical_reactor"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_reactor"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_chemical_reactor",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_circuit_assembler.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_circuit_assembler.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_circuit_assembler"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_circuit_assembler"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_circuit_assembler"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_circuit_assembler",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_combustion_engine.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_combustion_engine.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_combustion_engine",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_combustion_engine",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_combustion_engine"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_combustion_engine"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_combustion_engine"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_combustion_engine",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_combustion_engine",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_combustion_engine",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_combustion_engine",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_combustion_engine",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_combustion_engine",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_cutter.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_cutter.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_cutter",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_cutter",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_cutter"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_cutter"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_cutter"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_cutter",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_cutter",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_cutter",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_cutter",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_cutter",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_cutter",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_electrolyzer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_electrolyzer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electrolyzer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electrolyzer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electrolyzer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_electrolyzer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electrolyzer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electrolyzer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electrolyzer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electrolyzer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electrolyzer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electrolyzer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electrolyzer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_electromagnet.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_electromagnet.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electromagnet",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electromagnet",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electromagnet"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_electromagnet"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electromagnet"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electromagnet",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electromagnet",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electromagnet",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electromagnet",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_electromagnet",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_electromagnet",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_engraving_laser.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_engraving_laser.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_engraving_laser",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_engraving_laser",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_engraving_laser"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_engraving_laser"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_engraving_laser"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_engraving_laser",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_engraving_laser",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_engraving_laser",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_engraving_laser",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_engraving_laser",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_engraving_laser",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_extractor.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_extractor.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extractor",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extractor",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extractor"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_extractor"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extractor"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extractor",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extractor",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extractor",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extractor",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extractor",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extractor",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_extruder.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_extruder.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extruder",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extruder",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extruder"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_extruder"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extruder"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extruder",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extruder",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extruder",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extruder",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_extruder",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_extruder",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_maceration_tower.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_maceration_tower.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_maceration_tower",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_maceration_tower",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_maceration_tower"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_maceration_tower"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_maceration_tower"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_maceration_tower",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_maceration_tower",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_maceration_tower",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_maceration_tower",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_maceration_tower",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_maceration_tower",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_material_press.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_material_press.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_material_press",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_material_press",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_material_press"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_material_press"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_material_press"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_material_press",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_material_press",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_material_press",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_material_press",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_material_press",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_material_press",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_mixer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_mixer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_mixer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_mixer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_mixer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_mixer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_mixer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_mixer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_mixer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_mixer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_mixer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_mixer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_mixer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_packer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_packer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_packer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_packer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_packer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_packer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_packer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_packer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_packer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_packer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_packer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_packer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_packer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_sifting_funnel.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_sifting_funnel.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_sifting_funnel"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_sifting_funnel"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_sifting_funnel"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_sifting_funnel",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_solidifier.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_solidifier.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_solidifier",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_solidifier",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_solidifier"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_solidifier"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_solidifier"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_solidifier",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_solidifier",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_solidifier",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_solidifier",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_solidifier",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_solidifier",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/large_wiremill.json
+++ b/src/generated/resources/assets/gtceu/blockstates/large_wiremill.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_wiremill",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_wiremill",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_wiremill"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/large_wiremill"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_wiremill"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_wiremill",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_wiremill",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_wiremill",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_wiremill",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/large_wiremill",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/large_wiremill",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/luv_fusion_reactor.json
+++ b/src/generated/resources/assets/gtceu/blockstates/luv_fusion_reactor.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_fusion_reactor"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/luv_fusion_reactor"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_fusion_reactor"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_fusion_reactor",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/luv_large_miner.json
+++ b/src/generated/resources/assets/gtceu/blockstates/luv_large_miner.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_large_miner",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_large_miner",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_large_miner"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/luv_large_miner"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_large_miner"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_large_miner",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_large_miner",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_large_miner",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_large_miner",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/luv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/luv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/luv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/luv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/luv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/luv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/luv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/lv_super_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/lv_super_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/lv_super_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/lv_super_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/lv_super_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/lv_super_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/lv_super_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/lv_super_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/mega_blast_furnace.json
+++ b/src/generated/resources/assets/gtceu/blockstates/mega_blast_furnace.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_blast_furnace"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/mega_blast_furnace"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_blast_furnace"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_blast_furnace",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/mega_vacuum_freezer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/mega_vacuum_freezer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_vacuum_freezer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/mega_vacuum_freezer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_vacuum_freezer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mega_vacuum_freezer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/multi_smelter.json
+++ b/src/generated/resources/assets/gtceu/blockstates/multi_smelter.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/multi_smelter",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/multi_smelter",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/multi_smelter"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/multi_smelter"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/multi_smelter"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/multi_smelter",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/multi_smelter",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/multi_smelter",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/multi_smelter",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/multi_smelter",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/multi_smelter",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/mv_bedrock_ore_miner.json
+++ b/src/generated/resources/assets/gtceu/blockstates/mv_bedrock_ore_miner.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/mv_bedrock_ore_miner"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_bedrock_ore_miner",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/mv_fluid_drilling_rig.json
+++ b/src/generated/resources/assets/gtceu/blockstates/mv_fluid_drilling_rig.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/mv_fluid_drilling_rig"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_fluid_drilling_rig",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/mv_super_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/mv_super_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/mv_super_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/mv_super_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/mv_super_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/mv_super_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/mv_super_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/mv_super_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/network_switch.json
+++ b/src/generated/resources/assets/gtceu/blockstates/network_switch.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/network_switch",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/network_switch",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/network_switch"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/network_switch"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/network_switch"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/network_switch",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/network_switch",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/network_switch",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/network_switch",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/opv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/opv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/opv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/opv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/opv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/opv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/opv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/plasma_large_turbine.json
+++ b/src/generated/resources/assets/gtceu/blockstates/plasma_large_turbine.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/plasma_large_turbine"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/plasma_large_turbine"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/plasma_large_turbine"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/plasma_large_turbine",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/power_substation.json
+++ b/src/generated/resources/assets/gtceu/blockstates/power_substation.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/power_substation",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/power_substation",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/power_substation"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/power_substation"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/power_substation"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/power_substation",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/power_substation",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/power_substation",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/power_substation",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/power_substation",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/power_substation",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/primitive_blast_furnace.json
+++ b/src/generated/resources/assets/gtceu/blockstates/primitive_blast_furnace.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/primitive_blast_furnace"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/primitive_blast_furnace"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/primitive_blast_furnace"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/primitive_blast_furnace",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/pyrolyse_oven.json
+++ b/src/generated/resources/assets/gtceu/blockstates/pyrolyse_oven.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/pyrolyse_oven"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/pyrolyse_oven"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/pyrolyse_oven"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/pyrolyse_oven",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/research_station.json
+++ b/src/generated/resources/assets/gtceu/blockstates/research_station.json
@@ -1,7 +1,7 @@
 {
   "variants": {
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/research_station",
       "y": 90
     },
@@ -15,12 +15,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/research_station",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/research_station"
     },
     "facing=north,upwards_facing=north": {
@@ -31,11 +31,11 @@
       "model": "gtceu:block/machine/research_station"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/research_station"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/research_station",
       "y": 180
     },
@@ -49,12 +49,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/research_station",
       "y": 180
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/research_station",
       "y": 270
     },
@@ -68,7 +68,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/research_station",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/steam_grinder.json
+++ b/src/generated/resources/assets/gtceu/blockstates/steam_grinder.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_grinder",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_grinder",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_grinder"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/steam_grinder"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_grinder"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_grinder",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_grinder",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_grinder",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_grinder",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_grinder",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_grinder",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/steam_large_turbine.json
+++ b/src/generated/resources/assets/gtceu/blockstates/steam_large_turbine.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_large_turbine",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_large_turbine",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_large_turbine"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/steam_large_turbine"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_large_turbine"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_large_turbine",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_large_turbine",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_large_turbine",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_large_turbine",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_large_turbine",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_large_turbine",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/steam_oven.json
+++ b/src/generated/resources/assets/gtceu/blockstates/steam_oven.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_oven",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_oven",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_oven"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/steam_oven"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_oven"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_oven",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_oven",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_oven",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_oven",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steam_oven",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steam_oven",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/steel_multiblock_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/steel_multiblock_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steel_multiblock_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/steel_multiblock_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steel_multiblock_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/steel_multiblock_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uev_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uev_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uev_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uev_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uev_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uev_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uev_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uhv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uhv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uhv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uhv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uhv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uhv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uhv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uiv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uiv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uiv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uiv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uiv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uiv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uiv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uv_fusion_reactor.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uv_fusion_reactor.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_fusion_reactor"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uv_fusion_reactor"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_fusion_reactor"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_fusion_reactor",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uxv_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uxv_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uxv_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/uxv_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/uxv_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/uxv_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/uxv_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/vacuum_freezer.json
+++ b/src/generated/resources/assets/gtceu/blockstates/vacuum_freezer.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/vacuum_freezer",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/vacuum_freezer",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/vacuum_freezer"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/vacuum_freezer"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/vacuum_freezer"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/vacuum_freezer",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/vacuum_freezer",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/vacuum_freezer",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/vacuum_freezer",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/vacuum_freezer",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/vacuum_freezer",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/wooden_multiblock_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/wooden_multiblock_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/wooden_multiblock_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/wooden_multiblock_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/wooden_multiblock_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/wooden_multiblock_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/zpm_fusion_reactor.json
+++ b/src/generated/resources/assets/gtceu/blockstates/zpm_fusion_reactor.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_fusion_reactor"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/zpm_fusion_reactor"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_fusion_reactor"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_fusion_reactor",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/zpm_quantum_chest.json
+++ b/src/generated/resources/assets/gtceu/blockstates/zpm_quantum_chest.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_chest"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/zpm_quantum_chest"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_chest"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_chest",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/blockstates/zpm_quantum_tank.json
+++ b/src/generated/resources/assets/gtceu/blockstates/zpm_quantum_tank.json
@@ -20,7 +20,7 @@
       "x": 90
     },
     "facing=east,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "y": 90
     },
@@ -34,12 +34,12 @@
       "y": 90
     },
     "facing=east,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "y": 90
     },
     "facing=north,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_tank"
     },
     "facing=north,upwards_facing=north": {
@@ -50,11 +50,11 @@
       "model": "gtceu:block/machine/zpm_quantum_tank"
     },
     "facing=north,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_tank"
     },
     "facing=south,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "y": 180
     },
@@ -68,12 +68,12 @@
       "y": 180
     },
     "facing=south,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "y": 180
     },
     "facing=up,upwards_facing=east": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "x": 270
     },
@@ -87,12 +87,12 @@
       "x": 270
     },
     "facing=up,upwards_facing=west": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "x": 270
     },
     "facing=west,upwards_facing=east": {
-      "gtceu:z": 90,
+      "gtceu:z": 270,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "y": 270
     },
@@ -106,7 +106,7 @@
       "y": 270
     },
     "facing=west,upwards_facing=west": {
-      "gtceu:z": 270,
+      "gtceu:z": 90,
       "model": "gtceu:block/machine/zpm_quantum_tank",
       "y": 270
     }

--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1111,6 +1111,7 @@
   "block.gtceu.substation_capacitor.tooltip_filled": "∩Ǝ %dɟ§ :ʎʇıɔɐdɐƆ ʎbɹǝuƎɔ§",
   "block.gtceu.superconducting_coil": "ʞɔoןᗺ ןıoƆ buıʇɔnpuoɔɹǝdnS",
   "block.gtceu.tempered_glass": "ssɐן⅁ pǝɹǝdɯǝ⟘",
+  "block.gtceu.test_render": "ɹǝpuǝᴚ ʇsǝ⟘",
   "block.gtceu.the_end_marker": "puƎ ǝɥ⟘",
   "block.gtceu.the_nether_marker": "ɹǝɥʇǝN ǝɥ⟘",
   "block.gtceu.titanium_crate": "ǝʇɐɹƆ ɯnıuɐʇı⟘",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1111,6 +1111,7 @@
   "block.gtceu.substation_capacitor.tooltip_filled": "§cEnergy Capacity: §f%d EU",
   "block.gtceu.superconducting_coil": "Superconducting Coil Block",
   "block.gtceu.tempered_glass": "Tempered Glass",
+  "block.gtceu.test_render": "Test Render",
   "block.gtceu.the_end_marker": "The End",
   "block.gtceu.the_nether_marker": "The Nether",
   "block.gtceu.titanium_crate": "Titanium Crate",

--- a/src/generated/resources/assets/gtceu/models/block/machine/coke_oven_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/coke_oven_hatch.json
@@ -2,9 +2,6 @@
   "parent": "minecraft:block/block",
   "loader": "gtceu:machine",
   "machine": "gtceu:coke_oven_hatch",
-  "textures": {
-    "particle": "#all"
-  },
   "variants": {
     "": {
       "model": "gtceu:block/machine/part/coke_oven_hatch"

--- a/src/main/java/com/gregtechceu/gtceu/client/util/ExtendedBlockModelRotation.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/ExtendedBlockModelRotation.java
@@ -22,29 +22,29 @@ public enum ExtendedBlockModelRotation {
     DOWN_EAST(90, 0, 90),
 
     UP_SOUTH(270, 0, 0),
-    UP_WEST(270, 0, 90),
+    UP_WEST(270, 0, 270),
     UP_NORTH(270, 0, 180),
-    UP_EAST(270, 0, 270),
+    UP_EAST(270, 0, 90),
 
     NORTH_SOUTH(0, 0, 180),
-    NORTH_WEST(0, 0, 270),
+    NORTH_WEST(0, 0, 90),
     NORTH_NORTH(0, 0, 0), // Default
-    NORTH_EAST(0, 0, 90),
+    NORTH_EAST(0, 0, 270),
 
     SOUTH_SOUTH(0, 180, 180),
-    SOUTH_WEST(0, 180, 270),
+    SOUTH_WEST(0, 180, 90),
     SOUTH_NORTH(0, 180, 0),
-    SOUTH_EAST(0, 180, 90),
+    SOUTH_EAST(0, 180, 270),
 
     WEST_SOUTH(0, 270, 180),
-    WEST_WEST(0, 270, 270),
+    WEST_WEST(0, 270, 90),
     WEST_NORTH(0, 270, 0),
-    WEST_EAST(0, 270, 90),
+    WEST_EAST(0, 270, 270),
 
     EAST_SOUTH(0, 90, 180),
-    EAST_WEST(0, 90, 270),
+    EAST_WEST(0, 90, 90),
     EAST_NORTH(0, 90, 0),
-    EAST_EAST(0, 90, 90);
+    EAST_EAST(0, 90, 270);
 
     public static final ExtendedBlockModelRotation[] VALUES = values();
 


### PR DESCRIPTION
## What
The title, when upwards facing was east or west, and the front facing was not down, the overlay was rotated 180*

## Implementation Details
flip and datagen

## Outcome
visually looks correct now

## Potential Compatibility Issues
all addons that use those extended rotation states will need to datagen again :(