### PR TITLE
Add new Steam Grinder/Oven recipes with HP singleblocks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -85,7 +85,8 @@ public class RecipeAddition {
                     'H', GTBlocks.STEEL_HULL.asStack(),
                     'C', Tags.Items.CHESTS_WOODEN);
         } else {
-            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven",
+            // Doubled-up recipes to allow for either Low or High Pressure singleblock
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven_from_lp",
                     GTMultiMachines.STEAM_OVEN.asStack(),
                     "CGC", "FMF", "CGC",
                     'F', GTBlocks.FIREBOX_BRONZE.asStack(),
@@ -93,11 +94,26 @@ public class RecipeAddition {
                     'M', GTMachines.STEAM_FURNACE.left().asStack(),
                     'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Invar));
 
-            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_grinder",
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven_from_hp",
+                    GTMultiMachines.STEAM_OVEN.asStack(),
+                    "CGC", "FMF", "CGC",
+                    'F', GTBlocks.FIREBOX_BRONZE.asStack(),
+                    'C', GTBlocks.CASING_BRONZE_BRICKS.asStack(),
+                    'M', GTMachines.STEAM_FURNACE.right().asStack(),
+                    'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Invar));
+
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_grinder_from_lp",
                     GTMultiMachines.STEAM_GRINDER.asStack(),
                     "CGC", "CFC", "CGC",
                     'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Potin),
                     'F', GTMachines.STEAM_MACERATOR.left().asStack(),
+                    'C', GTBlocks.CASING_BRONZE_BRICKS.asStack());
+
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_grinder_from_hp",
+                    GTMultiMachines.STEAM_GRINDER.asStack(),
+                    "CGC", "CFC", "CGC",
+                    'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Potin),
+                    'F', GTMachines.STEAM_MACERATOR.right().asStack(),
                     'C', GTBlocks.CASING_BRONZE_BRICKS.asStack());
 
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_hatch",

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -51,45 +51,73 @@ public class RecipeAddition {
 
     private static void steelSteamMultiblocks(Consumer<FinishedRecipe> provider) {
         if (ConfigHolder.INSTANCE.machines.steelSteamMultiblocks) {
-            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven", GTMultiMachines.STEAM_OVEN.asStack(),
-                    "CGC",
-                    "FMF", "CGC", 'F', GTBlocks.FIREBOX_STEEL.asStack(), 'C', GTBlocks.CASING_STEEL_SOLID.asStack(),
-                    'M', GTMachines.STEAM_FURNACE.right().asStack(), 'G',
-                    new MaterialEntry(TagPrefix.gear, GTMaterials.Invar));
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven",
+                    GTMultiMachines.STEAM_OVEN.asStack(),
+                    "CGC", "FMF", "CGC",
+                    'F', GTBlocks.FIREBOX_STEEL.asStack(),
+                    'C', GTBlocks.CASING_STEEL_SOLID.asStack(),
+                    'M', GTMachines.STEAM_FURNACE.right().asStack(),
+                    'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Invar));
+
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_grinder",
                     GTMultiMachines.STEAM_GRINDER.asStack(),
-                    "CGC", "CFC", "CGC", 'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Potin), 'F',
-                    GTMachines.STEAM_MACERATOR.right().asStack(), 'C', GTBlocks.CASING_STEEL_SOLID.asStack());
-            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_hatch", GTMachines.STEAM_HATCH.asStack(), "BPB",
-                    "BTB", "BPB", 'B', new MaterialEntry(TagPrefix.plate, GTMaterials.Steel), 'P',
-                    new MaterialEntry(TagPrefix.pipeNormalFluid, GTMaterials.Steel), 'T',
-                    GTMachines.STEEL_DRUM.asStack());
+                    "CGC", "CFC", "CGC",
+                    'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Potin),
+                    'F', GTMachines.STEAM_MACERATOR.right().asStack(),
+                    'C', GTBlocks.CASING_STEEL_SOLID.asStack());
+
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_hatch",
+                    GTMachines.STEAM_HATCH.asStack(),
+                    "BPB", "BTB", "BPB",
+                    'B', new MaterialEntry(TagPrefix.plate, GTMaterials.Steel),
+                    'P', new MaterialEntry(TagPrefix.pipeNormalFluid, GTMaterials.Steel),
+                    'T', GTMachines.STEEL_DRUM.asStack());
+
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_input_bus",
-                    GTMachines.STEAM_IMPORT_BUS.asStack(), "C", "H", 'H', GTBlocks.STEEL_HULL.asStack(), 'C',
-                    Tags.Items.CHESTS_WOODEN);
+                    GTMachines.STEAM_IMPORT_BUS.asStack(),
+                    "C", "H",
+                    'H', GTBlocks.STEEL_HULL.asStack(),
+                    'C', Tags.Items.CHESTS_WOODEN);
+
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_output_bus",
-                    GTMachines.STEAM_EXPORT_BUS.asStack(), "H", "C", 'H', GTBlocks.STEEL_HULL.asStack(), 'C',
-                    Tags.Items.CHESTS_WOODEN);
+                    GTMachines.STEAM_EXPORT_BUS.asStack(),
+                    "H", "C",
+                    'H', GTBlocks.STEEL_HULL.asStack(),
+                    'C', Tags.Items.CHESTS_WOODEN);
         } else {
-            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven", GTMultiMachines.STEAM_OVEN.asStack(),
-                    "CGC",
-                    "FMF", "CGC", 'F', GTBlocks.FIREBOX_BRONZE.asStack(), 'C', GTBlocks.CASING_BRONZE_BRICKS.asStack(),
-                    'M', GTMachines.STEAM_FURNACE.left().asStack(), 'G',
-                    new MaterialEntry(TagPrefix.gear, GTMaterials.Invar));
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_oven",
+                    GTMultiMachines.STEAM_OVEN.asStack(),
+                    "CGC", "FMF", "CGC",
+                    'F', GTBlocks.FIREBOX_BRONZE.asStack(),
+                    'C', GTBlocks.CASING_BRONZE_BRICKS.asStack(),
+                    'M', GTMachines.STEAM_FURNACE.left().asStack(),
+                    'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Invar));
+
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_grinder",
                     GTMultiMachines.STEAM_GRINDER.asStack(),
-                    "CGC", "CFC", "CGC", 'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Potin), 'F',
-                    GTMachines.STEAM_MACERATOR.left().asStack(), 'C', GTBlocks.CASING_BRONZE_BRICKS.asStack());
-            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_hatch", GTMachines.STEAM_HATCH.asStack(), "BPB",
-                    "BTB", "BPB", 'B', new MaterialEntry(TagPrefix.plate, GTMaterials.Bronze), 'P',
-                    new MaterialEntry(TagPrefix.pipeNormalFluid, GTMaterials.Bronze), 'T',
-                    GTMachines.BRONZE_DRUM.asStack());
+                    "CGC", "CFC", "CGC",
+                    'G', new MaterialEntry(TagPrefix.gear, GTMaterials.Potin),
+                    'F', GTMachines.STEAM_MACERATOR.left().asStack(),
+                    'C', GTBlocks.CASING_BRONZE_BRICKS.asStack());
+
+            VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_hatch",
+                    GTMachines.STEAM_HATCH.asStack(),
+                    "BPB", "BTB", "BPB",
+                    'B', new MaterialEntry(TagPrefix.plate, GTMaterials.Bronze),
+                    'P', new MaterialEntry(TagPrefix.pipeNormalFluid, GTMaterials.Bronze),
+                    'T', GTMachines.BRONZE_DRUM.asStack());
+
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_input_bus",
-                    GTMachines.STEAM_IMPORT_BUS.asStack(), "C", "H", 'H', GTBlocks.BRONZE_HULL.asStack(), 'C',
-                    Tags.Items.CHESTS_WOODEN);
+                    GTMachines.STEAM_IMPORT_BUS.asStack(),
+                    "C", "H",
+                    'H', GTBlocks.BRONZE_HULL.asStack(),
+                    'C', Tags.Items.CHESTS_WOODEN);
+
             VanillaRecipeHelper.addShapedRecipe(provider, true, "steam_output_bus",
-                    GTMachines.STEAM_EXPORT_BUS.asStack(), "H", "C", 'H', GTBlocks.BRONZE_HULL.asStack(), 'C',
-                    Tags.Items.CHESTS_WOODEN);
+                    GTMachines.STEAM_EXPORT_BUS.asStack(),
+                    "H", "C",
+                    'H', GTBlocks.BRONZE_HULL.asStack(),
+                    'C', Tags.Items.CHESTS_WOODEN);
         }
     }
 


### PR DESCRIPTION
## What
Adds new recipes in addition to the original ones for Steam Grinder/Steam Oven to use HP singleblocks. This way, if the player upgrades their LP macerator/furnace to HP, they can still use it to make a Grinder/Oven later on

(check commits, first was just reformatting which is why it looks messy)