### PR TITLE
Fix KJS-made generators using the wrong EU info tooltips

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -163,7 +163,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         GTRegistryInfo.MACHINE.addType("simple", KJSWrappingMachineBuilder.class,
                 (id) -> new KJSWrappingMachineBuilder(id,
                         new KJSTieredMachineBuilder(id, SimpleTieredMachine::new,
-                                SimpleTieredMachine.EDITABLE_UI_CREATOR)),
+                                SimpleTieredMachine.EDITABLE_UI_CREATOR, false)),
                 true);
         GTRegistryInfo.MACHINE.addType("custom", KJSWrappingMachineBuilder.class,
                 (id) -> new KJSWrappingMachineBuilder(id, new KJSTieredMachineBuilder(id)),
@@ -173,7 +173,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         GTRegistryInfo.MACHINE.addType("generator", KJSWrappingMachineBuilder.class,
                 (id) -> new KJSWrappingMachineBuilder(id,
                         new KJSTieredMachineBuilder(id, SimpleGeneratorMachine::new,
-                                SimpleGeneratorMachine.EDITABLE_UI_CREATOR)),
+                                SimpleGeneratorMachine.EDITABLE_UI_CREATOR, true)),
                 false);
         GTRegistryInfo.MACHINE.addType("multiblock", MultiblockMachineBuilder.class,
                 KJSWrappingMultiblockBuilder::createKJSMulti, false);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -43,18 +43,23 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     public volatile Int2IntFunction tankScalingFunction = GTMachineUtils.defaultTankSizeFunction;
     @Setter
     public volatile boolean addDefaultTooltips = true;
+    @Setter
+    public volatile boolean isGenerator = false;
 
     public volatile BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI;
 
     public KJSTieredMachineBuilder(ResourceLocation id) {
         super(id);
+        this.addDefaultTooltips = false;
     }
 
     public KJSTieredMachineBuilder(ResourceLocation id, TieredCreationFunction machine,
-                                   BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI) {
+                                   BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI,
+                                   boolean isGenerator) {
         super(id);
         this.machine = machine;
         this.editableUI = editableUI;
+        this.isGenerator = isGenerator;
     }
 
     @Override
@@ -106,7 +111,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                 if (tankScalingFunction != null && addDefaultTooltips) {
                     builder.tooltips(
                             GTMachineUtils.workableTiered(tier, GTValues.V[tier], GTValues.V[tier] * 64, recipeType,
-                                    tankScalingFunction.applyAsInt(tier), true));
+                                    tankScalingFunction.applyAsInt(tier), !isGenerator));
                 }
             }
             this.builders[tier] = builder;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
@@ -52,6 +52,11 @@ public class KJSWrappingMachineBuilder extends BuilderBase<MachineDefinition> {
         return this;
     }
 
+    public KJSWrappingMachineBuilder isGenerator(boolean isGenerator) {
+        tieredBuilder.isGenerator(isGenerator);
+        return this;
+    }
+
     @Override
     public void generateDataJsons(@NotNull DataJsonGenerator generator) {
         tieredBuilder.generateDataJsons(generator);


### PR DESCRIPTION
## What
Fix generators made with KubeJS always having the EU input info tooltips instead of the output ones they should have.

## Implementation Details
extra parameter and field in KJSTieredMachineBuilder

## Outcome
fixes #2955 

## Potential Compatibility Issues
Addons that register new tiered singleblock builder types to KubeJS will need to add a value for that parameter.
I don't think anyone does that, though.