### PR TITLE
Fix recipe logic with Undyed Hatches and Distinctness Bypassing

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -353,10 +353,11 @@ public class RecipeHelper {
             map.computeIfAbsent(RecipeHandlerGroupDistinctness.BYPASS_DISTINCT, $ -> new ArrayList<>()).add(handler);
             return;
         }
-        // Add undyed RHL's to every group that's not distinct, and also the undyed group itself.
+        // Add undyed RHL's to every group that's not distinct, bypass, and also the undyed group itself.
         if (key.equals(RecipeHandlerGroupColor.UNDYED)) {
             for (var entry : map.entrySet()) {
                 if (entry.getKey().equals(RecipeHandlerGroupDistinctness.BUS_DISTINCT) ||
+                        entry.getKey().equals(RecipeHandlerGroupDistinctness.BYPASS_DISTINCT) ||
                         entry.getKey().equals(RecipeHandlerGroupColor.UNDYED)) {
                     continue;
                 }


### PR DESCRIPTION
## What
Undyed hatches used to get added to BYPASS_DISTINCT too, meaning they would be checked twice

## Implementation Details
Also added static imports and used .equals to clean up code

## Outcome
Recipes with 100ml polyethylene don't trigger the 144L polyethylene recipe and get voided

## Additional Information
supersedes #3624, reason being it makes more sense to solve this at the "adding to the map" level than at the "using the map" level

man this recipe logic stuff sure is complicated huh
