### PR TITLE
Add custom block outlines for steam machines

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -280,6 +280,10 @@ public class GTValues {
             RED.getColor()
     };
 
+    // Main color for steam machines
+    public static final int VC_LP_STEAM = 0xBB8E53;
+    public static final int VC_HP_STEAM = 0x79756F;
+
     /**
      * The long names for the voltages
      */

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/LevelRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/LevelRendererMixin.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.api.item.tool.aoe.AoESymmetrical;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
+import com.gregtechceu.gtceu.api.machine.steam.SteamMachine;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.common.blockentity.CableBlockEntity;
 import com.gregtechceu.gtceu.config.ConfigHolder;
@@ -182,9 +183,14 @@ public abstract class LevelRendererMixin {
             doRenderColoredOutline = true;
             rgb = materialEntry.material().getMaterialRGB();
         } else if (level.getBlockEntity(pos) instanceof IMachineBlockEntity mbe) {
-            if (rendererCfg.coloredTieredMachineOutline && mbe.getMetaMachine() instanceof ITieredMachine tiered) {
-                doRenderColoredOutline = true;
-                rgb = GTValues.VCM[tiered.getTier()];
+            if (rendererCfg.coloredTieredMachineOutline) {
+                if (mbe.getMetaMachine() instanceof SteamMachine steam) {
+                    doRenderColoredOutline = true;
+                    rgb = steam.isHighPressure() ? GTValues.VC_HP_STEAM : GTValues.VC_LP_STEAM;
+                } else if (mbe.getMetaMachine() instanceof ITieredMachine tiered) {
+                    doRenderColoredOutline = true;
+                    rgb = GTValues.VCM[tiered.getTier()];
+                }
             }
         } else if (rendererCfg.coloredWireOutline && level.getBlockEntity(pos) instanceof IPipeNode<?, ?> pipe) {
             doRenderColoredOutline = true;


### PR DESCRIPTION
LP steam:
<img width="854" height="480" alt="2025-07-20_23 43 27" src="https://github.com/user-attachments/assets/e8bffe62-9817-42d0-952d-6bc5487a4b39" />

HP steam:
<img width="854" height="480" alt="2025-07-20_23 43 39" src="https://github.com/user-attachments/assets/bae59503-8a4c-43c8-b4a9-8dff174e3610" />
