### PR TITLE
Fix AE2 placeholders only working if Create is installed

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -138,8 +138,11 @@ public class CommonProxy {
         GTPlaceholders.initPlaceholders();
         if (GTCEu.Mods.isCreateLoaded()) {
             GTCreateIntegration.init();
+        }
+        if (GTCEu.Mods.isAE2Loaded()) {
             GTAEPlaceholders.init();
         }
+
         GTCovers.init();
         GTFluids.init();
         GTCreativeModeTabs.init();


### PR DESCRIPTION
## What
bug I noticed whilst updating 1.21

## Outcome
AE2 placeholders are now initialized even if Create isn't installed, and MC doesn't crash if rcreate is installed but AE2 isn't