### PR TITLE
Optimize Network Switch for repeat CWU/t requests

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -546,6 +546,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
 
         /** Allocate computation on a given request. Allocates for one tick. */
         public int allocateCWUt(int cwut, boolean simulate) {
+            if (cwut == 0) return 0;
             int maxCWUt = getMaxCWUt();
             int availableCWUt = maxCWUt - this.allocatedCWUt;
             int toAllocate = Math.min(cwut, availableCWUt);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
@@ -183,10 +183,15 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
 
             // Exit early if this Network Switch has already provided all available CWUt on its subnetwork for this tick
             long timer = NetworkSwitchMachine.this.getOffsetTimer();
-            if (timerCWUt == timer && tickSaturated) {
-                return 0;
+            if (timerCWUt == timer) {
+                if (tickSaturated) {
+                    return 0;
+                }
+            } else {
+                // First call this tick, reset saturation
+                timerCWUt = timer;
+                tickSaturated = false;
             }
-            timerCWUt = timer;
 
             Collection<IOpticalComputationProvider> bridgeSeen = new ArrayList<>(seen);
             int allocatedCWUt = 0;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
@@ -141,7 +141,7 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
      */
 
     /** Handles computation load across multiple receivers and to multiple transmitters. */
-    private static class MultipleComputationHandler extends NotifiableComputationContainer {
+    private class MultipleComputationHandler extends NotifiableComputationContainer {
 
         // providers in the NS provide distributable computation to the NS
         private final Set<IOpticalComputationHatch> providers = new ObjectOpenHashSet<>();
@@ -151,6 +151,9 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
         /** The EU/t cost of this Network Switch given the attached providers and transmitters. */
         @Getter(value = AccessLevel.PRIVATE)
         private int EUt;
+
+        private boolean tickSaturated;
+        private long timerCWUt = -1;
 
         public MultipleComputationHandler(MetaMachine machine) {
             super(machine, IO.IN, false);
@@ -175,6 +178,16 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
             if (seen.contains(this)) return 0;
             // The max CWU/t that this Network Switch can provide, combining all its inputs.
             seen.add(this);
+
+            if (cwut == 0) return 0;
+
+            // Exit early if this Network Switch has already provided all available CWUt on its subnetwork for this tick
+            long timer = NetworkSwitchMachine.this.getOffsetTimer();
+            if (timerCWUt == timer && tickSaturated) {
+                return 0;
+            }
+            timerCWUt = timer;
+
             Collection<IOpticalComputationProvider> bridgeSeen = new ArrayList<>(seen);
             int allocatedCWUt = 0;
             for (var provider : providers) {
@@ -184,6 +197,12 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
                 cwut -= allocated;
                 if (cwut == 0) break;
             }
+
+            if (!simulate && allocatedCWUt == 0) {
+                // No computation left to give, remember this for subsequent calls this tick
+                tickSaturated = true;
+            }
+
             return allocatedCWUt;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/optical/OpticalNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/optical/OpticalNetHandler.java
@@ -10,6 +10,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,6 +22,7 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
     private final Level world;
     private final Direction facing;
 
+    @Getter
     private OpticalPipeNet net;
 
     public OpticalNetHandler(OpticalPipeNet net, @NotNull OpticalPipeBlockEntity pipe, @Nullable Direction facing) {
@@ -32,10 +34,6 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
 
     public void updateNetwork(OpticalPipeNet net) {
         this.net = net;
-    }
-
-    public OpticalPipeNet getNet() {
-        return net;
     }
 
     @Override
@@ -52,6 +50,7 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
 
     @Override
     public int requestCWUt(int cwut, boolean simulate, @NotNull Collection<IOpticalComputationProvider> seen) {
+        if (cwut == 0) return 0;
         int provided = traverseRequestCWUt(cwut, simulate, seen);
         if (provided > 0) setPipesActive();
         return provided;


### PR DESCRIPTION
Makes Network Switch keep track of if it has already used all its possible CWU/t for this tick, cutting parts of the computation network off from later scans 