### PR TITLE
Make release action always bump version + edit changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,7 +147,7 @@ jobs:
   # After successful release, PR version bump and changelog
   bump-version-and-changelog:
     name: Bump Version and Build Changelog
-    needs: [ build, upload-release-artifacts, publish-modrinth, publish-cf]
+    needs: [ build, upload-release-artifacts ]
     if: ${{ always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What
Removes the requirement for successful CF/MR publish from the version bump/changelog append