### PR TITLE
Fix servers crashing on load

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -27,6 +27,7 @@ import com.gregtechceu.gtceu.integration.kjs.events.GTBedrockFluidVeinKubeEvent;
 import com.gregtechceu.gtceu.integration.kjs.events.GTBedrockOreVeinKubeEvent;
 import com.gregtechceu.gtceu.integration.kjs.events.GTOreVeinKubeEvent;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.*;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -41,6 +42,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.material.Fluid;
@@ -415,6 +417,13 @@ public class MixinHelpers {
 
         private static void postBedrockOreEvent() {
             GTCEuServerEvents.BEDROCK_ORE_VEIN_MODIFICATION.post(new GTBedrockOreVeinKubeEvent());
+        }
+    }
+
+    public static final class ClientCallWrapper {
+
+        public static Level getClientLevel() {
+            return Minecraft.getInstance().level;
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/DummyWorldMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/DummyWorldMixin.java
@@ -1,5 +1,8 @@
 package com.gregtechceu.gtceu.core.mixins.ldlib;
 
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.core.MixinHelpers;
+
 import com.lowdragmc.lowdraglib.utils.DummyWorld;
 
 import net.minecraft.core.BlockPos;
@@ -12,17 +15,35 @@ import net.neoforged.neoforge.common.extensions.ILevelExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+
+import java.lang.ref.WeakReference;
 
 @Mixin(value = DummyWorld.class, remap = false)
 public abstract class DummyWorldMixin implements ILevelExtension, IBlockGetterExtension {
 
+    @Shadow
+    public WeakReference<Level> level;
+
     @Unique
     private final ModelDataManager gtceu$modelDataManager = new ModelDataManager((Level) (Object) this);
 
-    @Shadow
-    public abstract @NotNull Level getLevel();
+    /**
+     * @author screret
+     * @reason ensure client-server separation
+     */
+    @Overwrite
+    public @NotNull Level getLevel() {
+        Level level = this.level.get();
+        if (level == null && GTCEu.isClientThread()) {
+            level = MixinHelpers.ClientCallWrapper.getClientLevel();
+            this.level = new WeakReference<>(level);
+        }
+        assert level != null;
+        return level;
+    }
 
     @Override
     public @Nullable ModelDataManager getModelDataManager() {

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/TrackedDummyWorldMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/TrackedDummyWorldMixin.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.core.mixins.ldlib;
 
-import com.lowdragmc.lowdraglib.utils.DummyWorld;
 import com.lowdragmc.lowdraglib.utils.TrackedDummyWorld;
 
 import net.minecraft.core.BlockPos;
@@ -18,7 +17,7 @@ import java.lang.ref.WeakReference;
 import java.util.function.Predicate;
 
 @Mixin(value = TrackedDummyWorld.class, remap = false)
-public abstract class TrackedDummyWorldMixin extends DummyWorld implements ILevelExtension, IBlockGetterExtension {
+public abstract class TrackedDummyWorldMixin extends DummyWorldMixin implements ILevelExtension, IBlockGetterExtension {
 
     @Shadow
     private Predicate<BlockPos> renderFilter;
@@ -26,10 +25,6 @@ public abstract class TrackedDummyWorldMixin extends DummyWorld implements ILeve
     @Shadow
     @Final
     public WeakReference<Level> proxyWorld;
-
-    public TrackedDummyWorldMixin(Level level) {
-        super(level);
-    }
 
     @Override
     public @NotNull ModelData getModelData(@NotNull BlockPos pos) {


### PR DESCRIPTION
## What
Fixed servers crashing on load because LDLib loads a client-only class somewhere it really shouldn't have

## Implementation Details
_Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed._

## Outcome
Fixes #3501 