### PR TITLE
Offset facades by smaller number

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/FacadeCoverRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/FacadeCoverRenderer.java
@@ -49,19 +49,19 @@ import java.util.*;
  */
 public class FacadeCoverRenderer extends BaseBakedModel implements ICoverRenderer {
 
-    private static final AABB FACADE_PLANE = new AABB(0.01, 0.01, 0.01, 0.99, 0.99, 1 / 16f);
+    private static final AABB FACADE_PLANE = new AABB(0.001, 0.001, 0.001, 0.999, 0.999, 1 / 160f);
     private static final EnumSet<Direction> FACADE_EDGE_FACES = EnumSet.of(Direction.DOWN, Direction.UP,
             Direction.SOUTH, Direction.WEST, Direction.EAST);
     private static final Map<Direction, AABB> COVER_BACK_CUBES = Util.make(new EnumMap<>(Direction.class), map -> {
         for (Direction dir : GTUtil.DIRECTIONS) {
             var normal = dir.getNormal();
             var cube = new AABB(
-                    normal.getX() > 0 ? 1.01 : -0.01,
-                    normal.getY() > 0 ? 1.01 : -0.01,
-                    normal.getZ() > 0 ? 1.01 : -0.01,
-                    normal.getX() >= 0 ? 1.01 : -0.01,
-                    normal.getY() >= 0 ? 1.01 : -0.01,
-                    normal.getZ() >= 0 ? 1.01 : -0.01);
+                    normal.getX() > 0 ? 1.001 : -0.001,
+                    normal.getY() > 0 ? 1.001 : -0.001,
+                    normal.getZ() > 0 ? 1.001 : -0.001,
+                    normal.getX() >= 0 ? 1.001 : -0.001,
+                    normal.getY() >= 0 ? 1.001 : -0.001,
+                    normal.getZ() >= 0 ? 1.001 : -0.001);
             map.put(dir, cube);
         }
     });

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/FacadeCoverRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/cover/FacadeCoverRenderer.java
@@ -49,7 +49,7 @@ import java.util.*;
  */
 public class FacadeCoverRenderer extends BaseBakedModel implements ICoverRenderer {
 
-    private static final AABB FACADE_PLANE = new AABB(0.001, 0.001, 0.001, 0.999, 0.999, 1 / 160f);
+    private static final AABB FACADE_PLANE = new AABB(0.001, 0.001, 0.001, 0.999, 0.999, 1 / 16f);
     private static final EnumSet<Direction> FACADE_EDGE_FACES = EnumSet.of(Direction.DOWN, Direction.UP,
             Direction.SOUTH, Direction.WEST, Direction.EAST);
     private static final Map<Direction, AABB> COVER_BACK_CUBES = Util.make(new EnumMap<>(Direction.class), map -> {


### PR DESCRIPTION
## What
Closes #3727

## Implementation Details
I'm not exactly sure what the z2 value is for and why it was 1/16f instead of 0.001?

## Outcome
before
<img width="2560" height="1369" alt="2025-08-14_16 11 28" src="https://github.com/user-attachments/assets/34210f1d-3510-417e-bea4-5ff95d08cbdf" />
after
<img width="2560" height="1369" alt="2025-08-14_16 14 46" src="https://github.com/user-attachments/assets/23e3aad5-e7ae-47d8-b836-241227e0d523" />

requires review from @screret since they made this code for the model rewrite