### PR TITLE
Fix fluid cell dupe using AE2

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/ItemFluidContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ItemFluidContainer.java
@@ -15,7 +15,7 @@ public class ItemFluidContainer implements IRecipeRemainder {
             var drained = handler.drain(FluidType.BUCKET_VOLUME, FluidAction.SIMULATE);
             if (drained.getAmount() != FluidType.BUCKET_VOLUME) return ItemStack.EMPTY;
             handler.drain(FluidType.BUCKET_VOLUME, FluidAction.EXECUTE);
-            return handler.getContainer();
+            return ItemStack.EMPTY;
         }).orElse(itemStack);
     }
 }


### PR DESCRIPTION
## What
Fixes duplication of cells by using the recipe that was intended to empty the cell in an AE2 crafting terminal (or sophisticated backpacks crafting upgrade)

## Implementation Details
I kinda just removed the crafting item remainder (well it's better than being able to dupe the cells)

## Outcome
Fixes #3689
Fixes #3599