### PR TITLE
Fix Parallel logic calculating the required amount wrong when there are split ingredients

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -205,8 +205,22 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
             if (ing instanceof IntProviderFluidIngredient provider) amount = provider.getCountProvider().getMaxValue();
             else amount = ing.getAmount();
 
-            if (content.chance == 0) nonConsumables.addTo(ing, amount);
-            else consumables.addTo(ing, amount);
+            if (content.chance == 0) {
+                nonConsumables.addTo(ing, amount);
+            } else {
+                boolean has = false;
+                for (var recipeIng : consumables.object2LongEntrySet()) {
+                    var stack = ing.getStacks()[0];
+                    if (recipeIng.getKey().test(stack)) {
+                        recipeIng.setValue(recipeIng.getLongValue() + stack.getAmount());
+                        has = true;
+                        break;
+                    }
+                }
+                if (!has) {
+                    consumables.addTo(ing, amount);
+                }
+            }
         }
 
         // is this even possible

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -231,8 +231,22 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
             else if (ing instanceof IntProviderIngredient provider) count = provider.getCountProvider().getMaxValue();
             else count = 1;
 
-            if (content.chance == 0) nonConsumables.addTo(ing, count);
-            else consumables.addTo(ing, count);
+            if (content.chance == 0) {
+                nonConsumables.addTo(ing, count);
+            } else {
+                boolean has = false;
+                for (var recipeIng : consumables.object2LongEntrySet()) {
+                    var stack = ing.getItems()[0];
+                    if (recipeIng.getKey().test(stack)) {
+                        recipeIng.setValue(recipeIng.getLongValue() + stack.getCount());
+                        has = true;
+                        break;
+                    }
+                }
+                if (!has) {
+                    consumables.addTo(ing, count);
+                }
+            }
         }
 
         // is this even possible

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1228,11 +1228,7 @@ public class RecipeAddition {
         } else {
             ASSEMBLER_RECIPES.recipeBuilder("crafting_table").duration(80).EUt(6).circuitMeta(4)
                     .inputItems(ItemTags.PLANKS, 4).outputItems(new ItemStack(Blocks.CRAFTING_TABLE)).save(provider);
-            ASSEMBLER_RECIPES.recipeBuilder("furnace").circuitMeta(8)
-                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
-                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
-                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
-                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
+            ASSEMBLER_RECIPES.recipeBuilder("furnace").circuitMeta(8).inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 8)
                     .outputItems(new ItemStack(Blocks.FURNACE)).duration(100).EUt(VA[ULV])
                     .addMaterialInfo(true).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("enchanting_table").inputItems(new ItemStack(Blocks.OBSIDIAN, 4))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -1228,7 +1228,11 @@ public class RecipeAddition {
         } else {
             ASSEMBLER_RECIPES.recipeBuilder("crafting_table").duration(80).EUt(6).circuitMeta(4)
                     .inputItems(ItemTags.PLANKS, 4).outputItems(new ItemStack(Blocks.CRAFTING_TABLE)).save(provider);
-            ASSEMBLER_RECIPES.recipeBuilder("furnace").circuitMeta(8).inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 8)
+            ASSEMBLER_RECIPES.recipeBuilder("furnace").circuitMeta(8)
+                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
+                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
+                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
+                    .inputItems(ItemTags.STONE_CRAFTING_MATERIALS, 2)
                     .outputItems(new ItemStack(Blocks.FURNACE)).duration(100).EUt(VA[ULV])
                     .addMaterialInfo(true).save(provider);
             ASSEMBLER_RECIPES.recipeBuilder("enchanting_table").inputItems(new ItemStack(Blocks.OBSIDIAN, 4))


### PR DESCRIPTION
## What
if a recipe had split ingredients, finding the correct ratio was wrong as it was testing each ingredient to the content separately instead of collectively

## Implementation Details
merging the ingredients if they contain the same stack

## Outcome
proper parallel calculation if you have separate stacks