### PR TITLE
Ignore null predicates in machines(...)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/Predicates.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/Predicates.java
@@ -67,11 +67,13 @@ public class Predicates {
     }
 
     public static TraceabilityPredicate machines(MachineDefinition... definitions) {
-        IMachineBlock[] machineBlocks = new IMachineBlock[definitions.length];
-        for (int i = 0; i < machineBlocks.length; i++) {
-            machineBlocks[i] = definitions[i].get();
+        ArrayList<IMachineBlock> machineBlocks = new ArrayList<>(definitions.length);
+        for (var definition : definitions) {
+            if (definition != null) {
+                machineBlocks.add(definition.get());
+            }
         }
-        return blocks(machineBlocks);
+        return blocks(machineBlocks.toArray(IMachineBlock[]::new));
     }
 
     public static TraceabilityPredicate blockTag(TagKey<Block> tag) {


### PR DESCRIPTION
## What
Central monitor no longer NPEs on instances with highTier=false

## Implementation Details
Added a null check to the machines predicate, so now they will be ignored
Yes, it creates an arraylist and then immediately turns into an array, 2 extra allocations whenever you load a predicate for a machine, cry me a river :(

## Outcome
7.1.2 no longer spams logs