### PR TITLE
Fix the tool grid overlay wonkiness

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ configurations {
     extraRuntimeClasspath.extendsFrom extraLocalRuntime
     clientRuntimeClasspath.extendsFrom clientLocalRuntime
     extraClientRuntimeClasspath.extendsFrom clientExtraLocalRuntime
+
+    renderNurseCfg {
+        canBeConsumed = false
+    }
 }
 
 afterEvaluate {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -80,6 +80,7 @@ dependencies {
     // Client-only runtime mods //
     modClientLocalRuntime(forge.embeddium)
     modClientLocalRuntime(forge.oculus)
+    renderNurseCfg(libs.renderNurse)
 
     //////////////////////////////////////////////////////
     // Runtime mods for dev testing with unclean client //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,12 +8,14 @@ spotless = "7.0.2"
 modDevGradle = "2.0.86"
 lombok = "8.14"
 jetbrains-annotations = "26.0.1"
+renderNurse = "0.0.12"
 mixin = "0.8.7"
 
 [libraries]
 minecraft               = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 minecraftForge          = { module = "net.minecraftforge:forge", version.ref = "minecraftForge" }
 jetbrains-annotations   = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+renderNurse             = { module = "net.neoforged:render-nurse", version.ref = "renderNurse" }
 mixin                   = { module = "org.spongepowered:mixin", version.ref = "mixin" }
 
 [plugins]

--- a/gradle/scripts/moddevgradle.gradle
+++ b/gradle/scripts/moddevgradle.gradle
@@ -1,7 +1,23 @@
+import org.gradle.internal.os.OperatingSystem
+
+ext.isJetbrainsRuntime = System.getProperty('java.vm.vendor').contains('JetBrains')
+
 mixin {
     var refmap = add sourceSets.main, "gtceu.refmap.json"
     slimJar.from refmap
     config 'gtceu.mixins.json'
+}
+
+// we have to force LWJGL version 3.3.2, because RenderNurse requires Java 21, and LWJGL 3.3.1 cannot run on Java 21.
+configurations.configureEach {
+    resolutionStrategy {
+        eachDependency {
+            if (it.requested.group == "org.lwjgl") {
+                it.useVersion("3.3.2")
+                it.because("We need a version of LWJGL that supports java 21 for RenderDoc support")
+            }
+        }
+    }
 }
 
 legacyForge {
@@ -102,6 +118,27 @@ legacyForge {
             programArguments.addAll('--all')
             programArguments.addAll('--output', file('src/generated/resources/').getAbsolutePath())
             programArguments.addAll('--existing', file('src/main/resources/').getAbsolutePath())
+        }
+
+        String renderDocPath = System.getenv("RENDERDOC_LIB")
+        // RenderDoc cannot run on macos so we don't add the config for mac users
+        if(renderDocPath != null && !OperatingSystem.current().isMacOsX()) {
+            create("renderDocClient") {
+                client()
+                sourceSet = sourceSets.client
+                ideName = "Clean Client + RenderDoc (Requires Java 21)"
+
+                programArguments.addAll('--username', 'screret', '--uuid', '1184eb79-5831-4f7d-b8f4-3a46fccf7a1d')
+
+                systemProperty("neoforge.rendernurse.renderdoc.library", renderDocPath)
+                if(OperatingSystem.current().isLinux()) {
+                    environment("LD_PRELOAD", renderDocPath)
+                } else {
+                    // parses out the render nurse jar path and adds as `-javaagent:${path}`
+                    jvmArguments.addAll(project.configurations.renderNurseCfg.incoming.files.elements.map { it.collect { "-javaagent:${it.asFile.absolutePath}" }})
+                    jvmArguments.addAll("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+                }
+            }
         }
 
         // applies to all the run configs above

--- a/gradle/scripts/moddevgradle.gradle
+++ b/gradle/scripts/moddevgradle.gradle
@@ -133,11 +133,10 @@ legacyForge {
                 systemProperty("neoforge.rendernurse.renderdoc.library", renderDocPath)
                 if(OperatingSystem.current().isLinux()) {
                     environment("LD_PRELOAD", renderDocPath)
-                } else {
-                    // parses out the render nurse jar path and adds as `-javaagent:${path}`
-                    jvmArguments.addAll(project.configurations.renderNurseCfg.incoming.files.elements.map { it.collect { "-javaagent:${it.asFile.absolutePath}" }})
-                    jvmArguments.addAll("--enable-preview", "--enable-native-access=ALL-UNNAMED")
                 }
+                // parses out the render nurse jar path and adds as `-javaagent:${path}`
+                jvmArguments.addAll(project.configurations.renderNurseCfg.incoming.files.elements.map { it.collect { "-javaagent:${it.asFile.absolutePath}" }})
+                jvmArguments.addAll("--enable-preview", "--enable-native-access=ALL-UNNAMED")
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
@@ -184,14 +184,13 @@ public class BlockHighlightRenderer {
         bottomLeft.sub(cubeCenter);
         topLeft.sub(cubeCenter);
 
-        var south = Direction.SOUTH.step();
-        var frontVec = getDirectionAxis(facing);
-        var rotationAngle = getRotationAngle(south, frontVec);
-        var rotationAxis = getRotationAxis(south, frontVec);
-        topRight.rotateAxis(rotationAngle, rotationAxis.x(), rotationAxis.y(), rotationAxis.z());
-        bottomRight.rotateAxis(rotationAngle, rotationAxis.x(), rotationAxis.y(), rotationAxis.z());
-        bottomLeft.rotateAxis(rotationAngle, rotationAxis.x(), rotationAxis.y(), rotationAxis.z());
-        topLeft.rotateAxis(rotationAngle, rotationAxis.x(), rotationAxis.y(), rotationAxis.z());
+        Quaternionfc rotation = getRotation(Direction.SOUTH, facing);
+        topRight.rotate(rotation);
+        bottomRight.rotate(rotation);
+        bottomLeft.rotate(rotation);
+        topLeft.rotate(rotation);
+        shiftX.rotate(rotation);
+        shiftY.rotate(rotation);
 
         Direction front = facing;
         Direction back = facing.getOpposite();

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
@@ -102,11 +102,9 @@ public class BlockHighlightRenderer {
                         RenderSystem.defaultBlendFunc();
                         poseStack.translate(facing.getStepX() * 0.01f, facing.getStepY() * 0.01f,
                                 facing.getStepZ() * 0.01f);
-                        RenderUtil.moveToFace(poseStack,
-                                blockPos.getX() - cameraPos.x(),
-                                blockPos.getY() - cameraPos.y(),
-                                blockPos.getZ() - cameraPos.z(),
-                                facing);
+                        poseStack.translate(-cameraPos.x(), -cameraPos.y(), -cameraPos.z());
+
+                        RenderUtil.moveToFace(poseStack, blockCenter, facing);
                         if (facing.getAxis() == Direction.Axis.Y) {
                             RenderUtil.rotateToFace(poseStack, facing, Direction.SOUTH);
                         } else {
@@ -211,7 +209,10 @@ public class BlockHighlightRenderer {
         bottomLeft.add(cubeCenter);
         topLeft.add(cubeCenter);
 
-        var buffer = bufferSource.getBuffer(RenderType.lines());
+        poseStack.pushPose();
+        poseStack.translate(-cameraPos.x(), -cameraPos.y(), -cameraPos.z());
+
+        VertexConsumer buffer = bufferSource.getBuffer(RenderType.lines());
         RenderSystem.lineWidth(3);
         var mat = poseStack.last().pose();
         // straight top bottom lines
@@ -227,17 +228,15 @@ public class BlockHighlightRenderer {
         drawLine(mat, buffer, new Vector3f(bottomLeft).add(shiftVert),
                 new Vector3f(bottomRight).add(shiftVert));
 
-        poseStack.pushPose();
         RenderSystem.disableDepthTest();
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
-        poseStack.translate(facing.getStepX() * 0.01f, facing.getStepY() * 0.01f, facing.getStepZ() * 0.01f);
-        RenderUtil.moveToFace(poseStack,
-                blockPos.getX() - cameraPos.x(),
-                blockPos.getY() - cameraPos.y(),
-                blockPos.getZ() - cameraPos.z(),
-                facing);
-        RenderUtil.rotateToFace(poseStack, facing, Direction.SOUTH);
+
+        poseStack.pushPose();
+        poseStack.translate(front.getStepX() * 0.01f, front.getStepY() * 0.01f, front.getStepZ() * 0.01f);
+
+        RenderUtil.moveToFace(poseStack, cubeCenter, front);
+        RenderUtil.rotateToFace(poseStack, front, Direction.SOUTH);
         poseStack.scale(1f / 16, 1f / 16, 0);
         poseStack.translate(-8, -8, 0);
         poseStack.scale(0.9f, 0.9f, 1);
@@ -271,6 +270,8 @@ public class BlockHighlightRenderer {
         }
         RenderSystem.disableBlend();
         RenderSystem.enableDepthTest();
+
+        poseStack.popPose();
         poseStack.popPose();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
@@ -89,14 +89,14 @@ public class BlockHighlightRenderer {
                 if (gridHighlight == null) {
                     return;
                 }
-                var state = level.getBlockState(blockPos);
+                BlockState state = level.getBlockState(blockPos);
                 poseStack.pushPose();
                 if (gridHighlight.shouldRenderGrid(player, blockPos, state, held, toolType)) {
                     final IToolGridHighlight finalGridHighlight = gridHighlight;
                     drawGridOverlays(poseStack, multiBufferSource, cameraPos, target,
                             side -> finalGridHighlight.sideTips(player, blockPos, state, toolType, side));
                 } else {
-                    var facing = target.getDirection();
+                    Direction facing = target.getDirection();
                     var texture = gridHighlight.sideTips(player, blockPos, state, toolType, facing);
                     if (texture != null) {
                         RenderSystem.disableDepthTest();
@@ -163,42 +163,41 @@ public class BlockHighlightRenderer {
                                          BlockHitResult blockHitResult, Function<Direction, ResourceTexture> texture) {
         rColour = gColour = 0.2F + (float) Math.sin((System.currentTimeMillis() % (Mth.PI * 800)) / 800) / 2;
         bColour = 1f;
-        var blockPos = blockHitResult.getBlockPos();
-        var facing = blockHitResult.getDirection();
+        BlockPos blockPos = blockHitResult.getBlockPos();
         float minX = blockPos.getX();
         float maxX = blockPos.getX() + 1;
         float minY = blockPos.getY();
         float maxY = blockPos.getY() + 1;
         float maxZ = blockPos.getZ() + 1.01f;
-        var attachSide = ICoverable.traceCoverSide(blockHitResult);
-        var topRight = new Vector3f(maxX, maxY, maxZ);
-        var bottomRight = new Vector3f(maxX, minY, maxZ);
-        var bottomLeft = new Vector3f(minX, minY, maxZ);
-        var topLeft = new Vector3f(minX, maxY, maxZ);
-        var shift = new Vector3f(0.25f, 0, 0);
-        var shiftVert = new Vector3f(0, 0.25f, 0);
+        Direction attachSide = ICoverable.traceCoverSide(blockHitResult);
+        Vector3f topRight = new Vector3f(maxX, maxY, maxZ);
+        Vector3f bottomRight = new Vector3f(maxX, minY, maxZ);
+        Vector3f bottomLeft = new Vector3f(minX, minY, maxZ);
+        Vector3f topLeft = new Vector3f(minX, maxY, maxZ);
+        Vector3f shiftX = new Vector3f(0.25f, 0, 0);
+        Vector3f shiftY = new Vector3f(0, 0.25f, 0);
 
-        var cubeCenter = blockPos.getCenter().toVector3f();
+        Vector3f cubeCenter = blockPos.getCenter().toVector3f();
 
         topRight.sub(cubeCenter);
         bottomRight.sub(cubeCenter);
         bottomLeft.sub(cubeCenter);
         topLeft.sub(cubeCenter);
 
-        Quaternionfc rotation = getRotation(Direction.SOUTH, facing);
+        Direction front = blockHitResult.getDirection();
+        Direction back = front.getOpposite();
+        Direction left = RelativeDirection.LEFT.getActualDirection(front);
+        Direction right = RelativeDirection.RIGHT.getActualDirection(front);
+        Direction top = RelativeDirection.UP.getActualDirection(front);
+        Direction bottom = RelativeDirection.DOWN.getActualDirection(front);
+
+        Quaternionfc rotation = getRotation(Direction.SOUTH, front);
         topRight.rotate(rotation);
         bottomRight.rotate(rotation);
         bottomLeft.rotate(rotation);
         topLeft.rotate(rotation);
         shiftX.rotate(rotation);
         shiftY.rotate(rotation);
-
-        Direction front = facing;
-        Direction back = facing.getOpposite();
-        Direction left = RelativeDirection.LEFT.getActualDirection(facing);
-        Direction right = RelativeDirection.RIGHT.getActualDirection(facing);
-        Direction top = RelativeDirection.UP.getActualDirection(facing);
-        Direction bottom = RelativeDirection.DOWN.getActualDirection(facing);
 
         ResourceTexture leftBlocked = texture.apply(left);
         ResourceTexture rightBlocked = texture.apply(right);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
@@ -38,8 +38,9 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import lombok.experimental.ExtensionMethod;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Matrix4f;
+import org.joml.Quaternionfc;
 import org.joml.Vector3f;
+import org.joml.Vector3fc;
 
 import java.util.Set;
 import java.util.function.Function;
@@ -58,6 +59,7 @@ public class BlockHighlightRenderer {
         if (level != null && player != null) {
             ItemStack held = player.getMainHandItem();
             BlockPos blockPos = target.getBlockPos();
+            Vector3fc blockCenter = blockPos.getCenter().toVector3f();
 
             Set<GTToolType> toolType = ToolHelper.getToolTypes(held);
             BlockEntity blockEntity = level.getBlockEntity(blockPos);
@@ -100,6 +102,7 @@ public class BlockHighlightRenderer {
                         RenderSystem.disableDepthTest();
                         RenderSystem.enableBlend();
                         RenderSystem.defaultBlendFunc();
+
                         poseStack.translate(facing.getStepX() * 0.01f, facing.getStepY() * 0.01f,
                                 facing.getStepZ() * 0.01f);
                         poseStack.translate(-cameraPos.x(), -cameraPos.y(), -cameraPos.z());
@@ -214,19 +217,15 @@ public class BlockHighlightRenderer {
 
         VertexConsumer buffer = bufferSource.getBuffer(RenderType.lines());
         RenderSystem.lineWidth(3);
-        var mat = poseStack.last().pose();
+        PoseStack.Pose pose = poseStack.last();
         // straight top bottom lines
-        drawLine(mat, buffer, new Vector3f(topRight).add(new Vector3f(shift).mul(-1)),
-                new Vector3f(bottomRight).add(new Vector3f(shift).mul(-1)));
+        drawLine(pose, buffer, new Vector3f(topRight).sub(shiftX), new Vector3f(bottomRight).sub(shiftX));
 
-        drawLine(mat, buffer, new Vector3f(bottomLeft).add(shift), new Vector3f(topLeft).add(shift));
-
+        drawLine(pose, buffer, new Vector3f(bottomLeft).add(shiftX), new Vector3f(topLeft).add(shiftX));
         // straight side to side lines
-        drawLine(mat, buffer, new Vector3f(topLeft).add(new Vector3f(shiftVert).mul(-1)),
-                new Vector3f(topRight).add(new Vector3f(shiftVert).mul(-1)));
+        drawLine(pose, buffer, new Vector3f(topLeft).sub(shiftY), new Vector3f(topRight).sub(shiftY));
 
-        drawLine(mat, buffer, new Vector3f(bottomLeft).add(shiftVert),
-                new Vector3f(bottomRight).add(shiftVert));
+        drawLine(pose, buffer, new Vector3f(bottomLeft).add(shiftY), new Vector3f(bottomRight).add(shiftY));
 
         RenderSystem.disableDepthTest();
         RenderSystem.enableBlend();
@@ -275,16 +274,16 @@ public class BlockHighlightRenderer {
         poseStack.popPose();
     }
 
-    private static void drawLine(Matrix4f mat, VertexConsumer buffer, Vector3f from, Vector3f to) {
-        var normal = new Vector3f(from).sub(to);
+    private static void drawLine(PoseStack.Pose pose, VertexConsumer buffer, Vector3fc from, Vector3fc to) {
+        Vector3f normal = from.sub(to, new Vector3f());
 
-        buffer.vertex(mat, from.x, from.y, from.z)
+        buffer.vertex(pose.pose(), from.x(), from.y(), from.z())
                 .color(rColour, gColour, bColour, 1f)
-                .normal(normal.x, normal.y, normal.z)
+                .normal(pose.normal(), normal.x(), normal.y(), normal.z())
                 .endVertex();
-        buffer.vertex(mat, to.x, to.y, to.z)
+        buffer.vertex(pose.pose(), to.x(), to.y(), to.z())
                 .color(rColour, gColour, bColour, 1f)
-                .normal(normal.x, normal.y, normal.z)
+                .normal(pose.normal(), normal.x(), normal.y(), normal.z())
                 .endVertex();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockHighlightRenderer.java
@@ -219,11 +219,9 @@ public class BlockHighlightRenderer {
         PoseStack.Pose pose = poseStack.last();
         // straight top bottom lines
         drawLine(pose, buffer, new Vector3f(topRight).sub(shiftX), new Vector3f(bottomRight).sub(shiftX));
-
         drawLine(pose, buffer, new Vector3f(bottomLeft).add(shiftX), new Vector3f(topLeft).add(shiftX));
         // straight side to side lines
         drawLine(pose, buffer, new Vector3f(topLeft).sub(shiftY), new Vector3f(topRight).sub(shiftY));
-
         drawLine(pose, buffer, new Vector3f(bottomLeft).add(shiftY), new Vector3f(bottomRight).add(shiftY));
 
         RenderSystem.disableDepthTest();

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/QuantumChestItemRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/QuantumChestItemRender.java
@@ -95,7 +95,7 @@ public class QuantumChestItemRender extends DynamicRender<QuantumChestMachine, Q
             Quaternionf rotation = getRotation(Direction.NORTH, frontFacing);
             poseStack.mulPose(rotation);
         }
-        poseStack.mulPose(new Quaternionf().rotateAxis(totalTick * Mth.TWO_PI / 80, 0, 1, 0));
+        poseStack.mulPose(new Quaternionf().rotateY(totalTick * Mth.TWO_PI / 80));
         poseStack.scale(0.6f, 0.6f, 0.6f);
 
         itemRenderer.renderStatic(itemStack, ItemDisplayContext.FIXED,

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/QuantumChestItemRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/QuantumChestItemRender.java
@@ -125,7 +125,7 @@ public class QuantumChestItemRender extends DynamicRender<QuantumChestMachine, Q
         poseStack.translate(frontFacing.getStepX() * -1 / 16f, frontFacing.getStepY() * -1 / 16f,
                 frontFacing.getStepZ() * -1 / 16f);
 
-        RenderUtil.moveToFace(poseStack, 0, 0, 0, frontFacing);
+        RenderUtil.moveToFace(poseStack, 0.5f, 0.5f, 0.5f, frontFacing);
         RenderUtil.rotateToFace(poseStack, frontFacing, Direction.NORTH);
         poseStack.scale(1f / 64, 1f / 64, 0);
         poseStack.translate(-32, -32, 0);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/QuantumChestItemRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/QuantumChestItemRender.java
@@ -92,10 +92,8 @@ public class QuantumChestItemRender extends DynamicRender<QuantumChestMachine, Q
         poseStack.pushPose();
         poseStack.translate(0.5f, 0.5f, 0.5f);
         if (frontFacing.getAxis() == Direction.Axis.Y) {
-            var north = Direction.NORTH.step();
-            var front = frontFacing.step();
-            var rotationAngle = getRotationAngle(north, front);
-            poseStack.mulPose(new Quaternionf().fromAxisAngleRad(getRotationAxis(north, front), rotationAngle));
+            Quaternionf rotation = getRotation(Direction.NORTH, frontFacing);
+            poseStack.mulPose(rotation);
         }
         poseStack.mulPose(new Quaternionf().rotateAxis(totalTick * Mth.TWO_PI / 80, 0, 1, 0));
         poseStack.scale(0.6f, 0.6f, 0.6f);

--- a/src/main/java/com/gregtechceu/gtceu/client/util/RenderBufferHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/RenderBufferHelper.java
@@ -1,5 +1,7 @@
 package com.gregtechceu.gtceu.client.util;
 
+import com.gregtechceu.gtceu.utils.GTMatrixUtils;
+
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.Direction;
@@ -9,7 +11,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.mojang.blaze3d.vertex.*;
 import org.joml.Matrix4f;
-import org.joml.Vector3f;
+import org.joml.Vector3fc;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -156,7 +158,7 @@ public class RenderBufferHelper {
                                       float x2, float y2, float z2, float u2, float v2,
                                       float x3, float y3, float z3, float u3, float v3,
                                       float x4, float y4, float z4, float u4, float v4) {
-        Vector3f normal = normalDir.step();
+        Vector3fc normal = GTMatrixUtils.getDirectionAxis(normalDir);
 
         vertex(buffer, pose, x1, y1, z1, color, u1, v1, combinedLight, normal.x(), normal.y(), normal.z());
         vertex(buffer, pose, x2, y2, z2, color, u2, v2, combinedLight, normal.x(), normal.y(), normal.z());

--- a/src/main/java/com/gregtechceu/gtceu/client/util/RenderUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/RenderUtil.java
@@ -213,12 +213,12 @@ public class RenderUtil {
         Quaternionf rotation = new Quaternionf();
         if (face.getAxis() == Direction.Axis.Y) {
             poseStack.scale(1.0f, -1.0f, 1.0f);
-            rotation.rotateAxis(rotationAngle, new Vector3f(1, 0, 0));
+            rotation.rotateX(rotationAngle);
         } else {
             poseStack.scale(-1.0f, -1.0f, -1.0f);
-            rotation.rotateAxis(rotationAngle, new Vector3f(0, 1, 0));
+            rotation.rotateY(rotationAngle);
         }
-        rotation.rotateAxis(getSpinAngle(spin, face), new Vector3f(0, 0, 1));
+        rotation.rotateZ(getSpinAngle(spin, face));
 
         poseStack.mulPose(rotation);
     }

--- a/src/main/java/com/gregtechceu/gtceu/client/util/RenderUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/RenderUtil.java
@@ -192,10 +192,14 @@ public class RenderUtil {
         return fluid;
     }
 
-    public static void moveToFace(PoseStack poseStack, double x, double y, double z, Direction face) {
-        poseStack.translate(x + 0.5d + face.getStepX() * 0.5d,
-                y + 0.5d + face.getStepY() * 0.5d,
-                z + 0.5d + face.getStepZ() * 0.5d);
+    public static void moveToFace(PoseStack poseStack, Vector3fc pos, Direction face) {
+        moveToFace(poseStack, pos.x(), pos.y(), pos.z(), face);
+    }
+
+    public static void moveToFace(PoseStack poseStack, float x, float y, float z, Direction face) {
+        poseStack.translate(Math.fma(face.getStepX(), 0.5f, x),
+                Math.fma(face.getStepY(), 0.5f, y),
+                Math.fma(face.getStepZ(), 0.5f, z));
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/LevelRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/LevelRendererMixin.java
@@ -104,14 +104,15 @@ public abstract class LevelRendererMixin {
         UseOnContext context = new UseOnContext(minecraft.player, InteractionHand.MAIN_HAND, hitResult);
         var positions = ToolHelper.getHarvestableBlocks(aoeDefinition, context);
 
-        Vec3 vec3 = camera.getPosition();
-        double camX = vec3.x();
-        double camY = vec3.y();
-        double camZ = vec3.z();
+        Vec3 camPos = camera.getPosition();
+
+        poseStack.pushPose();
+        poseStack.translate(-camPos.x(), -camPos.y(), -camPos.z());
 
         for (BlockPos pos : positions) {
             poseStack.pushPose();
-            poseStack.translate(pos.getX() - camX, pos.getY() - camY, pos.getZ() - camZ);
+            poseStack.translate(pos.getX(), pos.getY(), pos.getZ());
+
             PoseStack.Pose last = poseStack.last();
             VertexConsumer breakProgressDecal = new SheetedDecalTextureGenerator(
                     this.renderBuffers.crumblingBufferSource()
@@ -122,6 +123,8 @@ public abstract class LevelRendererMixin {
                     level, poseStack, breakProgressDecal, modelData != null ? modelData : ModelData.EMPTY);
             poseStack.popPose();
         }
+
+        poseStack.popPose();
     }
 
     @Shadow

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTMatrixUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTMatrixUtils.java
@@ -10,11 +10,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
 import org.jetbrains.annotations.Contract;
-import org.joml.Matrix4f;
-import org.joml.Matrix4fc;
-import org.joml.Vector3f;
-import org.joml.Vector3fc;
+import org.joml.*;
 
+import java.lang.Math;
 import java.security.InvalidParameterException;
 import java.util.Objects;
 
@@ -62,8 +60,30 @@ public class GTMatrixUtils {
      * @param dest the vector to save the result to
      * @return {@code dest}
      */
-    public static Vector3f getRotationAxis(Vector3fc from, Vector3fc to, Vector3f dest) {
+    public static Vector3f getRotationAxis(final Vector3fc from, final Vector3fc to, Vector3f dest) {
         return from.cross(to, dest).normalize();
+    }
+
+    /**
+     * @param from the original vector
+     * @param to   the wanted vector
+     * @return the quaternion to make {@code from} point in the direction of {@code to}
+     */
+    @Contract(pure = true)
+    public static Quaternionf getRotation(final Vector3fc from, final Vector3fc to) {
+        float angle = getRotationAngle(from, to);
+        Vector3f axis = getRotationAxis(from, to, new Vector3f());
+        return new Quaternionf().fromAxisAngleRad(axis, angle);
+    }
+
+    /**
+     * @param from the original direction
+     * @param to   the wanted direction
+     * @return the quaternion to make a vector based on {@code from} point towards {@code to}
+     */
+    @Contract(pure = true)
+    public static Quaternionf getRotation(final Direction from, final Direction to) {
+        return getRotation(getDirectionAxis(from), getDirectionAxis(to));
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTMatrixUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTMatrixUtils.java
@@ -71,9 +71,7 @@ public class GTMatrixUtils {
      */
     @Contract(pure = true)
     public static Quaternionf getRotation(final Vector3fc from, final Vector3fc to) {
-        float angle = getRotationAngle(from, to);
-        Vector3f axis = getRotationAxis(from, to, new Vector3f());
-        return new Quaternionf().fromAxisAngleRad(axis, angle);
+        return from.rotationTo(to, new Quaternionf());
     }
 
     /**


### PR DESCRIPTION
## What
Fixes the tool grid overlay's sprites being offset by 4 pixels and the lines not rendering at all.

## Implementation Details
mmmm I sure do love matrix operations

## Outcome
no longer wonked up

## Additional Information
I chose to add a RenderDoc run config to test this, as launching the game through RenderDoc itself is quite annoying