### PR TITLE
Fix Ignore NBT in Not Working Properly in Robot Arms/Fluid Regulators

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
@@ -162,7 +162,8 @@ public class SimpleFluidFilter implements FluidFilter {
         for (var candidate : matches) {
             if (ignoreNbt && candidate.getFluid() == fluidStack.getFluid()) {
                 totalAmount += candidate.getAmount();
-            } else if (candidate.isFluidEqual(fluidStack)) {
+            }
+            if (!ignoreNbt && candidate.isFluidEqual(fluidStack)) {
                 totalAmount += candidate.getAmount();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -156,7 +156,8 @@ public class SimpleItemFilter implements ItemFilter {
         for (var candidate : matches) {
             if (ignoreNbt && ItemStack.isSameItem(candidate, itemStack)) {
                 totalCount += candidate.getCount();
-            } else if (ItemStack.isSameItemSameTags(candidate, itemStack)) {
+            }
+            if (!ignoreNbt && ItemStack.isSameItemSameTags(candidate, itemStack)) {
                 totalCount += candidate.getCount();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -405,13 +405,8 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
-
-            if(ignoreNBT){
-                if(!ItemStack.isSameItem(stack, slot)) continue;
-            } else {
-                if (!ItemStack.isSameItemSameTags(stack, slot)) continue;
-            } 
-
+            if (ignoreNBT && !ItemStack.isSameItem(stack, slot)) continue;
+            if (!ignoreNBT && !ItemStack.isSameItemSameTags(stack, slot)) continue;
             if (arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -405,8 +405,13 @@ public class ItemNetHandler implements IItemHandlerModifiable {
         for (int i = 0; i < handler.getSlots(); i++) {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
-            if (ignoreNBT && !ItemStack.isSameItem(stack, slot)) continue;
-            else if (!ItemStack.isSameItemSameTags(stack, slot)) continue;
+
+            if(ignoreNBT){
+                if(!ItemStack.isSameItem(stack, slot)) continue;
+            } else {
+                if (!ItemStack.isSameItemSameTags(stack, slot)) continue;
+            } 
+
             if (arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }


### PR DESCRIPTION
## What
Fixes incorrect logic for ignoring NBT data in robot arms/fluid regulators when they count how may items are in the target inventory to decide how many items to move in keep exact mode.
Fixes: https://github.com/GregTechCEu/GregTech-Modern/issues/3696

## Implementation Details
Only changes to if statement logic, hopefully wont break anything else

