### PR TITLE
Three fixes with Chanced and Ranged Outputs

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -16,10 +16,7 @@ import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.fluid.*;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.ui.GTRecipeTypeUI;
 import com.gregtechceu.gtceu.client.TooltipsHandler;
-import com.gregtechceu.gtceu.common.valueprovider.AddedFloat;
-import com.gregtechceu.gtceu.common.valueprovider.CastedFloat;
-import com.gregtechceu.gtceu.common.valueprovider.FlooredInt;
-import com.gregtechceu.gtceu.common.valueprovider.MultipliedFloat;
+import com.gregtechceu.gtceu.common.valueprovider.*;
 import com.gregtechceu.gtceu.integration.xei.entry.fluid.FluidEntryList;
 import com.gregtechceu.gtceu.integration.xei.entry.fluid.FluidStackList;
 import com.gregtechceu.gtceu.integration.xei.entry.fluid.FluidTagList;
@@ -34,9 +31,7 @@ import com.lowdragmc.lowdraglib.jei.IngredientIO;
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.valueproviders.ConstantFloat;
 import net.minecraft.util.valueproviders.IntProvider;
-import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -68,14 +63,8 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
     public FluidIngredient copyWithModifier(FluidIngredient content, ContentModifier modifier) {
         if (content.isEmpty()) return content.copy();
         if (content instanceof IntProviderFluidIngredient provider) {
-            var modifiedProvider = new FlooredInt(
-                    new AddedFloat(
-                            new MultipliedFloat(
-                                    new CastedFloat(provider.getCountProvider()),
-                                    ConstantFloat.of((float) modifier.multiplier())),
-                            ConstantFloat.of((float) modifier.addition())));
             return IntProviderFluidIngredient.of(provider.getInner(),
-                    UniformInt.of(modifiedProvider.getMinValue(), modifiedProvider.getMaxValue()));
+                    ModifiedIntProvider.of(provider.getCountProvider(), modifier));
         }
         FluidIngredient copy = content.copy();
         copy.setAmount(modifier.apply(copy.getAmount()));

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -36,6 +36,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.valueproviders.ConstantFloat;
 import net.minecraft.util.valueproviders.IntProvider;
+import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -67,13 +68,14 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
     public FluidIngredient copyWithModifier(FluidIngredient content, ContentModifier modifier) {
         if (content.isEmpty()) return content.copy();
         if (content instanceof IntProviderFluidIngredient provider) {
+            var modifiedProvider = new FlooredInt(
+                    new AddedFloat(
+                            new MultipliedFloat(
+                                    new CastedFloat(provider.getCountProvider()),
+                                    ConstantFloat.of((float) modifier.multiplier())),
+                            ConstantFloat.of((float) modifier.addition())));
             return IntProviderFluidIngredient.of(provider.getInner(),
-                    new FlooredInt(
-                            new AddedFloat(
-                                    new MultipliedFloat(
-                                            new CastedFloat(provider.getCountProvider()),
-                                            ConstantFloat.of((float) modifier.multiplier())),
-                                    ConstantFloat.of((float) modifier.addition()))));
+                    UniformInt.of(modifiedProvider.getMinValue(), modifiedProvider.getMaxValue()));
         }
         FluidIngredient copy = content.copy();
         copy.setAmount(modifier.apply(copy.getAmount()));

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -41,6 +41,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.valueproviders.ConstantFloat;
 import net.minecraft.util.valueproviders.IntProvider;
+import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.IntersectionIngredient;
@@ -75,13 +76,14 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
             return SizedIngredient.create(sizedIngredient.getInner(),
                     modifier.apply(sizedIngredient.getAmount()));
         } else if (content instanceof IntProviderIngredient intProviderIngredient) {
+            var modifiedProvider = new FlooredInt(
+                    new AddedFloat(
+                            new MultipliedFloat(
+                                    new CastedFloat(intProviderIngredient.getCountProvider()),
+                                    ConstantFloat.of((float) modifier.multiplier())),
+                            ConstantFloat.of((float) modifier.addition())));
             return IntProviderIngredient.of(intProviderIngredient.getInner(),
-                    new FlooredInt(
-                            new AddedFloat(
-                                    new MultipliedFloat(
-                                            new CastedFloat(intProviderIngredient.getCountProvider()),
-                                            ConstantFloat.of((float) modifier.multiplier())),
-                                    ConstantFloat.of((float) modifier.addition()))));
+                    UniformInt.of(modifiedProvider.getMinValue(), modifiedProvider.getMaxValue()));
         }
         return SizedIngredient.create(content, modifier.apply(1));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -18,10 +18,7 @@ import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.item.*;
 import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.ui.GTRecipeTypeUI;
 import com.gregtechceu.gtceu.common.recipe.condition.ResearchCondition;
-import com.gregtechceu.gtceu.common.valueprovider.AddedFloat;
-import com.gregtechceu.gtceu.common.valueprovider.CastedFloat;
-import com.gregtechceu.gtceu.common.valueprovider.FlooredInt;
-import com.gregtechceu.gtceu.common.valueprovider.MultipliedFloat;
+import com.gregtechceu.gtceu.common.valueprovider.*;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.IngredientAccessor;
 import com.gregtechceu.gtceu.core.mixins.TagValueAccessor;
@@ -39,9 +36,7 @@ import com.lowdragmc.lowdraglib.jei.IngredientIO;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.valueproviders.ConstantFloat;
 import net.minecraft.util.valueproviders.IntProvider;
-import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.crafting.IntersectionIngredient;
@@ -75,15 +70,9 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
         if (content instanceof SizedIngredient sizedIngredient) {
             return SizedIngredient.create(sizedIngredient.getInner(),
                     modifier.apply(sizedIngredient.getAmount()));
-        } else if (content instanceof IntProviderIngredient intProviderIngredient) {
-            var modifiedProvider = new FlooredInt(
-                    new AddedFloat(
-                            new MultipliedFloat(
-                                    new CastedFloat(intProviderIngredient.getCountProvider()),
-                                    ConstantFloat.of((float) modifier.multiplier())),
-                            ConstantFloat.of((float) modifier.addition())));
-            return IntProviderIngredient.of(intProviderIngredient.getInner(),
-                    UniformInt.of(modifiedProvider.getMinValue(), modifiedProvider.getMaxValue()));
+        } else if (content instanceof IntProviderIngredient provider) {
+            return IntProviderIngredient.of(provider.getInner(),
+                    ModifiedIntProvider.of(provider.getCountProvider(), modifier));
         }
         return SizedIngredient.create(content, modifier.apply(1));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -353,7 +353,7 @@ public class MultiblockDisplayText {
                 double maxDurationSec = (double) recipe.duration / 20.0;
                 var itemOutputs = recipe.getOutputContents(ItemRecipeCapability.CAP);
                 var fluidOutputs = recipe.getOutputContents(FluidRecipeCapability.CAP);
-//                int runs = recipe.parallels * recipe.batchParallels;
+                int runs = recipe.parallels * recipe.batchParallels;
 
                 for (var item : itemOutputs) {
                     boolean rounded = false;
@@ -361,16 +361,16 @@ public class MultiblockDisplayText {
                     int count = 0;
                     double countD = 1;
                     Component displaycount;
-                    if (item.chance < item.maxChance) {
-                        rounded = true;
-                        countD = countD * function.getBoostedChance(item, recipeTier, chanceTier) / item.maxChance;
-                    }
                     if (item.content instanceof IntProviderIngredient provider) {
                         rounded = true;
                         stack = provider.getMaxSizeStack();
                         displaycount = Component.translatable("gtceu.gui.content.range",
-                                provider.getCountProvider().getMinValue() * countD,
-                                provider.getCountProvider().getMaxValue() * countD);
+                                provider.getCountProvider().getMinValue(),
+                                provider.getCountProvider().getMaxValue());
+                        if (item.chance < item.maxChance) {
+                            countD = countD * runs * function.getBoostedChance(item, recipeTier, chanceTier) /
+                                    item.maxChance;
+                        }
                         countD = countD * provider.getMidRoll();
                     } else {
                         var stacks = ItemRecipeCapability.CAP.of(item.content).getItems();
@@ -378,6 +378,11 @@ public class MultiblockDisplayText {
                         stack = stacks[0];
                         count = stack.getCount();
                         countD *= count;
+                        if (item.chance < item.maxChance) {
+                            rounded = true;
+                            countD = countD * runs * function.getBoostedChance(item, recipeTier, chanceTier) /
+                                    item.maxChance;
+                        }
                         count = countD < 1 ? 1 : (int) Math.round(countD);
                         displaycount = Component.literal(String.valueOf(count));
                     }
@@ -397,16 +402,16 @@ public class MultiblockDisplayText {
                     int amount = 0;
                     double amountD = 1;
                     Component displaycount;
-                    if (fluid.chance < fluid.maxChance) {
-                        rounded = true;
-                        amountD = amountD * function.getBoostedChance(fluid, recipeTier, chanceTier) / fluid.maxChance;
-                    }
                     if (fluid.content instanceof IntProviderFluidIngredient provider) {
                         rounded = true;
                         stack = provider.getMaxSizeStack();
                         displaycount = Component.translatable("gtceu.gui.content.range",
-                                provider.getCountProvider().getMinValue() * amountD,
-                                provider.getCountProvider().getMaxValue() * amountD);
+                                provider.getCountProvider().getMinValue(),
+                                provider.getCountProvider().getMaxValue());
+                        if (fluid.chance < fluid.maxChance) {
+                            amountD = amountD * runs * function.getBoostedChance(fluid, recipeTier, chanceTier) /
+                                    fluid.maxChance;
+                        }
                         amountD = amountD * provider.getMidRoll();
                     } else {
                         var stacks = FluidRecipeCapability.CAP.of(fluid.content).getStacks();
@@ -414,6 +419,11 @@ public class MultiblockDisplayText {
                         stack = stacks[0];
                         amount = stack.getAmount();
                         amountD *= amount;
+                        if (fluid.chance < fluid.maxChance) {
+                            rounded = true;
+                            amountD = amountD * runs * function.getBoostedChance(fluid, recipeTier, chanceTier) /
+                                    fluid.maxChance;
+                        }
                         amount = amountD < 1 ? 1 : (int) Math.round(amountD);
                         displaycount = Component.literal(String.valueOf(amount));
                     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -353,36 +353,41 @@ public class MultiblockDisplayText {
                 double maxDurationSec = (double) recipe.duration / 20.0;
                 var itemOutputs = recipe.getOutputContents(ItemRecipeCapability.CAP);
                 var fluidOutputs = recipe.getOutputContents(FluidRecipeCapability.CAP);
-                int runs = recipe.parallels * recipe.batchParallels;
+//                int runs = recipe.parallels * recipe.batchParallels;
 
                 for (var item : itemOutputs) {
                     boolean rounded = false;
                     ItemStack stack;
                     int count = 0;
-                    double countD = runs;
+                    double countD = 1;
+                    Component displaycount;
+                    if (item.chance < item.maxChance) {
+                        rounded = true;
+                        countD = countD * function.getBoostedChance(item, recipeTier, chanceTier) / item.maxChance;
+                    }
                     if (item.content instanceof IntProviderIngredient provider) {
                         rounded = true;
                         stack = provider.getMaxSizeStack();
+                        displaycount = Component.translatable("gtceu.gui.content.range",
+                                provider.getCountProvider().getMinValue() * countD,
+                                provider.getCountProvider().getMaxValue() * countD);
                         countD = countD * provider.getMidRoll();
                     } else {
                         var stacks = ItemRecipeCapability.CAP.of(item.content).getItems();
                         if (stacks.length == 0) continue;
                         stack = stacks[0];
                         count = stack.getCount();
-                        countD = count;
+                        countD *= count;
+                        count = countD < 1 ? 1 : (int) Math.round(countD);
+                        displaycount = Component.literal(String.valueOf(count));
                     }
-                    if (item.chance < item.maxChance) {
-                        rounded = true;
-                        countD = countD * function.getBoostedChance(item, recipeTier, chanceTier) / item.maxChance;
-                    }
-                    if (rounded) count = countD < 1 ? 1 : (int) Math.round(countD);
-                    if (count < maxDurationSec) {
+                    if (countD < maxDurationSec) {
                         String key = "gtceu.multiblock.output_line." + (rounded ? "2" : "0");
-                        textList.add(Component.translatable(key, stack.getHoverName(), count,
+                        textList.add(Component.translatable(key, stack.getHoverName(), displaycount,
                                 FormattingUtil.formatNumber2Places(maxDurationSec / countD)));
                     } else {
                         String key = "gtceu.multiblock.output_line." + (rounded ? "3" : "1");
-                        textList.add(Component.translatable(key, stack.getHoverName(), count,
+                        textList.add(Component.translatable(key, stack.getHoverName(), displaycount,
                                 FormattingUtil.formatNumber2Places(countD / maxDurationSec)));
                     }
                 }
@@ -390,31 +395,35 @@ public class MultiblockDisplayText {
                     boolean rounded = false;
                     FluidStack stack;
                     int amount = 0;
-                    double amountD = runs;
+                    double amountD = 1;
+                    Component displaycount;
+                    if (fluid.chance < fluid.maxChance) {
+                        rounded = true;
+                        amountD = amountD * function.getBoostedChance(fluid, recipeTier, chanceTier) / fluid.maxChance;
+                    }
                     if (fluid.content instanceof IntProviderFluidIngredient provider) {
                         rounded = true;
                         stack = provider.getMaxSizeStack();
+                        displaycount = Component.translatable("gtceu.gui.content.range",
+                                provider.getCountProvider().getMinValue() * amountD,
+                                provider.getCountProvider().getMaxValue() * amountD);
                         amountD = amountD * provider.getMidRoll();
                     } else {
                         var stacks = FluidRecipeCapability.CAP.of(fluid.content).getStacks();
                         if (stacks.length == 0) continue;
                         stack = stacks[0];
                         amount = stack.getAmount();
-                        amountD = amount;
+                        amountD *= amount;
+                        amount = amountD < 1 ? 1 : (int) Math.round(amountD);
+                        displaycount = Component.literal(String.valueOf(amount));
                     }
-                    if (fluid.chance < fluid.maxChance) {
-                        rounded = true;
-                        amountD = amountD * runs *
-                                function.getBoostedChance(fluid, recipeTier, chanceTier) / fluid.maxChance;
-                    }
-                    if (rounded) amount = amountD < 1 ? 1 : (int) Math.round(amountD);
-                    if (amount < maxDurationSec) {
+                    if (amountD < maxDurationSec) {
                         String key = "gtceu.multiblock.output_line." + (rounded ? "2" : "0");
-                        textList.add(Component.translatable(key, stack.getDisplayName(), amount,
+                        textList.add(Component.translatable(key, stack.getDisplayName(), displaycount,
                                 FormattingUtil.formatNumber2Places(maxDurationSec / amountD)));
                     } else {
                         String key = "gtceu.multiblock.output_line." + (rounded ? "3" : "1");
-                        textList.add(Component.translatable(key, stack.getDisplayName(), amount,
+                        textList.add(Component.translatable(key, stack.getDisplayName(), displaycount,
                                 FormattingUtil.formatNumber2Places(amountD / maxDurationSec)));
                     }
                 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -7,6 +7,8 @@ import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
+import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
+import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -15,6 +17,8 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -349,45 +353,67 @@ public class MultiblockDisplayText {
                 double maxDurationSec = (double) recipe.duration / 20.0;
                 var itemOutputs = recipe.getOutputContents(ItemRecipeCapability.CAP);
                 var fluidOutputs = recipe.getOutputContents(FluidRecipeCapability.CAP);
+                int runs = recipe.parallels * recipe.batchParallels;
 
                 for (var item : itemOutputs) {
-                    var stacks = ItemRecipeCapability.CAP.of(item.content).getItems();
-                    if (stacks.length == 0) continue;
-                    var stack = stacks[0];
-                    int count = stack.getCount();
-                    double countD = count;
-                    if (item.chance < item.maxChance) {
-                        countD = countD * recipe.parallels * recipe.batchParallels *
-                                function.getBoostedChance(item, recipeTier, chanceTier) / item.maxChance;
-                        count = countD < 1 ? 1 : (int) Math.round(countD);
+                    boolean rounded = false;
+                    ItemStack stack;
+                    int count = 0;
+                    double countD = runs;
+                    if (item.content instanceof IntProviderIngredient provider) {
+                        rounded = true;
+                        stack = provider.getMaxSizeStack();
+                        countD = countD * provider.getMidRoll();
+                    } else {
+                        var stacks = ItemRecipeCapability.CAP.of(item.content).getItems();
+                        if (stacks.length == 0) continue;
+                        stack = stacks[0];
+                        count = stack.getCount();
+                        countD = count;
                     }
+                    if (item.chance < item.maxChance) {
+                        rounded = true;
+                        countD = countD * function.getBoostedChance(item, recipeTier, chanceTier) / item.maxChance;
+                    }
+                    if (rounded) count = countD < 1 ? 1 : (int) Math.round(countD);
                     if (count < maxDurationSec) {
-                        String key = "gtceu.multiblock.output_line." + (item.chance < item.maxChance ? "2" : "0");
+                        String key = "gtceu.multiblock.output_line." + (rounded ? "2" : "0");
                         textList.add(Component.translatable(key, stack.getHoverName(), count,
                                 FormattingUtil.formatNumber2Places(maxDurationSec / countD)));
                     } else {
-                        String key = "gtceu.multiblock.output_line." + (item.chance < item.maxChance ? "3" : "1");
+                        String key = "gtceu.multiblock.output_line." + (rounded ? "3" : "1");
                         textList.add(Component.translatable(key, stack.getHoverName(), count,
                                 FormattingUtil.formatNumber2Places(countD / maxDurationSec)));
                     }
                 }
                 for (var fluid : fluidOutputs) {
-                    var stacks = FluidRecipeCapability.CAP.of(fluid.content).getStacks();
-                    if (stacks.length == 0) continue;
-                    var stack = stacks[0];
-                    int amount = stack.getAmount();
-                    double amountD = amount;
-                    if (fluid.chance < fluid.maxChance) {
-                        amountD = amountD * recipe.parallels * recipe.batchParallels *
-                                function.getBoostedChance(fluid, recipeTier, chanceTier) / fluid.maxChance;
-                        amount = amountD < 1 ? 1 : (int) Math.round(amountD);
+                    boolean rounded = false;
+                    FluidStack stack;
+                    int amount = 0;
+                    double amountD = runs;
+                    if (fluid.content instanceof IntProviderFluidIngredient provider) {
+                        rounded = true;
+                        stack = provider.getMaxSizeStack();
+                        amountD = amountD * provider.getMidRoll();
+                    } else {
+                        var stacks = FluidRecipeCapability.CAP.of(fluid.content).getStacks();
+                        if (stacks.length == 0) continue;
+                        stack = stacks[0];
+                        amount = stack.getAmount();
+                        amountD = amount;
                     }
+                    if (fluid.chance < fluid.maxChance) {
+                        rounded = true;
+                        amountD = amountD * runs *
+                                function.getBoostedChance(fluid, recipeTier, chanceTier) / fluid.maxChance;
+                    }
+                    if (rounded) amount = amountD < 1 ? 1 : (int) Math.round(amountD);
                     if (amount < maxDurationSec) {
-                        String key = "gtceu.multiblock.output_line." + (fluid.chance < fluid.maxChance ? "2" : "0");
+                        String key = "gtceu.multiblock.output_line." + (rounded ? "2" : "0");
                         textList.add(Component.translatable(key, stack.getDisplayName(), amount,
                                 FormattingUtil.formatNumber2Places(maxDurationSec / amountD)));
                     } else {
-                        String key = "gtceu.multiblock.output_line." + (fluid.chance < fluid.maxChance ? "3" : "1");
+                        String key = "gtceu.multiblock.output_line." + (rounded ? "3" : "1");
                         textList.add(Component.translatable(key, stack.getDisplayName(), amount,
                                 FormattingUtil.formatNumber2Places(amountD / maxDurationSec)));
                     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredient.java
@@ -136,6 +136,13 @@ public class IntProviderFluidIngredient extends FluidIngredient {
         return sampledCount;
     }
 
+    /**
+     * @return the average roll of this ranged amount
+     */
+    public double getMidRoll() {
+        return ((countProvider.getMaxValue() + countProvider.getMinValue()) / 2.0);
+    }
+
     @Override
     public boolean isEmpty() {
         return inner.isEmpty();

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredient.java
@@ -133,6 +133,13 @@ public class IntProviderIngredient extends Ingredient {
         return sampledCount;
     }
 
+    /**
+     * @return the average roll of this ranged amount
+     */
+    public double getMidRoll() {
+        return ((countProvider.getMaxValue() + countProvider.getMinValue()) / 2.0);
+    }
+
     @Override
     public @NotNull IntList getStackingIds() {
         return inner.getStackingIds();

--- a/src/main/java/com/gregtechceu/gtceu/common/valueprovider/ModifiedIntProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/valueprovider/ModifiedIntProvider.java
@@ -1,0 +1,32 @@
+package com.gregtechceu.gtceu.common.valueprovider;
+
+import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
+
+import net.minecraft.util.valueproviders.BiasedToBottomInt;
+import net.minecraft.util.valueproviders.ConstantFloat;
+import net.minecraft.util.valueproviders.IntProvider;
+import net.minecraft.util.valueproviders.UniformInt;
+
+/**
+ * Returns a new {@link IntProvider} with a {@link ContentModifier} applied. Mainly for use in modifying the providers
+ * used in {@link com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient}
+ * and {@link com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient}
+ * for recipe batches/parallels.
+ */
+public class ModifiedIntProvider {
+
+    public static IntProvider of(IntProvider source, ContentModifier modifier) {
+        if (source instanceof UniformInt uniform) {
+            return UniformInt.of(modifier.apply(uniform.getMinValue()), modifier.apply(uniform.getMaxValue()));
+        }
+        if (source instanceof BiasedToBottomInt biased) {
+            return BiasedToBottomInt.of(modifier.apply(biased.getMinValue()), modifier.apply(biased.getMaxValue()));
+        }
+        return new FlooredInt(
+                new AddedFloat(
+                        new MultipliedFloat(
+                                new CastedFloat(source),
+                                ConstantFloat.of((float) modifier.multiplier())),
+                        ConstantFloat.of((float) modifier.addition())));
+    }
+}


### PR DESCRIPTION
## What
Fixes three bugs with Chanced and Ranged outputs:
1. Jade provider shows the wrong value for Chanced Outputs run in Batches.
2. Multiblock Info Screen shows constantly randomized values for Ranged Outputs.
3. Recipe Logic for Ranged Outputs does a single output roll and multiplies it for batches/parallels, meaning that for high batch counts the ranged outputs produce very chunky values rather than smooth values.