### PR TITLE
Separate out recipe types per test

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -248,7 +248,7 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
      * @param newType The new recipe type
      */
     @ApiStatus.Internal
-    public void setRecipeType(GTRecipeType newType){
+    public void setRecipeType(GTRecipeType newType) {
         recipeTypes[activeRecipeType] = newType;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -19,6 +19,7 @@ import lombok.Setter;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.*;
 
@@ -248,6 +249,7 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
      * @param newType The new recipe type
      */
     @ApiStatus.Internal
+    @VisibleForTesting
     public void setRecipeType(GTRecipeType newType) {
         recipeTypes[activeRecipeType] = newType;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -16,6 +16,7 @@ import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -237,5 +238,17 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
     @NotNull
     public GTRecipeType getRecipeType() {
         return recipeTypes[activeRecipeType];
+    }
+
+    /**
+     * Sets a recipe type of the machine.
+     * FOR INTERNAL / TESTING USE ONLY!
+     * NOT SUPPORTED FOR PRODUCTION USE!
+     *
+     * @param newType The new recipe type
+     */
+    @ApiStatus.Internal
+    public void setRecipeType(GTRecipeType newType){
+        recipeTypes[activeRecipeType] = newType;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -36,6 +36,7 @@ import lombok.Setter;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.*;
 
@@ -307,6 +308,7 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
      * @param newType The new recipe type
      */
     @ApiStatus.Internal
+    @VisibleForTesting
     public void setRecipeType(GTRecipeType newType) {
         recipeTypes[activeRecipeType] = newType;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -296,5 +297,17 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
     @NotNull
     public GTRecipeType getRecipeType() {
         return recipeTypes[activeRecipeType];
+    }
+
+    /**
+     * Sets a recipe type of the machine.
+     * FOR INTERNAL / TESTING USE ONLY!
+     * NOT SUPPORTED FOR PRODUCTION USE!
+     *
+     * @param newType The new recipe type
+     */
+    @ApiStatus.Internal
+    public void setRecipeType(GTRecipeType newType){
+        recipeTypes[activeRecipeType] = newType;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -307,7 +307,7 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
      * @param newType The new recipe type
      */
     @ApiStatus.Internal
-    public void setRecipeType(GTRecipeType newType){
+    public void setRecipeType(GTRecipeType newType) {
         recipeTypes[activeRecipeType] = newType;
     }
 }

--- a/src/test/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogicTest.java
@@ -77,8 +77,7 @@ public class RecipeLogicTest {
         GTRecipeType type = recipeLogicMachine.getRecipeType();
         type.getLookup().removeAllRecipes();
         type.getLookup().addRecipe(type
-                .recipeBuilder(GTCEu.id("test-multiblock-recipelogic"))
-                .id(GTCEu.id("test-multiblock-recipelogic"))
+                .recipeBuilder(GTCEu.id("test_multiblock_recipelogic"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.VA[GTValues.UV]).duration(1)
@@ -166,8 +165,7 @@ public class RecipeLogicTest {
         GTRecipeType type = recipeLogicMachine.getRecipeType();
         type.getLookup().removeAllRecipes();
         type.getLookup().addRecipe(type
-                .recipeBuilder(GTCEu.id("test-singleblock"))
-                .id(GTCEu.id("test-singleblock"))
+                .recipeBuilder(GTCEu.id("test_singleblock"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(512).duration(1)

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
@@ -29,11 +29,10 @@ public class InputSeparationTest {
 
     @BeforeBatch(batch = "InputSeparation")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("InputSeparationLCRTests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("input_separation_tests");
         // Force insert the recipe into the manager.
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
-                .recipeBuilder(GTCEu.id("test-multiblock-input-separation"))
-                .id(GTCEu.id("test-multiblock-input-separation"))
+                .recipeBuilder(GTCEu.id("test_multiblock_input_separation"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.ACACIA_WOOD))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.VA[GTValues.HV]).duration(1)

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.FluidHatchPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
@@ -26,12 +27,13 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.LARGE_CHEMICAL_REC
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class InputSeparationTest {
+    private static GTRecipeType LCRrecipeType;
 
     @BeforeBatch(batch = "InputSeparation")
     public static void prepare(ServerLevel level) {
+        LCRrecipeType = TestUtils.createRecipeType("InputSeparationLCRTests");
         // Force insert the recipe into the manager.
-        LARGE_CHEMICAL_RECIPES.getLookup().removeAllRecipes();
-        LARGE_CHEMICAL_RECIPES.getLookup().addRecipe(LARGE_CHEMICAL_RECIPES
+        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
                 .recipeBuilder(GTCEu.id("test-multiblock-input-separation"))
                 .id(GTCEu.id("test-multiblock-input-separation"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.ACACIA_WOOD))
@@ -46,7 +48,7 @@ public class InputSeparationTest {
     }
 
     private record BusHolder(ItemBusPartMachine inputBus1, ItemBusPartMachine inputBus2, ItemBusPartMachine outputBus1,
-                             FluidHatchPartMachine outputHatch1) {}
+                             FluidHatchPartMachine outputHatch1, WorkableMultiblockMachine controller) {}
 
     /**
      * Retrieves the busses for this specific template and force a multiblock structure check
@@ -55,9 +57,10 @@ public class InputSeparationTest {
      * @return the busses, in the BusHolder record.
      */
     private static BusHolder getBussesAndForm(GameTestHelper helper) {
-        MultiblockControllerMachine controller = (MultiblockControllerMachine) getMetaMachine(
+        WorkableMultiblockMachine controller = (WorkableMultiblockMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(1, 2, 0)));
         TestUtils.formMultiblock(controller);
+        controller.setRecipeType(LCRrecipeType);
         ItemBusPartMachine inputBus1 = (ItemBusPartMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(2, 1, 0)));
         ItemBusPartMachine inputBus2 = (ItemBusPartMachine) getMetaMachine(
@@ -66,7 +69,7 @@ public class InputSeparationTest {
                 helper.getBlockEntity(new BlockPos(0, 1, 0)));
         FluidHatchPartMachine outputHatch1 = (FluidHatchPartMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(0, 2, 0)));
-        return new BusHolder(inputBus1, inputBus2, outputBus1, outputHatch1);
+        return new BusHolder(inputBus1, inputBus2, outputBus1, outputHatch1, controller);
     }
 
     // Test for putting both ingredients in the same bus.

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.FluidHatchPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
@@ -22,11 +21,10 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
-import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.LARGE_CHEMICAL_RECIPES;
-
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class InputSeparationTest {
+
     private static GTRecipeType LCRrecipeType;
 
     @BeforeBatch(batch = "InputSeparation")

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
@@ -25,13 +25,13 @@ import net.minecraftforge.gametest.PrefixGameTestTemplate;
 @GameTestHolder(GTCEu.MOD_ID)
 public class InputSeparationTest {
 
-    private static GTRecipeType LCRrecipeType;
+    private static GTRecipeType LCR_RECIPE_TYPE;
 
     @BeforeBatch(batch = "InputSeparation")
     public static void prepare(ServerLevel level) {
-        LCRrecipeType = TestUtils.createRecipeType("InputSeparationLCRTests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("InputSeparationLCRTests");
         // Force insert the recipe into the manager.
-        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
+        LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test-multiblock-input-separation"))
                 .id(GTCEu.id("test-multiblock-input-separation"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.ACACIA_WOOD))
@@ -58,7 +58,7 @@ public class InputSeparationTest {
         WorkableMultiblockMachine controller = (WorkableMultiblockMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(1, 2, 0)));
         TestUtils.formMultiblock(controller);
-        controller.setRecipeType(LCRrecipeType);
+        controller.setRecipeType(LCR_RECIPE_TYPE);
         ItemBusPartMachine inputBus1 = (ItemBusPartMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(2, 1, 0)));
         ItemBusPartMachine inputBus2 = (ItemBusPartMachine) getMetaMachine(

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
@@ -8,7 +8,6 @@ import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
@@ -30,12 +29,12 @@ import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
 import static com.gregtechceu.gtceu.api.recipe.OverclockingLogic.*;
 import static com.gregtechceu.gtceu.common.data.GTRecipeModifiers.*;
-import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.CHEMICAL_RECIPES;
 import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.LARGE_CHEMICAL_RECIPES;
 
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class OverclockLogicTest {
+
     private static GTRecipeType LCRrecipeType;
     private static GTRecipeType CRrecipeType;
 
@@ -43,7 +42,6 @@ public class OverclockLogicTest {
     public static void prepare(ServerLevel level) {
         LCRrecipeType = TestUtils.createRecipeType("OverclockLogicLCRTests");
         CRrecipeType = TestUtils.createRecipeType("OverclockLogicCRTests");
-
 
         LCRrecipeType.getLookup().addRecipe(LCRrecipeType
                 .recipeBuilder(GTCEu.id("test-overlock-logic"))

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.FluidHatchPartMachine;
@@ -35,10 +36,16 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.LARGE_CHEMICAL_REC
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class OverclockLogicTest {
+    private static GTRecipeType LCRrecipeType;
+    private static GTRecipeType CRrecipeType;
 
     @BeforeBatch(batch = "OverclockLogic")
     public static void prepare(ServerLevel level) {
-        LARGE_CHEMICAL_RECIPES.getLookup().addRecipe(LARGE_CHEMICAL_RECIPES
+        LCRrecipeType = TestUtils.createRecipeType("OverclockLogicLCRTests");
+        CRrecipeType = TestUtils.createRecipeType("OverclockLogicCRTests");
+
+
+        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
                 .recipeBuilder(GTCEu.id("test-overlock-logic"))
                 .id(GTCEu.id("test-overlock-logic"))
                 .inputItems(new ItemStack(Items.RED_BED))
@@ -47,7 +54,7 @@ public class OverclockLogicTest {
                 .duration(20)
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
-        LARGE_CHEMICAL_RECIPES.getLookup().addRecipe(LARGE_CHEMICAL_RECIPES
+        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
                 .recipeBuilder(GTCEu.id("test-overlock-logic-2"))
                 .id(GTCEu.id("test-overlock-logic-2"))
                 .inputItems(new ItemStack(Items.STICK))
@@ -56,7 +63,7 @@ public class OverclockLogicTest {
                 .duration(1)
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
-        LARGE_CHEMICAL_RECIPES.getLookup().addRecipe(LARGE_CHEMICAL_RECIPES
+        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
                 .recipeBuilder(GTCEu.id("test-overlock-logic-3"))
                 .id(GTCEu.id("test-overlock-logic-3"))
                 .inputItems(new ItemStack(Items.BROWN_BED))
@@ -65,7 +72,7 @@ public class OverclockLogicTest {
                 .duration(1)
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
-        CHEMICAL_RECIPES.getLookup().addRecipe(CHEMICAL_RECIPES
+        CRrecipeType.getLookup().addRecipe(CRrecipeType
                 .recipeBuilder(GTCEu.id("test-overlock-logic-4"))
                 .id(GTCEu.id("test-overlock-logic-4"))
                 .inputItems(new ItemStack(Items.RED_BED))
@@ -74,7 +81,7 @@ public class OverclockLogicTest {
                 .duration(16)
                 // NBT has a schematic in it with an HV charged singleblock CR in it
                 .buildRawRecipe());
-        CHEMICAL_RECIPES.getLookup().addRecipe(CHEMICAL_RECIPES
+        CRrecipeType.getLookup().addRecipe(CRrecipeType
                 .recipeBuilder(GTCEu.id("test-overlock-logic-5"))
                 .id(GTCEu.id("test-overlock-logic-5"))
                 .inputItems(new ItemStack(Items.BROWN_BED))
@@ -90,7 +97,7 @@ public class OverclockLogicTest {
     }
 
     private record BusHolder(ItemBusPartMachine inputBus1, ItemBusPartMachine inputBus2, ItemBusPartMachine outputBus1,
-                             FluidHatchPartMachine outputHatch1, MultiblockControllerMachine controller) {}
+                             FluidHatchPartMachine outputHatch1, WorkableMultiblockMachine controller) {}
 
     /**
      * Retrieves the busses for this specific template and force a multiblock structure check
@@ -99,9 +106,10 @@ public class OverclockLogicTest {
      * @return the busses, in the BusHolder record.
      */
     private static BusHolder getBussesAndForm(GameTestHelper helper) {
-        MultiblockControllerMachine controller = (MultiblockControllerMachine) getMetaMachine(
+        WorkableMultiblockMachine controller = (WorkableMultiblockMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(1, 2, 0)));
         TestUtils.formMultiblock(controller);
+        controller.setRecipeType(LCRrecipeType);
         ItemBusPartMachine inputBus1 = (ItemBusPartMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(2, 1, 0)));
         ItemBusPartMachine inputBus2 = (ItemBusPartMachine) getMetaMachine(
@@ -320,6 +328,7 @@ public class OverclockLogicTest {
         SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(0, 1, 0)));
 
+        machine.setRecipeType(CRrecipeType);
         NotifiableEnergyContainer energyContainer = (NotifiableEnergyContainer) machine
                 .getCapabilitiesFlat(IO.IN, EURecipeCapability.CAP).get(0);
         NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
@@ -353,6 +362,7 @@ public class OverclockLogicTest {
         SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(0, 1, 0)));
 
+        machine.setRecipeType(CRrecipeType);
         NotifiableEnergyContainer energyContainer = (NotifiableEnergyContainer) machine
                 .getCapabilitiesFlat(IO.IN, EURecipeCapability.CAP).get(0);
         NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
@@ -35,15 +35,15 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.LARGE_CHEMICAL_REC
 @GameTestHolder(GTCEu.MOD_ID)
 public class OverclockLogicTest {
 
-    private static GTRecipeType LCRrecipeType;
-    private static GTRecipeType CRrecipeType;
+    private static GTRecipeType LCR_RECIPE_TYPE;
+    private static GTRecipeType CR_RECIPE_TYPE;
 
     @BeforeBatch(batch = "OverclockLogic")
     public static void prepare(ServerLevel level) {
-        LCRrecipeType = TestUtils.createRecipeType("OverclockLogicLCRTests");
-        CRrecipeType = TestUtils.createRecipeType("OverclockLogicCRTests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("OverclockLogicLCRTests");
+        CR_RECIPE_TYPE = TestUtils.createRecipeType("OverclockLogicCRTests");
 
-        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
+        LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test-overlock-logic"))
                 .id(GTCEu.id("test-overlock-logic"))
                 .inputItems(new ItemStack(Items.RED_BED))
@@ -52,7 +52,7 @@ public class OverclockLogicTest {
                 .duration(20)
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
-        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
+        LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test-overlock-logic-2"))
                 .id(GTCEu.id("test-overlock-logic-2"))
                 .inputItems(new ItemStack(Items.STICK))
@@ -61,7 +61,7 @@ public class OverclockLogicTest {
                 .duration(1)
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
-        LCRrecipeType.getLookup().addRecipe(LCRrecipeType
+        LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test-overlock-logic-3"))
                 .id(GTCEu.id("test-overlock-logic-3"))
                 .inputItems(new ItemStack(Items.BROWN_BED))
@@ -70,7 +70,7 @@ public class OverclockLogicTest {
                 .duration(1)
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
-        CRrecipeType.getLookup().addRecipe(CRrecipeType
+        CR_RECIPE_TYPE.getLookup().addRecipe(CR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test-overlock-logic-4"))
                 .id(GTCEu.id("test-overlock-logic-4"))
                 .inputItems(new ItemStack(Items.RED_BED))
@@ -79,7 +79,7 @@ public class OverclockLogicTest {
                 .duration(16)
                 // NBT has a schematic in it with an HV charged singleblock CR in it
                 .buildRawRecipe());
-        CRrecipeType.getLookup().addRecipe(CRrecipeType
+        CR_RECIPE_TYPE.getLookup().addRecipe(CR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test-overlock-logic-5"))
                 .id(GTCEu.id("test-overlock-logic-5"))
                 .inputItems(new ItemStack(Items.BROWN_BED))
@@ -107,7 +107,7 @@ public class OverclockLogicTest {
         WorkableMultiblockMachine controller = (WorkableMultiblockMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(1, 2, 0)));
         TestUtils.formMultiblock(controller);
-        controller.setRecipeType(LCRrecipeType);
+        controller.setRecipeType(LCR_RECIPE_TYPE);
         ItemBusPartMachine inputBus1 = (ItemBusPartMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(2, 1, 0)));
         ItemBusPartMachine inputBus2 = (ItemBusPartMachine) getMetaMachine(
@@ -326,7 +326,7 @@ public class OverclockLogicTest {
         SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(0, 1, 0)));
 
-        machine.setRecipeType(CRrecipeType);
+        machine.setRecipeType(CR_RECIPE_TYPE);
         NotifiableEnergyContainer energyContainer = (NotifiableEnergyContainer) machine
                 .getCapabilitiesFlat(IO.IN, EURecipeCapability.CAP).get(0);
         NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
@@ -360,7 +360,7 @@ public class OverclockLogicTest {
         SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
                 helper.getBlockEntity(new BlockPos(0, 1, 0)));
 
-        machine.setRecipeType(CRrecipeType);
+        machine.setRecipeType(CR_RECIPE_TYPE);
         NotifiableEnergyContainer energyContainer = (NotifiableEnergyContainer) machine
                 .getCapabilitiesFlat(IO.IN, EURecipeCapability.CAP).get(0);
         NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
@@ -40,12 +40,11 @@ public class OverclockLogicTest {
 
     @BeforeBatch(batch = "OverclockLogic")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("OverclockLogicLCRTests");
-        CR_RECIPE_TYPE = TestUtils.createRecipeType("OverclockLogicCRTests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("overclock_logic_lcr_tests");
+        CR_RECIPE_TYPE = TestUtils.createRecipeType("overclock_logic_cr_tests");
 
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
-                .recipeBuilder(GTCEu.id("test-overlock-logic"))
-                .id(GTCEu.id("test-overlock-logic"))
+                .recipeBuilder(GTCEu.id("test_overclock_logic"))
                 .inputItems(new ItemStack(Items.RED_BED))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.V[GTValues.HV])
@@ -53,8 +52,7 @@ public class OverclockLogicTest {
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
-                .recipeBuilder(GTCEu.id("test-overlock-logic-2"))
-                .id(GTCEu.id("test-overlock-logic-2"))
+                .recipeBuilder(GTCEu.id("test_overclock_logic_2"))
                 .inputItems(new ItemStack(Items.STICK))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.V[GTValues.LV])
@@ -62,8 +60,7 @@ public class OverclockLogicTest {
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
-                .recipeBuilder(GTCEu.id("test-overlock-logic-3"))
-                .id(GTCEu.id("test-overlock-logic-3"))
+                .recipeBuilder(GTCEu.id("test_overclock_logic_3"))
                 .inputItems(new ItemStack(Items.BROWN_BED))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.V[GTValues.EV])
@@ -71,8 +68,7 @@ public class OverclockLogicTest {
                 // NBT has a schematic in it with an HV energy input hatch
                 .buildRawRecipe());
         CR_RECIPE_TYPE.getLookup().addRecipe(CR_RECIPE_TYPE
-                .recipeBuilder(GTCEu.id("test-overlock-logic-4"))
-                .id(GTCEu.id("test-overlock-logic-4"))
+                .recipeBuilder(GTCEu.id("test_overclock_logic_4"))
                 .inputItems(new ItemStack(Items.RED_BED))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.V[GTValues.HV])
@@ -80,8 +76,7 @@ public class OverclockLogicTest {
                 // NBT has a schematic in it with an HV charged singleblock CR in it
                 .buildRawRecipe());
         CR_RECIPE_TYPE.getLookup().addRecipe(CR_RECIPE_TYPE
-                .recipeBuilder(GTCEu.id("test-overlock-logic-5"))
-                .id(GTCEu.id("test-overlock-logic-5"))
+                .recipeBuilder(GTCEu.id("test_overclock_logic_5"))
                 .inputItems(new ItemStack(Items.BROWN_BED))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.V[GTValues.MV])

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
@@ -1,32 +1,26 @@
 package com.gregtechceu.gtceu.api.recipe.lookup;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.AbstractMapIngredient;
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.item.ItemStackMapIngredient;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
-
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
-import com.gregtechceu.gtceu.utils.GTUtil;
+
 import net.minecraft.gametest.framework.BeforeBatch;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-
-import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.ELECTRIC;
 
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
@@ -10,6 +10,8 @@ import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.AbstractMapIngredient;
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.item.ItemStackMapIngredient;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 
+import com.gregtechceu.gtceu.gametest.util.TestUtils;
+import com.gregtechceu.gtceu.utils.GTUtil;
 import net.minecraft.gametest.framework.BeforeBatch;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
@@ -33,31 +35,27 @@ public class GTRecipeLookupTest {
     private static GTRecipeLookup lookup;
     private static final Predicate<GTRecipe> ALWAYS_TRUE = gtRecipe -> true;
     private static final Predicate<GTRecipe> ALWAYS_FALSE = gtRecipe -> false;
+    private static GTRecipeType recipeType;
     private static GTRecipe smeltStone, smeltAcaciaWood, smeltBirchWood, smeltCherryWood;
 
     @BeforeBatch(batch = "GTRecipeLookup")
     public static void prepare(ServerLevel level) {
-        GTRegistries.RECIPE_TYPES.unfreeze();
-        GTRegistries.RECIPE_CATEGORIES.unfreeze();
-        RecipeType<?> proxyRecipes = RecipeType.SMELTING;
-        GTRecipeType type = new GTRecipeType(GTCEu.id("test_recipes"), ELECTRIC, proxyRecipes)
-                .setEUIO(IO.IN)
-                .setMaxIOSize(1, 1, 0, 0);
-        lookup = new GTRecipeLookup(type);
+        recipeType = TestUtils.createRecipeType("recipeLookup");
+        lookup = new GTRecipeLookup(recipeType);
 
-        smeltStone = type.recipeBuilder("smelt_stone")
+        smeltStone = recipeType.recipeBuilder("smelt_stone")
                 .inputItems(Items.COBBLESTONE, 1)
                 .outputItems(Items.STONE, 1)
                 .buildRawRecipe();
-        smeltAcaciaWood = type.recipeBuilder("smelt_acacia_wood")
+        smeltAcaciaWood = recipeType.recipeBuilder("smelt_acacia_wood")
                 .inputItems(Items.ACACIA_WOOD, 1)
                 .outputItems(Items.CHARCOAL, 1)
                 .buildRawRecipe();
-        smeltBirchWood = type.recipeBuilder("smelt_birch_wood")
+        smeltBirchWood = recipeType.recipeBuilder("smelt_birch_wood")
                 .inputItems(Items.BIRCH_WOOD, 1)
                 .outputItems(Items.CHARCOAL, 1)
                 .buildRawRecipe();
-        smeltCherryWood = type.recipeBuilder("smelt_cherry_wood")
+        smeltCherryWood = recipeType.recipeBuilder("smelt_cherry_wood")
                 .inputItems(Items.CHERRY_WOOD, 16)
                 .outputItems(Items.CHARCOAL, 1)
                 .buildRawRecipe();
@@ -68,9 +66,6 @@ public class GTRecipeLookupTest {
                 smeltCherryWood)) {
             lookup.addRecipe(recipe);
         }
-
-        GTRegistries.RECIPE_TYPES.freeze();
-        GTRegistries.RECIPE_CATEGORIES.freeze();
     }
 
     private static List<List<AbstractMapIngredient>> createIngredients(ItemStack... stacks) {

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
@@ -34,8 +34,8 @@ public class GTRecipeLookupTest {
 
     @BeforeBatch(batch = "GTRecipeLookup")
     public static void prepare(ServerLevel level) {
-        RECIPE_TYPE = TestUtils.createRecipeType("recipeLookup");
-        LOOKUP = new GTRecipeLookup(RECIPE_TYPE);
+        RECIPE_TYPE = TestUtils.createRecipeType("recipe_lookup");
+        LOOKUP = RECIPE_TYPE.getLookup();
 
         SMELT_STONE = RECIPE_TYPE.recipeBuilder("smelt_stone")
                 .inputItems(Items.COBBLESTONE, 1)

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
@@ -26,39 +26,39 @@ import java.util.function.Predicate;
 @GameTestHolder(GTCEu.MOD_ID)
 public class GTRecipeLookupTest {
 
-    private static GTRecipeLookup lookup;
+    private static GTRecipeLookup LOOKUP;
     private static final Predicate<GTRecipe> ALWAYS_TRUE = gtRecipe -> true;
     private static final Predicate<GTRecipe> ALWAYS_FALSE = gtRecipe -> false;
-    private static GTRecipeType recipeType;
-    private static GTRecipe smeltStone, smeltAcaciaWood, smeltBirchWood, smeltCherryWood;
+    private static GTRecipeType RECIPE_TYPE;
+    private static GTRecipe SMELT_STONE, SMELT_ACACIA_WOOD, SMELT_BIRCH_WOOD, SMELT_CHERRY_WOOD;
 
     @BeforeBatch(batch = "GTRecipeLookup")
     public static void prepare(ServerLevel level) {
-        recipeType = TestUtils.createRecipeType("recipeLookup");
-        lookup = new GTRecipeLookup(recipeType);
+        RECIPE_TYPE = TestUtils.createRecipeType("recipeLookup");
+        LOOKUP = new GTRecipeLookup(RECIPE_TYPE);
 
-        smeltStone = recipeType.recipeBuilder("smelt_stone")
+        SMELT_STONE = RECIPE_TYPE.recipeBuilder("smelt_stone")
                 .inputItems(Items.COBBLESTONE, 1)
                 .outputItems(Items.STONE, 1)
                 .buildRawRecipe();
-        smeltAcaciaWood = recipeType.recipeBuilder("smelt_acacia_wood")
+        SMELT_ACACIA_WOOD = RECIPE_TYPE.recipeBuilder("smelt_acacia_wood")
                 .inputItems(Items.ACACIA_WOOD, 1)
                 .outputItems(Items.CHARCOAL, 1)
                 .buildRawRecipe();
-        smeltBirchWood = recipeType.recipeBuilder("smelt_birch_wood")
+        SMELT_BIRCH_WOOD = RECIPE_TYPE.recipeBuilder("smelt_birch_wood")
                 .inputItems(Items.BIRCH_WOOD, 1)
                 .outputItems(Items.CHARCOAL, 1)
                 .buildRawRecipe();
-        smeltCherryWood = recipeType.recipeBuilder("smelt_cherry_wood")
+        SMELT_CHERRY_WOOD = RECIPE_TYPE.recipeBuilder("smelt_cherry_wood")
                 .inputItems(Items.CHERRY_WOOD, 16)
                 .outputItems(Items.CHARCOAL, 1)
                 .buildRawRecipe();
 
-        for (GTRecipe recipe : List.of(smeltStone,
-                smeltAcaciaWood,
-                smeltBirchWood,
-                smeltCherryWood)) {
-            lookup.addRecipe(recipe);
+        for (GTRecipe recipe : List.of(SMELT_STONE,
+                SMELT_ACACIA_WOOD,
+                SMELT_BIRCH_WOOD,
+                SMELT_CHERRY_WOOD)) {
+            LOOKUP.addRecipe(recipe);
         }
     }
 
@@ -73,8 +73,8 @@ public class GTRecipeLookupTest {
     @GameTest(template = "empty", batch = "GTRecipeLookup")
     public static void recipeLookupSimpleSuccessTest(GameTestHelper helper) {
         var ingredients = createIngredients(new ItemStack(Items.COBBLESTONE, 1));
-        GTRecipe resultRecipe = lookup.recurseIngredientTreeFindRecipe(ingredients, lookup.getLookup(), ALWAYS_TRUE);
-        helper.assertTrue(smeltStone.equals(resultRecipe),
+        GTRecipe resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(ingredients, LOOKUP.getLookup(), ALWAYS_TRUE);
+        helper.assertTrue(SMELT_STONE.equals(resultRecipe),
                 "GT Recipe should be smelt_stone, instead was " + resultRecipe);
         helper.succeed();
     }
@@ -84,7 +84,7 @@ public class GTRecipeLookupTest {
     @GameTest(template = "empty", batch = "GTRecipeLookup")
     public static void recipeLookupSimpleFailureTest(GameTestHelper helper) {
         var ingredients = createIngredients(new ItemStack(Items.REDSTONE_TORCH, 1));
-        GTRecipe resultRecipe = lookup.recurseIngredientTreeFindRecipe(ingredients, lookup.getLookup(), ALWAYS_TRUE);
+        GTRecipe resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(ingredients, LOOKUP.getLookup(), ALWAYS_TRUE);
         helper.assertTrue(resultRecipe == null, "GT Recipe should be empty (null), instead was " + resultRecipe);
         helper.succeed();
     }
@@ -94,7 +94,7 @@ public class GTRecipeLookupTest {
     @GameTest(template = "empty", batch = "GTRecipeLookup")
     public static void recipeLookupFalsePredicateFailureTest(GameTestHelper helper) {
         var ingredients = createIngredients(new ItemStack(Items.COBBLESTONE, 1));
-        GTRecipe resultRecipe = lookup.recurseIngredientTreeFindRecipe(ingredients, lookup.getLookup(), ALWAYS_FALSE);
+        GTRecipe resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(ingredients, LOOKUP.getLookup(), ALWAYS_FALSE);
         helper.assertTrue(resultRecipe == null, "GT Recipe should be empty (null), instead was " + resultRecipe);
         helper.succeed();
     }
@@ -104,8 +104,8 @@ public class GTRecipeLookupTest {
     public static void recipeLookupMultipleIngredientsSuccessTest(GameTestHelper helper) {
         var ingredients = createIngredients(new ItemStack(Items.COBBLESTONE, 1),
                 new ItemStack(Items.REDSTONE_TORCH, 1));
-        GTRecipe resultRecipe = lookup.recurseIngredientTreeFindRecipe(ingredients, lookup.getLookup(), ALWAYS_TRUE);
-        helper.assertTrue(smeltStone.equals(resultRecipe),
+        GTRecipe resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(ingredients, LOOKUP.getLookup(), ALWAYS_TRUE);
+        helper.assertTrue(SMELT_STONE.equals(resultRecipe),
                 "GT Recipe should be smelt_stone, instead was " + resultRecipe);
         helper.succeed();
     }
@@ -116,14 +116,14 @@ public class GTRecipeLookupTest {
     public static void recipeLookupIngredientCountSucceedTest(GameTestHelper helper) {
         // NOTE: RecipeLookup only checks item type, not item count, so this will still work
         var notEnoughIngredients = createIngredients(new ItemStack(Items.CHERRY_WOOD, 8));
-        GTRecipe resultRecipe = lookup.recurseIngredientTreeFindRecipe(notEnoughIngredients, lookup.getLookup(),
+        GTRecipe resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(notEnoughIngredients, LOOKUP.getLookup(),
                 ALWAYS_TRUE);
-        helper.assertTrue(smeltCherryWood.equals(resultRecipe),
+        helper.assertTrue(SMELT_CHERRY_WOOD.equals(resultRecipe),
                 "GT Recipe should be smelt_cherry_wood, instead was " + resultRecipe);
 
         var enoughIngredients = createIngredients(new ItemStack(Items.CHERRY_WOOD, 16));
-        resultRecipe = lookup.recurseIngredientTreeFindRecipe(enoughIngredients, lookup.getLookup(), ALWAYS_TRUE);
-        helper.assertTrue(smeltCherryWood.equals(resultRecipe),
+        resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(enoughIngredients, LOOKUP.getLookup(), ALWAYS_TRUE);
+        helper.assertTrue(SMELT_CHERRY_WOOD.equals(resultRecipe),
                 "GT Recipe should be smelt_cherry_wood, instead was " + resultRecipe);
         helper.succeed();
     }
@@ -134,17 +134,17 @@ public class GTRecipeLookupTest {
         var ingredients = createIngredients(new ItemStack(Items.CHERRY_WOOD, 16));
         // Do a recipe check with a condition that requires at least 4 ingredients in the inputs
         // The recipe has 8, so this should succeed
-        GTRecipe resultRecipe = lookup.recurseIngredientTreeFindRecipe(ingredients, lookup.getLookup(),
+        GTRecipe resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(ingredients, LOOKUP.getLookup(),
                 recipe -> recipe.inputs
                         .getOrDefault(ItemRecipeCapability.CAP, List.of())
                         .stream()
                         .allMatch(content -> ((SizedIngredient) content.getContent()).getAmount() > 4));
-        helper.assertTrue(smeltCherryWood.equals(resultRecipe),
+        helper.assertTrue(SMELT_CHERRY_WOOD.equals(resultRecipe),
                 "GT Recipe should be smelt_cherry_wood, instead was " + resultRecipe);
 
         // Do a recipe check with a condition that requires at least 32 ingredients in the inputs
         // The recipe has 8, so this should fail
-        resultRecipe = lookup.recurseIngredientTreeFindRecipe(ingredients, lookup.getLookup(), recipe -> recipe.inputs
+        resultRecipe = LOOKUP.recurseIngredientTreeFindRecipe(ingredients, LOOKUP.getLookup(), recipe -> recipe.inputs
                 .getOrDefault(ItemRecipeCapability.CAP, List.of())
                 .stream()
                 .allMatch(content -> ((SizedIngredient) content.getContent()).getAmount() > 32));

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -1,13 +1,16 @@
 package com.gregtechceu.gtceu.gametest.util;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.block.Blocks;
 
 import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.ELECTRIC;
 
@@ -24,6 +27,19 @@ public class TestUtils {
     public static void formMultiblock(MultiblockControllerMachine controller) {
         controller.getPattern().checkPatternAt(controller.getMultiblockState(), false);
         controller.onStructureFormed();
+    }
+
+    // Creates a dummy recipe type that also includes a basic, HV, 1 tick, cobblestone -> stone recipe
+    public static GTRecipeType createRecipeTypeAndInsertRecipe(String name){
+        GTRecipeType type = createRecipeType(name);
+        type.getLookup().addRecipe(type
+                .recipeBuilder(GTCEu.id("testRecipe"))
+                .id(GTCEu.id("testRecipe"))
+                .inputItems(new ItemStack(Items.COBBLESTONE))
+                .outputItems(new ItemStack(Blocks.STONE))
+                .EUt(GTValues.V[GTValues.HV])
+                .duration(1).buildRawRecipe());
+        return type;
     }
 
     public static GTRecipeType createRecipeType(String name) {

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -30,7 +30,7 @@ public class TestUtils {
     }
 
     // Creates a dummy recipe type that also includes a basic, HV, 1 tick, cobblestone -> stone recipe
-    public static GTRecipeType createRecipeTypeAndInsertRecipe(String name){
+    public static GTRecipeType createRecipeTypeAndInsertRecipe(String name) {
         GTRecipeType type = createRecipeType(name);
         type.getLookup().addRecipe(type
                 .recipeBuilder(GTCEu.id("testRecipe"))

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -1,8 +1,15 @@
 package com.gregtechceu.gtceu.gametest.util;
 
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeType;
+
+import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.ELECTRIC;
 
 public class TestUtils {
 
@@ -17,5 +24,22 @@ public class TestUtils {
     public static void formMultiblock(MultiblockControllerMachine controller) {
         controller.getPattern().checkPatternAt(controller.getMultiblockState(), false);
         controller.onStructureFormed();
+    }
+
+    public static GTRecipeType createRecipeType(String name){
+        return createRecipeType(name, 1, 1, 1, 1);
+    }
+
+    public static GTRecipeType createRecipeType(String name, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs){
+
+        GTRegistries.RECIPE_TYPES.unfreeze();
+        GTRegistries.RECIPE_CATEGORIES.unfreeze();
+        GTRecipeType type = new GTRecipeType(GTCEu.id(name), ELECTRIC, RecipeType.SMELTING)
+                .setEUIO(IO.IN)
+                .setMaxIOSize(maxInputs, maxOutputs, maxFluidInputs, maxFluidOutputs);
+
+        GTRegistries.RECIPE_CATEGORIES.freeze();
+        GTRegistries.RECIPE_TYPES.freeze();
+        return type;
     }
 }

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -33,8 +33,7 @@ public class TestUtils {
     public static GTRecipeType createRecipeTypeAndInsertRecipe(String name) {
         GTRecipeType type = createRecipeType(name);
         type.getLookup().addRecipe(type
-                .recipeBuilder(GTCEu.id("testRecipe"))
-                .id(GTCEu.id("testRecipe"))
+                .recipeBuilder(GTCEu.id("test_recipe"))
                 .inputItems(new ItemStack(Items.COBBLESTONE))
                 .outputItems(new ItemStack(Blocks.STONE))
                 .EUt(GTValues.V[GTValues.HV])

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -3,9 +3,9 @@ package com.gregtechceu.gtceu.gametest.util;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
-
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
+
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
 
@@ -26,12 +26,12 @@ public class TestUtils {
         controller.onStructureFormed();
     }
 
-    public static GTRecipeType createRecipeType(String name){
+    public static GTRecipeType createRecipeType(String name) {
         return createRecipeType(name, 1, 1, 1, 1);
     }
 
-    public static GTRecipeType createRecipeType(String name, int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs){
-
+    public static GTRecipeType createRecipeType(String name, int maxInputs, int maxOutputs, int maxFluidInputs,
+                                                int maxFluidOutputs) {
         GTRegistries.RECIPE_TYPES.unfreeze();
         GTRegistries.RECIPE_CATEGORIES.unfreeze();
         GTRecipeType type = new GTRecipeType(GTCEu.id(name), ELECTRIC, RecipeType.SMELTING)


### PR DESCRIPTION
## What
Create a new GTRecipeType per testing class

## Implementation Details
Opens up machine.setRecipeType()
this should ONLY BE USED for testing
I am open to hear other options, but I can't think of any else

also tests that are currently being written, I will rewrite to use this later :prayge:

## Outcome
We no longer edit the global recipe map for our tests
