### PR TITLE
Fix Central Monitor loading machines too early

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CentralMonitorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CentralMonitorMachine.java
@@ -69,15 +69,7 @@ public class CentralMonitorMachine extends WorkableElectricMultiblockMachine
     public static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(CentralMonitorMachine.class,
             WorkableMultiblockMachine.MANAGED_FIELD_HOLDER);
 
-    public static final TraceabilityPredicate BLOCK_PREDICATE = Predicates.abilities(PartAbility.INPUT_ENERGY)
-            .setMinGlobalLimited(1).setMaxGlobalLimited(2).setPreviewCount(1)
-            .or(Predicates.abilities(PartAbility.DATA_ACCESS).setPreviewCount(1)
-                    .or(Predicates.machines(GTMachines.BATTERY_BUFFER_4).setPreviewCount(0))
-                    .or(Predicates.machines(GTMachines.BATTERY_BUFFER_16).setPreviewCount(0))
-                    .setMaxGlobalLimited(4))
-            .or(Predicates.machines(GTMachines.HULL))
-            .or(Predicates.machines(GTMachines.MONITOR))
-            .or(Predicates.blocks(GTBlocks.CASING_ALUMINIUM_FROSTPROOF.get()));
+    public static TraceabilityPredicate BLOCK_PREDICATE;
 
     @Persisted
     @DescSynced
@@ -95,6 +87,17 @@ public class CentralMonitorMachine extends WorkableElectricMultiblockMachine
 
     public CentralMonitorMachine(IMachineBlockEntity holder) {
         super(holder);
+        if (BLOCK_PREDICATE == null) {
+            BLOCK_PREDICATE = Predicates.abilities(PartAbility.INPUT_ENERGY)
+                    .setMinGlobalLimited(1).setMaxGlobalLimited(2).setPreviewCount(1)
+                    .or(Predicates.abilities(PartAbility.DATA_ACCESS).setPreviewCount(1)
+                            .or(Predicates.machines(GTMachines.BATTERY_BUFFER_4).setPreviewCount(0))
+                            .or(Predicates.machines(GTMachines.BATTERY_BUFFER_16).setPreviewCount(0))
+                            .setMaxGlobalLimited(4))
+                    .or(Predicates.machines(GTMachines.HULL))
+                    .or(Predicates.machines(GTMachines.MONITOR))
+                    .or(Predicates.blocks(GTBlocks.CASING_ALUMINIUM_FROSTPROOF.get()));
+        }
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes a crash when you place a central monitor

## Implementation Details
dont create the predicate in clinit

## Outcome
no more crash