### PR TITLE
Fix FluidAreaRenders not showing when controller is offscreen

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/FluidAreaRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/FluidAreaRender.java
@@ -14,6 +14,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.phys.AABB;
 import net.minecraftforge.client.RenderTypeHelper;
 
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -119,5 +120,20 @@ public class FluidAreaRender extends DynamicRender<IFluidRenderMulti, FluidAreaR
     private Optional<Fluid> getFixedFluid() {
         if (fixedFluid) return Optional.ofNullable(cachedFluid);
         else return Optional.empty();
+    }
+
+    @Override
+    public boolean shouldRenderOffScreen(IFluidRenderMulti machine) {
+        return true;
+    }
+
+    @Override
+    public AABB getRenderBoundingBox(IFluidRenderMulti machine) {
+        AABB box = super.getRenderBoundingBox(machine);
+        var offsets = machine.getFluidOffsets();
+        for (var offset : offsets) {
+            box = box.minmax(new AABB(offset));
+        }
+        return box.inflate(getViewDistance());
     }
 }


### PR DESCRIPTION
## What
Fixes FluidAreaRenders not being shown to the player when the controller is offscreen.

## Implementation Details
impls shouldRenderOffScreen and getRenderBoundingBox for FluidAreaRender

## Outcome
fluidarearenders can be seen offscreen.