### PR TITLE
Fix quantum tanks' fluid handlers not checking if the contained fluid is valid

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/misc/forge/QuantumFluidHandlerItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/forge/QuantumFluidHandlerItemStack.java
@@ -42,7 +42,7 @@ public class QuantumFluidHandlerItemStack implements IFluidHandlerItem, ICapabil
             return FluidStack.EMPTY;
         }
         FluidStack stack = FluidStack.loadFluidStackFromNBT(tagCompound.getCompound("stored"));
-        if (stack != FluidStack.EMPTY) {
+        if (!stack.isEmpty()) {
             stack.setAmount(GTMath.saturatedCast(tagCompound.getLong("storedAmount")));
         }
         return stack;

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/forge/QuantumFluidHandlerItemStack.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/forge/QuantumFluidHandlerItemStack.java
@@ -42,7 +42,9 @@ public class QuantumFluidHandlerItemStack implements IFluidHandlerItem, ICapabil
             return FluidStack.EMPTY;
         }
         FluidStack stack = FluidStack.loadFluidStackFromNBT(tagCompound.getCompound("stored"));
-        stack.setAmount(GTMath.saturatedCast(tagCompound.getLong("storedAmount")));
+        if (stack != FluidStack.EMPTY) {
+            stack.setAmount(GTMath.saturatedCast(tagCompound.getLong("storedAmount")));
+        }
         return stack;
     }
 


### PR DESCRIPTION
## What

Fixed a bug where QuantumFluidHandlerItemStack didn't handle empty FluidStacks properly

closes #3714

