### PR TITLE
Make `MachineDefinition#recipeTypes` be nonnull

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
@@ -63,8 +63,7 @@ public class MachineDefinition implements Supplier<IMachineBlock> {
     private Function<IMachineBlockEntity, MetaMachine> machineSupplier;
     @Getter
     @Setter
-    @Nullable
-    private GTRecipeType[] recipeTypes;
+    private @NotNull GTRecipeType @NotNull [] recipeTypes;
     @Getter
     @Setter
     private int tier;

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -131,7 +131,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     @Setter
     private NonNullConsumer<BlockEntityType<BlockEntity>> onBlockEntityRegister = NonNullConsumer.noop();
     @Getter // getter for KJS
-    private @Nullable GTRecipeType @Nullable [] recipeTypes = null;
+    private @NotNull GTRecipeType @NotNull [] recipeTypes = new GTRecipeType[0];
     @Getter
     @Setter // getter for KJS
     private int tier;
@@ -200,6 +200,12 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     }
 
     public MachineBuilder<DEFINITION> recipeType(GTRecipeType type) {
+        // noinspection ConstantValue
+        if (type == null) {
+            GTCEu.LOGGER.error("Tried to set null recipe type on machine {}. Did you create the recipe type before this machine?",
+                    this.id);
+            return this;
+        }
         this.recipeTypes = ArrayUtils.add(this.recipeTypes, type);
         initRecipeMachineModelProperties(type);
         return this;
@@ -207,16 +213,28 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
 
     @Tolerate
     public MachineBuilder<DEFINITION> recipeTypes(GTRecipeType... types) {
-        for (GTRecipeType type : types) {
-            this.recipeTypes = ArrayUtils.add(this.recipeTypes, type);
+        List<GTRecipeType> typeList = new ArrayList<>();
+        Collections.addAll(typeList, this.recipeTypes);
+
+        for (int i = 0; i < types.length; i++) {
+            GTRecipeType type = types[i];
+            if (type != null) {
+                initRecipeMachineModelProperties(type);
+                typeList.add(type);
+            } else {
+                GTCEu.LOGGER.error("Tried to set null recipe type on machine {} (index {}). Did you create the recipe type before this machine?",
+                        this.id, i);
+            }
         }
-        initRecipeMachineModelProperties(types);
+        this.recipeTypes = typeList.toArray(GTRecipeType[]::new);
         return this;
     }
 
-    protected void initRecipeMachineModelProperties(GTRecipeType... types) {
-        if (types.length > 0 &&
-                Arrays.stream(types).noneMatch(type -> type == GTRecipeTypes.DUMMY_RECIPES)) {
+    protected void initRecipeMachineModelProperties(GTRecipeType type) {
+        if (type == GTRecipeTypes.DUMMY_RECIPES) {
+            return;
+        }
+        if (!modelProperties.containsKey(RecipeLogic.STATUS_PROPERTY)) {
             modelProperty(RecipeLogic.STATUS_PROPERTY, RecipeLogic.Status.IDLE);
         }
     }
@@ -528,11 +546,9 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         definition.setRegressWhenWaiting(this.regressWhenWaiting);
         definition.setAllowCoverOnFront(this.allowCoverOnFront);
 
-        if (recipeTypes != null) {
-            for (GTRecipeType type : recipeTypes) {
-                if (type != null && type.getIconSupplier() == null) {
-                    type.setIconSupplier(definition::asStack);
-                }
+        for (GTRecipeType type : recipeTypes) {
+            if (type.getIconSupplier() == null) {
+                type.setIconSupplier(definition::asStack);
             }
         }
         if (appearance == null) {

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -202,7 +202,8 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     public MachineBuilder<DEFINITION> recipeType(GTRecipeType type) {
         // noinspection ConstantValue
         if (type == null) {
-            GTCEu.LOGGER.error("Tried to set null recipe type on machine {}. Did you create the recipe type before this machine?",
+            GTCEu.LOGGER.error(
+                    "Tried to set null recipe type on machine {}. Did you create the recipe type before this machine?",
                     this.id);
             return this;
         }
@@ -222,7 +223,8 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
                 initRecipeMachineModelProperties(type);
                 typeList.add(type);
             } else {
-                GTCEu.LOGGER.error("Tried to set null recipe type on machine {} (index {}). Did you create the recipe type before this machine?",
+                GTCEu.LOGGER.error(
+                        "Tried to set null recipe type on machine {} (index {}). Did you create the recipe type before this machine?",
                         this.id, i);
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/oreprocessing/GTOreProcessingEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/oreprocessing/GTOreProcessingEmiCategory.java
@@ -44,13 +44,11 @@ public class GTOreProcessingEmiCategory extends EmiRecipeCategory {
                 CHEMICAL_BATH_RECIPES, ELECTROMAGNETIC_SEPARATOR_RECIPES, SIFTER_RECIPES
         };
         for (MachineDefinition machine : GTRegistries.MACHINES) {
-            if (machine.getRecipeTypes() != null) {
-                for (GTRecipeType type : machine.getRecipeTypes()) {
-                    for (GTRecipeType validType : validTypes) {
-                        if (type == validType && !registeredMachines.contains(machine)) {
-                            registry.addWorkstation(CATEGORY, EmiStack.of(machine.asStack()));
-                            registeredMachines.add(machine);
-                        }
+            for (GTRecipeType type : machine.getRecipeTypes()) {
+                for (GTRecipeType validType : validTypes) {
+                    if (type == validType && !registeredMachines.contains(machine)) {
+                        registry.addWorkstation(CATEGORY, EmiStack.of(machine.asStack()));
+                        registeredMachines.add(machine);
                     }
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/GTRecipeEMICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/GTRecipeEMICategory.java
@@ -44,9 +44,7 @@ public class GTRecipeEMICategory extends EmiRecipeCategory {
 
     public static void registerWorkStations(EmiRegistry registry) {
         for (MachineDefinition machine : GTRegistries.MACHINES) {
-            if (machine.getRecipeTypes() == null) continue;
             for (GTRecipeType type : machine.getRecipeTypes()) {
-                if (type == null) continue;
                 for (GTRecipeCategory category : type.getCategories()) {
                     if (!category.isXEIVisible() && !GTCEu.isDev()) continue;
                     registry.addWorkstation(machineCategory(category), EmiStack.of(machine.asStack()));

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
@@ -63,9 +63,7 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipe> {
 
     public static void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         for (MachineDefinition machine : GTRegistries.MACHINES) {
-            if (machine.getRecipeTypes() == null) continue;
             for (GTRecipeType type : machine.getRecipeTypes()) {
-                if (type == null) continue;
                 for (GTRecipeCategory category : type.getCategories()) {
                     if (!category.isXEIVisible() && !GTCEu.isDev()) continue;
                     registration.addRecipeCatalyst(machine.asStack(), machineType(category));

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -98,7 +98,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                     .workableTieredHullModel(id.withPrefix("block/machines/"))
                     .tier(tier);
             this.definition.apply(tier, builder);
-            if (builder.recipeTypes() != null && builder.recipeTypes().length > 0) {
+            if (builder.recipeTypes().length > 0) {
                 GTRecipeType recipeType = builder.recipeTypes()[0];
                 if (this.editableUI != null && builder.editableUI() == null) {
                     builder.editableUI(this.editableUI.apply(this.id, recipeType));

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/recipe/GTRecipeREICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/recipe/GTRecipeREICategory.java
@@ -58,9 +58,7 @@ public class GTRecipeREICategory extends ModularUIDisplayCategory<GTRecipeDispla
 
     public static void registerWorkStations(CategoryRegistry registry) {
         for (MachineDefinition machine : GTRegistries.MACHINES) {
-            if (machine.getRecipeTypes() == null) continue;
             for (GTRecipeType type : machine.getRecipeTypes()) {
-                if (type == null) continue;
                 for (GTRecipeCategory category : type.getCategories()) {
                     if (!category.isXEIVisible() && !GTCEu.isDev()) continue;
                     registry.addWorkstations(machineCategory(category), EntryStacks.of(machine.asStack()));

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/MachineModeProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/MachineModeProvider.java
@@ -18,7 +18,6 @@ import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoProvider;
 import mcjty.theoneprobe.api.ProbeMode;
-import org.jetbrains.annotations.Nullable;
 
 public class MachineModeProvider implements IProbeInfoProvider {
 
@@ -31,16 +30,17 @@ public class MachineModeProvider implements IProbeInfoProvider {
     public void addProbeInfo(ProbeMode probeMode, IProbeInfo iProbeInfo, Player player, Level level,
                              BlockState blockState, IProbeHitData iProbeHitData) {
         if (level.getBlockEntity(iProbeHitData.getPos()) instanceof MetaMachineBlockEntity blockEntity) {
-            @Nullable
             GTRecipeType[] recipeTypes = blockEntity.getMetaMachine().getDefinition().getRecipeTypes();
-            if (recipeTypes != null && recipeTypes.length > 1) {
+            if (recipeTypes.length > 1) {
                 if (blockEntity.getMetaMachine() instanceof IRecipeLogicMachine recipeLogicMachine) {
                     GTRecipeType currentRecipeType = recipeLogicMachine.getRecipeType();
                     if (player.isShiftKeyDown()) {
                         iProbeInfo.text(Component.translatable("gtceu.top.machine_mode"));
+
                         for (GTRecipeType recipeType : recipeTypes) {
                             IProbeInfo horizontalPane = iProbeInfo.horizontal(
                                     iProbeInfo.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER));
+
                             if (recipeType == currentRecipeType) {
                                 horizontalPane.text(ChatFormatting.BLUE + " > ");
                                 horizontalPane.text(CompoundText.create().important("%s.%s".formatted(
@@ -52,11 +52,8 @@ public class MachineModeProvider implements IProbeInfoProvider {
                             }
                         }
                     } else {
-                        iProbeInfo.text(
-                                Component.translatable("gtceu.top.machine_mode")
-                                        .append(Component.translatable("%s.%s".formatted(
-                                                currentRecipeType.registryName.getNamespace(),
-                                                currentRecipeType.registryName.getPath()))));
+                        iProbeInfo.text(Component.translatable("gtceu.top.machine_mode")
+                                .append(Component.translatable(currentRecipeType.registryName.toLanguageKey())));
                     }
                 }
             }


### PR DESCRIPTION
## What
Made the array and its contents nonnull & log an error for each invalid value that's passed

## Outcome
fixes the cryptic crash that happens when using a null recipe type in a multiblock