### PR TITLE
Fix generators exploding

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/IMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/IMachineBlock.java
@@ -159,7 +159,7 @@ public interface IMachineBlock extends EntityBlock {
                 var list = getCapabilitiesFromTraits(machine.getMetaMachine().getTraits(), side,
                         IEnergyContainer.class);
                 if (!list.isEmpty()) {
-                    return new EnergyContainerList(list);
+                    return list.size() == 1 ? list.get(0) : new EnergyContainerList(list);
                 }
             }
             return null;


### PR DESCRIPTION
## What
Fixes a bug that causes generators to explode when fed power on the output side.

## Implementation Details
Make it so `CAPABILITY_ENERGY_CONTAINER` only returns a `EnergyContainerList` if there are more than 1 energy container. This matches the 1.20 behavior:
https://github.com/GregTechCEu/GregTech-Modern/blob/33091596384f5132b9fa8b5c5b91630eff0543f8/src/main/java/com/gregtechceu/gtceu/api/blockentity/MetaMachineBlockEntity.java#L188-L196

## Outcome
Fixes: #3637 

## Additional Information
Bug was caused by `CAPABILITY_ENERGY_CONTAINER` returning an `EnergyContainerList`, which overrides `inputEnergy` to always return true.

An alternative fix would be to iterate each energy container in `NotifiableEnergyContainer` `serverTick`, so it properly checks `inputEnergy` bool.

A third alternative would be to make the `inputEnergy` override return true only if it returns true on one of the energy containers.

## Potential Compatibility Issues
Maybe something in 1.21 expects EnergyContainerList to always be returned? I haven't tested this very extensively.