### PR TITLE
Queue an update for pattern buffers when they are placed

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -171,6 +171,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
                         this.detailsSlotMap.put(patternDetails, this.internalInventory[i]);
                     }
                 }
+                needPatternSync = true;
             }));
         }
     }


### PR DESCRIPTION
## What
Closes #3550

## Implementation Details
By marking our pattern buffers as dirty on place, they get updated when the system connects and therefore the ME system can see the patterns properly