### PR TITLE
Fix recipe viewer integration not working with research recipes that contain fluids

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -106,6 +106,8 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
                 Collection<ItemStack> added = new ObjectOpenHashSet<>();
                 outer:
                 for (GTRecipe recipe : recipes) {
+                    var contents = recipe.getOutputContents(ItemRecipeCapability.CAP);
+                    if (contents.isEmpty()) continue;
                     ItemStack output = ItemRecipeCapability.CAP
                             .of(recipe.getOutputContents(ItemRecipeCapability.CAP).get(0).content).getItems()[0];
                     for (var item : added) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.common.item;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
+import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
 import com.gregtechceu.gtceu.api.item.component.IDataItem;
@@ -26,6 +27,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.fluids.FluidStack;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import lombok.Getter;
@@ -103,20 +105,36 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
             Collection<GTRecipe> recipes = researchData.recipeType().getDataStickEntry(researchData.researchId());
             if (recipes != null && !recipes.isEmpty()) {
                 tooltipComponents.add(Component.translatable("behavior.data_item.assemblyline.title"));
-                Collection<ItemStack> added = new ObjectOpenHashSet<>();
-                outer:
+                Collection<ItemStack> addedItems = new ObjectOpenHashSet<>();
+                Collection<FluidStack> addedFluids = new ObjectOpenHashSet<>();
+                outerItems:
                 for (GTRecipe recipe : recipes) {
                     var contents = recipe.getOutputContents(ItemRecipeCapability.CAP);
                     if (contents.isEmpty()) continue;
-                    ItemStack output = ItemRecipeCapability.CAP
+                    ItemStack outputItems = ItemRecipeCapability.CAP
                             .of(recipe.getOutputContents(ItemRecipeCapability.CAP).get(0).content).getItems()[0];
-                    for (var item : added) {
-                        if (output.is(item.getItem())) continue outer;
+                    for (var item : addedItems) {
+                        if (outputItems.is(item.getItem())) continue outerItems;
                     }
-                    if (added.add(output)) {
+                    if (addedItems.add(outputItems)) {
                         tooltipComponents.add(
                                 Component.translatable("behavior.data_item.assemblyline.data",
-                                        output.getDisplayName()));
+                                        outputItems.getDisplayName()));
+                    }
+                }
+                outerFluids:
+                for (GTRecipe recipe : recipes) {
+                    var contents = recipe.getOutputContents(FluidRecipeCapability.CAP);
+                    if (contents.isEmpty()) continue;
+                    FluidStack outputFluids = FluidRecipeCapability.CAP
+                            .of(recipe.getOutputContents(FluidRecipeCapability.CAP).get(0).content).getStacks()[0];
+                    for (var fluid : addedFluids) {
+                        if (outputFluids.isFluidStackIdentical(fluid)) continue outerFluids;
+                    }
+                    if (addedFluids.add(outputFluids)) {
+                        tooltipComponents.add(
+                                Component.translatable("behavior.data_item.assemblyline.data",
+                                        outputFluids.getDisplayName()));
                     }
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -112,7 +112,7 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
                     var contents = recipe.getOutputContents(ItemRecipeCapability.CAP);
                     if (contents.isEmpty()) continue;
                     ItemStack outputItems = ItemRecipeCapability.CAP
-                            .of(recipe.getOutputContents(ItemRecipeCapability.CAP).get(0).content).getItems()[0];
+                            .of(contents.get(0).content).getItems()[0];
                     for (var item : addedItems) {
                         if (outputItems.is(item.getItem())) continue outerItems;
                     }
@@ -127,7 +127,7 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
                     var contents = recipe.getOutputContents(FluidRecipeCapability.CAP);
                     if (contents.isEmpty()) continue;
                     FluidStack outputFluids = FluidRecipeCapability.CAP
-                            .of(recipe.getOutputContents(FluidRecipeCapability.CAP).get(0).content).getStacks()[0];
+                            .of(contents.get(0).content).getStacks()[0];
                     for (var fluid : addedFluids) {
                         if (outputFluids.isFluidStackIdentical(fluid)) continue outerFluids;
                     }


### PR DESCRIPTION
## What
This PR adds an `contents.isEmpty()` check to appendHoverText to stop XEI from failing ungracefully.

## Outcome
No more XEI error for Items OR Fluids!

<img width="910" height="818" alt="image" src="https://github.com/user-attachments/assets/bf1c7868-ff50-46ed-8a3f-7f36df9b2ae3" />

<img width="748" height="209" alt="image" src="https://github.com/user-attachments/assets/b3e9a77b-ccb5-417b-98e5-03ee78552699" />


## Potential Compatibility Issues
I don't believe there's much we can do about the lang atm, I'll leave that to the Lang Refactor.
None found currently, resolved the problem where it didn't do FluidStacks!
