### PR TITLE
Match rubber log centrifuge EU/t to sticky resin

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
@@ -109,7 +109,7 @@ public class SeparationRecipes {
                 .outputFluids(Glue.getFluid(100))
                 .save(provider);
 
-        CENTRIFUGE_RECIPES.recipeBuilder("rubber_log_separation").duration(200).EUt(20)
+        CENTRIFUGE_RECIPES.recipeBuilder("rubber_log_separation").duration(200).EUt(5)
                 .inputItems(GTBlocks.RUBBER_LOG.asStack())
                 .chancedOutput(STICKY_RESIN.asStack(), 6400, 0)
                 .chancedOutput(PLANT_BALL.asStack(), 4000, 0)


### PR DESCRIPTION
Changes Rubber Log centrifuging from 20EU/t -> 5EU/t to match sticky resin