### PR TITLE
Add name to research error

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
@@ -313,6 +313,11 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
                 continue;
             }
 
+            // Check if recipe voltage is less than or equal to handler voltage
+            if (io.support(IO.IN) && stack.voltage() > this.getInputVoltage()) {
+                continue;
+            }
+
             long totalEU = stack.getTotalEU();
             long canTransfer = Math.min(totalEU, (io == IO.IN ? this.getEnergyStored() :
                     this.getEnergyCapacity() - this.getEnergyStored()));

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ResearchRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ResearchRecipeBuilder.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 import com.gregtechceu.gtceu.utils.GTStringUtils;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -58,9 +59,10 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
         return (T) this;
     }
 
-    protected void validateResearchItem() {
+    protected void validateResearchItem(ResourceLocation recipeId) {
         if (itemResearchStack.isEmpty() && fluidResearchStack.isEmpty()) {
-            throw new IllegalArgumentException("Research recipe must have an item or fluid stack!");
+            throw new IllegalArgumentException(
+                    "Research recipe for " + recipeId + " must have an item or fluid stack!");
         }
 
         if (researchId == null) {
@@ -90,7 +92,7 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
 
     public abstract ItemStack getDefaultDataItem();
 
-    public abstract GTRecipeBuilder.ResearchRecipeEntry build();
+    public abstract GTRecipeBuilder.ResearchRecipeEntry build(ResourceLocation recipeId);
 
     @NoArgsConstructor
     public static class ScannerRecipeBuilder extends ResearchRecipeBuilder<ScannerRecipeBuilder> {
@@ -111,8 +113,8 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
         }
 
         @Override
-        public GTRecipeBuilder.ResearchRecipeEntry build() {
-            validateResearchItem();
+        public GTRecipeBuilder.ResearchRecipeEntry build(ResourceLocation recipeId) {
+            validateResearchItem(recipeId);
             if (duration <= 0) duration = DEFAULT_SCANNER_DURATION;
             if (eut == null || eut.voltage() <= 0) eut = new EnergyStack(DEFAULT_SCANNER_EUT, 1);
             return new GTRecipeBuilder.ResearchRecipeEntry(researchId, itemResearchStack, fluidResearchStack, dataStack,
@@ -149,8 +151,8 @@ public abstract class ResearchRecipeBuilder<T extends ResearchRecipeBuilder<T>> 
         }
 
         @Override
-        public GTRecipeBuilder.ResearchRecipeEntry build() {
-            validateResearchItem();
+        public GTRecipeBuilder.ResearchRecipeEntry build(ResourceLocation recipeId) {
+            validateResearchItem(recipeId);
             if (cwut <= 0 || totalCWU <= 0) {
                 throw new IllegalArgumentException("CWU/t and total CWU must both be set, and non-zero!");
             }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1225,7 +1225,7 @@ public class GTRecipeBuilder {
      * Generates a research recipe for the Scanner.
      */
     public GTRecipeBuilder scannerResearch(UnaryOperator<ResearchRecipeBuilder.ScannerRecipeBuilder> research) {
-        ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.ScannerRecipeBuilder()).build();
+        ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.ScannerRecipeBuilder()).build(this.id);
         if (applyResearchProperty(new ResearchData.ResearchEntry(entry.researchId, entry.dataStack))) {
             this.researchRecipeEntries.add(entry);
         }
@@ -1246,7 +1246,7 @@ public class GTRecipeBuilder {
      * Generates a research recipe for the Research Station.
      */
     public GTRecipeBuilder stationResearch(UnaryOperator<ResearchRecipeBuilder.StationRecipeBuilder> research) {
-        ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.StationRecipeBuilder()).build();
+        ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.StationRecipeBuilder()).build(this.id);
         if (applyResearchProperty(new ResearchData.ResearchEntry(entry.researchId, entry.dataStack))) {
             this.researchRecipeEntries.add(entry);
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -968,7 +968,7 @@ public interface GTRecipeSchema {
          */
         public GTRecipeJS scannerResearch(UnaryOperator<ResearchRecipeBuilder.ScannerRecipeBuilder> research) {
             GTRecipeBuilder.ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.ScannerRecipeBuilder())
-                    .build();
+                    .build(this.id);
             if (applyResearchProperty(new ResearchData.ResearchEntry(entry.researchId(), entry.dataStack()))) {
                 this.researchRecipeEntries.add(entry);
             }
@@ -990,7 +990,7 @@ public interface GTRecipeSchema {
          */
         public GTRecipeJS stationResearch(UnaryOperator<ResearchRecipeBuilder.StationRecipeBuilder> research) {
             GTRecipeBuilder.ResearchRecipeEntry entry = research.apply(new ResearchRecipeBuilder.StationRecipeBuilder())
-                    .build();
+                    .build(this.id);
             if (applyResearchProperty(new ResearchData.ResearchEntry(entry.researchId(), entry.dataStack()))) {
                 this.researchRecipeEntries.add(entry);
             }


### PR DESCRIPTION
## What
Passes the name of the recipe to the research entry build function so we can log if something goes wrong more effectively

## Implementation Details
Idk if this changes KubeJS stuff? I don't think so, worst comes to worst a recipe has a null ID and it just logs "null"

## Outcome
You can actually see what's wrong with your research recipe

Blocked by #3735 because I'm a little poopyhead and cba to fix my git history