### PR TITLE
Fix wood pipes/frames/etc not requiring wrench with wrench cfg enabled

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -154,14 +154,19 @@ public class MixinHelpers {
                     tagMap.computeIfAbsent(CustomTags.TOOL_TIERS[material.getBlockHarvestLevel()].location(),
                             path -> new ArrayList<>()).addAll(entries);
                     if (material.hasProperty(PropertyKey.WOOD)) {
-                        // Wood blocks with this tag require an Axe without the config enabled, or a Wrench with it
-                        if (ConfigHolder.INSTANCE.machines.requireGTToolsForBlocks &&
-                                entry.tagPrefix().miningToolTag()
-                                        .contains(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)) {
+                        // Wood blocks with this tag always allow a Wrench, but only allow an Axe if the config is
+                        // not set. Pickaxe is never allowed (special case)
+                        if (entry.tagPrefix().miningToolTag()
+                                .contains(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)) {
                             tagMap.computeIfAbsent(CustomTags.MINEABLE_WITH_WRENCH.location(),
-                                    path -> new ArrayList<>())
-                                    .addAll(entries);
+                                    path -> new ArrayList<>()).addAll(entries);
+                            if (!ConfigHolder.INSTANCE.machines.requireGTToolsForBlocks) {
+                                tagMap.computeIfAbsent(BlockTags.MINEABLE_WITH_AXE.location(),
+                                        path -> new ArrayList<>())
+                                        .addAll(entries);
+                            }
                         } else {
+                            // Other wood stuff should still get the Axe tag
                             tagMap.computeIfAbsent(BlockTags.MINEABLE_WITH_AXE.location(), path -> new ArrayList<>())
                                     .addAll(entries);
                         }

--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -154,8 +154,17 @@ public class MixinHelpers {
                     tagMap.computeIfAbsent(CustomTags.TOOL_TIERS[material.getBlockHarvestLevel()].location(),
                             path -> new ArrayList<>()).addAll(entries);
                     if (material.hasProperty(PropertyKey.WOOD)) {
-                        tagMap.computeIfAbsent(BlockTags.MINEABLE_WITH_AXE.location(), path -> new ArrayList<>())
-                                .addAll(entries);
+                        // Wood blocks with this tag require an Axe without the config enabled, or a Wrench with it
+                        if (ConfigHolder.INSTANCE.machines.requireGTToolsForBlocks &&
+                                entry.tagPrefix().miningToolTag()
+                                        .contains(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)) {
+                            tagMap.computeIfAbsent(CustomTags.MINEABLE_WITH_WRENCH.location(),
+                                    path -> new ArrayList<>())
+                                    .addAll(entries);
+                        } else {
+                            tagMap.computeIfAbsent(BlockTags.MINEABLE_WITH_AXE.location(), path -> new ArrayList<>())
+                                    .addAll(entries);
+                        }
                     } else {
                         for (var tag : entry.tagPrefix().miningToolTag()) {
                             tagMap.computeIfAbsent(tag.location(), path -> new ArrayList<>()).addAll(entries);


### PR DESCRIPTION
Fixes Wood pipes, frames, and other similar things not requiring a Wrench when the `requireGTToolsForBlocks` config is enabled