### PR TITLE
Add offsets to the item stack widgets in JEI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewSlotWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewSlotWidget.java
@@ -1,0 +1,112 @@
+package com.gregtechceu.gtceu.api.gui.widget;
+
+import com.lowdragmc.lowdraglib.gui.modular.ModularUIGuiContainer;
+import com.lowdragmc.lowdraglib.gui.util.DrawerHelper;
+import com.lowdragmc.lowdraglib.utils.ColorUtils;
+import com.lowdragmc.lowdraglib.utils.Position;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.opengl.GL11;
+
+import javax.annotation.Nonnull;
+
+public class PatternPreviewSlotWidget extends SlotWidget {
+
+    public PatternPreviewSlotWidget(IItemHandlerModifiable itemHandler, int slotIndex, int xPosition, int yPosition,
+                                    boolean canTakeItems, boolean canPutItems) {
+        super(itemHandler, slotIndex, xPosition, yPosition, canTakeItems, canPutItems);
+    }
+
+    /**
+     * Override the draw method for regular slot widget since we do custom offsets when drawing the stack
+     */
+    @Override
+    public void drawInBackground(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+        super.drawBackgroundTexture(graphics, mouseX, mouseY);
+        Position pos = this.getPosition();
+        if (this.slotReference != null) {
+            ItemStack itemStack = this.getRealStack(this.slotReference.getItem());
+            ModularUIGuiContainer modularUIGui = this.gui == null ? null : this.gui.getModularUIGui();
+            if (itemStack.isEmpty() && modularUIGui != null && modularUIGui.getQuickCrafting() &&
+                    modularUIGui.getQuickCraftSlots().contains(this.slotReference)) {
+                int splitSize = modularUIGui.getQuickCraftSlots().size();
+                itemStack = this.gui.getModularUIContainer().getCarried();
+                if (!itemStack.isEmpty() && splitSize > 1 &&
+                        AbstractContainerMenu.canItemQuickReplace(this.slotReference, itemStack, true)) {
+                    itemStack = itemStack.copy();
+                    itemStack.grow(AbstractContainerMenu.getQuickCraftPlaceCount(modularUIGui.getQuickCraftSlots(),
+                            modularUIGui.dragSplittingLimit, itemStack));
+                    int k = Math.min(itemStack.getMaxStackSize(), this.slotReference.getMaxStackSize(itemStack));
+                    if (itemStack.getCount() > k) {
+                        itemStack.setCount(k);
+                    }
+                }
+            }
+
+            if (!itemStack.isEmpty()) {
+                drawItemStack(graphics, itemStack, pos.x + 1, pos.y + 1, -1, (String) null);
+            }
+        }
+
+        this.drawOverlay(graphics, mouseX, mouseY, partialTicks);
+        if (this.drawHoverOverlay && this.isMouseOverElement((double) mouseX, (double) mouseY) &&
+                this.getHoverElement((double) mouseX, (double) mouseY) == this) {
+            RenderSystem.colorMask(true, true, true, false);
+            DrawerHelper.drawSolidRect(graphics, this.getPosition().x + 1, this.getPosition().y + 1, 16, 16,
+                    -2130706433);
+            RenderSystem.colorMask(true, true, true, true);
+        }
+    }
+
+    public static void drawItemStack(@Nonnull GuiGraphics graphics, ItemStack itemStack, int x, int y, int color,
+                                     @Nullable String altTxt) {
+        var a = ColorUtils.alpha(color);
+        var r = ColorUtils.red(color);
+        var g = ColorUtils.green(color);
+        var b = ColorUtils.blue(color);
+        RenderSystem.setShaderColor(r, g, b, a);
+
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthMask(true);
+
+        Minecraft mc = Minecraft.getInstance();
+
+        graphics.pose().pushPose();
+        graphics.pose().translate(0, 0, 100);
+
+        graphics.renderItem(itemStack, x, y);
+        graphics.pose().translate(0, 0, 100);
+
+        graphics.pose().pushPose();
+
+        // actual offset bit that's important :3
+        int xOffset = 0;
+        if (itemStack.getCount() / 100_000 != 0) {
+            xOffset = 9;
+        } else if (itemStack.getCount() / 10_000 != 0) {
+            xOffset = 6;
+        } else if (itemStack.getCount() / 1000 != 0) {
+            xOffset = 3;
+        }
+
+        graphics.renderItemDecorations(mc.font, itemStack, x + xOffset, y, altTxt);
+        graphics.pose().popPose();
+
+        graphics.pose().popPose();
+
+        // clear depth buffer,it may cause some rendering issues?
+        RenderSystem.clear(GL11.GL_DEPTH_BUFFER_BIT, Minecraft.ON_OSX);
+        RenderSystem.depthMask(false);
+        RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
+        RenderSystem.enableBlend();
+        RenderSystem.disableDepthTest();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/PatternPreviewWidget.java
@@ -247,10 +247,21 @@ public class PatternPreviewWidget extends WidgetGroup {
         }
         slotWidgets = new SlotWidget[Math.min(pattern.parts.size(), 18)];
         var itemHandler = new CycleItemStackHandler(pattern.parts);
+        int xOffset = 0;
         for (int i = 0; i < slotWidgets.length; i++) {
-            slotWidgets[i] = new SlotWidget(itemHandler, i, 4 + i * 18, 0, false, false)
+            int padding = 1;
+            if (itemHandler.getStackInSlot(i).getCount() / 100_000 >= 1) {
+                padding = 10;
+            } else if (itemHandler.getStackInSlot(i).getCount() / 10_000 >= 1) {
+                padding = 7;
+            } else if (itemHandler.getStackInSlot(i).getCount() / 1_000 >= 1) {
+                padding = 4;
+            }
+
+            slotWidgets[i] = new PatternPreviewSlotWidget(itemHandler, i, (4 + xOffset + padding), 0, false, false)
                     .setBackgroundTexture(ColorPattern.T_GRAY.rectTexture())
                     .setIngredientIO(IngredientIO.INPUT);
+            xOffset += 18 + (2 * padding);
             scrollableWidgetGroup.addWidget(slotWidgets[i]);
         }
     }
@@ -467,11 +478,9 @@ public class PatternPreviewWidget extends WidgetGroup {
 
         public List<ItemStack> getItemStack() {
             return Arrays.stream(itemStackKey.getItemStack())
-                    .map(itemStack -> {
-                        var item = itemStack.copy();
-                        item.setCount(amount);
-                        return item;
-                    }).filter(item -> !item.isEmpty()).toList();
+                    .map(stack -> stack.copyWithCount(amount))
+                    .filter(item -> !item.isEmpty())
+                    .toList();
         }
     }
 


### PR DESCRIPTION
## What
adds offsets to the item widgets in the JEI preview based on the count of the item stack, so that you can cleanly see the number of each item

## Implementation Details
some x offsets, and needing to create a new widget class for custom text rendering

## Outcome
you can see the count cleanly 🥹 