### PR TITLE
Fix recipe logic overconsumption

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.api.recipe;
 
-import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.IRecipeCapabilityHolder;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
@@ -140,23 +139,6 @@ public class RecipeRunner {
                             Collections.emptyList())) {
                         recipeContents = bypassHandler.handleRecipe(io, recipe, recipeContents, false);
                     }
-                    // If there's items left in recipeContents here, that means we didn't consume all the items, while
-                    // our simulation said we could.
-                    if (!recipeContents.isEmpty()) {
-                        StringBuilder warningString = new StringBuilder(
-                                "Couldn't consume all items during recipe handle consumption: ");
-                        for (var recipeEntry : recipeContents.entrySet()) {
-                            for (var recipeItem : recipeEntry.getValue()) {
-                                warningString.append("[")
-                                        .append(recipeEntry.getKey())
-                                        .append(", ")
-                                        .append(recipeItem)
-                                        .append("], ");
-                            }
-                        }
-
-                        GTCEu.LOGGER.warn(warningString);
-                    }
                 }
                 recipeContents.clear();
                 return ActionResult.SUCCESS;
@@ -211,23 +193,6 @@ public class RecipeRunner {
                     recipeContents.clear();
                     return ActionResult.SUCCESS;
                 }
-            }
-            // If there's items left in copiedRecipeContents here, that means we didn't consume all the items, while
-            // our simulation said we could.
-            if (!copiedRecipeContents.isEmpty()) {
-                StringBuilder warningString = new StringBuilder(
-                        "Couldn't consume all items during recipe handle consumption: ");
-                for (var recipeEntry : copiedRecipeContents.entrySet()) {
-                    for (var recipeItem : recipeEntry.getValue()) {
-                        warningString.append("[")
-                                .append(recipeEntry.getKey())
-                                .append(", ")
-                                .append(recipeItem)
-                                .append("], ");
-                    }
-                }
-
-                GTCEu.LOGGER.warn(warningString);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -137,7 +137,7 @@ public class RecipeRunner {
                     for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
                             RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                             Collections.emptyList())) {
-                        res = bypass_handler.handleRecipe(io, recipe, res, false);
+                        bypass_handler.handleRecipe(io, recipe, recipeContents, false);
                     }
                 }
                 recipeContents.clear();

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -125,19 +125,19 @@ public class RecipeRunner {
                 Collections.emptyList())) {
             // Handle the contents of this handler and also all the bypassed handlers
             var res = handler.handleRecipe(io, recipe, searchRecipeContents, true);
-            for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+            for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
                     RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                     Collections.emptyList())) {
-                res = bypass_handler.handleRecipe(io, recipe, res, true);
+                res = bypassHandler.handleRecipe(io, recipe, res, true);
             }
             if (res.isEmpty()) {
                 if (!simulated) {
                     // Actually consume the contents of this handler and also all the bypassed handlers
                     handler.handleRecipe(io, recipe, recipeContents, false);
-                    for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+                    for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
                             RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                             Collections.emptyList())) {
-                        bypass_handler.handleRecipe(io, recipe, recipeContents, false);
+                        bypassHandler.handleRecipe(io, recipe, recipeContents, false);
                     }
                 }
                 recipeContents.clear();
@@ -161,10 +161,10 @@ public class RecipeRunner {
                     break;
                 }
             }
-            for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+            for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
                     RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                     Collections.emptyList())) {
-                copiedRecipeContents = bypass_handler.handleRecipe(io, recipe, copiedRecipeContents, true);
+                copiedRecipeContents = bypassHandler.handleRecipe(io, recipe, copiedRecipeContents, true);
                 if (copiedRecipeContents.isEmpty()) {
                     found = true;
                     break;
@@ -185,10 +185,10 @@ public class RecipeRunner {
                 }
             }
             // Then go through the handlers that bypass the distinctness system and empty those
-            for (RecipeHandlerList bypass_handler : handlerGroups.getOrDefault(
+            for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
                     RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                     Collections.emptyList())) {
-                copiedRecipeContents = bypass_handler.handleRecipe(io, recipe, copiedRecipeContents, false);
+                copiedRecipeContents = bypassHandler.handleRecipe(io, recipe, copiedRecipeContents, false);
                 if (copiedRecipeContents.isEmpty()) {
                     recipeContents.clear();
                     return ActionResult.SUCCESS;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.recipe;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.IRecipeCapabilityHolder;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
@@ -133,11 +134,28 @@ public class RecipeRunner {
             if (res.isEmpty()) {
                 if (!simulated) {
                     // Actually consume the contents of this handler and also all the bypassed handlers
-                    handler.handleRecipe(io, recipe, recipeContents, false);
+                    recipeContents = handler.handleRecipe(io, recipe, recipeContents, false);
                     for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
                             RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
                             Collections.emptyList())) {
-                        bypassHandler.handleRecipe(io, recipe, recipeContents, false);
+                        recipeContents = bypassHandler.handleRecipe(io, recipe, recipeContents, false);
+                    }
+                    // If there's items left in recipeContents here, that means we didn't consume all the items, while
+                    // our simulation said we could.
+                    if (!recipeContents.isEmpty()) {
+                        StringBuilder warningString = new StringBuilder(
+                                "Couldn't consume all items during recipe handle consumption: ");
+                        for (var recipeEntry : recipeContents.entrySet()) {
+                            for (var recipeItem : recipeEntry.getValue()) {
+                                warningString.append("[")
+                                        .append(recipeEntry.getKey())
+                                        .append(", ")
+                                        .append(recipeItem)
+                                        .append("], ");
+                            }
+                        }
+
+                        GTCEu.LOGGER.warn(warningString);
                     }
                 }
                 recipeContents.clear();
@@ -193,6 +211,23 @@ public class RecipeRunner {
                     recipeContents.clear();
                     return ActionResult.SUCCESS;
                 }
+            }
+            // If there's items left in copiedRecipeContents here, that means we didn't consume all the items, while
+            // our simulation said we could.
+            if (!copiedRecipeContents.isEmpty()) {
+                StringBuilder warningString = new StringBuilder(
+                        "Couldn't consume all items during recipe handle consumption: ");
+                for (var recipeEntry : copiedRecipeContents.entrySet()) {
+                    for (var recipeItem : recipeEntry.getValue()) {
+                        warningString.append("[")
+                                .append(recipeEntry.getKey())
+                                .append(", ")
+                                .append(recipeItem)
+                                .append("], ");
+                    }
+                }
+
+                GTCEu.LOGGER.warn(warningString);
             }
         }
 


### PR DESCRIPTION
Blocked by #3604


## What
If a recipe had a distinct bus, all bypassed busses would consume as much of the contents as they could, for every bus

Now we keep track of how much was consumed and only consume whatever's left

## Implementation Details
Also added warning logging if we simulate -> there's enough to run a recipe, and then we consume and actually can't consume it all

## Outcome
Energy hatches and other bypassed busses now consume the correct amount

See https://discord.com/channels/701354865217110096/1089296351906504835/1401232616610463775 for example