### PR TITLE
Revert "Add overloads without tiered chances for chanced in/out builder functions"

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -689,14 +689,6 @@ public class GTRecipeBuilder {
         return notConsumable(IntCircuitIngredient.of(configuration));
     }
 
-    public GTRecipeBuilder chancedInput(ItemStack stack, int chance) {
-        return chancedInput(stack, chance, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedInput(ItemStack stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
@@ -711,14 +703,6 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedInput(FluidStack stack, int chance) {
-        return chancedInput(stack, chance, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedInput(FluidStack stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
@@ -733,14 +717,6 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(ItemStack stack, int chance) {
-        return chancedOutput(stack, chance, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(ItemStack stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
@@ -755,14 +731,6 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(FluidStack stack, int chance) {
-        return chancedOutput(stack, chance, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(FluidStack stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
@@ -777,31 +745,14 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(TagPrefix tag, Material mat, int chance) {
-        return chancedOutput(ChemicalHelper.get(tag, mat), chance, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(TagPrefix tag, Material mat, int chance, int tierChanceBoost) {
         return chancedOutput(ChemicalHelper.get(tag, mat), chance, tierChanceBoost);
     }
 
-    // Overload without tierChanceBoost would conflict
     public GTRecipeBuilder chancedOutput(TagPrefix tag, Material mat, int count, int chance, int tierChanceBoost) {
         return chancedOutput(ChemicalHelper.get(tag, mat, count), chance, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedOutput(ItemStack stack, String fraction) {
-        return chancedOutput(stack, fraction, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(ItemStack stack, String fraction, int tierChanceBoost) {
         if (stack.isEmpty()) {
             return this;
@@ -854,63 +805,23 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(TagPrefix prefix, Material material, int count, String fraction) {
-        return chancedOutput(ChemicalHelper.get(prefix, material, count), fraction, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(TagPrefix prefix, Material material, int count, String fraction,
                                          int tierChanceBoost) {
         return chancedOutput(ChemicalHelper.get(prefix, material, count), fraction, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedOutput(TagPrefix prefix, Material material, String fraction) {
-        return chancedOutput(prefix, material, 1, fraction, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(TagPrefix prefix, Material material, String fraction, int tierChanceBoost) {
         return chancedOutput(prefix, material, 1, fraction, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedOutput(Item item, int count, String fraction) {
-        return chancedOutput(new ItemStack(item, count), fraction, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(Item item, int count, String fraction, int tierChanceBoost) {
         return chancedOutput(new ItemStack(item, count), fraction, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedOutput(Item item, String fraction) {
-        return chancedOutput(item, 1, fraction, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedOutput(Item item, String fraction, int tierChanceBoost) {
         return chancedOutput(item, 1, fraction, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedFluidOutput(FluidStack stack, String fraction) {
-        return chancedFluidOutput(stack, fraction, 0);
-    }
-
-    /**
-     * @deprecated overclock chance boosting will be removed in a future update
-     */
-    @Deprecated(since = "7.0.0")
     public GTRecipeBuilder chancedFluidOutput(FluidStack stack, String fraction, int tierChanceBoost) {
         if (stack.isEmpty()) {
             return this;

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/OreRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/OreRecipeHandler.java
@@ -125,7 +125,7 @@ public final class OreRecipeHandler {
                     .inputItems(IntersectionIngredient.of(Ingredient.of(orePrefix.getItemTags(material)[0]),
                             Ingredient.of(orePrefix.getItemParentTags()[0])))
                     .outputItems(crushedStack.copyWithCount(property.getOreMultiplier() * 2 * oreTypeMultiplier))
-                    .chancedOutput(byproductStack, 1400)
+                    .chancedOutput(byproductStack, 1400, 0)
                     .EUt(2)
                     .category(GTRecipeCategories.ORE_CRUSHING)
                     .duration(400);
@@ -133,7 +133,7 @@ public final class OreRecipeHandler {
             for (MaterialStack secondaryMaterial : orePrefix.secondaryMaterials()) {
                 if (secondaryMaterial.material().hasProperty(PropertyKey.DUST)) {
                     ItemStack dustStack = ChemicalHelper.getGem(secondaryMaterial);
-                    builder.chancedOutput(dustStack, 6700);
+                    builder.chancedOutput(dustStack, 6700, 0);
                 }
             }
 
@@ -202,7 +202,7 @@ public final class OreRecipeHandler {
                     .recipeBuilder("macerate_raw_" + material.getName() + "_ore_to_crushed_ore")
                     .inputItems(rawOre, material)
                     .outputItems(crushedStack.copyWithCount(property.getOreMultiplier() * 2))
-                    .chancedOutput(byproductStack, 1400)
+                    .chancedOutput(byproductStack, 1400, 0)
                     .EUt(2)
                     .category(GTRecipeCategories.ORE_CRUSHING)
                     .duration(400);
@@ -210,7 +210,7 @@ public final class OreRecipeHandler {
             for (MaterialStack secondaryMaterial : ore.secondaryMaterials()) {
                 if (secondaryMaterial.material().hasProperty(PropertyKey.DUST)) {
                     ItemStack dustStack = ChemicalHelper.getGem(secondaryMaterial);
-                    builder.chancedOutput(dustStack, 6700);
+                    builder.chancedOutput(dustStack, 6700, 0);
                 }
             }
 
@@ -272,7 +272,8 @@ public final class OreRecipeHandler {
                 .inputItems(crushed, material)
                 .outputItems(impureDustStack)
                 .duration(400).EUt(2)
-                .chancedOutput(ChemicalHelper.get(dust, byproductMaterial, property.getByProductMultiplier()), 1400)
+                .chancedOutput(ChemicalHelper.get(dust, byproductMaterial, property.getByProductMultiplier()), 1400,
+                        0)
                 .category(GTRecipeCategories.ORE_CRUSHING)
                 .save(provider);
 
@@ -295,7 +296,7 @@ public final class OreRecipeHandler {
                 .inputFluids(Water.getFluid(1000))
                 .circuitMeta(1)
                 .outputItems(crushedPurifiedOre)
-                .chancedOutput(TagPrefix.dust, byproductMaterial, "1/3")
+                .chancedOutput(TagPrefix.dust, byproductMaterial, "1/3", 0)
                 .outputItems(TagPrefix.dust, GTMaterials.Stone)
                 .save(provider);
 
@@ -303,7 +304,7 @@ public final class OreRecipeHandler {
                 .inputItems(crushed, material)
                 .inputFluids(DistilledWater.getFluid(100))
                 .outputItems(crushedPurifiedOre)
-                .chancedOutput(TagPrefix.dust, byproductMaterial, "1/3")
+                .chancedOutput(TagPrefix.dust, byproductMaterial, "1/3", 0)
                 .outputItems(TagPrefix.dust, GTMaterials.Stone)
                 .duration(200)
                 .save(provider);
@@ -312,7 +313,7 @@ public final class OreRecipeHandler {
                 .inputItems(crushed, material)
                 .outputItems(crushedCentrifugedOre)
                 .chancedOutput(TagPrefix.dust, property.getOreByProduct(1, material), property.getByProductMultiplier(),
-                        "1/3")
+                        "1/3", 0)
                 .outputItems(TagPrefix.dust, GTMaterials.Stone)
                 .save(provider);
 
@@ -323,8 +324,9 @@ public final class OreRecipeHandler {
                     .inputItems(crushed, material)
                     .inputFluids(washedInTuple.first().getFluid(washedInTuple.secondInt()))
                     .outputItems(crushedPurifiedOre)
-                    .chancedOutput(ChemicalHelper.get(dust, washingByproduct, property.getByProductMultiplier()), 7000)
-                    .chancedOutput(ChemicalHelper.get(dust, Stone), 4000)
+                    .chancedOutput(ChemicalHelper.get(dust, washingByproduct, property.getByProductMultiplier()), 7000,
+                            0)
+                    .chancedOutput(ChemicalHelper.get(dust, Stone), 4000, 0)
                     .duration(200).EUt(VA[LV])
                     .category(GTRecipeCategories.ORE_BATHING)
                     .save(provider);
@@ -355,7 +357,7 @@ public final class OreRecipeHandler {
         MACERATOR_RECIPES.recipeBuilder("macerate_" + material.getName() + "_refined_ore_to_dust")
                 .inputItems(crushedRefined, material)
                 .outputItems(dustStack)
-                .chancedOutput(byproductStack, 1400)
+                .chancedOutput(byproductStack, 1400, 0)
                 .duration(400).EUt(2)
                 .category(GTRecipeCategories.ORE_CRUSHING)
                 .save(provider);
@@ -390,7 +392,7 @@ public final class OreRecipeHandler {
         MACERATOR_RECIPES.recipeBuilder("macerate_" + material.getName() + "_crushed_ore_to_dust")
                 .inputItems(crushedPurified, material)
                 .outputItems(dustStack)
-                .chancedOutput(byproductStack, 1400)
+                .chancedOutput(byproductStack, 1400, 0)
                 .duration(400).EUt(2)
                 .category(GTRecipeCategories.ORE_CRUSHING)
                 .save(provider);
@@ -404,7 +406,7 @@ public final class OreRecipeHandler {
                     .recipeBuilder("centrifuge_" + material.getName() + "_purified_ore_to_refined_ore")
                     .inputItems(crushedPurified, material)
                     .outputItems(crushedCentrifugedStack)
-                    .chancedOutput(TagPrefix.dust, byproductMaterial, "1/3")
+                    .chancedOutput(TagPrefix.dust, byproductMaterial, "1/3", 0)
                     .save(provider);
         }
 
@@ -419,32 +421,32 @@ public final class OreRecipeHandler {
                 GTRecipeBuilder builder = SIFTER_RECIPES
                         .recipeBuilder("sift_" + material.getName() + "_purified_ore_to_gems")
                         .inputItems(crushedPurified, material)
-                        .chancedOutput(exquisiteStack, 500)
-                        .chancedOutput(flawlessStack, 1500)
-                        .chancedOutput(gemStack, 5000)
-                        .chancedOutput(dustStack, 2500)
+                        .chancedOutput(exquisiteStack, 500, 0)
+                        .chancedOutput(flawlessStack, 1500, 0)
+                        .chancedOutput(gemStack, 5000, 0)
+                        .chancedOutput(dustStack, 2500, 0)
                         .duration(400).EUt(16);
 
                 if (!flawedStack.isEmpty())
-                    builder.chancedOutput(flawedStack, 2000);
+                    builder.chancedOutput(flawedStack, 2000, 0);
                 if (!chippedStack.isEmpty())
-                    builder.chancedOutput(chippedStack, 3000);
+                    builder.chancedOutput(chippedStack, 3000, 0);
 
                 builder.save(provider);
             } else {
                 GTRecipeBuilder builder = SIFTER_RECIPES
                         .recipeBuilder("sift_" + material.getName() + "_purified_ore_to_gems")
                         .inputItems(crushedPurified, material)
-                        .chancedOutput(exquisiteStack, 300)
-                        .chancedOutput(flawlessStack, 1000)
-                        .chancedOutput(gemStack, 3500)
-                        .chancedOutput(dustStack, 5000)
+                        .chancedOutput(exquisiteStack, 300, 0)
+                        .chancedOutput(flawlessStack, 1000, 0)
+                        .chancedOutput(gemStack, 3500, 0)
+                        .chancedOutput(dustStack, 5000, 0)
                         .duration(400).EUt(16);
 
                 if (!flawedStack.isEmpty())
-                    builder.chancedOutput(flawedStack, 2500);
+                    builder.chancedOutput(flawedStack, 2500, 0);
                 if (!chippedStack.isEmpty())
-                    builder.chancedOutput(chippedStack, 3500);
+                    builder.chancedOutput(chippedStack, 3500, 0);
 
                 builder.save(provider);
             }
@@ -468,7 +470,7 @@ public final class OreRecipeHandler {
                 .duration((int) (material.getMass() * 4)).EUt(24);
 
         if (byproduct.hasProperty(PropertyKey.DUST)) {
-            builder.chancedOutput(TagPrefix.dust, byproduct, "1/9");
+            builder.chancedOutput(TagPrefix.dust, byproduct, "1/9", 0);
         } else {
             builder.outputFluids(byproduct.getFluid(L / 9));
         }
@@ -506,8 +508,8 @@ public final class OreRecipeHandler {
             ELECTROMAGNETIC_SEPARATOR_RECIPES.recipeBuilder("separate_" + material.getName() + "_pure_dust_to_dust")
                     .inputItems(dustPure, material)
                     .outputItems(dustStack)
-                    .chancedOutput(TagPrefix.dust, separatedMaterial.get(0), 1000)
-                    .chancedOutput(separatedStack2, prefix == TagPrefix.dust ? 500 : 2000)
+                    .chancedOutput(TagPrefix.dust, separatedMaterial.get(0), 1000, 0)
+                    .chancedOutput(separatedStack2, prefix == TagPrefix.dust ? 500 : 2000, 0)
                     .duration(200).EUt(24)
                     .save(provider);
         }
@@ -515,7 +517,7 @@ public final class OreRecipeHandler {
         CENTRIFUGE_RECIPES.recipeBuilder("centrifuge_" + material.getName() + "_pure_dust_to_dust")
                 .inputItems(dustPure, material)
                 .outputItems(dustStack)
-                .chancedOutput(TagPrefix.dust, byproductMaterial, "1/9")
+                .chancedOutput(TagPrefix.dust, byproductMaterial, "1/9", 0)
                 .duration(100)
                 .EUt(5)
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CircuitRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CircuitRecipes.java
@@ -690,14 +690,14 @@ public class CircuitRecipes {
         AUTOCLAVE_RECIPES.recipeBuilder("raw_crystal_chip_emerald")
                 .inputItems(gemExquisite, Emerald)
                 .inputFluids(Europium.getFluid(L / 9))
-                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 2500)
+                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 2500, 0)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .duration(12000).EUt(320).save(provider);
 
         AUTOCLAVE_RECIPES.recipeBuilder("raw_crystal_chip_olivine")
                 .inputItems(gemExquisite, Olivine)
                 .inputFluids(Europium.getFluid(L / 9))
-                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 2500)
+                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 2500, 0)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .duration(12000).EUt(320).save(provider);
 
@@ -716,14 +716,14 @@ public class CircuitRecipes {
         AUTOCLAVE_RECIPES.recipeBuilder("raw_crystal_chip_from_part_mutagen")
                 .inputItems(RAW_CRYSTAL_CHIP_PART)
                 .inputFluids(Mutagen.getFluid(250))
-                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 8500)
+                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 8500, 0)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .duration(12000).EUt(VA[HV]).save(provider);
 
         AUTOCLAVE_RECIPES.recipeBuilder("raw_crystal_chip_from_part_bacterial_sludge")
                 .inputItems(RAW_CRYSTAL_CHIP_PART)
                 .inputFluids(BacterialSludge.getFluid(250))
-                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 8500)
+                .chancedOutput(RAW_CRYSTAL_CHIP.asStack(), 8500, 0)
                 .cleanroom(CleanroomType.CLEANROOM)
                 .duration(12000).EUt(VA[HV]).save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -203,10 +203,10 @@ public class MachineRecipeLoader {
                 .inputItems(dust, Charcoal, 2).outputItems(ingot, Steel).outputItems(dustTiny, DarkAsh, 2)
                 .duration(1800).save(provider);
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder("steel_from_coke_gem").inputItems(ingot, Iron)
-                .inputItems(gem, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9").duration(1500)
+                .inputItems(gem, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9", 0).duration(1500)
                 .save(provider);
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder("steel_from_coke_dust").inputItems(ingot, Iron)
-                .inputItems(dust, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9").duration(1500)
+                .inputItems(dust, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9", 0).duration(1500)
                 .save(provider);
 
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder("steel_from_coal_block").inputItems(block, Iron)
@@ -233,10 +233,10 @@ public class MachineRecipeLoader {
                 .duration(800)
                 .save(provider);
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder("steel_from_coke_gem_wrought").inputItems(ingot, WroughtIron)
-                .inputItems(gem, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9").duration(600)
+                .inputItems(gem, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9", 0).duration(600)
                 .save(provider);
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder("steel_from_coke_dust_wrought").inputItems(ingot, WroughtIron)
-                .inputItems(dust, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9").duration(600)
+                .inputItems(dust, Coke).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9", 0).duration(600)
                 .save(provider);
 
         PRIMITIVE_BLAST_FURNACE_RECIPES.recipeBuilder("steel_from_coal_block_wrought").inputItems(block, WroughtIron)
@@ -319,7 +319,7 @@ public class MachineRecipeLoader {
         AUTOCLAVE_RECIPES.recipeBuilder("silicon_dioxide_to_quartzite_gem")
                 .inputItems(dust, SiliconDioxide)
                 .inputFluids(DistilledWater.getFluid(250))
-                .chancedOutput(ChemicalHelper.get(gem, Quartzite), 4500)
+                .chancedOutput(ChemicalHelper.get(gem, Quartzite), 4500, 0)
                 .duration(1200).EUt(24).save(provider);
 
         // todo find UU-Matter replacement
@@ -1056,26 +1056,26 @@ public class MachineRecipeLoader {
 
     private static void registerBlastFurnaceRecipes(Consumer<FinishedRecipe> provider) {
         BLAST_RECIPES.recipeBuilder("aluminium_from_ruby_dust").duration(400).EUt(100).inputItems(dust, Ruby)
-                .outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9").blastFurnaceTemp(1200)
+                .outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9", 0).blastFurnaceTemp(1200)
                 .save(provider);
         BLAST_RECIPES.recipeBuilder("aluminium_from_ruby_gem").duration(320).EUt(100).inputItems(gem, Ruby)
-                .outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9").blastFurnaceTemp(1200)
+                .outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9", 0).blastFurnaceTemp(1200)
                 .save(provider);
         BLAST_RECIPES.recipeBuilder("aluminium_from_green_sapphire_dust").duration(400).EUt(100)
-                .inputItems(dust, GreenSapphire).outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9")
+                .inputItems(dust, GreenSapphire).outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9", 0)
                 .blastFurnaceTemp(1200).save(provider);
         BLAST_RECIPES.recipeBuilder("aluminium_from_green_sapphire_gem").duration(320).EUt(100)
-                .inputItems(gem, GreenSapphire).outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9")
+                .inputItems(gem, GreenSapphire).outputItems(nugget, Aluminium, 3).chancedOutput(dust, Ash, "1/9", 0)
                 .blastFurnaceTemp(1200).save(provider);
         BLAST_RECIPES.recipeBuilder("aluminium_from_sapphire_dust").duration(400).EUt(100).inputItems(dust, Sapphire)
                 .outputItems(nugget, Aluminium, 3).blastFurnaceTemp(1200).save(provider);
         BLAST_RECIPES.recipeBuilder("aluminium_from_sapphire_gem").duration(320).EUt(100).inputItems(gem, Sapphire)
                 .outputItems(nugget, Aluminium, 3).blastFurnaceTemp(1200).save(provider);
         BLAST_RECIPES.recipeBuilder("steel_from_iron").duration(500).EUt(VA[MV]).inputItems(ingot, Iron)
-                .inputFluids(Oxygen.getFluid(200)).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9")
+                .inputFluids(Oxygen.getFluid(200)).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9", 0)
                 .blastFurnaceTemp(1000).save(provider);
         BLAST_RECIPES.recipeBuilder("steel_from_wrought_iron").duration(300).EUt(VA[MV]).inputItems(ingot, WroughtIron)
-                .inputFluids(Oxygen.getFluid(200)).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9")
+                .inputFluids(Oxygen.getFluid(200)).outputItems(ingot, Steel).chancedOutput(dust, Ash, "1/9", 0)
                 .blastFurnaceTemp(1000).save(provider);
 
         BLAST_RECIPES.recipeBuilder("tempered_glass_blasting")
@@ -1131,7 +1131,7 @@ public class MachineRecipeLoader {
                 .inputItems(dust, SiliconDioxide, 3)
                 .inputItems(dust, Carbon, 2)
                 .outputItems(ingotHot, Silicon)
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonMonoxide.getFluid(2000))
                 .save(provider);
     }
@@ -1143,7 +1143,7 @@ public class MachineRecipeLoader {
                 .inputItems(dust, inputMaterial)
                 .inputFluids(Oxygen.getFluid(3000))
                 .outputItems(dust, outputMaterial)
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(SulfurDioxide.getFluid(sulfurDioxideAmount))
                 .save(provider);
     }
@@ -1217,14 +1217,14 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder("macerate_end_stone")
                 .inputItems(new ItemStack(Blocks.END_STONE))
                 .outputItems(dust, Endstone)
-                .chancedOutput(dust, Tungstate, 330)
+                .chancedOutput(dust, Tungstate, 330, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_netherrack")
                 .inputItems(new ItemStack(Blocks.NETHERRACK))
                 .outputItems(dust, Netherrack)
-                .chancedOutput(nugget, Gold, 750)
+                .chancedOutput(nugget, Gold, 750, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
@@ -1254,56 +1254,56 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder("macerate_marble")
                 .inputItems(rock, Marble)
                 .outputItems(dust, Marble)
-                .chancedOutput(dust, Marble, 1500)
+                .chancedOutput(dust, Marble, 1500, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_basalt")
                 .inputItems(Blocks.BASALT.asItem())
                 .outputItems(dust, Basalt)
-                .chancedOutput(dust, Basalt, 1500)
+                .chancedOutput(dust, Basalt, 1500, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_deepslate")
                 .inputItems(Blocks.DEEPSLATE.asItem())
                 .outputItems(dust, Deepslate)
-                .chancedOutput(dust, Thorium, 150)
+                .chancedOutput(dust, Thorium, 150, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_red_granite")
                 .inputItems(rock, GraniteRed)
                 .outputItems(dust, GraniteRed)
-                .chancedOutput(dust, Uranium238, 25)
+                .chancedOutput(dust, Uranium238, 25, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_andesite")
                 .inputItems(Blocks.ANDESITE.asItem())
                 .outputItems(dust, Andesite)
-                .chancedOutput(dust, Stone, 25)
+                .chancedOutput(dust, Stone, 25, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_diorite")
                 .inputItems(Blocks.DIORITE.asItem())
                 .outputItems(dust, Diorite)
-                .chancedOutput(dust, Stone, 25)
+                .chancedOutput(dust, Stone, 25, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_granite")
                 .inputItems(Blocks.GRANITE.asItem())
                 .outputItems(dust, Granite)
-                .chancedOutput(dust, Stone, 25)
+                .chancedOutput(dust, Stone, 25, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_calcite")
                 .inputItems(Blocks.CALCITE.asItem())
                 .outputItems(dust, Calcite)
-                .chancedOutput(dust, Stone, 25)
+                .chancedOutput(dust, Stone, 25, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 
@@ -1323,14 +1323,14 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder("macerate_pork_chop")
                 .inputItems(new ItemStack(Items.PORKCHOP))
                 .outputItems(dust, Meat)
-                .chancedOutput(dust, Meat, 6500)
+                .chancedOutput(dust, Meat, 6500, 0)
                 .outputItems(dustTiny, Bone)
                 .duration(102).EUt(2).save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_fish")
                 .inputItems(ItemTags.FISHES)
                 .outputItems(dust, Meat)
-                .chancedOutput(dust, Meat, 5000)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .outputItems(dustTiny, Bone)
                 .duration(102).EUt(2).save(provider);
 
@@ -1343,14 +1343,14 @@ public class MachineRecipeLoader {
         MACERATOR_RECIPES.recipeBuilder("macerate_steak")
                 .inputItems(new ItemStack(Items.BEEF))
                 .outputItems(dust, Meat)
-                .chancedOutput(dust, Meat, 5000)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .outputItems(dustTiny, Bone)
                 .duration(102).EUt(2).save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("macerate_rabbit")
                 .inputItems(new ItemStack(Items.RABBIT))
                 .outputItems(dust, Meat)
-                .chancedOutput(dust, Meat, 5000)
+                .chancedOutput(dust, Meat, 5000, 0)
                 .outputItems(dustTiny, Bone)
                 .duration(102).EUt(2).save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -70,11 +70,11 @@ public class MiscRecipeLoader {
         SIFTER_RECIPES.recipeBuilder("gravel_sifting").duration(100).EUt(16)
                 .inputItems(new ItemStack(Blocks.GRAVEL))
                 .outputItems(gem, Flint)
-                .chancedOutput(gem, Flint, 9000)
-                .chancedOutput(gem, Flint, 8000)
-                .chancedOutput(gem, Flint, 6000)
-                .chancedOutput(gem, Flint, "1/3")
-                .chancedOutput(gem, Flint, 2500)
+                .chancedOutput(gem, Flint, 9000, 0)
+                .chancedOutput(gem, Flint, 8000, 0)
+                .chancedOutput(gem, Flint, 6000, 0)
+                .chancedOutput(gem, Flint, "1/3", 0)
+                .chancedOutput(gem, Flint, 2500, 0)
                 .save(provider);
 
         PACKER_RECIPES.recipeBuilder("matchbox")

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -278,7 +278,7 @@ public class VanillaStandardRecipes {
         MACERATOR_RECIPES.recipeBuilder("gravel_to_flint")
                 .inputItems(new ItemStack(Blocks.GRAVEL, 1))
                 .outputItems(dust, Stone)
-                .chancedOutput(new ItemStack(Items.FLINT), 3300)
+                .chancedOutput(new ItemStack(Items.FLINT), 3300, 0)
                 .duration(400).EUt(2)
                 .save(provider);
 
@@ -345,7 +345,7 @@ public class VanillaStandardRecipes {
         MACERATOR_RECIPES.recipeBuilder("macerate_melon_block")
                 .inputItems(new ItemStack(Blocks.MELON))
                 .outputItems(new ItemStack(Items.MELON_SLICE, 8))
-                .chancedOutput(new ItemStack(Items.MELON_SEEDS), 8500)
+                .chancedOutput(new ItemStack(Items.MELON_SEEDS), 8500, 0)
                 .duration(400).EUt(2)
                 .save(provider);
 
@@ -364,9 +364,9 @@ public class VanillaStandardRecipes {
         MACERATOR_RECIPES.recipeBuilder("macerate_wool")
                 .inputItems(ItemTags.WOOL)
                 .outputItems(new ItemStack(Items.STRING))
-                .chancedOutput(new ItemStack(Items.STRING), 9000)
-                .chancedOutput(new ItemStack(Items.STRING), 5000)
-                .chancedOutput(new ItemStack(Items.STRING), 2000)
+                .chancedOutput(new ItemStack(Items.STRING), 9000, 0)
+                .chancedOutput(new ItemStack(Items.STRING), 5000, 0)
+                .chancedOutput(new ItemStack(Items.STRING), 2000, 0)
                 .duration(200).EUt(2)
                 .save(provider);
     }
@@ -378,7 +378,7 @@ public class VanillaStandardRecipes {
         MACERATOR_RECIPES.recipeBuilder("macerate_logs")
                 .inputItems(ItemTags.LOGS)
                 .outputItems(dust, Wood, 6)
-                .chancedOutput(dust, Wood, 8500)
+                .chancedOutput(dust, Wood, 8500, 0)
                 .duration(150).EUt(2)
                 .save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/WoodMachineRecipes.java
@@ -1215,21 +1215,21 @@ public class WoodMachineRecipes {
         // COAL TAR ============================================
         PYROLYSE_RECIPES.recipeBuilder("charcoal_to_coal_tar").circuitMeta(8)
                 .inputItems(Items.CHARCOAL, 32)
-                .chancedOutput(dust, Ash, 5000)
+                .chancedOutput(dust, Ash, 5000, 0)
                 .outputFluids(CoalTar.getFluid(1000))
                 .duration(640).EUt(64)
                 .save(provider);
 
         PYROLYSE_RECIPES.recipeBuilder("coal_to_coal_tar").circuitMeta(8)
                 .inputItems(Items.COAL, 12)
-                .chancedOutput(dust, DarkAsh, 5000)
+                .chancedOutput(dust, DarkAsh, 5000, 0)
                 .outputFluids(CoalTar.getFluid(3000))
                 .duration(320).EUt(96)
                 .save(provider);
 
         PYROLYSE_RECIPES.recipeBuilder("coke_to_coal_tar").circuitMeta(8)
                 .inputItems(gem, Coke, 8)
-                .chancedOutput(dust, Ash, 7500)
+                .chancedOutput(dust, Ash, 7500, 0)
                 .outputFluids(CoalTar.getFluid(4000))
                 .duration(320).EUt(96)
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/DistillationRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/DistillationRecipes.java
@@ -33,7 +33,7 @@ public class DistillationRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_charcoal_byproducts")
                 .inputFluids(CharcoalByproducts.getFluid(1000))
-                .chancedOutput(dust, Charcoal, 2500)
+                .chancedOutput(dust, Charcoal, 2500, 0)
                 .outputFluids(WoodTar.getFluid(250))
                 .outputFluids(WoodVinegar.getFluid(400))
                 .outputFluids(WoodGas.getFluid(250))
@@ -117,14 +117,14 @@ public class DistillationRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_biomass")
                 .inputFluids(Biomass.getFluid(1000))
-                .chancedOutput(dust, Wood, 5000)
+                .chancedOutput(dust, Wood, 5000, 0)
                 .outputFluids(Ethanol.getFluid(600))
                 .outputFluids(Water.getFluid(300))
                 .duration(32).EUt(400).save(provider);
 
         DISTILLATION_RECIPES.recipeBuilder("distill_coal_gas")
                 .inputFluids(CoalGas.getFluid(1000))
-                .chancedOutput(dust, Coke, 2500)
+                .chancedOutput(dust, Coke, 2500, 0)
                 .outputFluids(CoalTar.getFluid(200))
                 .outputFluids(Ammonia.getFluid(300))
                 .outputFluids(Ethylbenzene.getFluid(250))
@@ -134,7 +134,7 @@ public class DistillationRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_coal_tar")
                 .inputFluids(CoalTar.getFluid(1000))
-                .chancedOutput(dust, Coke, 2500)
+                .chancedOutput(dust, Coke, 2500, 0)
                 .outputFluids(Naphthalene.getFluid(400))
                 .outputFluids(HydrogenSulfide.getFluid(300))
                 .outputFluids(Creosote.getFluid(200))
@@ -149,7 +149,7 @@ public class DistillationRecipes {
                 .outputFluids(CarbonDioxide.getFluid(2500))
                 .outputFluids(Helium.getFluid(1000))
                 .outputFluids(Argon.getFluid(500))
-                .chancedOutput(dust, Ice, 9000)
+                .chancedOutput(dust, Ice, 9000, 0)
                 .disableDistilleryRecipes(true)
                 .duration(2000).EUt(VA[HV]).save(provider);
 
@@ -161,7 +161,7 @@ public class DistillationRecipes {
                 .outputFluids(SulfurDioxide.getFluid(7500))
                 .outputFluids(Helium3.getFluid(2500))
                 .outputFluids(Neon.getFluid(500))
-                .chancedOutput(dust, Ash, 2250)
+                .chancedOutput(dust, Ash, 2250, 0)
                 .disableDistilleryRecipes(true)
                 .duration(2000).EUt(VA[EV]).save(provider);
 
@@ -174,7 +174,7 @@ public class DistillationRecipes {
                 .outputFluids(Krypton.getFluid(1000))
                 .outputFluids(Xenon.getFluid(1000))
                 .outputFluids(Radon.getFluid(1000))
-                .chancedOutput(dust, EnderPearl, 1000)
+                .chancedOutput(dust, EnderPearl, 1000, 0)
                 .disableDistilleryRecipes(true)
                 .duration(2000).EUt(VA[IV]).save(provider);
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GemSlurryRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GemSlurryRecipes.java
@@ -24,9 +24,9 @@ public class GemSlurryRecipes {
                 .inputFluids(RubySlurry.getFluid(3000))
                 .outputItems(dust, Aluminium, 2)
                 .outputItems(dust, Chromium)
-                .chancedOutput(dust, Titanium, 200)
-                .chancedOutput(dust, Iron, 200)
-                .chancedOutput(dust, Vanadium, 200)
+                .chancedOutput(dust, Titanium, 200, 0)
+                .chancedOutput(dust, Iron, 200, 0)
+                .chancedOutput(dust, Vanadium, 200, 0)
                 .outputFluids(DilutedHydrochloricAcid.getFluid(2000))
                 .save(provider);
 
@@ -40,9 +40,9 @@ public class GemSlurryRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder("sapphire_slurry_centrifuging").duration(320).EUt(VA[HV])
                 .inputFluids(SapphireSlurry.getFluid(3000))
                 .outputItems(dust, Aluminium, 2)
-                .chancedOutput(dust, Titanium, 200)
-                .chancedOutput(dust, Iron, 200)
-                .chancedOutput(dust, Vanadium, 200)
+                .chancedOutput(dust, Titanium, 200, 0)
+                .chancedOutput(dust, Iron, 200, 0)
+                .chancedOutput(dust, Vanadium, 200, 0)
                 .outputFluids(DilutedHydrochloricAcid.getFluid(2000))
                 .save(provider);
 
@@ -56,10 +56,10 @@ public class GemSlurryRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder("green_sapphire_slurry_centrifuging").duration(320).EUt(VA[HV])
                 .inputFluids(GreenSapphireSlurry.getFluid(3000))
                 .outputItems(dust, Aluminium, 2)
-                .chancedOutput(dust, Beryllium, 200)
-                .chancedOutput(dust, Titanium, 200)
-                .chancedOutput(dust, Iron, 200)
-                .chancedOutput(dust, Vanadium, 200)
+                .chancedOutput(dust, Beryllium, 200, 0)
+                .chancedOutput(dust, Titanium, 200, 0)
+                .chancedOutput(dust, Iron, 200, 0)
+                .chancedOutput(dust, Vanadium, 200, 0)
                 .outputFluids(DilutedHydrochloricAcid.getFluid(2000))
                 .save(provider);
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GrowthMediumRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GrowthMediumRecipes.java
@@ -23,8 +23,8 @@ public class GrowthMediumRecipes {
                 .inputItems(PLANT_BALL, 2)
                 .outputItems(BIO_CHAFF)
                 .outputItems(BIO_CHAFF)
-                .chancedOutput(BIO_CHAFF.asStack(), 5000)
-                .chancedOutput(BIO_CHAFF.asStack(), 2500)
+                .chancedOutput(BIO_CHAFF.asStack(), 5000, 0)
+                .chancedOutput(BIO_CHAFF.asStack(), 2500, 0)
                 .save(provider);
 
         MACERATOR_RECIPES.recipeBuilder("dirt_from_bio_chaff").EUt(4).duration(300)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/NaquadahRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/NaquadahRecipes.java
@@ -89,7 +89,7 @@ public class NaquadahRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("enriched_naquadah_waste_separation").EUt(VA[HV]).duration(300)
                 .inputFluids(EnrichedNaquadahWaste.getFluid(2000))
-                .chancedOutput(dust, BariumSulfide, 5000)
+                .chancedOutput(dust, BariumSulfide, 5000, 0)
                 .outputFluids(SulfuricAcid.getFluid(500))
                 .outputFluids(EnrichedNaquadahSolution.getFluid(250))
                 .outputFluids(NaquadriaSolution.getFluid(100))
@@ -126,7 +126,7 @@ public class NaquadahRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("naquadria_waste_separation").EUt(VA[HV]).duration(300)
                 .inputFluids(NaquadriaWaste.getFluid(2000))
-                .chancedOutput(dust, GalliumSulfide, 5000)
+                .chancedOutput(dust, GalliumSulfide, 5000, 0)
                 .outputFluids(SulfuricAcid.getFluid(500))
                 .outputFluids(NaquadriaSolution.getFluid(250))
                 .outputFluids(EnrichedNaquadahSolution.getFluid(100))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/PetrochemRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/PetrochemRecipes.java
@@ -123,7 +123,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_steam_cracked_ethane")
                 .inputFluids(SteamCrackedEthane.getFluid(1000))
-                .chancedOutput(dust, Carbon, 2500)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .outputFluids(Ethylene.getFluid(250))
                 .outputFluids(Methane.getFluid(1250))
                 .duration(120).EUt(VA[MV]).save(provider);
@@ -148,7 +148,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_steam_cracked_propene")
                 .inputFluids(SteamCrackedPropene.getFluid(1000))
-                .chancedOutput(dust, Carbon, 5000)
+                .chancedOutput(dust, Carbon, 5000, 0)
                 .outputFluids(Ethylene.getFluid(1000))
                 .outputFluids(Methane.getFluid(500))
                 .duration(120).EUt(VA[MV]).save(provider);
@@ -161,7 +161,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_steam_cracked_propane")
                 .inputFluids(SteamCrackedPropane.getFluid(1000))
-                .chancedOutput(dust, Carbon, 2500)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .outputFluids(Ethylene.getFluid(750))
                 .outputFluids(Methane.getFluid(1250))
                 .duration(120).EUt(VA[MV]).save(provider);
@@ -175,7 +175,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_steam_cracked_butane")
                 .inputFluids(SteamCrackedButane.getFluid(1000))
-                .chancedOutput(dust, Carbon, 2500)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .outputFluids(Propane.getFluid(125))
                 .outputFluids(Ethane.getFluid(750))
                 .outputFluids(Ethylene.getFluid(750))
@@ -193,7 +193,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_steam_cracked_butene")
                 .inputFluids(SteamCrackedButene.getFluid(1000))
-                .chancedOutput(dust, Carbon, 2500)
+                .chancedOutput(dust, Carbon, 2500, 0)
                 .outputFluids(Propene.getFluid(250))
                 .outputFluids(Ethylene.getFluid(1500))
                 .outputFluids(Methane.getFluid(250))
@@ -207,7 +207,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_steam_cracked_butadiene")
                 .inputFluids(SteamCrackedButadiene.getFluid(1000))
-                .chancedOutput(dust, Carbon, 5000)
+                .chancedOutput(dust, Carbon, 5000, 0)
                 .outputFluids(Propene.getFluid(125))
                 .outputFluids(Ethylene.getFluid(250))
                 .outputFluids(Methane.getFluid(1125))
@@ -235,7 +235,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_lightly_steam_cracked_heavy_fuel")
                 .inputFluids(LightlySteamCrackedHeavyFuel.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/9")
+                .chancedOutput(dust, Carbon, "1/9", 0)
                 .outputFluids(LightFuel.getFluid(300))
                 .outputFluids(Naphtha.getFluid(50))
                 .outputFluids(Toluene.getFluid(25))
@@ -251,7 +251,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_severely_steam_cracked_heavy_fuel")
                 .inputFluids(SeverelySteamCrackedHeavyFuel.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/3")
+                .chancedOutput(dust, Carbon, "1/3", 0)
                 .outputFluids(LightFuel.getFluid(100))
                 .outputFluids(Naphtha.getFluid(125))
                 .outputFluids(Toluene.getFluid(80))
@@ -287,7 +287,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_lightly_steam_cracked_light_fuel")
                 .inputFluids(LightlySteamCrackedLightFuel.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/9")
+                .chancedOutput(dust, Carbon, "1/9", 0)
                 .outputFluids(HeavyFuel.getFluid(150))
                 .outputFluids(Naphtha.getFluid(400))
                 .outputFluids(Toluene.getFluid(40))
@@ -303,7 +303,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_severely_steam_cracked_light_fuel")
                 .inputFluids(SeverelySteamCrackedLightFuel.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/3")
+                .chancedOutput(dust, Carbon, "1/3", 0)
                 .outputFluids(HeavyFuel.getFluid(50))
                 .outputFluids(Naphtha.getFluid(100))
                 .outputFluids(Toluene.getFluid(30))
@@ -335,7 +335,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_lightly_steam_cracked_naphtha")
                 .inputFluids(LightlySteamCrackedNaphtha.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/9")
+                .chancedOutput(dust, Carbon, "1/9", 0)
                 .outputFluids(HeavyFuel.getFluid(75))
                 .outputFluids(LightFuel.getFluid(150))
                 .outputFluids(Toluene.getFluid(40))
@@ -351,7 +351,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_severely_steam_cracked_naphtha")
                 .inputFluids(SeverelySteamCrackedNaphtha.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/3")
+                .chancedOutput(dust, Carbon, "1/3", 0)
                 .outputFluids(HeavyFuel.getFluid(25))
                 .outputFluids(LightFuel.getFluid(50))
                 .outputFluids(Toluene.getFluid(20))
@@ -381,7 +381,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_lightly_steam_cracked_gas")
                 .inputFluids(LightlySteamCrackedGas.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/9")
+                .chancedOutput(dust, Carbon, "1/9", 0)
                 .outputFluids(Propene.getFluid(45))
                 .outputFluids(Ethane.getFluid(8))
                 .outputFluids(Ethylene.getFluid(85))
@@ -391,7 +391,7 @@ public class PetrochemRecipes {
 
         DISTILLATION_RECIPES.recipeBuilder("distill_severely_steam_cracked_gas")
                 .inputFluids(SeverelySteamCrackedGas.getFluid(1000))
-                .chancedOutput(dust, Carbon, "1/9")
+                .chancedOutput(dust, Carbon, "1/9", 0)
                 .outputFluids(Propene.getFluid(8))
                 .outputFluids(Ethane.getFluid(45))
                 .outputFluids(Ethylene.getFluid(92))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/ReactorRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/ReactorRecipes.java
@@ -377,7 +377,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .inputItems(gem, Charcoal)
                 .inputFluids(Oxygen.getFluid(1000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 
@@ -385,7 +385,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .inputItems(gem, Coal)
                 .inputFluids(Oxygen.getFluid(1000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 
@@ -393,7 +393,7 @@ public class ReactorRecipes {
                 .circuitMeta(1)
                 .inputItems(dust, Charcoal)
                 .inputFluids(Oxygen.getFluid(1000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonMonoxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 
@@ -402,7 +402,7 @@ public class ReactorRecipes {
                 .inputItems(dust, Coal)
                 .circuitMeta(1)
                 .inputFluids(Oxygen.getFluid(1000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonMonoxide.getFluid(1000))
                 .save(provider);
 
@@ -447,7 +447,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .inputItems(gem, Charcoal)
                 .inputFluids(Oxygen.getFluid(2000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 
@@ -455,7 +455,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .inputItems(gem, Coal)
                 .inputFluids(Oxygen.getFluid(2000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 
@@ -463,7 +463,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .inputItems(dust, Charcoal)
                 .inputFluids(Oxygen.getFluid(2000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 
@@ -471,7 +471,7 @@ public class ReactorRecipes {
                 .circuitMeta(2)
                 .inputItems(dust, Coal)
                 .inputFluids(Oxygen.getFluid(2000))
-                .chancedOutput(dust, Ash, "1/9")
+                .chancedOutput(dust, Ash, "1/9", 0)
                 .outputFluids(CarbonDioxide.getFluid(1000))
                 .duration(80).EUt(VA[ULV]).save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
@@ -49,13 +49,13 @@ public class SeparationRecipes {
 
         CENTRIFUGE_RECIPES.recipeBuilder("oilsands_ore_separation")
                 .inputItems(ore, Oilsands)
-                .chancedOutput(new ItemStack(Blocks.SAND), 7500)
+                .chancedOutput(new ItemStack(Blocks.SAND), 7500, 0)
                 .outputFluids(Oil.getFluid(2000))
                 .duration(200).EUt(30).save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("oilsands_dust_separation")
                 .inputItems(dust, Oilsands)
-                .chancedOutput(new ItemStack(Blocks.SAND), 7500)
+                .chancedOutput(new ItemStack(Blocks.SAND), 7500, 0)
                 .outputFluids(OilHeavy.getFluid(2000))
                 .duration(200).EUt(30).save(provider);
 
@@ -105,50 +105,50 @@ public class SeparationRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder("sticky_resin_separation").duration(400).EUt(5)
                 .inputItems(STICKY_RESIN)
                 .outputItems(dust, RawRubber, 3)
-                .chancedOutput(PLANT_BALL.asStack(), 1500)
+                .chancedOutput(PLANT_BALL.asStack(), 1500, 0)
                 .outputFluids(Glue.getFluid(100))
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("rubber_log_separation").duration(200).EUt(5)
                 .inputItems(GTBlocks.RUBBER_LOG.asStack())
-                .chancedOutput(STICKY_RESIN.asStack(), 6400)
-                .chancedOutput(PLANT_BALL.asStack(), 4000)
-                .chancedOutput(dust, Carbon, 3000)
-                .chancedOutput(dust, Wood, 3000)
+                .chancedOutput(STICKY_RESIN.asStack(), 6400, 0)
+                .chancedOutput(PLANT_BALL.asStack(), 4000, 0)
+                .chancedOutput(dust, Carbon, 3000, 0)
+                .chancedOutput(dust, Wood, 3000, 0)
                 .outputFluids(Methane.getFluid(60))
                 .save(provider);
 
         // TODO Other kinds of dirt?
         CENTRIFUGE_RECIPES.recipeBuilder("dirt_separation").duration(250).EUt(VA[LV])
                 .inputItems(Blocks.DIRT.asItem())
-                .chancedOutput(PLANT_BALL.asStack(), 1400)
-                .chancedOutput(new ItemStack(Blocks.SAND), 6000)
-                .chancedOutput(dust, Clay, 550)
+                .chancedOutput(PLANT_BALL.asStack(), 1400, 0)
+                .chancedOutput(new ItemStack(Blocks.SAND), 6000, 0)
+                .chancedOutput(dust, Clay, 550, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("grass_block_separation").duration(250).EUt(VA[LV])
                 .inputItems(Blocks.GRASS_BLOCK.asItem())
-                .chancedOutput(PLANT_BALL.asStack(), 3500)
-                .chancedOutput(new ItemStack(Blocks.SAND), 5500)
-                .chancedOutput(dust, Clay, 550)
+                .chancedOutput(PLANT_BALL.asStack(), 3500, 0)
+                .chancedOutput(new ItemStack(Blocks.SAND), 5500, 0)
+                .chancedOutput(dust, Clay, 550, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("mycelium_separation").duration(650).EUt(VA[LV])
                 .inputItems(new ItemStack(Blocks.MYCELIUM))
-                .chancedOutput(new ItemStack(Blocks.RED_MUSHROOM), 2800)
-                .chancedOutput(new ItemStack(Blocks.BROWN_MUSHROOM), 2800)
-                .chancedOutput(new ItemStack(Blocks.SAND), 6200)
-                .chancedOutput(dust, Clay, 550)
+                .chancedOutput(new ItemStack(Blocks.RED_MUSHROOM), 2800, 0)
+                .chancedOutput(new ItemStack(Blocks.BROWN_MUSHROOM), 2800, 0)
+                .chancedOutput(new ItemStack(Blocks.SAND), 6200, 0)
+                .chancedOutput(dust, Clay, 550, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("ash_separation").duration(240).EUt(VA[LV])
                 .inputItems(dust, Ash)
-                .chancedOutput(dust, Quicklime, 4950)
-                .chancedOutput(dust, Potash, 1600)
-                .chancedOutput(dust, Magnesia, 1500)
-                .chancedOutput(dust, PhosphorusPentoxide, 60)
-                .chancedOutput(dust, SodaAsh, 600)
-                .chancedOutput(dust, Hematite, 275)
+                .chancedOutput(dust, Quicklime, 4950, 0)
+                .chancedOutput(dust, Potash, 1600, 0)
+                .chancedOutput(dust, Magnesia, 1500, 0)
+                .chancedOutput(dust, PhosphorusPentoxide, 60, 0)
+                .chancedOutput(dust, SodaAsh, 600, 0)
+                .chancedOutput(dust, Hematite, 275, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("dark_ash_separation").duration(250).EUt(6)
@@ -170,65 +170,65 @@ public class SeparationRecipes {
 
         CENTRIFUGE_RECIPES.recipeBuilder("uranium_238_separation").duration(800).EUt(320)
                 .inputItems(dust, Uranium238)
-                .chancedOutput(dustTiny, Plutonium239, 280)
-                .chancedOutput(dustTiny, Uranium235, 2300)
+                .chancedOutput(dustTiny, Plutonium239, 280, 0)
+                .chancedOutput(dustTiny, Uranium235, 2300, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("plutonium_239_separation").duration(1600).EUt(320)
                 .inputItems(dust, Plutonium239)
-                .chancedOutput(dustTiny, Uranium238, 3400)
-                .chancedOutput(dust, Plutonium241, 2500)
+                .chancedOutput(dustTiny, Uranium238, 3400, 0)
+                .chancedOutput(dust, Plutonium241, 2500, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("endstone_separation").duration(320).EUt(20)
                 .inputItems(dust, Endstone)
-                .chancedOutput(new ItemStack(Blocks.SAND), 9000)
-                .chancedOutput(dust, Tungstate, 445)
-                .chancedOutput(dust, Platinum, 80)
+                .chancedOutput(new ItemStack(Blocks.SAND), 9000, 0)
+                .chancedOutput(dust, Tungstate, 445, 0)
+                .chancedOutput(dust, Platinum, 80, 0)
                 .outputFluids(Helium.getFluid(120))
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("netherrack_separation").duration(160).EUt(20)
                 .inputItems(dust, Netherrack)
-                .chancedOutput(dust, Redstone, 700)
-                .chancedOutput(dust, Gold, 75)
-                .chancedOutput(dust, Sulfur, 2500)
-                .chancedOutput(dust, Coal, 700)
+                .chancedOutput(dust, Redstone, 700, 0)
+                .chancedOutput(dust, Gold, 75, 0)
+                .chancedOutput(dust, Sulfur, 2500, 0)
+                .chancedOutput(dust, Coal, 700, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("soul_sand_separation").duration(200).EUt(80)
                 .inputItems(Blocks.SOUL_SAND.asItem())
-                .chancedOutput(new ItemStack(Blocks.SAND), 9250)
-                .chancedOutput(dust, Saltpeter, 2250)
-                .chancedOutput(dust, Coal, 225)
+                .chancedOutput(new ItemStack(Blocks.SAND), 9250, 0)
+                .chancedOutput(dust, Saltpeter, 2250, 0)
+                .chancedOutput(dust, Coal, 225, 0)
                 .outputFluids(Oil.getFluid(80))
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("lava_separation").duration(80).EUt(80)
                 .inputFluids(Lava.getFluid(100))
-                .chancedOutput(dust, SiliconDioxide, 1250)
-                .chancedOutput(dust, Magnesia, 250)
-                .chancedOutput(dust, Quicklime, 250)
-                .chancedOutput(nugget, Gold, 250)
-                .chancedOutput(dust, Sapphire, 315)
-                .chancedOutput(dust, Tantalite, 125)
+                .chancedOutput(dust, SiliconDioxide, 1250, 0)
+                .chancedOutput(dust, Magnesia, 250, 0)
+                .chancedOutput(dust, Quicklime, 250, 0)
+                .chancedOutput(nugget, Gold, 250, 0)
+                .chancedOutput(dust, Sapphire, 315, 0)
+                .chancedOutput(dust, Tantalite, 125, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("rare_earth_separation").duration(64).EUt(20)
                 .inputItems(dust, RareEarth)
-                .chancedOutput(dustSmall, Cadmium, 3500)
-                .chancedOutput(dustSmall, Neodymium, 4500)
-                .chancedOutput(dustSmall, Samarium, 3500)
-                .chancedOutput(dustSmall, Cerium, 5500)
-                .chancedOutput(dustSmall, Yttrium, 3500)
-                .chancedOutput(dustSmall, Lanthanum, 2500)
+                .chancedOutput(dustSmall, Cadmium, 3500, 0)
+                .chancedOutput(dustSmall, Neodymium, 4500, 0)
+                .chancedOutput(dustSmall, Samarium, 3500, 0)
+                .chancedOutput(dustSmall, Cerium, 5500, 0)
+                .chancedOutput(dustSmall, Yttrium, 3500, 0)
+                .chancedOutput(dustSmall, Lanthanum, 2500, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("red_sand_separation").duration(50).EUt(VA[LV])
                 .inputItems(Blocks.RED_SAND.asItem())
-                .chancedOutput(dust, Iron, 5000)
-                .chancedOutput(dust, Diamond, 35)
-                .chancedOutput(new ItemStack(Blocks.SAND), 8500)
+                .chancedOutput(dust, Iron, 5000, 0)
+                .chancedOutput(dust, Diamond, 35, 0)
+                .chancedOutput(new ItemStack(Blocks.SAND), 8500, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("hydrogen_separation").duration(160).EUt(20)
@@ -267,28 +267,28 @@ public class SeparationRecipes {
         // Stone Dust
         CENTRIFUGE_RECIPES.recipeBuilder("stone_dust_separation").duration(480).EUt(VA[MV])
                 .inputItems(dust, Stone)
-                .chancedOutput(dust, Quartzite, 2500)
-                .chancedOutput(dust, PotassiumFeldspar, 2500)
-                .chancedOutput(dust, Marble, "2/9")
-                .chancedOutput(dust, Biotite, "1/9")
-                .chancedOutput(dust, MetalMixture, 925)
-                .chancedOutput(dust, Sodalite, 650)
+                .chancedOutput(dust, Quartzite, 2500, 0)
+                .chancedOutput(dust, PotassiumFeldspar, 2500, 0)
+                .chancedOutput(dust, Marble, "2/9", 0)
+                .chancedOutput(dust, Biotite, "1/9", 0)
+                .chancedOutput(dust, MetalMixture, 925, 0)
+                .chancedOutput(dust, Sodalite, 650, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("metal_mixture_separation").duration(1000).EUt(900)
                 .inputItems(dust, MetalMixture)
-                .chancedOutput(dust, Hematite, 2500)
-                .chancedOutput(dust, Bauxite, 2500)
-                .chancedOutput(dust, Pyrolusite, "2/9")
-                .chancedOutput(dust, Barite, "1/9")
-                .chancedOutput(dust, Chromite, 855)
-                .chancedOutput(dust, Ilmenite, 575)
+                .chancedOutput(dust, Hematite, 2500, 0)
+                .chancedOutput(dust, Bauxite, 2500, 0)
+                .chancedOutput(dust, Pyrolusite, "2/9", 0)
+                .chancedOutput(dust, Barite, "1/9", 0)
+                .chancedOutput(dust, Chromite, 855, 0)
+                .chancedOutput(dust, Ilmenite, 575, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("quartz_sand_separation").duration(60).EUt(VA[LV])
                 .inputItems(dust, QuartzSand, 2)
                 .outputItems(dust, Quartzite)
-                .chancedOutput(dust, CertusQuartz, 2500)
+                .chancedOutput(dust, CertusQuartz, 2500, 0)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("red_alloy_separation").duration(900).EUt(VA[LV])
@@ -339,7 +339,7 @@ public class SeparationRecipes {
                 .inputItems(dust, Sphalerite, 2)
                 .outputItems(dust, Zinc)
                 .outputItems(dust, Sulfur)
-                .chancedOutput(dust, Gallium, 750)
+                .chancedOutput(dust, Gallium, 750, 0)
                 .duration(200).EUt(VA[LV]).save(provider);
 
         ELECTROLYZER_RECIPES.recipeBuilder("water_electrolysis")
@@ -552,7 +552,7 @@ public class SeparationRecipes {
 
         EXTRACTOR_RECIPES.recipeBuilder("wood_dust_extraction").duration(16).EUt(4)
                 .inputItems(dust, Wood)
-                .chancedOutput(PLANT_BALL.asStack(), 225)
+                .chancedOutput(PLANT_BALL.asStack(), 225, 0)
                 .outputFluids(Creosote.getFluid(5))
                 .save(provider);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/TitaniumRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/TitaniumRecipes.java
@@ -167,9 +167,9 @@ public class TitaniumRecipes {
         // Byproduct separation for Ilmenite
         ELECTROMAGNETIC_SEPARATOR_RECIPES.recipeBuilder("ilmenite_separation")
                 .inputItems(dust, IlmeniteSlag)
-                .chancedOutput(dust, Iron, 8000)
-                .chancedOutput(dust, Tantalum, 2000)
-                .chancedOutput(dust, Niobium, 500)
+                .chancedOutput(dust, Iron, 8000, 0)
+                .chancedOutput(dust, Tantalum, 2000, 0)
+                .chancedOutput(dust, Niobium, 500, 0)
                 .duration(50).EUt(VA[MV]).save(provider);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -426,14 +426,6 @@ public interface GTRecipeSchema {
             return notConsumable(InputItem.of(IntCircuitIngredient.of(configuration), 1));
         }
 
-        public GTRecipeJS chancedInput(InputItem stack, int chance) {
-            return chancedInput(stack, chance, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedInput(InputItem stack, int chance, int tierChanceBoost) {
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
@@ -450,14 +442,6 @@ public interface GTRecipeSchema {
             return this;
         }
 
-        public GTRecipeJS chancedFluidInput(GTRecipeComponents.FluidIngredientJS stack, int chance) {
-            return chancedFluidInput(stack, chance, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedFluidInput(GTRecipeComponents.FluidIngredientJS stack, int chance,
                                             int tierChanceBoost) {
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
@@ -475,14 +459,6 @@ public interface GTRecipeSchema {
             return this;
         }
 
-        public GTRecipeJS chancedOutput(ExtendedOutputItem stack, int chance) {
-            return chancedOutput(stack, chance, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedOutput(ExtendedOutputItem stack, int chance, int tierChanceBoost) {
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
@@ -499,35 +475,15 @@ public interface GTRecipeSchema {
             return this;
         }
 
-        public GTRecipeJS chancedOutput(TagPrefix tag, Material mat, int chance) {
-            return chancedOutput(new ExtendedOutputItem(ChemicalHelper.get(tag, mat), null), chance, tierChanceBoost);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedOutput(TagPrefix tag, Material mat, int chance, int tierChanceBoost) {
             return chancedOutput(new ExtendedOutputItem(ChemicalHelper.get(tag, mat), null), chance, tierChanceBoost);
         }
 
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedOutput(TagPrefix tag, Material mat, int count, int chance, int tierChanceBoost) {
             return chancedOutput(new ExtendedOutputItem(ChemicalHelper.get(tag, mat, count), null), chance,
                     tierChanceBoost);
         }
 
-        public GTRecipeJS chancedOutput(ExtendedOutputItem stack, String fraction) {
-            return chancedOutput(stack, fraction, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedOutput(ExtendedOutputItem stack, String fraction, int tierChanceBoost) {
             if (stack.isEmpty()) {
                 return this;
@@ -591,40 +547,16 @@ public interface GTRecipeSchema {
             return this;
         }
 
-        public GTRecipeJS chancedOutput(TagPrefix prefix, Material material, int count, String fraction) {
-            return chancedOutput(prefix, material, count, fraction, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedOutput(TagPrefix prefix, Material material, int count, String fraction,
                                         int tierChanceBoost) {
             return chancedOutput(new ExtendedOutputItem(ChemicalHelper.get(prefix, material, count), null),
                     fraction, tierChanceBoost);
         }
 
-        public GTRecipeJS chancedOutput(TagPrefix prefix, Material material, String fraction) {
-            return chancedOutput(prefix, material, 1, fraction, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedOutput(TagPrefix prefix, Material material, String fraction, int tierChanceBoost) {
             return chancedOutput(prefix, material, 1, fraction, tierChanceBoost);
         }
 
-        public GTRecipeJS chancedFluidOutput(FluidStackJS stack, int chance) {
-            return chancedFluidOutput(stack, chance, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedFluidOutput(FluidStackJS stack, int chance, int tierChanceBoost) {
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
@@ -641,14 +573,6 @@ public interface GTRecipeSchema {
             return this;
         }
 
-        public GTRecipeJS chancedFluidOutput(FluidStackJS stack, String fraction) {
-            return chancedFluidOutput(stack, fraction, 0);
-        }
-
-        /**
-         * @deprecated overclock chance boosting will be removed in a future update
-         */
-        @Deprecated(since = "7.0.0")
         public GTRecipeJS chancedFluidOutput(FluidStackJS stack, String fraction, int tierChanceBoost) {
             if (stack.getAmount() == 0) {
                 return this;


### PR DESCRIPTION
Reverts GregTechCEu/GregTech-Modern#3518


Two reasons
A. This is considered API Breaking - The Overloads are not parsed properly in kube and cause 'ambiguous methods' (as kube can't understand overloads very well)
B. Even upon fixing that, having people forced to modify their chance-boost recipes in 7.1

This will need further discussion on discord, but for now I'm opting to revert it.
