### PR TITLE
Fix kjs material registration not allowing nested materials

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/MaterialStackWrapper.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/helpers/MaterialStackWrapper.java
@@ -33,7 +33,8 @@ public record MaterialStackWrapper(Supplier<Material> material, long amount) {
         }
 
         final String copyFinal = copy;
-        cached = new MaterialStackWrapper(() -> GTMaterials.get(copyFinal), count);
+        Supplier<Material> mat = () -> GTMaterials.get(copyFinal);
+        cached = new MaterialStackWrapper(mat, count);
         PARSE_CACHE.put(trimmed, cached);
         return cached.copy();
     }
@@ -44,7 +45,7 @@ public record MaterialStackWrapper(Supplier<Material> material, long amount) {
     }
 
     public boolean isEmpty() {
-        return this.amount < 1 || this.material.get().isNull();
+        return this.amount < 1 || this.material == null;
     }
 
     public MaterialStack toMatStack() {


### PR DESCRIPTION
## What
Fixes #3120 
Fixes #3295 

## Implementation Details
no longer resolve the material supplier when checking if the material stack wrapper is empty

## Outcome
you can nest materials in kube again