### PR TITLE
Fix KubeJS recipe output

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -115,7 +115,7 @@ public interface GTRecipeSchema {
         }
 
         public <T> GTKubeRecipe output(RecipeCapability<T> capability, Object... obj) {
-            var key = perTick ? ALL_TICK_INPUTS : ALL_INPUTS;
+            var key = perTick ? ALL_TICK_OUTPUTS : ALL_OUTPUTS;
             if (getValue(key) == null) setValue(key, new CapabilityMap());
             CapabilityMap map = getValue(key);
             for (Object object : obj) {


### PR DESCRIPTION
## What
Just a single-line bug fix that probably came from a copy-paste error in #3432.

## Outcome
KubeJS integration _actually_ actually works now.