### PR TITLE
Add CraftingComponent for emitter/sensor gems

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/GTCraftingComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/GTCraftingComponents.java
@@ -46,6 +46,7 @@ public class GTCraftingComponents {
     public static CraftingComponent MOTOR;
     public static CraftingComponent ROTOR;
     public static CraftingComponent SENSOR;
+    public static CraftingComponent SENSOR_EMITTER_GEM;
     public static CraftingComponent GRINDER;
     public static CraftingComponent SAWBLADE;
     public static CraftingComponent PISTON;
@@ -511,6 +512,16 @@ public class GTCraftingComponents {
                     .add(UXV, GTItems.SENSOR_UXV.asStack())
                     .add(OpV, GTItems.SENSOR_OpV.asStack());
         }
+
+        SENSOR_EMITTER_GEM = CraftingComponent.of("sensor_emitter_gem", gem, Quartzite)
+                .add(LV, gem, Quartzite)
+                .add(MV, gemFlawless, Emerald)
+                .add(HV, gem, EnderEye)
+                .add(EV, GTItems.QUANTUM_EYE.asStack())
+                .add(IV, GTItems.QUANTUM_STAR.asStack())
+                .add(LuV, GTItems.QUANTUM_STAR.asStack())
+                .add(ZPM, GTItems.QUANTUM_STAR.asStack())
+                .add(UV, GTItems.GRAVI_STAR.asStack());
 
         CONVEYOR = CraftingComponent.of("conveyor", GTItems.CONVEYOR_MODULE_LV.asStack())
                 .add(LV, GTItems.CONVEYOR_MODULE_LV.asStack())

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/ComponentRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/ComponentRecipes.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.data.recipe.misc;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
+import com.gregtechceu.gtceu.data.recipe.GTCraftingComponents;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
 
 import net.minecraft.data.recipes.FinishedRecipe;
@@ -906,25 +907,25 @@ public class ComponentRecipes {
         // Start-------------------------------------------------------------------------------------------------
         VanillaRecipeHelper.addShapedRecipe(provider, true, "sensor_lv", SENSOR_LV.asStack(), "P G", "PR ", "XPP", 'P',
                 new MaterialEntry(plate, Steel), 'R', new MaterialEntry(rod, Brass), 'G',
-                new MaterialEntry(gem, Quartzite), 'X', CustomTags.LV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(LV), 'X', CustomTags.LV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "sensor_mv", SENSOR_MV.asStack(), "P G", "PR ", "XPP", 'P',
                 new MaterialEntry(plate, Aluminium), 'R', new MaterialEntry(rod, Electrum), 'G',
-                new MaterialEntry(gemFlawless, Emerald), 'X', CustomTags.MV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(MV), 'X', CustomTags.MV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "sensor_hv", SENSOR_HV.asStack(), "P G", "PR ", "XPP", 'P',
                 new MaterialEntry(plate, StainlessSteel), 'R', new MaterialEntry(rod, Chromium), 'G',
-                new MaterialEntry(gem, EnderEye), 'X', CustomTags.HV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(HV), 'X', CustomTags.HV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "sensor_ev", SENSOR_EV.asStack(), "P G", "PR ", "XPP", 'P',
                 new MaterialEntry(plate, Titanium), 'R', new MaterialEntry(rod, Platinum), 'G',
-                QUANTUM_EYE.asStack(), 'X', CustomTags.EV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(EV), 'X', CustomTags.EV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "sensor_iv", SENSOR_IV.asStack(), "P G", "PR ", "XPP", 'P',
                 new MaterialEntry(plate, TungstenSteel), 'R', new MaterialEntry(rod, Iridium), 'G',
-                QUANTUM_STAR.asStack(), 'X', CustomTags.IV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(IV), 'X', CustomTags.IV_CIRCUITS);
 
         ASSEMBLER_RECIPES.recipeBuilder("sensor_lv")
                 .inputItems(rod, Brass)
                 .inputItems(plate, Steel, 4)
                 .inputItems(CustomTags.LV_CIRCUITS)
-                .inputItems(gem, Quartzite)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(LV))
                 .outputItems(SENSOR_LV)
                 .duration(100).EUt(VA[LV]).save(provider);
 
@@ -932,7 +933,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Electrum)
                 .inputItems(plate, Aluminium, 4)
                 .inputItems(CustomTags.MV_CIRCUITS)
-                .inputItems(gemFlawless, Emerald)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(MV))
                 .outputItems(SENSOR_MV)
                 .duration(100).EUt(VA[LV]).save(provider);
 
@@ -940,7 +941,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Chromium)
                 .inputItems(plate, StainlessSteel, 4)
                 .inputItems(CustomTags.HV_CIRCUITS)
-                .inputItems(gem, EnderEye)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(HV))
                 .outputItems(SENSOR_HV)
                 .duration(100).EUt(VA[LV]).save(provider);
 
@@ -948,7 +949,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Platinum)
                 .inputItems(plate, Titanium, 4)
                 .inputItems(CustomTags.EV_CIRCUITS)
-                .inputItems(QUANTUM_EYE)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(EV))
                 .outputItems(SENSOR_EV)
                 .duration(100).EUt(VA[LV]).save(provider);
 
@@ -956,7 +957,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Iridium)
                 .inputItems(plate, TungstenSteel, 4)
                 .inputItems(CustomTags.IV_CIRCUITS)
-                .inputItems(QUANTUM_STAR)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(IV))
                 .outputItems(SENSOR_IV)
                 .duration(100).EUt(VA[LV]).save(provider);
 
@@ -964,7 +965,7 @@ public class ComponentRecipes {
                 .inputItems(frameGt, HSSS)
                 .inputItems(ELECTRIC_MOTOR_LuV)
                 .inputItems(plate, Ruridit, 4)
-                .inputItems(QUANTUM_STAR)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(LuV))
                 .inputItems(CustomTags.LuV_CIRCUITS, 2)
                 .inputItems(foil, Palladium, 64)
                 .inputItems(foil, Palladium, 32)
@@ -982,7 +983,7 @@ public class ComponentRecipes {
                 .inputItems(frameGt, NaquadahAlloy)
                 .inputItems(ELECTRIC_MOTOR_ZPM)
                 .inputItems(plate, Osmiridium, 4)
-                .inputItems(QUANTUM_STAR, 2)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(ZPM), 2)
                 .inputItems(CustomTags.ZPM_CIRCUITS, 2)
                 .inputItems(foil, Trinium, 64)
                 .inputItems(foil, Trinium, 32)
@@ -999,7 +1000,7 @@ public class ComponentRecipes {
                 .inputItems(frameGt, Tritanium)
                 .inputItems(ELECTRIC_MOTOR_UV)
                 .inputItems(plate, Tritanium, 4)
-                .inputItems(GRAVI_STAR)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(UV))
                 .inputItems(CustomTags.UV_CIRCUITS, 2)
                 .inputItems(foil, Naquadria, 64)
                 .inputItems(foil, Naquadria, 32)
@@ -1018,25 +1019,25 @@ public class ComponentRecipes {
         // Start------------------------------------------------------------------------------------------------
         VanillaRecipeHelper.addShapedRecipe(provider, true, "emitter_lv", EMITTER_LV.asStack(), "CRX", "RGR", "XRC",
                 'R', new MaterialEntry(rod, Brass), 'C', new MaterialEntry(cableGtSingle, Tin), 'G',
-                new MaterialEntry(gem, Quartzite), 'X', CustomTags.LV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(LV), 'X', CustomTags.LV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "emitter_mv", EMITTER_MV.asStack(), "CRX", "RGR", "XRC",
                 'R', new MaterialEntry(rod, Electrum), 'C', new MaterialEntry(cableGtSingle, Copper), 'G',
-                new MaterialEntry(gemFlawless, Emerald), 'X', CustomTags.MV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(MV), 'X', CustomTags.MV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "emitter_hv", EMITTER_HV.asStack(), "CRX", "RGR", "XRC",
                 'R', new MaterialEntry(rod, Chromium), 'C', new MaterialEntry(cableGtSingle, Gold), 'G',
-                new MaterialEntry(gem, EnderEye), 'X', CustomTags.HV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(HV), 'X', CustomTags.HV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "emitter_ev", EMITTER_EV.asStack(), "CRX", "RGR", "XRC",
                 'R', new MaterialEntry(rod, Platinum), 'C', new MaterialEntry(cableGtSingle, Aluminium), 'G',
-                QUANTUM_EYE.asStack(), 'X', CustomTags.EV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(EV), 'X', CustomTags.EV_CIRCUITS);
         VanillaRecipeHelper.addShapedRecipe(provider, true, "emitter_iv", EMITTER_IV.asStack(), "CRX", "RGR", "XRC",
                 'R', new MaterialEntry(rod, Iridium), 'C', new MaterialEntry(cableGtSingle, Tungsten), 'G',
-                QUANTUM_STAR.asStack(), 'X', CustomTags.IV_CIRCUITS);
+                GTCraftingComponents.SENSOR_EMITTER_GEM.get(IV), 'X', CustomTags.IV_CIRCUITS);
 
         ASSEMBLER_RECIPES.recipeBuilder("emitter_lv")
                 .inputItems(rod, Brass, 4)
                 .inputItems(cableGtSingle, Tin, 2)
                 .inputItems(CustomTags.LV_CIRCUITS, 2)
-                .inputItems(gem, Quartzite)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(LV))
                 .circuitMeta(1)
                 .outputItems(EMITTER_LV)
                 .duration(100).EUt(VA[LV]).save(provider);
@@ -1045,7 +1046,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Electrum, 4)
                 .inputItems(cableGtSingle, Copper, 2)
                 .inputItems(CustomTags.MV_CIRCUITS, 2)
-                .inputItems(gemFlawless, Emerald)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(MV))
                 .circuitMeta(1)
                 .outputItems(EMITTER_MV)
                 .duration(100).EUt(VA[LV]).save(provider);
@@ -1054,7 +1055,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Chromium, 4)
                 .inputItems(cableGtSingle, Gold, 2)
                 .inputItems(CustomTags.HV_CIRCUITS, 2)
-                .inputItems(gem, EnderEye)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(HV))
                 .circuitMeta(1)
                 .outputItems(EMITTER_HV)
                 .duration(100).EUt(VA[LV]).save(provider);
@@ -1063,7 +1064,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Platinum, 4)
                 .inputItems(cableGtSingle, Aluminium, 2)
                 .inputItems(CustomTags.EV_CIRCUITS, 2)
-                .inputItems(QUANTUM_EYE)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(EV))
                 .circuitMeta(1)
                 .outputItems(EMITTER_EV)
                 .duration(100).EUt(VA[LV]).save(provider);
@@ -1072,7 +1073,7 @@ public class ComponentRecipes {
                 .inputItems(rod, Iridium, 4)
                 .inputItems(cableGtSingle, Tungsten, 2)
                 .inputItems(CustomTags.IV_CIRCUITS, 2)
-                .inputItems(QUANTUM_STAR)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(IV))
                 .circuitMeta(1)
                 .outputItems(EMITTER_IV)
                 .duration(100).EUt(VA[LV]).save(provider);
@@ -1081,7 +1082,7 @@ public class ComponentRecipes {
                 .inputItems(frameGt, HSSS)
                 .inputItems(ELECTRIC_MOTOR_LuV)
                 .inputItems(rodLong, Ruridit, 4)
-                .inputItems(QUANTUM_STAR)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(LuV))
                 .inputItems(CustomTags.LuV_CIRCUITS, 2)
                 .inputItems(foil, Palladium, 64)
                 .inputItems(foil, Palladium, 32)
@@ -1099,7 +1100,7 @@ public class ComponentRecipes {
                 .inputItems(frameGt, NaquadahAlloy)
                 .inputItems(ELECTRIC_MOTOR_ZPM)
                 .inputItems(rodLong, Osmiridium, 4)
-                .inputItems(QUANTUM_STAR, 2)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(ZPM), 2)
                 .inputItems(CustomTags.ZPM_CIRCUITS, 2)
                 .inputItems(foil, Trinium, 64)
                 .inputItems(foil, Trinium, 32)
@@ -1116,7 +1117,7 @@ public class ComponentRecipes {
                 .inputItems(frameGt, Tritanium)
                 .inputItems(ELECTRIC_MOTOR_UV)
                 .inputItems(rodLong, Tritanium, 4)
-                .inputItems(GRAVI_STAR)
+                .inputItems(GTCraftingComponents.SENSOR_EMITTER_GEM.get(UV))
                 .inputItems(CustomTags.UV_CIRCUITS, 2)
                 .inputItems(foil, Naquadria, 64)
                 .inputItems(foil, Naquadria, 32)


### PR DESCRIPTION
## What
Adds CraftingComponent for gems used in emitters and sensors for ease of editing recipes.

## Implementation Details
We create a new CraftingComponent, SENSOR_EMITTER_GEM, and update the sensor component recipes to use it.

## Outcome
Sensor and emitter recipes are unchanged but now use SENSOR_EMITTER_GEM. Resolves #3642
