### PR TITLE
Add an optional `GTRegistrate` parameter to all methods in `GTMachineUtils`

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -193,6 +193,10 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
     private RegistryEntry<CreativeModeTab> currentTab;
     private static final Map<RegistryEntry<?>, RegistryEntry<CreativeModeTab>> TAB_LOOKUP = new IdentityHashMap<>();
 
+    public RegistryEntry<CreativeModeTab> creativeModeTab() {
+        return this.currentTab;
+    }
+
     public void creativeModeTab(Supplier<RegistryEntry<CreativeModeTab>> currentTab) {
         this.currentTab = currentTab.get();
     }


### PR DESCRIPTION
## What

Instead of always using the GTCEu `REGISTRATE` for registering machines, addons can choose to use their own to get machines registered under their namespace, instead of having to duplicate the needed methods in their own mod and just change the `REGISTRATE` reference.

## Implementation Details

Also adds a method to get the current creative mode tab to be able to restore the correct one after temporarily hiding RF converters if they're disabled.