### PR TITLE
Fix EnergyContainerList drain logic with multiple hatches

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/misc/EnergyContainerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/EnergyContainerList.java
@@ -146,7 +146,7 @@ public class EnergyContainerList implements IEnergyContainer {
         long energyAdded = 0L;
         for (IEnergyContainer container : this.energyContainerList) {
             energyAdded += container.changeEnergy(energyToAdd - energyAdded);
-            if (energyAdded >= energyToAdd) {
+            if (energyAdded == energyToAdd) {
                 return energyAdded;
             }
         }


### PR DESCRIPTION
## What
If an EnergyContainerList had multiple hatches in it, whenever a drain call was run, power would only be able to drain from the first hatch in the list, resulting in strange behaviors