### PR TITLE
Update docs for creating custom coils. Fix tooltip on coil energy usage.

### DIFF
--- a/docs/content/Modpacks/Other-Topics/Custom-Coils.md
+++ b/docs/content/Modpacks/Other-Topics/Custom-Coils.md
@@ -20,4 +20,9 @@ StartupEvents.registry('block', event => {
 })
 ```
 
-1. The Energy Discount must be at least 1.
+Temperature, Level, energyDiscount, and Tier all must be integers.
+* `temperature`: Used by Electric Blast Furnace recipes
+* `level`: Used to determine Multi-Smelter Parallels, at 32*level
+* `energyDiscount`: Used to determine Multi-Smelter power usage. EU/t = (4 * Parallels) / (8 * Discount), before overclocks.
+* `tier`: Used for Speed Bonus in the Pyrolyze Oven, and Energy Discount in the Cracking Unit. +50% Speed, 
+-10% Energy per tier.

--- a/docs/content/Modpacks/Other-Topics/Custom-Coils.md
+++ b/docs/content/Modpacks/Other-Topics/Custom-Coils.md
@@ -5,6 +5,9 @@ title: Custom Coils
 
 ## Coil Creation
 
+Certain multiblock machines such as the Electric Blast Furnace, Alloy Blast Smelter, Multi-Smelter, Pyrolyze Oven, and 
+Cracker use Heating Coils as part of their structure. The following code is used to define a custom Heating Coil block:
+
 ```js
 StartupEvents.registry('block', event => {
     event.create('infinity_coil_block', 'gtceu:coil')
@@ -20,9 +23,9 @@ StartupEvents.registry('block', event => {
 })
 ```
 
-Temperature, Level, energyDiscount, and Tier all must be integers.
-* `temperature`: Used by Electric Blast Furnace recipes
-* `level`: Used to determine Multi-Smelter Parallels, at 32*level
+`temperature`, `level`, `energyDiscount`, and `tier` all must be integers.
+* `temperature`: Used by Electric Blast Furnace recipes.
+* `level`: Used to determine Multi-Smelter Parallels, at 32*level.
 * `energyDiscount`: Used to determine Multi-Smelter power usage. EU/t = (4 * Parallels) / (8 * Discount), before overclocks.
 * `tier`: Used for Speed Bonus in the Pyrolyze Oven, and Energy Discount in the Cracking Unit. +50% Speed, 
--10% Energy per tier.
+-10% Energy per tier. (Tiers above 10 will not cause the Cracker to consume negative energy.)

--- a/src/main/java/com/gregtechceu/gtceu/common/block/CoilBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/CoilBlock.java
@@ -43,7 +43,7 @@ public class CoilBlock extends ActiveBlock {
             tooltip.add(
                     Component.translatable("block.gtceu.wire_coil.tooltip_parallel_smelter", coilType.getLevel() * 32));
             tooltip.add(Component.translatable("block.gtceu.wire_coil.tooltip_energy_smelter",
-                    (4 * coilType.getLevel() * 32 / (8 * coilType.getEnergyDiscount()))));
+                    Math.max(1, (4 * coilType.getLevel() * 32 / (8 * coilType.getEnergyDiscount())))));
             tooltip.add(Component.translatable("block.gtceu.wire_coil.tooltip_pyro"));
             tooltip.add(Component.translatable("block.gtceu.wire_coil.tooltip_speed_pyro",
                     coilTier == 0 ? 75 : 50 * (coilTier + 1)));

--- a/src/main/java/com/gregtechceu/gtceu/common/block/CoilBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/CoilBlock.java
@@ -43,7 +43,7 @@ public class CoilBlock extends ActiveBlock {
             tooltip.add(
                     Component.translatable("block.gtceu.wire_coil.tooltip_parallel_smelter", coilType.getLevel() * 32));
             tooltip.add(Component.translatable("block.gtceu.wire_coil.tooltip_energy_smelter",
-                    Math.max(1, 16 / coilType.getEnergyDiscount())));
+                    (4 * coilType.getLevel() * 32 / (8 * coilType.getEnergyDiscount()))));
             tooltip.add(Component.translatable("block.gtceu.wire_coil.tooltip_pyro"));
             tooltip.add(Component.translatable("block.gtceu.wire_coil.tooltip_speed_pyro",
                     coilTier == 0 ? 75 : 50 * (coilTier + 1)));

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
@@ -228,7 +228,7 @@ public class GTRecipeModifiers {
      * <li>Calculates the maximum parallel as {@code 32 × coilLevel}</li>
      * <li>Finds the actual parallel amount that the smelter can do</li>
      * <li>Sets the recipe duration to {@code 128 × 2 × parallels / maxParallels}</li>
-     * <li>Sets the recipe EUt to {@code parallels / (8 × coilDiscount)}</li>
+     * <li>Sets the recipe EUt to {@code 4 × (parallels / (8 × coilDiscount))}</li>
      * <li>Applies {@link OverclockingLogic#NON_PERFECT_OVERCLOCK} to this modified recipe</li>
      * <li>Multiplies the recipe contents by the parallel amount</li>
      * </ol>


### PR DESCRIPTION
## What
The wiki docs for using kjs to create custom heating coils were very incomplete. This fills them out with the important properties, and how those properties work.

Furthermore, the in-game tooltip for the multi-smelter energy cost of a given coil tier was completely wrong, so this fixes that too. Incidentally, this makes the coil blocks all look _a lot worse_ for multi-smelter energy usage; but this is actually just showing their current state (which we may want to reconsider the balance of)