### PR TITLE
Fix Storage Cover missing its cover icon texture in machine UI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/gui/GuiTextures.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/GuiTextures.java
@@ -191,7 +191,7 @@ public class GuiTextures {
     public static final ResourceTexture MAINTENANCE_ICON = new ResourceTexture(
             "gtceu:textures/block/overlay/machine/overlay_maintenance.png");
     public static final ResourceTexture STORAGE_ICON = new ResourceTexture(
-            "gtceu:textures/item/storage.png");
+            "gtceu:textures/item/storage_cover.png");
     public static final ResourceTexture BUTTON_MINER_MODES = new ResourceTexture(
             "gtceu:textures/gui/widget/button_miner_modes.png");
 


### PR DESCRIPTION
## What
exactly as the title describes. not sure if theres any more detail i can give

## Implementation Details
at some point the line directing where the texture is for the storage cover ResourceTexture was changed to search for ``storage.png`` without changing the name of the original texture, which was titled ``storage_cover.png``. this reverts that change, directing the ResourceTexture to the actual texture (``storage_cover.png``) and not a missing one

## Outcome
Closes https://github.com/GregTechCEu/GregTech-Modern/issues/3673

## Additional Information
before PR:
<img width="444" height="382" alt="temp1" src="https://github.com/user-attachments/assets/b93e9e42-fe8f-4446-a0a3-ad71fd8a36dd" />
after PR:
<img width="444" height="382" alt="temp2" src="https://github.com/user-attachments/assets/c45e851c-5ab0-44c7-b47e-7b3f4a3e7125" />
note that everything still seems fine even when the cover's storage is opened 
