### PR TITLE
make multiblock maintenance time configurable

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1811,6 +1811,7 @@
   "config.gtceu.option.machines": "sǝuıɥɔɐɯ",
   "config.gtceu.option.machinesEmissiveTextures": "sǝɹnʇxǝ⟘ǝʌıssıɯƎsǝuıɥɔɐɯ",
   "config.gtceu.option.machinesHaveBERsByDefault": "ʇןnɐɟǝᗡʎᗺsᴚƎᗺǝʌɐHsǝuıɥɔɐɯ",
+  "config.gtceu.option.maintenanceTime": "ǝɯı⟘ǝɔuɐuǝʇuıɐɯ",
   "config.gtceu.option.meHatchEnergyUsage": "ǝbɐs∩ʎbɹǝuƎɥɔʇɐHǝɯ",
   "config.gtceu.option.minerSpeed": "pǝǝdSɹǝuıɯ",
   "config.gtceu.option.minimap": "dɐɯıuıɯ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1811,6 +1811,7 @@
   "config.gtceu.option.machines": "machines",
   "config.gtceu.option.machinesEmissiveTextures": "machinesEmissiveTextures",
   "config.gtceu.option.machinesHaveBERsByDefault": "machinesHaveBERsByDefault",
+  "config.gtceu.option.maintenanceTime": "maintenanceTime",
   "config.gtceu.option.meHatchEnergyUsage": "meHatchEnergyUsage",
   "config.gtceu.option.minerSpeed": "minerSpeed",
   "config.gtceu.option.minimap": "minimap",

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMaintenanceMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMaintenanceMachine.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 public interface IMaintenanceMachine extends IMultiPart {
 
     BooleanProperty MAINTENANCE_TAPED_PROPERTY = GTMachineModelProperties.IS_TAPED;
-    int MINIMUM_MAINTENANCE_TIME = 3456000; // 48 real-life hours = 3456000 ticks
     byte ALL_PROBLEMS = 0;
     byte NO_PROBLEMS = 0b111111;
 
@@ -86,7 +85,7 @@ public interface IMaintenanceMachine extends IMultiPart {
      */
     default boolean calculateTime(int duration) {
         setTimeActive(duration + getTimeActive());
-        var value = getTimeActive() - MINIMUM_MAINTENANCE_TIME;
+        var value = getTimeActive() - ConfigHolder.INSTANCE.machines.maintenanceTime;
         if (value > 0) {
             setTimeActive(value);
             return true;

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -460,6 +460,11 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Whether to enable the Maintenance Hatch, required for Multiblocks.", "Default: true" })
         public boolean enableMaintenance = true;
+        @Configurable
+        @Configurable.Comment({
+                "Time in ticks between when Multiblocks can require Maintenance. By default, 48 hours.",
+                "Default: 3456000" })
+        public int maintenanceTime = 3456000;
 
         @Configurable
         @Configurable.Comment({


### PR DESCRIPTION
## What
Multiblock machine maintenance time is now configurable. Defaults to current hardcoded value. Can be changed in game without reload. 

Changing it to a lower value _may_ cause a lot of your machines to suddenly need maintenance.

Implements part of #998. (Does not alter consequences for maintenance issues.)