### PR TITLE
Adds a Shortcut for removing property keys in kube

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -516,11 +516,15 @@ public class Material implements Comparable<Material> {
     }
 
     public <T extends IMaterialProperty> boolean hasProperty(PropertyKey<T> key) {
-        return getProperty(key) != null;
+        return properties.hasProperty(key);
     }
 
     public <T extends IMaterialProperty> T getProperty(PropertyKey<T> key) {
         return properties.getProperty(key);
+    }
+
+    public <T extends IMaterialProperty> void removeProperty(PropertyKey<T> key) {
+        properties.removeProperty(key);
     }
 
     public <T extends IMaterialProperty> void setProperty(PropertyKey<T> key, IMaterialProperty property) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/MaterialProperties.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/MaterialProperties.java
@@ -37,7 +37,7 @@ public class MaterialProperties {
     }
 
     public <T extends IMaterialProperty> boolean hasProperty(PropertyKey<T> key) {
-        return propertyMap.get(key) != null;
+        return propertyMap.containsKey(key);
     }
 
     public <T extends IMaterialProperty> void setProperty(PropertyKey<T> key, IMaterialProperty value) {


### PR DESCRIPTION
## What
titlE

## Implementation Details
allows you to remove property keys from the material without referencing the property map

## Outcome
shorter kube lines