### PR TITLE
Fix Large Maceration Tower not receiving dropped items as input

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/gcym/LargeMacerationTowerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/gcym/LargeMacerationTowerMachine.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
@@ -61,8 +62,8 @@ public class LargeMacerationTowerMachine extends WorkableElectricMultiblockMachi
 
     private void updateBounds() {
         var fl = RelativeDirection.offsetPos(getPos(), getFrontFacing(), getUpwardsFacing(), isFlipped(), 1, 1, -1);
-        var br = RelativeDirection.offsetPos(getPos(), getFrontFacing(), getUpwardsFacing(), isFlipped(), 2, -2, -4);
-        grindBound = new AABB(fl, br);
+        var br = RelativeDirection.offsetPos(getPos(), getFrontFacing(), getUpwardsFacing(), isFlipped(), 1, -2, -4);
+        grindBound = AABB.of(BoundingBox.fromCorners(fl, br));
     }
 
     private void spinWheels() {


### PR DESCRIPTION
## What
The Large Maceration Tower has a mechanic where items dropped on the crushing wheels may be picked up by the machine into the input bus. However, only some of the crushing wheels worked with this mechanic, while others would just not pick up items on top of them. The broken crushing wheels would also fail to damage players standing above them, which is unintended behavior. The Maceration Tower crossing chunk boundaries would exacerbate this issue, causing more spaces to stop working. This PR fixes both issues while also ensuring the bounding box works across chunk boundaries; items within the bounding box will now be picked up and players will be damaged.

## Implementation Details
On line 66 of `LargeMacerationTowerMachine.java`, initialize the AABB with the corners of a BoundingBox rather than pure coordinates (as was implemented before). This method seems to be working for the item collector and fixes the item pickup and player damage issues with the Maceration Tower. 

## Outcome
Closes #3572

## Additional Information
Behavior before: see #3572 

Behavior after:

https://github.com/user-attachments/assets/8d96034b-8e6c-406d-801a-a46f0d1093bc

