### PR TITLE
Refactor the rock breaker recipe condition

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -5442,7 +5442,7 @@
   "recipe.condition.quest.completed.tooltip": "pǝʇǝןdɯoɔ %s sǝɹınbǝᴚ",
   "recipe.condition.quest.not_completed.tooltip": "pǝʇǝןdɯoɔ ʇou %s sǝɹınbǝᴚ",
   "recipe.condition.rain.tooltip": "%d :ןǝʌǝꞀ uıɐᴚ",
-  "recipe.condition.rock_breaker.tooltip": "punoɹɐ sʞɔoןq pınןℲ",
+  "recipe.condition.adjacent_fluid.tooltip": "punoɹɐ sʞɔoןq pınןℲ",
   "recipe.condition.steam_vent.tooltip": "ʇuǝʌ ɯɐǝʇs uɐǝןƆ",
   "recipe.condition.thunder.tooltip": "%d :ןǝʌǝꞀ ɹǝpunɥ⟘",
   "tagprefix.andesite": "ǝɹO %s ǝʇısǝpuⱯ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -5442,7 +5442,7 @@
   "recipe.condition.quest.completed.tooltip": "Requires %s completed",
   "recipe.condition.quest.not_completed.tooltip": "Requires %s not completed",
   "recipe.condition.rain.tooltip": "Rain Level: %d",
-  "recipe.condition.rock_breaker.tooltip": "Fluid blocks around",
+  "recipe.condition.adjacent_fluid.tooltip": "Fluid blocks around",
   "recipe.condition.steam_vent.tooltip": "Clean steam vent",
   "recipe.condition.thunder.tooltip": "Thunder Level: %d",
   "tagprefix.andesite": "Andesite %s Ore",

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
@@ -25,7 +25,7 @@ public final class GTRecipeConditions {
     public static final RecipeConditionType<RainingCondition> RAINING = GTRegistries.RECIPE_CONDITIONS.register("rain",
             new RecipeConditionType<>(RainingCondition::new, RainingCondition.CODEC));
     public static final RecipeConditionType<RockBreakerCondition> ROCK_BREAKER = GTRegistries.RECIPE_CONDITIONS
-            .register("rock_breaker", new RecipeConditionType<>(RockBreakerCondition::new, RockBreakerCondition.CODEC));
+            .register("adjacent_fluid", new RecipeConditionType<>(RockBreakerCondition::new, RockBreakerCondition.CODEC));
     public static final RecipeConditionType<AdjacentBlockCondition> ADJACENT_BLOCK = GTRegistries.RECIPE_CONDITIONS
             .register("adjacent_block",
                     new RecipeConditionType<>(AdjacentBlockCondition::new, AdjacentBlockCondition.CODEC));
@@ -65,6 +65,9 @@ public final class GTRecipeConditions {
                     .register("heracles_quest",
                             new RecipeConditionType<>(HeraclesQuestCondition::new, HeraclesQuestCondition.CODEC));
         }
+        // fix the rock breaker condition's ID
+        GTRegistries.RECIPE_CONDITIONS.remap("rock_breaker", "adjacent_fluid");
+
         // noinspection unchecked
         ModLoader.get().postEvent(new GTCEuAPI.RegisterEvent<>(GTRegistries.RECIPE_CONDITIONS,
                 (Class<RecipeConditionType<?>>) (Class<?>) RecipeConditionType.class));

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeConditions.java
@@ -2,11 +2,14 @@ package com.gregtechceu.gtceu.common.data;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
+import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
 import com.gregtechceu.gtceu.api.recipe.condition.RecipeConditionType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.recipe.condition.*;
 
 import net.minecraftforge.fml.ModLoader;
+
+import com.mojang.serialization.Codec;
 
 public final class GTRecipeConditions {
 
@@ -16,54 +19,34 @@ public final class GTRecipeConditions {
 
     private GTRecipeConditions() {}
 
-    public static final RecipeConditionType<BiomeCondition> BIOME = GTRegistries.RECIPE_CONDITIONS.register("biome",
-            new RecipeConditionType<>(BiomeCondition::new, BiomeCondition.CODEC));
-    public static final RecipeConditionType<DimensionCondition> DIMENSION = GTRegistries.RECIPE_CONDITIONS
-            .register("dimension", new RecipeConditionType<>(DimensionCondition::new, DimensionCondition.CODEC));
-    public static final RecipeConditionType<PositionYCondition> POSITION_Y = GTRegistries.RECIPE_CONDITIONS
-            .register("pos_y", new RecipeConditionType<>(PositionYCondition::new, PositionYCondition.CODEC));
-    public static final RecipeConditionType<RainingCondition> RAINING = GTRegistries.RECIPE_CONDITIONS.register("rain",
-            new RecipeConditionType<>(RainingCondition::new, RainingCondition.CODEC));
-    public static final RecipeConditionType<RockBreakerCondition> ROCK_BREAKER = GTRegistries.RECIPE_CONDITIONS
-            .register("adjacent_fluid", new RecipeConditionType<>(RockBreakerCondition::new, RockBreakerCondition.CODEC));
-    public static final RecipeConditionType<AdjacentBlockCondition> ADJACENT_BLOCK = GTRegistries.RECIPE_CONDITIONS
-            .register("adjacent_block",
-                    new RecipeConditionType<>(AdjacentBlockCondition::new, AdjacentBlockCondition.CODEC));
-    public static final RecipeConditionType<ThunderCondition> THUNDER = GTRegistries.RECIPE_CONDITIONS
-            .register("thunder", new RecipeConditionType<>(ThunderCondition::new, ThunderCondition.CODEC));
-    public static final RecipeConditionType<VentCondition> VENT = GTRegistries.RECIPE_CONDITIONS.register("steam_vent",
-            new RecipeConditionType<>(VentCondition::new, VentCondition.CODEC));
-    public static final RecipeConditionType<CleanroomCondition> CLEANROOM = GTRegistries.RECIPE_CONDITIONS
-            .register("cleanroom", new RecipeConditionType<>(CleanroomCondition::new, CleanroomCondition.CODEC));
-    public static final RecipeConditionType<EUToStartCondition> EU_TO_START = GTRegistries.RECIPE_CONDITIONS
-            .register("eu_to_start", new RecipeConditionType<>(EUToStartCondition::new, EUToStartCondition.CODEC));
-    public static final RecipeConditionType<ResearchCondition> RESEARCH = GTRegistries.RECIPE_CONDITIONS
-            .register("research", new RecipeConditionType<>(ResearchCondition::new, ResearchCondition.CODEC));
-    public static final RecipeConditionType<EnvironmentalHazardCondition> ENVIRONMENTAL_HAZARD = GTRegistries.RECIPE_CONDITIONS
-            .register("environmental_hazard",
-                    new RecipeConditionType<>(EnvironmentalHazardCondition::new, EnvironmentalHazardCondition.CODEC));
-    public static final RecipeConditionType<DaytimeCondition> DAYTIME = GTRegistries.RECIPE_CONDITIONS
-            .register("daytime", new RecipeConditionType<>(DaytimeCondition::new, DaytimeCondition.CODEC));
+    // spotless:off
+    public static final RecipeConditionType<BiomeCondition> BIOME = register("biome", BiomeCondition::new, BiomeCondition.CODEC);
+    public static final RecipeConditionType<DimensionCondition> DIMENSION = register("dimension", DimensionCondition::new, DimensionCondition.CODEC);
+    public static final RecipeConditionType<PositionYCondition> POSITION_Y = register("pos_y", PositionYCondition::new, PositionYCondition.CODEC);
+    public static final RecipeConditionType<RainingCondition> RAINING = register("rain", RainingCondition::new, RainingCondition.CODEC);
+    public static final RecipeConditionType<AdjacentFluidCondition> ADJACENT_FLUID = register("adjacent_fluid", AdjacentFluidCondition::new, AdjacentFluidCondition.CODEC);
+    public static final RecipeConditionType<AdjacentBlockCondition> ADJACENT_BLOCK = register("adjacent_block", AdjacentBlockCondition::new, AdjacentBlockCondition.CODEC);
+    public static final RecipeConditionType<ThunderCondition> THUNDER = register("thunder", ThunderCondition::new, ThunderCondition.CODEC);
+    public static final RecipeConditionType<VentCondition> VENT = register("steam_vent", VentCondition::new, VentCondition.CODEC);
+    public static final RecipeConditionType<CleanroomCondition> CLEANROOM = register("cleanroom", CleanroomCondition::new, CleanroomCondition.CODEC);
+    public static final RecipeConditionType<EUToStartCondition> EU_TO_START = register("eu_to_start", EUToStartCondition::new, EUToStartCondition.CODEC);
+    public static final RecipeConditionType<ResearchCondition> RESEARCH = register("research", ResearchCondition::new, ResearchCondition.CODEC);
+    public static final RecipeConditionType<EnvironmentalHazardCondition> ENVIRONMENTAL_HAZARD = register("environmental_hazard", EnvironmentalHazardCondition::new, EnvironmentalHazardCondition.CODEC);
+    public static final RecipeConditionType<DaytimeCondition> DAYTIME = register("daytime", DaytimeCondition::new, DaytimeCondition.CODEC);
+    // spotless:on
     public static RecipeConditionType<FTBQuestCondition> FTB_QUEST;
     public static RecipeConditionType<GameStageCondition> GAMESTAGE;
     public static RecipeConditionType<HeraclesQuestCondition> HERACLES_QUEST;
 
     public static void init() {
         if (GTCEu.Mods.isFTBQuestsLoaded()) {
-            FTB_QUEST = GTRegistries.RECIPE_CONDITIONS
-                    .register("ftb_quest", new RecipeConditionType<>(FTBQuestCondition::new, FTBQuestCondition.CODEC));
+            FTB_QUEST = register("ftb_quest", FTBQuestCondition::new, FTBQuestCondition.CODEC);
         }
-
         if (GTCEu.Mods.isGameStagesLoaded()) {
-            GAMESTAGE = GTRegistries.RECIPE_CONDITIONS
-                    .register("game_stage",
-                            new RecipeConditionType<>(GameStageCondition::new, GameStageCondition.CODEC));
+            GAMESTAGE = register("game_stage", GameStageCondition::new, GameStageCondition.CODEC);
         }
-
         if (GTCEu.Mods.isHeraclesLoaded()) {
-            HERACLES_QUEST = GTRegistries.RECIPE_CONDITIONS
-                    .register("heracles_quest",
-                            new RecipeConditionType<>(HeraclesQuestCondition::new, HeraclesQuestCondition.CODEC));
+            HERACLES_QUEST = register("heracles_quest", HeraclesQuestCondition::new, HeraclesQuestCondition.CODEC);
         }
         // fix the rock breaker condition's ID
         GTRegistries.RECIPE_CONDITIONS.remap("rock_breaker", "adjacent_fluid");
@@ -72,5 +55,11 @@ public final class GTRecipeConditions {
         ModLoader.get().postEvent(new GTCEuAPI.RegisterEvent<>(GTRegistries.RECIPE_CONDITIONS,
                 (Class<RecipeConditionType<?>>) (Class<?>) RecipeConditionType.class));
         GTRegistries.RECIPE_CONDITIONS.freeze();
+    }
+
+    private static <T extends RecipeCondition> RecipeConditionType<T> register(String name,
+                                                                               RecipeConditionType.ConditionFactory<T> factory,
+                                                                               Codec<T> codec) {
+        return GTRegistries.RECIPE_CONDITIONS.register(name, new RecipeConditionType<>(factory, codec));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -15,12 +15,14 @@ import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.sound.ExistingSoundEntry;
-import com.gregtechceu.gtceu.api.transfer.fluid.CustomFluidTank;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMachine;
 import com.gregtechceu.gtceu.common.machine.trait.customlogic.*;
-import com.gregtechceu.gtceu.common.recipe.condition.RockBreakerCondition;
+import com.gregtechceu.gtceu.common.recipe.condition.AdjacentFluidCondition;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
+import com.gregtechceu.gtceu.integration.xei.entry.fluid.FluidEntryList;
+import com.gregtechceu.gtceu.integration.xei.entry.fluid.FluidHolderSetList;
+import com.gregtechceu.gtceu.integration.xei.handlers.fluid.CycleFluidEntryHandler;
 import com.gregtechceu.gtceu.integration.xei.handlers.item.CycleItemStackHandler;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.ResearchManager;
@@ -28,14 +30,15 @@ import com.gregtechceu.gtceu.utils.ResearchManager;
 import com.lowdragmc.lowdraglib.utils.LocalizationUtils;
 
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.level.material.Fluids;
-import net.minecraftforge.fluids.FluidStack;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fml.ModLoader;
 
 import java.util.ArrayList;
@@ -417,19 +420,32 @@ public class GTRecipeTypes {
             .setProgressBar(GuiTextures.PROGRESS_BAR_MACERATE, LEFT_TO_RIGHT)
             .setIconSupplier(() -> GTMachines.ROCK_CRUSHER[GTValues.LV].asStack())
             .setSteamProgressBar(GuiTextures.PROGRESS_BAR_MACERATE_STEAM, LEFT_TO_RIGHT)
-            .prepareBuilder(recipeBuilder -> recipeBuilder.addCondition(RockBreakerCondition.INSTANCE))
+            .prepareBuilder(recipeBuilder -> {
+                recipeBuilder.addCondition(AdjacentFluidCondition.fromTags(FluidTags.LAVA, FluidTags.WATER));
+            })
             .setUiBuilder((recipe, widgetGroup) -> {
-                var fluidA = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidA")));
-                var fluidB = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidB")));
-                if (fluidA != Fluids.EMPTY) {
-                    widgetGroup.addWidget(new TankWidget(new CustomFluidTank(new FluidStack(fluidA, 1000)),
-                            widgetGroup.getSize().width - 30, widgetGroup.getSize().height - 30, false, false)
-                            .setBackground(GuiTextures.FLUID_SLOT).setShowAmount(false));
+                List<HolderSet<Fluid>> fluids = new ArrayList<>();
+                for (RecipeCondition condition : recipe.conditions) {
+                    if (condition instanceof AdjacentFluidCondition adjacentFluid) {
+                        fluids.addAll(adjacentFluid.getOrInitFluids(recipe));
+                    }
                 }
-                if (fluidB != Fluids.EMPTY) {
-                    widgetGroup.addWidget(new TankWidget(new CustomFluidTank(new FluidStack(fluidB, 1000)),
-                            widgetGroup.getSize().width - 30 - 20, widgetGroup.getSize().height - 30, false, false)
-                            .setBackground(GuiTextures.FLUID_SLOT).setShowAmount(false));
+                if (fluids.isEmpty()) {
+                    return;
+                }
+
+                int xOffset = 0;
+                for (HolderSet<Fluid> set : fluids) {
+                    if (set.size() == 0) {
+                        continue;
+                    }
+                    List<FluidEntryList> slots = Collections.singletonList(FluidHolderSetList.of(set, 1000, null));
+                    TankWidget tank = new TankWidget(new CycleFluidEntryHandler(slots),
+                            widgetGroup.getSize().width - 30 - xOffset, widgetGroup.getSize().height - 30, false, false)
+                            .setBackground(GuiTextures.FLUID_SLOT).setShowAmount(false);
+                    widgetGroup.addWidget(tank);
+
+                    xOffset += 20;
                 }
             })
             .setMaxTooltips(4)

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
@@ -4,29 +4,85 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
 import com.gregtechceu.gtceu.api.recipe.condition.RecipeConditionType;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTRecipeConditions;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
-import net.minecraft.core.Direction;
+import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryCodecs;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
 
 @NoArgsConstructor
 public class AdjacentBlockCondition extends RecipeCondition {
 
-    public static final Codec<AdjacentBlockCondition> CODEC = RecordCodecBuilder
-            .create(instance -> RecipeCondition.isReverse(instance)
-                    .apply(instance, AdjacentBlockCondition::new));
-    public final static AdjacentBlockCondition INSTANCE = new AdjacentBlockCondition();
+    // spotless:off
+    private static final Codec<List<HolderSet<Block>>> BLOCK_CODEC = ExtraCodecs.lazyInitializedCodec(
+            () -> RegistryCodecs.homogeneousList(Registries.BLOCK).listOf()
+    );
 
-    public AdjacentBlockCondition(boolean isReverse) {
+    public static final Codec<AdjacentBlockCondition> CODEC = RecordCodecBuilder.create(instance -> RecipeCondition.isReverse(instance).and(
+            BLOCK_CODEC.fieldOf("blocks").forGetter(AdjacentBlockCondition::getBlocks)
+    ).apply(instance, AdjacentBlockCondition::new));
+    // spotless:on
+
+    @Getter
+    @Setter
+    private @NotNull List<HolderSet<Block>> blocks = new ArrayList<>();
+
+    public AdjacentBlockCondition(@NotNull List<HolderSet<Block>> blocks) {
+        this.blocks.addAll(blocks);
+    }
+
+    public AdjacentBlockCondition(boolean isReverse, @NotNull List<HolderSet<Block>> blocks) {
         super(isReverse);
+        this.blocks.addAll(blocks);
+    }
+
+    public static AdjacentBlockCondition fromBlocks(Collection<Block> blocks) {
+        return new AdjacentBlockCondition(blocks.stream()
+                .map(Block::builtInRegistryHolder)
+                .<HolderSet<Block>>map(HolderSet::direct)
+                .toList());
+    }
+
+    public static AdjacentBlockCondition fromBlocks(Block... blocks) {
+        return fromBlocks(Arrays.asList(blocks));
+    }
+
+    public static AdjacentBlockCondition fromTags(Collection<TagKey<Block>> tags) {
+        return new AdjacentBlockCondition(tags.stream()
+                .<HolderSet<Block>>map(BuiltInRegistries.BLOCK::getOrCreateTag)
+                .toList());
+    }
+
+    @SafeVarargs
+    public static AdjacentBlockCondition fromTags(TagKey<Block>... tags) {
+        return fromTags(Arrays.asList(tags));
     }
 
     @Override
@@ -41,24 +97,86 @@ public class AdjacentBlockCondition extends RecipeCondition {
 
     @Override
     public boolean testCondition(@NotNull GTRecipe recipe, @NotNull RecipeLogic recipeLogic) {
-        var blockA = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockA")));
-        var blockB = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockB")));
-        boolean hasBlockA = false, hasBlockB = false;
-        var level = recipeLogic.machine.self().getLevel();
-        var pos = recipeLogic.machine.self().getPos();
-        for (Direction side : GTUtil.DIRECTIONS) {
-            if (side.getAxis() != Direction.Axis.Y) {
-                var block = level.getBlockState(pos.relative(side));
-                if (block.getBlock() == blockA) hasBlockA = true;
-                if (block.getBlock() == blockA) hasBlockB = true;
-                if (hasBlockA && hasBlockB) return true;
+        Level level = recipeLogic.getMachine().getLevel();
+        BlockPos pos = recipeLogic.getMachine().getPos();
+        if (level == null) {
+            return false;
+        }
+        Set<HolderSet<Block>> remainingBlocks = new HashSet<>(getOrInitBlocks(recipe));
+        if (remainingBlocks.isEmpty()) {
+            return true;
+        }
+
+        for (BlockPos offset : GTUtil.NON_CORNER_NEIGHBOURS) {
+            BlockState block = level.getBlockState(pos.offset(offset));
+            for (var it = remainingBlocks.iterator(); it.hasNext();) {
+                if (block.is(it.next())) {
+                    it.remove();
+                    break;
+                }
             }
+            if (remainingBlocks.isEmpty()) return true;
         }
         return false;
+    }
+
+    public @NotNull List<HolderSet<Block>> getOrInitBlocks(@NotNull GTRecipe recipe) {
+        if (this.blocks.isEmpty() || (recipe.data.contains("blockA") && recipe.data.contains("blockB"))) {
+            List<HolderSet<Block>> blocks = new ArrayList<>();
+            if (recipe.data.contains("blockA")) {
+                Block blockA = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockA")));
+                if (!blockA.defaultBlockState().isAir()) {
+                    blocks.add(HolderSet.direct(blockA.builtInRegistryHolder()));
+                }
+            }
+            if (recipe.data.contains("blockB")) {
+                Block blockB = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockB")));
+                if (!blockB.defaultBlockState().isAir()) {
+                    blocks.add(HolderSet.direct(blockB.builtInRegistryHolder()));
+                }
+            }
+            this.blocks = blocks;
+        }
+        return this.blocks;
     }
 
     @Override
     public RecipeCondition createTemplate() {
         return new AdjacentBlockCondition();
+    }
+
+    @NotNull
+    @Override
+    public JsonObject serialize() {
+        JsonObject config = super.serialize();
+
+        var ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
+        JsonElement blocksJson = Util.getOrThrow(BLOCK_CODEC.encodeStart(ops, this.blocks), IllegalStateException::new);
+        config.add("blocks", blocksJson);
+
+        return config;
+    }
+
+    @Override
+    public RecipeCondition deserialize(@NotNull JsonObject config) {
+        super.deserialize(config);
+        var ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
+        this.blocks = BLOCK_CODEC.parse(ops, config.get("blocks")).result().orElse(new ArrayList<>());
+        return this;
+    }
+
+    @Override
+    public RecipeCondition fromNetwork(FriendlyByteBuf buf) {
+        super.fromNetwork(buf);
+        var ops = RegistryOps.create(NbtOps.INSTANCE, GTRegistries.builtinRegistry());
+        this.blocks = buf.readWithCodec(ops, BLOCK_CODEC);
+        return this;
+    }
+
+    @Override
+    public void toNetwork(FriendlyByteBuf buf) {
+        super.toNetwork(buf);
+        var ops = RegistryOps.create(NbtOps.INSTANCE, GTRegistries.builtinRegistry());
+        buf.writeWithCodec(ops, BLOCK_CODEC, this.blocks);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
@@ -123,17 +123,14 @@ public class AdjacentBlockCondition extends RecipeCondition {
     public @NotNull List<HolderSet<Block>> getOrInitBlocks(@NotNull GTRecipe recipe) {
         if (this.blocks.isEmpty() || (recipe.data.contains("blockA") && recipe.data.contains("blockB"))) {
             List<HolderSet<Block>> blocks = new ArrayList<>();
-            if (recipe.data.contains("blockA")) {
-                Block blockA = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockA")));
-                if (!blockA.defaultBlockState().isAir()) {
-                    blocks.add(HolderSet.direct(blockA.builtInRegistryHolder()));
-                }
+
+            Block blockA = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockA")));
+            if (!blockA.defaultBlockState().isAir()) {
+                blocks.add(HolderSet.direct(blockA.builtInRegistryHolder()));
             }
-            if (recipe.data.contains("blockB")) {
-                Block blockB = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockB")));
-                if (!blockB.defaultBlockState().isAir()) {
-                    blocks.add(HolderSet.direct(blockB.builtInRegistryHolder()));
-                }
+            Block blockB = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockB")));
+            if (!blockB.defaultBlockState().isAir()) {
+                blocks.add(HolderSet.direct(blockB.builtInRegistryHolder()));
             }
             this.blocks = blocks;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
@@ -18,26 +18,26 @@ import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
 @NoArgsConstructor
-public class RockBreakerCondition extends RecipeCondition {
+public class AdjacentFluidCondition extends RecipeCondition {
 
-    public static final Codec<RockBreakerCondition> CODEC = RecordCodecBuilder
+    public static final Codec<AdjacentFluidCondition> CODEC = RecordCodecBuilder
             .create(instance -> RecipeCondition.isReverse(instance)
-                    .apply(instance, RockBreakerCondition::new));
+                    .apply(instance, AdjacentFluidCondition::new));
 
-    public final static RockBreakerCondition INSTANCE = new RockBreakerCondition();
+    public final static AdjacentFluidCondition INSTANCE = new AdjacentFluidCondition();
 
-    public RockBreakerCondition(boolean isReverse) {
+    public AdjacentFluidCondition(boolean isReverse) {
         super(isReverse);
     }
 
     @Override
     public RecipeConditionType<?> getType() {
-        return GTRecipeConditions.ROCK_BREAKER;
+        return GTRecipeConditions.ADJACENT_FLUID;
     }
 
     @Override
     public Component getTooltips() {
-        return Component.translatable("recipe.condition.rock_breaker.tooltip");
+        return Component.translatable("recipe.condition.adjacent_fluid.tooltip");
     }
 
     @Override
@@ -60,6 +60,6 @@ public class RockBreakerCondition extends RecipeCondition {
 
     @Override
     public RecipeCondition createTemplate() {
-        return new RockBreakerCondition();
+        return new AdjacentFluidCondition();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
@@ -123,18 +123,16 @@ public class AdjacentFluidCondition extends RecipeCondition {
     public @NotNull List<HolderSet<Fluid>> getOrInitFluids(@NotNull GTRecipe recipe) {
         if (this.fluids.isEmpty() || (recipe.data.contains("fluidA") && recipe.data.contains("fluidB"))) {
             List<HolderSet<Fluid>> fluids = new ArrayList<>();
-            if (recipe.data.contains("fluidA")) {
-                Fluid fluidA = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidA")));
-                if (!fluidA.defaultFluidState().isEmpty()) {
-                    fluids.add(HolderSet.direct(fluidA.builtInRegistryHolder()));
-                }
+
+            Fluid fluidA = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidA")));
+            if (!fluidA.defaultFluidState().isEmpty()) {
+                fluids.add(HolderSet.direct(fluidA.builtInRegistryHolder()));
             }
-            if (recipe.data.contains("fluidB")) {
-                Fluid fluidB = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidB")));
-                if (!fluidB.defaultFluidState().isEmpty()) {
-                    fluids.add(HolderSet.direct(fluidB.builtInRegistryHolder()));
-                }
+            Fluid fluidB = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidB")));
+            if (!fluidB.defaultFluidState().isEmpty()) {
+                fluids.add(HolderSet.direct(fluidB.builtInRegistryHolder()));
             }
+
             this.fluids = fluids;
         }
         return this.fluids;

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
@@ -4,30 +4,85 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeCondition;
 import com.gregtechceu.gtceu.api.recipe.condition.RecipeConditionType;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTRecipeConditions;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
-import net.minecraft.core.Direction;
+import net.minecraft.Util;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderSet;
+import net.minecraft.core.RegistryCodecs;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
 
 @NoArgsConstructor
 public class AdjacentFluidCondition extends RecipeCondition {
 
-    public static final Codec<AdjacentFluidCondition> CODEC = RecordCodecBuilder
-            .create(instance -> RecipeCondition.isReverse(instance)
-                    .apply(instance, AdjacentFluidCondition::new));
+    // spotless:off
+    private static final Codec<List<HolderSet<Fluid>>> FLUID_CODEC = ExtraCodecs.lazyInitializedCodec(
+            () -> RegistryCodecs.homogeneousList(Registries.FLUID).listOf()
+    );
 
-    public final static AdjacentFluidCondition INSTANCE = new AdjacentFluidCondition();
+    public static final Codec<AdjacentFluidCondition> CODEC = RecordCodecBuilder.create(instance -> RecipeCondition.isReverse(instance).and(
+            FLUID_CODEC.fieldOf("fluids").forGetter(AdjacentFluidCondition::getFluids)
+    ).apply(instance, AdjacentFluidCondition::new));
+    // spotless:on
 
-    public AdjacentFluidCondition(boolean isReverse) {
+    @Getter
+    @Setter
+    private @NotNull List<HolderSet<Fluid>> fluids = new ArrayList<>();
+
+    public AdjacentFluidCondition(@NotNull List<HolderSet<Fluid>> fluids) {
+        this.fluids.addAll(fluids);
+    }
+
+    public AdjacentFluidCondition(boolean isReverse, @NotNull List<HolderSet<Fluid>> fluids) {
         super(isReverse);
+        this.fluids.addAll(fluids);
+    }
+
+    public static AdjacentFluidCondition fromFluids(Collection<Fluid> fluids) {
+        return new AdjacentFluidCondition(fluids.stream()
+                .map(Fluid::builtInRegistryHolder)
+                .<HolderSet<Fluid>>map(HolderSet::direct)
+                .toList());
+    }
+
+    public static AdjacentFluidCondition fromFluids(Fluid... fluids) {
+        return fromFluids(Arrays.asList(fluids));
+    }
+
+    public static AdjacentFluidCondition fromTags(Collection<TagKey<Fluid>> tags) {
+        return new AdjacentFluidCondition(tags.stream()
+                .<HolderSet<Fluid>>map(BuiltInRegistries.FLUID::getOrCreateTag)
+                .toList());
+    }
+
+    @SafeVarargs
+    public static AdjacentFluidCondition fromTags(TagKey<Fluid>... tags) {
+        return fromTags(Arrays.asList(tags));
     }
 
     @Override
@@ -42,24 +97,86 @@ public class AdjacentFluidCondition extends RecipeCondition {
 
     @Override
     public boolean testCondition(@NotNull GTRecipe recipe, @NotNull RecipeLogic recipeLogic) {
-        var fluidA = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidA")));
-        var fluidB = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidB")));
-        boolean hasFluidA = false, hasFluidB = false;
-        var level = recipeLogic.machine.self().getLevel();
-        var pos = recipeLogic.machine.self().getPos();
-        for (Direction side : GTUtil.DIRECTIONS) {
-            if (side.getAxis() != Direction.Axis.Y) {
-                var fluid = level.getFluidState(pos.relative(side));
-                if (fluid.getType() == fluidA) hasFluidA = true;
-                if (fluid.getType() == fluidB) hasFluidB = true;
-                if (hasFluidA && hasFluidB) return true;
+        Level level = recipeLogic.getMachine().getLevel();
+        BlockPos pos = recipeLogic.getMachine().getPos();
+        if (level == null) {
+            return false;
+        }
+        Set<HolderSet<Fluid>> remainingFluids = new HashSet<>(getOrInitFluids(recipe));
+        if (remainingFluids.isEmpty()) {
+            return true;
+        }
+
+        for (BlockPos offset : GTUtil.NON_CORNER_NEIGHBOURS) {
+            FluidState fluid = level.getFluidState(pos.offset(offset));
+            for (var it = remainingFluids.iterator(); it.hasNext();) {
+                if (fluid.is(it.next())) {
+                    it.remove();
+                    break;
+                }
             }
+            if (remainingFluids.isEmpty()) return true;
         }
         return false;
+    }
+
+    public @NotNull List<HolderSet<Fluid>> getOrInitFluids(@NotNull GTRecipe recipe) {
+        if (this.fluids.isEmpty() || (recipe.data.contains("fluidA") && recipe.data.contains("fluidB"))) {
+            List<HolderSet<Fluid>> fluids = new ArrayList<>();
+            if (recipe.data.contains("fluidA")) {
+                Fluid fluidA = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidA")));
+                if (!fluidA.defaultFluidState().isEmpty()) {
+                    fluids.add(HolderSet.direct(fluidA.builtInRegistryHolder()));
+                }
+            }
+            if (recipe.data.contains("fluidB")) {
+                Fluid fluidB = BuiltInRegistries.FLUID.get(new ResourceLocation(recipe.data.getString("fluidB")));
+                if (!fluidB.defaultFluidState().isEmpty()) {
+                    fluids.add(HolderSet.direct(fluidB.builtInRegistryHolder()));
+                }
+            }
+            this.fluids = fluids;
+        }
+        return this.fluids;
     }
 
     @Override
     public RecipeCondition createTemplate() {
         return new AdjacentFluidCondition();
+    }
+
+    @NotNull
+    @Override
+    public JsonObject serialize() {
+        JsonObject config = super.serialize();
+
+        var ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
+        JsonElement fluidsJson = Util.getOrThrow(FLUID_CODEC.encodeStart(ops, this.fluids), IllegalStateException::new);
+        config.add("fluids", fluidsJson);
+
+        return config;
+    }
+
+    @Override
+    public RecipeCondition deserialize(@NotNull JsonObject config) {
+        super.deserialize(config);
+        var ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
+        this.fluids = FLUID_CODEC.parse(ops, config.get("fluids")).result().orElse(new ArrayList<>());
+        return this;
+    }
+
+    @Override
+    public RecipeCondition fromNetwork(FriendlyByteBuf buf) {
+        super.fromNetwork(buf);
+        var ops = RegistryOps.create(NbtOps.INSTANCE, GTRegistries.builtinRegistry());
+        this.fluids = buf.readWithCodec(ops, FLUID_CODEC);
+        return this;
+    }
+
+    @Override
+    public void toNetwork(FriendlyByteBuf buf) {
+        super.toNetwork(buf);
+        var ops = RegistryOps.create(NbtOps.INSTANCE, GTRegistries.builtinRegistry());
+        buf.writeWithCodec(ops, FLUID_CODEC, this.fluids);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/unification/material/MaterialRegistryImpl.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/unification/material/MaterialRegistryImpl.java
@@ -8,7 +8,6 @@ import com.gregtechceu.gtceu.common.data.GTMaterials;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.Collections;
 
 public class MaterialRegistryImpl extends MaterialRegistry {
 
@@ -46,7 +45,7 @@ public class MaterialRegistryImpl extends MaterialRegistry {
     @NotNull
     @Override
     public Collection<Material> getAllMaterials() {
-        return Collections.unmodifiableCollection(this.registry.values());
+        return this.values();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -57,7 +57,7 @@ public class LangHandler {
         provider.add("recipe.condition.biome.tooltip", "Biome: %s");
         provider.add("recipe.condition.pos_y.tooltip", "Y Level: %d <= Y <= %d");
         provider.add("recipe.condition.steam_vent.tooltip", "Clean steam vent");
-        provider.add("recipe.condition.rock_breaker.tooltip", "Fluid blocks around");
+        provider.add("recipe.condition.adjacent_fluid.tooltip", "Fluid blocks around");
         provider.add("recipe.condition.adjacent_block.tooltip", "Blocks around");
         provider.add("recipe.condition.eu_to_start.tooltip", "EU to Start: %d%s");
         provider.add("recipe.condition.daytime.day.tooltip", "Requires day time to work");

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -30,6 +30,7 @@ import com.gregtechceu.gtceu.utils.ResearchManager;
 import com.lowdragmc.lowdraglib.utils.NBTToJsonConverter;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.recipes.FinishedRecipe;
@@ -46,6 +47,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -1112,6 +1114,54 @@ public class GTRecipeBuilder {
 
     public GTRecipeBuilder environmentalHazard(MedicalCondition condition) {
         return environmentalHazard(condition, false);
+    }
+
+    public GTRecipeBuilder adjacentFluid(Fluid... fluids) {
+        return adjacentFluid(false, fluids);
+    }
+
+    public GTRecipeBuilder adjacentFluid(boolean isReverse, Fluid... fluids) {
+        return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
+    }
+
+    public GTRecipeBuilder adjacentFluid(TagKey<Fluid>... tags) {
+        return adjacentFluid(false, tags);
+    }
+
+    public GTRecipeBuilder adjacentFluid(boolean isReverse, TagKey<Fluid>... tags) {
+        return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
+    }
+
+    public GTRecipeBuilder adjacentFluid(Collection<HolderSet<Fluid>> fluids) {
+        return adjacentFluid(fluids, false);
+    }
+
+    public GTRecipeBuilder adjacentFluid(Collection<HolderSet<Fluid>> fluids, boolean isReverse) {
+        return addCondition(new AdjacentFluidCondition(isReverse, new ArrayList<>(fluids)));
+    }
+
+    public GTRecipeBuilder adjacentBlock(Block... blocks) {
+        return adjacentBlock(false, blocks);
+    }
+
+    public GTRecipeBuilder adjacentBlock(boolean isReverse, Block... blocks) {
+        return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
+    }
+
+    public GTRecipeBuilder adjacentBlock(TagKey<Block>... tags) {
+        return adjacentBlock(false, tags);
+    }
+
+    public GTRecipeBuilder adjacentBlock(boolean isReverse, TagKey<Block>... tags) {
+        return addCondition(AdjacentBlockCondition.fromTags(tags).setReverse(isReverse));
+    }
+
+    public GTRecipeBuilder adjacentBlock(Collection<HolderSet<Block>> blocks) {
+        return adjacentBlock(blocks, false);
+    }
+
+    public GTRecipeBuilder adjacentBlock(Collection<HolderSet<Block>> blocks, boolean isReverse) {
+        return addCondition(new AdjacentBlockCondition(isReverse, new ArrayList<>(blocks)));
     }
 
     public GTRecipeBuilder daytime(boolean isNight) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -90,8 +90,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.COBBLESTONE.asItem())
                 .duration(16)
                 .EUt(VA[ULV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("stone")
@@ -99,8 +97,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.STONE.asItem())
                 .duration(16)
                 .EUt(VA[ULV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("andesite")
@@ -108,8 +104,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.ANDESITE.asItem())
                 .duration(16)
                 .EUt(VHA[MV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("granite")
@@ -117,8 +111,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.GRANITE.asItem())
                 .duration(16)
                 .EUt(VHA[MV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("diorite")
@@ -126,8 +118,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.DIORITE.asItem())
                 .duration(16)
                 .EUt(VHA[MV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("obsidian")
@@ -135,8 +125,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.OBSIDIAN.asItem())
                 .duration(16)
                 .EUt(VHA[HV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("basalt")
@@ -144,8 +132,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.BASALT.asItem())
                 .duration(16)
                 .EUt(VHA[HV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("blackstone")
@@ -153,8 +139,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.BLACKSTONE.asItem())
                 .duration(16)
                 .EUt(VHA[HV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("deepslate")
@@ -162,8 +146,6 @@ public class MiscRecipeLoader {
                 .outputItems(Blocks.DEEPSLATE.asItem())
                 .duration(16)
                 .EUt(VHA[EV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("marble")
@@ -171,8 +153,6 @@ public class MiscRecipeLoader {
                 .outputItems(rock, Marble)
                 .duration(16)
                 .EUt(VHA[HV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("basalt")
@@ -180,8 +160,6 @@ public class MiscRecipeLoader {
                 .outputItems(rock, Basalt)
                 .duration(16)
                 .EUt(VHA[HV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         ROCK_BREAKER_RECIPES.recipeBuilder("red_granite")
@@ -189,8 +167,6 @@ public class MiscRecipeLoader {
                 .outputItems(rock, GraniteRed)
                 .duration(16)
                 .EUt(VHA[EV])
-                .addData("fluidA", "minecraft:lava")
-                .addData("fluidB", "minecraft:water")
                 .save(provider);
 
         // Jetpacks

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -42,6 +42,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.common.crafting.StrictNBTIngredient;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -861,6 +863,44 @@ public interface GTRecipeSchema {
 
         public GTRecipeJS environmentalHazard(MedicalCondition condition) {
             return environmentalHazard(condition, false);
+        }
+
+        public GTRecipeJS adjacentFluid(Fluid... fluids) {
+            return adjacentFluid(false, fluids);
+        }
+
+        public GTRecipeJS adjacentFluid(boolean isReverse, Fluid... fluids) {
+            return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
+        }
+
+        public GTRecipeJS adjacentFluid(ResourceLocation... tagNames) {
+            return adjacentFluid(false, tagNames);
+        }
+
+        public GTRecipeJS adjacentFluid(boolean isReverse, ResourceLocation... tagNames) {
+            List<TagKey<Fluid>> tags = Arrays.stream(tagNames)
+                    .map(id -> TagKey.create(Registries.FLUID, id))
+                    .toList();
+            return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
+        }
+
+        public GTRecipeJS adjacentBlock(Block... blocks) {
+            return adjacentBlock(false, blocks);
+        }
+
+        public GTRecipeJS adjacentBlock(boolean isReverse, Block... blocks) {
+            return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
+        }
+
+        public GTRecipeJS adjacentBlock(ResourceLocation... tagNames) {
+            return adjacentBlock(false, tagNames);
+        }
+
+        public GTRecipeJS adjacentBlock(boolean isReverse, ResourceLocation... tagNames) {
+            List<TagKey<Block>> tags = Arrays.stream(tagNames)
+                    .map(id -> TagKey.create(Registries.BLOCK, id))
+                    .toList();
+            return addCondition(AdjacentBlockCondition.fromTags(tags).setReverse(isReverse));
         }
 
         public GTRecipeJS daytime(boolean isNight) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
@@ -18,9 +18,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.nbt.TagParser;
+import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.GsonHelper;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
@@ -211,13 +211,10 @@ public class GTRecipeComponents {
                     return type.factory.createDefault();
                 }
             } else if (from instanceof JsonObject jsonObject) {
-                var conditionKey = GsonHelper.getAsString(jsonObject, "type", "");
-                var type = GTRegistries.RECIPE_CONDITIONS.get(conditionKey);
-                if (type != null) {
-                    RecipeCondition condition = type.factory.createDefault();
-                    if (condition != null) {
-                        return condition.deserialize(jsonObject);
-                    }
+                var ops = RegistryOps.create(JsonOps.INSTANCE, GTRegistries.builtinRegistry());
+                var condition = RecipeCondition.CODEC.parse(ops, jsonObject).result();
+                if (condition.isPresent()) {
+                    return condition.get();
                 }
             } else if (from instanceof Tag tag) {
                 return read(recipe, NBTUtils.toJson(tag));

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/fluid/FluidEntryList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/fluid/FluidEntryList.java
@@ -4,7 +4,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import java.util.List;
 
-public sealed interface FluidEntryList permits FluidStackList, FluidTagList {
+public sealed interface FluidEntryList permits FluidStackList, FluidTagList, FluidHolderSetList {
 
     List<FluidStack> getStacks();
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/fluid/FluidHolderSetList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/fluid/FluidHolderSetList.java
@@ -1,0 +1,53 @@
+package com.gregtechceu.gtceu.integration.xei.entry.fluid;
+
+import net.minecraft.core.HolderSet;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class FluidHolderSetList implements FluidEntryList {
+
+    @Getter
+    private final List<FluidHolderSetEntry> entries = new ArrayList<>();
+
+    public static FluidHolderSetList of(@NotNull HolderSet<Fluid> set, int amount, @Nullable CompoundTag nbt) {
+        var list = new FluidHolderSetList();
+        list.add(set, amount, nbt);
+        return list;
+    }
+
+    public void add(FluidHolderSetEntry entry) {
+        entries.add(entry);
+    }
+
+    public void add(@NotNull HolderSet<Fluid> set, int amount, @Nullable CompoundTag nbt) {
+        add(new FluidHolderSetEntry(set, amount, nbt));
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+
+    @Override
+    public List<FluidStack> getStacks() {
+        return entries.stream()
+                .flatMap(FluidHolderSetEntry::stacks)
+                .toList();
+    }
+
+    public record FluidHolderSetEntry(@NotNull HolderSet<Fluid> set, int amount, @Nullable CompoundTag nbt) {
+
+        public Stream<FluidStack> stacks() {
+            return set.stream().map(holder -> new FluidStack(holder.get(), amount, nbt));
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/item/ItemEntryList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/item/ItemEntryList.java
@@ -4,7 +4,7 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.List;
 
-public sealed interface ItemEntryList permits ItemStackList, ItemTagList {
+public sealed interface ItemEntryList permits ItemStackList, ItemTagList, ItemHolderSetList {
 
     List<ItemStack> getStacks();
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/item/ItemHolderSetList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/item/ItemHolderSetList.java
@@ -1,0 +1,53 @@
+package com.gregtechceu.gtceu.integration.xei.entry.item;
+
+import net.minecraft.core.HolderSet;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class ItemHolderSetList implements ItemEntryList {
+
+    @Getter
+    private final List<ItemHolderSetEntry> entries = new ArrayList<>();
+
+    public static ItemHolderSetList of(@NotNull HolderSet<Item> set, int amount, @Nullable CompoundTag nbt) {
+        var list = new ItemHolderSetList();
+        list.add(set, amount, nbt);
+        return list;
+    }
+
+    public void add(ItemHolderSetEntry entry) {
+        entries.add(entry);
+    }
+
+    public void add(@NotNull HolderSet<Item> set, int amount, @Nullable CompoundTag nbt) {
+        add(new ItemHolderSetEntry(set, amount, nbt));
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return entries.isEmpty();
+    }
+
+    @Override
+    public List<ItemStack> getStacks() {
+        return entries.stream()
+                .flatMap(ItemHolderSetEntry::stacks)
+                .toList();
+    }
+
+    public record ItemHolderSetEntry(@NotNull HolderSet<Item> set, int amount, @Nullable CompoundTag nbt) {
+
+        public Stream<ItemStack> stacks() {
+            return set.stream().map(holder -> ItemTagList.stackWithTag(holder, amount, nbt));
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/item/ItemTagList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/entry/item/ItemTagList.java
@@ -55,7 +55,7 @@ public final class ItemTagList implements ItemEntryList {
         }
     }
 
-    private static ItemStack stackWithTag(Holder<Item> holder, int amount, @Nullable CompoundTag nbt) {
+    static ItemStack stackWithTag(Holder<Item> holder, int amount, @Nullable CompoundTag nbt) {
         ItemStack stack = new ItemStack(holder.value(), amount);
         stack.setTag(nbt);
         return stack;

--- a/src/main/resources/assets/gtceu/lang/ja_jp.json
+++ b/src/main/resources/assets/gtceu/lang/ja_jp.json
@@ -5351,7 +5351,7 @@
   "recipe.condition.eu_to_start.tooltip": "開始エネルギー: %d%s",
   "recipe.condition.pos_y.tooltip": "Y座標レベル: %d <= Y <= %d",
   "recipe.condition.rain.tooltip": "雨レベル: %d",
-  "recipe.condition.rock_breaker.tooltip": "周囲の液体ブロック",
+  "recipe.condition.adjacent_fluid.tooltip": "周囲の液体ブロック",
   "recipe.condition.steam_vent.tooltip": "蒸気排出口の清掃",
   "recipe.condition.thunder.tooltip": "雷レベル: %d",
   "tagprefix.andesite": "%s鉱石 (安山岩)",

--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -2855,7 +2855,7 @@
     "recipe.condition.eu_to_start.tooltip": "Запуск: %d EU",
     "recipe.condition.pos_y.tooltip": "Высота Y: %d <= Y <= %d",
     "recipe.condition.rain.tooltip": "Уровень дождя: %d",
-    "recipe.condition.rock_breaker.tooltip": "Блоки жидкости вокруг",
+    "recipe.condition.adjacent_fluid.tooltip": "Блоки жидкости вокруг",
     "recipe.condition.steam_vent.tooltip": "Очистите пароотвод",
     "recipe.condition.thunder.tooltip": "Уровень грозы: %d",
     "tagprefix.andesite": "%s (Андезитовая руда)",

--- a/src/main/resources/assets/gtceu/lang/uk_ua.json
+++ b/src/main/resources/assets/gtceu/lang/uk_ua.json
@@ -5101,7 +5101,7 @@
   "recipe.condition.dimension_marker.tooltip": "Вимір:",
   "recipe.condition.dimension.tooltip": "Вимір: %s",
   "recipe.condition.eu_to_start.tooltip": "EU до запуску: %d%s",
-  "recipe.condition.rock_breaker.tooltip": "Прилеглі розміщені рідини",
+  "recipe.condition.adjacent_fluid.tooltip": "Прилеглі розміщені рідини",
   "recipe.condition.rain.tooltip": "Рівень дощу: %d",
   "recipe.condition.thunder.tooltip": "Рівень грози: %d",
   "recipe.condition.pos_y.tooltip": "Рівень Y: %d <= Y <= %d",

--- a/src/main/resources/assets/gtceu/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceu/lang/zh_cn.json
@@ -5452,7 +5452,7 @@
     "recipe.condition.quest.completed.tooltip": "完成任务：%s",
     "recipe.condition.quest.not_completed.tooltip": "未完成任务：%s",
     "recipe.condition.rain.tooltip": "雨量：%d",
-    "recipe.condition.rock_breaker.tooltip": "水平相邻方块需要为流体源",
+    "recipe.condition.adjacent_fluid.tooltip": "水平相邻方块需要为流体源",
     "recipe.condition.steam_vent.tooltip": "清洁蒸汽排气口",
     "recipe.condition.thunder.tooltip": "雷级：%d",
     "tagprefix.andesite": "安山岩%s矿石",

--- a/src/main/resources/assets/gtceu/lang/zh_tw.json
+++ b/src/main/resources/assets/gtceu/lang/zh_tw.json
@@ -5426,7 +5426,7 @@
     "recipe.condition.quest.completed.tooltip": "完成任務：%s",
     "recipe.condition.quest.not_completed.tooltip": "未完成任務：%s",
     "recipe.condition.rain.tooltip": "雨量：%d",
-    "recipe.condition.rock_breaker.tooltip": "水平相鄰方塊需要為流體源",
+    "recipe.condition.adjacent_fluid.tooltip": "水平相鄰方塊需要為流體源",
     "recipe.condition.steam_vent.tooltip": "清潔蒸汽排氣口",
     "recipe.condition.thunder.tooltip": "雷級：%d",
     "tagprefix.andesite": "安山岩%s礦",


### PR DESCRIPTION
## What
Refactor the rock breaker (and adjacent block) recipe condition to match how we handle and store all other conditions
Also made them able to use tags and lists of blocks for matching, and allowed setting any number of required blocks/fluids instead of exactly two.

## Implementation Details
- Added a function to GTRegistry for "remapping" a removed ID to an existing one
- Renamed the `rock_breaker` recipe condition to `adjacent_fluid`
- Made both adjacency conditions use a list of holder sets for tag support

## Outcome
cleaner code, no more odd separate way to set rock breaker conditions that nothing else did

## Potential Compatibility Issues
Addons and modpacks with custom recipe types that have the rock breaker condition's valid fluid slots will need to update to work with the new condition.