### PR TITLE
335,544.32% recipe logic improvement

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -125,9 +125,12 @@ public class RecipeRunner {
         for (RecipeHandlerList handler : handlerGroups.getOrDefault(BUS_DISTINCT, Collections.emptyList())) {
             // Handle the contents of this handler and also all the bypassed handlers
             var res = handler.handleRecipe(io, recipe, searchRecipeContents, true);
-            for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(BYPASS_DISTINCT,
-                    Collections.emptyList())) {
-                res = bypassHandler.handleRecipe(io, recipe, res, true);
+            if (!res.isEmpty()) {
+                for (RecipeHandlerList bypassHandler : handlerGroups.getOrDefault(BYPASS_DISTINCT,
+                        Collections.emptyList())) {
+                    res = bypassHandler.handleRecipe(io, recipe, res, true);
+                    if (res.isEmpty()) break;
+                }
             }
             if (res.isEmpty()) {
                 if (!simulated) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -494,9 +494,10 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
 
         public List<FluidStack> getFluids() {
             if (fluidStacks == null) {
-                fluidStacks = fluidInventory.object2LongEntrySet().stream()
-                        .map(e -> new FluidStack(e.getKey(), GTMath.saturatedCast(e.getLongValue())))
-                        .toList();
+                fluidStacks = new ArrayList<>();
+                fluidInventory.object2LongEntrySet().stream()
+                        .map(e -> GTMath.splitFluidStacks(e.getKey(), e.getLongValue()))
+                        .forEach(fluidStacks::addAll);
             }
             return fluidStacks;
         }

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTMath.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTMath.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.utils;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
@@ -24,12 +25,28 @@ public class GTMath {
     }
 
     public static List<ItemStack> splitStacks(ItemStack stack, long amount) {
-        int count = saturatedCast(amount);
-        int fullStacks = count / 64;
-        int rem = count % 64;
+        int fullStacks = (int) (amount / Integer.MAX_VALUE);
+        int rem = (int) (amount % Integer.MAX_VALUE);
         List<ItemStack> stacks = new ObjectArrayList<>(fullStacks + 1);
-        if (fullStacks > 0) stacks.addAll(Collections.nCopies(fullStacks, stack.copyWithCount(64)));
+        if (fullStacks > 0) stacks.addAll(Collections.nCopies(fullStacks, stack.copyWithCount(Integer.MAX_VALUE)));
         if (rem > 0) stacks.add(stack.copyWithCount(rem));
+        return stacks;
+    }
+
+    public static List<FluidStack> splitFluidStacks(FluidStack stack, long amount) {
+        int fullStacks = (int) (amount / Integer.MAX_VALUE);
+        int rem = (int) (amount % Integer.MAX_VALUE);
+        List<FluidStack> stacks = new ObjectArrayList<>(fullStacks + 1);
+        if (fullStacks > 0) {
+            var copy = stack.copy();
+            copy.setAmount(Integer.MAX_VALUE);
+            stacks.addAll(Collections.nCopies(fullStacks, copy));
+        }
+        if (rem > 0) {
+            var copy = stack.copy();
+            copy.setAmount(rem);
+            stacks.add(copy);
+        }
         return stacks;
     }
 


### PR DESCRIPTION
## What
Improve Pattern Buffer content gathering
split the pattern buffers internal content by item and fluid stacks of max int size rather than 64 :skull:
also added early breaking for if simulated content is empty in the bypass distinct group iteration

## Implementation Details
pretty much that