### PR TITLE
Fix setting model properties' default values with KubeJS

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -60,6 +60,7 @@ import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
 import dev.latvian.mods.rhino.util.HideFromJS;
+import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.Getter;
@@ -79,8 +80,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static com.gregtechceu.gtceu.common.data.models.GTMachineModels.*;
 import static com.gregtechceu.gtceu.integration.kjs.GregTechKubeJSPlugin.RUNTIME_BLOCKSTATE_PROVIDER;
 
+@SuppressWarnings("unused")
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
+@RemapPrefixForJS("kjs$")
 @Accessors(chain = true, fluent = true)
 public class MachineBuilder<DEFINITION extends MachineDefinition> extends BuilderBase<DEFINITION> {
 
@@ -370,6 +373,22 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
                                                                               @Nullable T defaultValue) {
         this.modelProperties.put(property, defaultValue);
         return this;
+    }
+
+    // KJS helpers for model property defaults
+    // These don't need to be copied to the multiblock builder because KJS doesn't care about the return type downgrade
+
+    public MachineBuilder<DEFINITION> kjs$modelPropertyBool(Property<Boolean> property, boolean defaultValue) {
+        return modelProperty(property, defaultValue);
+    }
+
+    public MachineBuilder<DEFINITION> kjs$modelPropertyInt(Property<Integer> property, int defaultValue) {
+        return modelProperty(property, defaultValue);
+    }
+
+    public <T extends Enum<T> & Comparable<T>> MachineBuilder<DEFINITION> kjs$modelPropertyEnum(Property<T> property,
+                                                                                                T defaultValue) {
+        return modelProperty(property, defaultValue);
     }
 
     @Tolerate

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -43,11 +43,15 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     public volatile Int2IntFunction tankScalingFunction = GTMachineUtils.defaultTankSizeFunction;
     @Setter
     public volatile boolean addDefaultTooltips = true;
+    @Setter
+    public volatile boolean addDefaultModel = true;
 
     public volatile BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI;
 
     public KJSTieredMachineBuilder(ResourceLocation id) {
         super(id);
+        this.addDefaultTooltips = false;
+        this.addDefaultModel = false;
     }
 
     public KJSTieredMachineBuilder(ResourceLocation id, TieredCreationFunction machine,
@@ -80,7 +84,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     }
 
     @Override
-    public MachineDefinition @NotNull [] register() {
+    public @Nullable MachineDefinition @NotNull [] register() {
         Preconditions.checkNotNull(tiers, "Tiers can't be null!");
         Preconditions.checkArgument(tiers.length > 0, "tiers must have at least one tier!");
         Preconditions.checkNotNull(machine, "You must set a machine creation function! " +
@@ -95,9 +99,12 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                     holder -> machine.create(holder, tier, tankScalingFunction));
 
             builder.langValue("%s %s %s".formatted(VLVH[tier], toEnglishName(this.id.getPath()), VLVT[tier]))
-                    .workableTieredHullModel(id.withPrefix("block/machines/"))
                     .tier(tier);
+            if (this.addDefaultModel) {
+                builder.workableTieredHullModel(id.withPrefix("block/machines/"));
+            }
             this.definition.apply(tier, builder);
+
             if (builder.recipeTypes() != null && builder.recipeTypes().length > 0) {
                 GTRecipeType recipeType = builder.recipeTypes()[0];
                 if (this.editableUI != null && builder.editableUI() == null) {
@@ -109,6 +116,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                                     tankScalingFunction.applyAsInt(tier), true));
                 }
             }
+
             this.builders[tier] = builder;
             definitions[tier] = builder.register();
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -56,7 +56,7 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
     }
 
     @Override
-    public void generateLang(@NotNull LangEventJS lang) {
+    public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
         for (int tier : tiers) {
             MultiblockMachineBuilder builder = this.builders[tier];
@@ -67,7 +67,7 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
     }
 
     @Override
-    public MultiblockMachineDefinition @NotNull [] register() {
+    public @Nullable MultiblockMachineDefinition @NotNull [] register() {
         Preconditions.checkNotNull(tiers, "Tiers can't be null!");
         Preconditions.checkArgument(tiers.length > 0, "tiers must have at least one tier!");
         Preconditions.checkNotNull(machine, "You must set a machine creation function! " +

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
@@ -11,11 +11,11 @@ import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
+@SuppressWarnings("unused")
 public class KJSWrappingMachineBuilder extends BuilderBase<MachineDefinition> {
 
     @HideFromJS
@@ -52,8 +52,13 @@ public class KJSWrappingMachineBuilder extends BuilderBase<MachineDefinition> {
         return this;
     }
 
+    public KJSWrappingMachineBuilder addDefaultModel(boolean addDefaultModel) {
+        tieredBuilder.addDefaultModel(addDefaultModel);
+        return this;
+    }
+
     @Override
-    public void generateDataJsons(@NotNull DataJsonGenerator generator) {
+    public void generateDataJsons(DataJsonGenerator generator) {
         tieredBuilder.generateDataJsons(generator);
     }
 
@@ -63,13 +68,12 @@ public class KJSWrappingMachineBuilder extends BuilderBase<MachineDefinition> {
     }
 
     @Override
-    public void generateLang(@NotNull LangEventJS lang) {
-        super.generateLang(lang);
+    public void generateLang(LangEventJS lang) {
         tieredBuilder.generateLang(lang);
     }
 
     @Override
-    public @NotNull MachineDefinition register() {
+    public MachineDefinition register() {
         tieredBuilder.register();
         for (var def : tieredBuilder.get()) {
             if (def != null) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
@@ -14,9 +14,9 @@ import net.minecraft.resources.ResourceLocation;
 
 import dev.latvian.mods.kubejs.client.LangEventJS;
 import dev.latvian.mods.kubejs.generator.AssetJsonGenerator;
+import dev.latvian.mods.kubejs.generator.DataJsonGenerator;
 import dev.latvian.mods.rhino.util.HideFromJS;
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
@@ -48,19 +48,22 @@ public class KJSWrappingMultiblockBuilder extends BuilderBase<MultiblockMachineD
     }
 
     @Override
+    public void generateDataJsons(DataJsonGenerator generator) {
+        tieredBuilder.generateDataJsons(generator);
+    }
+
+    @Override
     public void generateAssetJsons(@Nullable AssetJsonGenerator generator) {
-        super.generateAssetJsons(generator);
         tieredBuilder.generateAssetJsons(generator);
     }
 
     @Override
-    public void generateLang(@NotNull LangEventJS lang) {
-        super.generateLang(lang);
+    public void generateLang(LangEventJS lang) {
         tieredBuilder.generateLang(lang);
     }
 
     @Override
-    public @NotNull MultiblockMachineDefinition register() {
+    public MultiblockMachineDefinition register() {
         tieredBuilder.register();
         for (var def : tieredBuilder.get()) {
             if (def != null) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/package-info.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.gregtechceu.gtceu.integration.kjs.builders.machine;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/package-info.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.gregtechceu.gtceu.integration.kjs.builders;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
## What
Fix Rhino not being able to find the generic `modelProperty(property, defaultValue)` method by adding helper methods for all 3 types of property in vanilla.

## Implementation Details
Added three methods that accept the respective types of property vanilla provides.

## Outcome
You can set default values for model properties now (fixes #3435)

## Additional Information
before: 
<img width="856" height="512" alt="before" src="https://github.com/user-attachments/assets/997b3541-8613-45e1-be5c-11598a4882e6" />
after:
<img width="856" height="512" alt="after" src="https://github.com/user-attachments/assets/085f7024-28d3-4aeb-80dd-3bbf5be2075e" />
Testing script I used:
```javascript
const $RotorHolderPartMachine = Java.loadClass('com.gregtechceu.gtceu.common.machine.multiblock.part.RotorHolderPartMachine')
const $IRotorHolderMachine = Java.loadClass('com.gregtechceu.gtceu.api.machine.feature.multiblock.IRotorHolderMachine')
const $IMultiController = Java.loadClass('com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController')

GTCEuStartupEvents.registry('gtceu:machine', event => {
    event.create('uhv_rotor_holder', 'custom')
        .machine((holder, tier) => new $RotorHolderPartMachine(holder, tier))
        .definition((tier, builder) => builder
                .rotationState(RotationState.ALL)
                .abilities(PartAbility.ROTOR_HOLDER)
                .modelPropertyBool($IMultiController.IS_FORMED_PROPERTY, false)
                .modelPropertyBool(($IRotorHolderMachine.HAS_ROTOR_PROPERTY, false)
                .modelPropertyBool($IRotorHolderMachine.ROTOR_SPINNING_PROPERTY, false)
                .modelPropertyBool($IRotorHolderMachine.EMISSIVE_ROTOR_PROPERTY, false)
                .model(GTMachineModels.createRotorHolderModel()))
        .tiers(GTValues.UHV)
})
```