### PR TITLE
Add check for recipe voltage in notifiableEnergyContainer

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
@@ -313,6 +313,11 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
                 continue;
             }
 
+            // Check if recipe voltage is less than or equal to handler voltage
+            if (io.support(IO.IN) && stack.voltage() > this.getInputVoltage()) {
+                continue;
+            }
+
             long totalEU = stack.getTotalEU();
             long canTransfer = Math.min(totalEU, (io == IO.IN ? this.getEnergyStored() :
                     this.getEnergyCapacity() - this.getEnergyStored()));

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
@@ -314,7 +314,8 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
             }
 
             // Check if recipe voltage is less than or equal to handler voltage
-            if (io.support(IO.IN) && stack.voltage() > this.getInputVoltage()) {
+            long maxVoltage = io == IO.IN ? this.getInputVoltage() : this.getOutputVoltage();
+            if (stack.voltage() > maxVoltage) {
                 continue;
             }
 


### PR DESCRIPTION
## What
Fail the HandleRecipe of the NotifiableEnergyContainer if the tier is too low

## Outcome
This way, if the tier doesn't match, it stops recipe checking instead of lagging for no reason

Closes #3700