### PR TITLE
Fix recipe logic checking bypass hatches twice

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -161,13 +161,16 @@ public class RecipeRunner {
                     break;
                 }
             }
-            for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
-                    RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
-                    Collections.emptyList())) {
-                copiedRecipeContents = bypassHandler.handleRecipe(io, recipe, copiedRecipeContents, true);
-                if (copiedRecipeContents.isEmpty()) {
-                    found = true;
-                    break;
+            // If we're already in the bypass_distinct group, don't check it twice.
+            if (handlerListEntry.getKey() != RecipeHandlerGroupDistinctness.BYPASS_DISTINCT) {
+                for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
+                        RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
+                        Collections.emptyList())) {
+                    copiedRecipeContents = bypassHandler.handleRecipe(io, recipe, copiedRecipeContents, true);
+                    if (copiedRecipeContents.isEmpty()) {
+                        found = true;
+                        break;
+                    }
                 }
             }
 
@@ -185,13 +188,16 @@ public class RecipeRunner {
                 }
             }
             // Then go through the handlers that bypass the distinctness system and empty those
-            for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
-                    RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
-                    Collections.emptyList())) {
-                copiedRecipeContents = bypassHandler.handleRecipe(io, recipe, copiedRecipeContents, false);
-                if (copiedRecipeContents.isEmpty()) {
-                    recipeContents.clear();
-                    return ActionResult.SUCCESS;
+            // If we're already in the bypass_distinct group, don't check it twice.
+            if (handlerListEntry.getKey() != RecipeHandlerGroupDistinctness.BYPASS_DISTINCT) {
+                for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(
+                        RecipeHandlerGroupDistinctness.BYPASS_DISTINCT,
+                        Collections.emptyList())) {
+                    copiedRecipeContents = bypassHandler.handleRecipe(io, recipe, copiedRecipeContents, false);
+                    if (copiedRecipeContents.isEmpty()) {
+                        recipeContents.clear();
+                        return ActionResult.SUCCESS;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What
```
for(entry : groupEntries_which_includes_bypass) {
    processRecipe(entry)
    for(entry : bypass){
        processRecipe(bypass)
    }
}
```
oops

## Outcome
you can now have a bus with >50% of a recipe contents without the machine going "Oh! You have 100% of the contents! let me start the recipe!"
<img width="271" height="186" alt="image" src="https://github.com/user-attachments/assets/11d21d3e-cca9-4deb-9571-f99fb770f165" />

## Additional Information
RecipeRunner.handleRecipe my beloathed