### PR TITLE
Fix recipe showing 'missing x' indicator all the tme

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -468,7 +468,9 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                     setStatus(Status.SUSPEND);
                 } else {
                     setStatus(Status.IDLE);
-                    waitingReason = recipeCheck.reason();
+                    if (recipeCheck.io() != IO.IN || recipeCheck.capability() == EURecipeCapability.CAP) {
+                        waitingReason = recipeCheck.reason();
+                    }
                 }
                 consecutiveRecipes = 0;
                 progress = 0;


### PR DESCRIPTION
## Outcome
Doesn't show missing inputs anymore if it's an energy problem or an input problem
<img width="1170" height="1044" alt="image" src="https://github.com/user-attachments/assets/c18ea1d0-9cc5-4d07-9fd1-79ade14d2222" />
See https://discord.com/channels/701354865217110096/1089296351906504835/1397478103869161533