### PR TITLE
Fix firebox casing value and material info

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MachineRecipeLoader.java
@@ -759,7 +759,8 @@ public class MachineRecipeLoader {
                 .inputItems(rod, Bronze, 3)
                 .inputItems(frameGt, Bronze)
                 .inputItems(plate, Bronze, 3)
-                .outputItems(GTBlocks.FIREBOX_BRONZE, 2)
+                .outputItems(GTBlocks.FIREBOX_BRONZE, ConfigHolder.INSTANCE.recipes.casingsPerCraft)
+                .addMaterialInfo(true, true)
                 .duration(100)
                 .EUt(VA[LV])
                 .save(provider);
@@ -767,7 +768,8 @@ public class MachineRecipeLoader {
                 .inputItems(rod, Steel, 3)
                 .inputItems(frameGt, Steel)
                 .inputItems(plate, Steel, 3)
-                .outputItems(GTBlocks.FIREBOX_STEEL, 2)
+                .outputItems(GTBlocks.FIREBOX_STEEL, ConfigHolder.INSTANCE.recipes.casingsPerCraft)
+                .addMaterialInfo(true, true)
                 .duration(200)
                 .EUt(VA[LV])
                 .save(provider);
@@ -775,7 +777,8 @@ public class MachineRecipeLoader {
                 .inputItems(rod, Titanium, 3)
                 .inputItems(frameGt, Titanium)
                 .inputItems(plate, Titanium, 3)
-                .outputItems(GTBlocks.FIREBOX_TITANIUM, 2)
+                .outputItems(GTBlocks.FIREBOX_TITANIUM, ConfigHolder.INSTANCE.recipes.casingsPerCraft)
+                .addMaterialInfo(true, true)
                 .duration(300)
                 .EUt(VA[HV])
                 .save(provider);
@@ -783,7 +786,8 @@ public class MachineRecipeLoader {
                 .inputItems(rod, TungstenSteel, 3)
                 .inputItems(frameGt, TungstenSteel)
                 .inputItems(plate, TungstenSteel, 3)
-                .outputItems(GTBlocks.FIREBOX_TUNGSTENSTEEL, 2)
+                .outputItems(GTBlocks.FIREBOX_TUNGSTENSTEEL, ConfigHolder.INSTANCE.recipes.casingsPerCraft)
+                .addMaterialInfo(true, true)
                 .duration(400)
                 .EUt(VA[EV])
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MetaTileEntityLoader.java
@@ -138,21 +138,26 @@ public class MetaTileEntityLoader {
                 "PIP", "IFI", "PIP", 'P', new MaterialEntry(TagPrefix.plate, GTMaterials.Polytetrafluoroethylene),
                 'F', new MaterialEntry(TagPrefix.frameGt, GTMaterials.Polytetrafluoroethylene), 'I',
                 new MaterialEntry(TagPrefix.pipeNormalFluid, GTMaterials.Polytetrafluoroethylene));
-        VanillaRecipeHelper.addShapedRecipe(provider, true, "casing_bronze_firebox", GTBlocks.FIREBOX_BRONZE.asStack(2),
+        // Decomposition info handled by the assembler recipe
+        VanillaRecipeHelper.addShapedRecipe(provider, false, "casing_bronze_firebox",
+                GTBlocks.FIREBOX_BRONZE.asStack(ConfigHolder.INSTANCE.recipes.casingsPerCraft),
                 "PSP", "SFS", "PSP", 'P', new MaterialEntry(TagPrefix.plate, GTMaterials.Bronze), 'F',
                 new MaterialEntry(TagPrefix.frameGt, GTMaterials.Bronze), 'S',
                 new MaterialEntry(TagPrefix.rod, GTMaterials.Bronze));
-        VanillaRecipeHelper.addShapedRecipe(provider, true, "casing_steel_firebox", GTBlocks.FIREBOX_STEEL.asStack(2),
+        VanillaRecipeHelper.addShapedRecipe(provider, false, "casing_steel_firebox",
+                GTBlocks.FIREBOX_STEEL.asStack(ConfigHolder.INSTANCE.recipes.casingsPerCraft),
                 "PSP", "SFS", "PSP", 'P', new MaterialEntry(TagPrefix.plate, GTMaterials.Steel), 'F',
                 new MaterialEntry(TagPrefix.frameGt, GTMaterials.Steel), 'S',
                 new MaterialEntry(TagPrefix.rod, GTMaterials.Steel));
-        VanillaRecipeHelper.addShapedRecipe(provider, true, "casing_titanium_firebox",
-                GTBlocks.FIREBOX_TITANIUM.asStack(2), "PSP", "SFS", "PSP", 'P',
+        VanillaRecipeHelper.addShapedRecipe(provider, false, "casing_titanium_firebox",
+                GTBlocks.FIREBOX_TITANIUM.asStack(ConfigHolder.INSTANCE.recipes.casingsPerCraft), "PSP", "SFS", "PSP",
+                'P',
                 new MaterialEntry(TagPrefix.plate, GTMaterials.Titanium), 'F',
                 new MaterialEntry(TagPrefix.frameGt, GTMaterials.Titanium), 'S',
                 new MaterialEntry(TagPrefix.rod, GTMaterials.Titanium));
-        VanillaRecipeHelper.addShapedRecipe(provider, true, "casing_tungstensteel_firebox",
-                GTBlocks.FIREBOX_TUNGSTENSTEEL.asStack(2), "PSP", "SFS", "PSP", 'P',
+        VanillaRecipeHelper.addShapedRecipe(provider, false, "casing_tungstensteel_firebox",
+                GTBlocks.FIREBOX_TUNGSTENSTEEL.asStack(ConfigHolder.INSTANCE.recipes.casingsPerCraft), "PSP", "SFS",
+                "PSP", 'P',
                 new MaterialEntry(TagPrefix.plate, GTMaterials.TungstenSteel), 'F',
                 new MaterialEntry(TagPrefix.frameGt, GTMaterials.TungstenSteel), 'S',
                 new MaterialEntry(TagPrefix.rod, GTMaterials.TungstenSteel));


### PR DESCRIPTION
## What
Make decomposition recipe factor in the cheaper recipe 
Before:
<img width="469" height="342" alt="image" src="https://github.com/user-attachments/assets/9fac1471-edbf-4066-af8c-481efabb5a88" />

After:
<img width="1006" height="583" alt="image" src="https://github.com/user-attachments/assets/3c4d8de3-6391-4d18-a051-3760cf7cc470" />

also makes firebox casing take in casingPerCraft