### PR TITLE
[1.21] Fix GT tool repair logic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RepairItemRecipeMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RepairItemRecipeMixin.java
@@ -69,9 +69,9 @@ public abstract class RepairItemRecipeMixin extends CustomRecipe {
             cancellable = true)
     public void gtceu$assemble(CraftingInput input, HolderLookup.Provider registries,
                                CallbackInfoReturnable<ItemStack> cir,
-                               @Local(name = "itemstack") ItemStack itemstack,
-                               @Local(name = "i") int maxItemDamage,
-                               @Local(name = "l") int calculatedDamage) {
+                               @Local(ordinal = 0) ItemStack itemstack,
+                               @Local(ordinal = 0) int maxItemDamage,
+                               @Local(ordinal = 3) int calculatedDamage) {
         if (itemstack.getItem() instanceof IGTTool tool) {
             ItemStack ret = cir.getReturnValue();
             ItemEnchantments doneEnchants = EnchantmentHelper.getEnchantmentsForCrafting(ret);

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RepairItemRecipeMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RepairItemRecipeMixin.java
@@ -69,8 +69,9 @@ public abstract class RepairItemRecipeMixin extends CustomRecipe {
             cancellable = true)
     public void gtceu$assemble(CraftingInput input, HolderLookup.Provider registries,
                                CallbackInfoReturnable<ItemStack> cir,
-                               @Local(ordinal = 0) ItemStack itemstack,
-                               @Local(ordinal = 3) int calculatedDamage) {
+                               @Local(name = "itemstack") ItemStack itemstack,
+                               @Local(name = "i") int maxItemDamage,
+                               @Local(name = "l") int calculatedDamage) {
         if (itemstack.getItem() instanceof IGTTool tool) {
             ItemStack ret = cir.getReturnValue();
             ItemEnchantments doneEnchants = EnchantmentHelper.getEnchantmentsForCrafting(ret);
@@ -84,7 +85,7 @@ public abstract class RepairItemRecipeMixin extends CustomRecipe {
                             .forEach(enchant -> {
                                 itemEnchants.upgrade(enchant, doneEnchants.getLevel(enchant));
                             }));
-            ret.setDamageValue(calculatedDamage);
+            ret.setDamageValue(Math.max(maxItemDamage - calculatedDamage, 0));
 
             cir.setReturnValue(ret);
         }


### PR DESCRIPTION
Fixes https://github.com/GregTechCEu/GregTech-Modern/issues/3439

## What
See https://github.com/GregTechCEu/GregTech-Modern/issues/3439

## Implementation Details
Previous logic was setting the new item's damage to an incorrect value

## Outcome
Fixed logic for repairing GT tools to mimic vanilla repair logic

## Additional Information
<img width="1215" height="666" alt="image" src="https://github.com/user-attachments/assets/ae72511e-b75c-4ca6-a3c6-275aa00913b6" />
<img width="1455" height="756" alt="image" src="https://github.com/user-attachments/assets/63673f7b-244d-4bcf-a556-8e4211f2581a" />

