### PR TITLE
Add recipe handler bypass system

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -443,4 +443,10 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
          */
         int limitFluidParallel(GTRecipe recipe, int multiplier, boolean tick);
     }
+
+    // Fluids should be respected for distinct checks
+    @Override
+    public boolean shouldBypassDistinct() {
+        return false;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -565,4 +565,10 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
          */
         int limitItemParallel(GTRecipe recipe, int multiplier, boolean tick);
     }
+
+    // Items should be respected for distinct checks
+    @Override
+    public boolean shouldBypassDistinct() {
+        return false;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
@@ -213,4 +213,13 @@ public abstract class RecipeCapability<T> {
     public boolean isTickSlot(int index, IO io, GTRecipe recipe) {
         return index >= (io == IO.IN ? recipe.getInputContents(this) : recipe.getOutputContents(this)).size();
     }
+
+    /**
+     * Should this RecipeCapability bypass distinct checks?
+     * E.g. should this bus be added to all recipe checks on a multi, even distinct ones like ME Pattern buffers.
+     * for example: energy hatches, soul hatches, other "global per multi" hatches.
+     */
+    public boolean shouldBypassDistinct() {
+        return true;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerGroupDistinctness.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerGroupDistinctness.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.machine.trait;
 
 public enum RecipeHandlerGroupDistinctness implements RecipeHandlerGroup {
-    BUS_DISTINCT
+    BUS_DISTINCT,
+    BYPASS_DISTINCT
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
@@ -143,6 +143,20 @@ public class RecipeHandlerList {
         return getHandlerMap().getOrDefault(cap, Collections.emptyList());
     }
 
+    public @NotNull Set<RecipeCapability<?>> getCapabilities() {
+        return getHandlerMap().keySet();
+    }
+
+    /**
+     * @return whether any of the capabilities in this RHL should bypass distinct checks
+     */
+    public boolean doesCapabilityBypassDistinct() {
+        for (var capability : getCapabilities()) {
+            if (capability.shouldBypassDistinct()) return true;
+        }
+        return false;
+    }
+
     public boolean isValid(IO extIO) {
         if (this == NO_DATA || handlerIO == IO.NONE) return false;
         return (extIO == IO.BOTH || handlerIO == IO.BOTH || extIO == handlerIO);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -347,11 +347,9 @@ public class RecipeHelper {
 
     public static void addToRecipeHandlerMap(RecipeHandlerGroup key, RecipeHandlerList handler,
                                              Map<RecipeHandlerGroup, List<RecipeHandlerList>> map) {
-        // If they should bypass this system, add them to every group regardless.
+        // If they should bypass this system, add them to the BYPASS_DISTINCT group.
         if (handler.doesCapabilityBypassDistinct()) {
-            for (var mapKey : map.keySet()) {
-                map.get(mapKey).add(handler);
-            }
+            map.computeIfAbsent(RecipeHandlerGroupDistinctness.BYPASS_DISTINCT, $ -> new ArrayList<>()).add(handler);
             return;
         }
         // Add undyed RHL's to every group that's not distinct, and also the undyed group itself.

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -347,6 +347,13 @@ public class RecipeHelper {
 
     public static void addToRecipeHandlerMap(RecipeHandlerGroup key, RecipeHandlerList handler,
                                              Map<RecipeHandlerGroup, List<RecipeHandlerList>> map) {
+        // If they should bypass this system, add them to every group regardless.
+        if (handler.doesCapabilityBypassDistinct()) {
+            for (var mapKey : map.keySet()) {
+                map.get(mapKey).add(handler);
+            }
+            return;
+        }
         // Add undyed RHL's to every group that's not distinct, and also the undyed group itself.
         if (key.equals(RecipeHandlerGroupColor.UNDYED)) {
             for (var entry : map.entrySet()) {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -105,19 +105,14 @@ public class RecipeRunner {
     }
 
     private ActionResult handleContents() {
-        var result = handleContentsInternal(io);
-        return result;
-    }
-
-    private ActionResult handleContentsInternal(IO capIO) {
         if (recipeContents.isEmpty()) return ActionResult.SUCCESS;
-        if (!capabilityProxies.containsKey(capIO)) {
+        if (!capabilityProxies.containsKey(io)) {
             return ActionResult.FAIL_NO_CAPABILITIES;
         }
 
-        List<RecipeHandlerList> handlers = capabilityProxies.getOrDefault(capIO, Collections.emptyList());
+        List<RecipeHandlerList> handlers = capabilityProxies.getOrDefault(io, Collections.emptyList());
         // Only sort for non-tick outputs
-        if (!isTick && capIO.support(IO.OUT)) {
+        if (!isTick && io.support(IO.OUT)) {
             handlers.sort(RecipeHandlerList.COMPARATOR.reversed());
         }
 
@@ -203,7 +198,7 @@ public class RecipeRunner {
 
         for (var entry : recipeContents.entrySet()) {
             if (entry.getValue() != null && !entry.getValue().isEmpty()) {
-                return ActionResult.fail(null, entry.getKey(), capIO);
+                return ActionResult.fail(null, entry.getKey(), io);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -128,23 +128,37 @@ public class RecipeRunner {
         // Specifically check distinct handlers first
         for (RecipeHandlerList handler : handlerGroups.getOrDefault(RecipeHandlerGroupDistinctness.BUS_DISTINCT,
                 Collections.emptyList())) {
+            // Handle the contents of this handler and also all the bypassed handlers
             var res = handler.handleRecipe(io, recipe, searchRecipeContents, true);
+            for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+                    RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
+                    Collections.emptyList())) {
+                res = bypass_handler.handleRecipe(io, recipe, res, true);
+            }
             if (res.isEmpty()) {
                 if (!simulated) {
+                    // Actually consume the contents of this handler and also all the bypassed handlers
                     handler.handleRecipe(io, recipe, recipeContents, false);
+                    for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+                            RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
+                            Collections.emptyList())) {
+                        res = bypass_handler.handleRecipe(io, recipe, res, false);
+                    }
                 }
                 recipeContents.clear();
                 return ActionResult.SUCCESS;
             }
         }
 
-        // Check the others
+        // Check the other groups. For every group, try consuming the ingredients,
+        // see if it succeeds.
         for (Map.Entry<RecipeHandlerGroup, List<RecipeHandlerList>> handlerListEntry : handlerGroups.entrySet()) {
             if (handlerListEntry.getKey() == RecipeHandlerGroupDistinctness.BUS_DISTINCT) continue;
 
             // List to keep track of the remaining items for this RecipeHandlerGroup
             Map<RecipeCapability<?>, List<Object>> copiedRecipeContents = searchRecipeContents;
             boolean found = false;
+
             for (RecipeHandlerList handler : handlerListEntry.getValue()) {
                 copiedRecipeContents = handler.handleRecipe(io, recipe, copiedRecipeContents, true);
                 if (copiedRecipeContents.isEmpty()) {
@@ -152,12 +166,30 @@ public class RecipeRunner {
                     break;
                 }
             }
+            for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+                    RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
+                    Collections.emptyList())) {
+                copiedRecipeContents = bypass_handler.handleRecipe(io, recipe, copiedRecipeContents, true);
+            }
+
             if (!found) continue;
             if (simulated) return ActionResult.SUCCESS;
-            // Start actually removing items, keep track of the remaining items for this RecipeHandlerGroup
+            // Start actually removing items.
+            // Keep track of the remaining items for this RecipeHandlerGroup
             copiedRecipeContents = recipeContents;
+            // First go through the handlers of the group
             for (RecipeHandlerList handler : handlerListEntry.getValue()) {
                 copiedRecipeContents = handler.handleRecipe(io, recipe, copiedRecipeContents, false);
+                if (copiedRecipeContents.isEmpty()) {
+                    recipeContents.clear();
+                    return ActionResult.SUCCESS;
+                }
+            }
+            // Then go through the handlers that bypass the distinctness system and empty those
+            for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+                    RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
+                    Collections.emptyList())) {
+                copiedRecipeContents = bypass_handler.handleRecipe(io, recipe, copiedRecipeContents, false);
                 if (copiedRecipeContents.isEmpty()) {
                     recipeContents.clear();
                     return ActionResult.SUCCESS;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -170,6 +170,10 @@ public class RecipeRunner {
                     RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                     Collections.emptyList())) {
                 copiedRecipeContents = bypass_handler.handleRecipe(io, recipe, copiedRecipeContents, true);
+                if (copiedRecipeContents.isEmpty()) {
+                    found = true;
+                    break;
+                }
             }
 
             if (!found) continue;


### PR DESCRIPTION
## What
Add a per-capability bypass for the recipe distinction / color separation system.

## Implementation Details
The default for this is true, since the only real caps we handle distinctness for are items and fluids.
Specifically: if you have a recipe that needs something else, then a ME Pattern Buffer will never work for it.

## Outcome
You can now use CC Soul hatches with a ME Pattern Buffer