### PR TITLE
Fix singleblock generator models not rendering

### DIFF
--- a/src/main/resources/assets/gtceu/models/block/machine/template/generator_machine.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/template/generator_machine.json
@@ -32,7 +32,7 @@
         {
             "from": [ -0.02, -0.02, -0.02 ],
             "to":   [ 16.02, 16.02, 16.02 ],
-            "forge_data": { "block_light": 15, "sky_light": 15 },
+            "neoforge_data": { "block_light": 15, "sky_light": 15 },
             "shade": false,
             "faces": {
                 "north": { "uv": [0, 0, 16, 16], "texture": "#overlay_front_emissive",  "cullface": "north", "tintindex": -101 },


### PR DESCRIPTION
## What
Fix an issue on 1.21 where the singleblock generators were not rendering.

## Implementation Details
`forge_data` doens't work on neoforge, so this just replaces it with `neoforge_data`.

## Outcome
Fixes #3526