### PR TITLE
Fix all TEs showing Maintenance Status

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MaintenanceBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MaintenanceBlockProvider.java
@@ -11,6 +11,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -56,21 +57,23 @@ public class MaintenanceBlockProvider extends CapabilityBlockProvider<IMaintenan
     @Override
     protected void addTooltip(CompoundTag compoundTag, ITooltip iTooltip, Player player, BlockAccessor blockAccessor,
                               BlockEntity blockEntity, IPluginConfig iPluginConfig) {
-        if (compoundTag.getBoolean("hasProblems")) {
-            if (blockAccessor.showDetails()) {
-                int problems = compoundTag.getInt("maintenanceProblems");
-                for (byte i = 0; i < 6; i++) {
-                    if (((problems >> i) & 1) == 0) {
-                        var tuple = GTUtil.getMaintenanceText(i);
-                        iTooltip.add(IElementHelper.get().smallItem(tuple.getA()));
-                        iTooltip.append(tuple.getB());
+        if (compoundTag.contains("hasProblems", Tag.TAG_BYTE)) {
+            if (compoundTag.getBoolean("hasProblems")) {
+                if (blockAccessor.showDetails()) {
+                    int problems = compoundTag.getInt("maintenanceProblems");
+                    for (byte i = 0; i < 6; i++) {
+                        if (((problems >> i) & 1) == 0) {
+                            var tuple = GTUtil.getMaintenanceText(i);
+                            iTooltip.add(IElementHelper.get().smallItem(tuple.getA()));
+                            iTooltip.append(tuple.getB());
+                        }
                     }
+                } else {
+                    iTooltip.add(Component.translatable("gtceu.top.maintenance_broken").withStyle(ChatFormatting.RED));
                 }
             } else {
-                iTooltip.add(Component.translatable("gtceu.top.maintenance_broken").withStyle(ChatFormatting.RED));
+                iTooltip.add(Component.translatable("gtceu.top.maintenance_fixed").withStyle(ChatFormatting.GREEN));
             }
-        } else {
-            iTooltip.add(Component.translatable("gtceu.top.maintenance_fixed").withStyle(ChatFormatting.GREEN));
         }
     }
 }


### PR DESCRIPTION
## What
Fixes #3417

## Implementation Details
Missed hasProblems NBT check

## Outcome
Only show maintenance status on blocks that can have maintenance 

## Additional Information
<img width="469" height="175" alt="image" src="https://github.com/user-attachments/assets/23def6fd-27c0-45f7-aa76-781b1da85dee" />
<img width="730" height="261" alt="image" src="https://github.com/user-attachments/assets/6a936a68-2215-4381-ac2e-d58311e9cd3e" />

