### PR TITLE
Fix Multiblocks not unforming when the controller breaks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
@@ -78,10 +78,6 @@ public abstract class LevelMixin implements LevelAccessor {
         MultiblockWorldSavedData mwsd = MultiblockWorldSavedData.getOrCreate(serverLevel);
         Set<MultiblockState> defensiveCopy = new HashSet<>(mwsd.getControllersInChunk(chunk.getPos()));
         for (MultiblockState structure : defensiveCopy) {
-            if (structure.getController() == null || !structure.getController().isFormed()) {
-                // skip for unloaded/unformed multiblocks
-                continue;
-            }
             if (structure.isPosInCache(pos)) {
                 serverLevel.getServer().executeBlocking(() -> structure.onBlockStateChanged(pos, newState));
             }


### PR DESCRIPTION
## What
allows ats to boom again

## Implementation Details
got rid of the random continue in the level mixin if it was a controller

## Outcome
controllers properly call onBlockStateChange when broken