### PR TITLE
Fix Multi-Smelter Energy Usage

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1592,7 +1592,7 @@
   "block.gtceu.white_studs": "spnʇS ǝʇıɥM",
   "block.gtceu.wire_coil.tooltip_cracking": ":ʇıu∩ buıʞɔɐɹƆ8§",
   "block.gtceu.wire_coil.tooltip_energy_cracking": "%s%%ɟ§ :ǝbɐs∩ ʎbɹǝuƎɐ§  ",
-  "block.gtceu.wire_coil.tooltip_energy_smelter": "ǝdıɔǝɹ ɹǝd8§ ʇ/∩Ǝ %sɟ§ :ǝbɐs∩ ʎbɹǝuƎɐ§  ",
+  "block.gtceu.wire_coil.tooltip_energy_smelter": "ʇ/∩Ǝ %sɟ§ :ǝbɐs∩ ʎbɹǝuƎɐ§  ",
   "block.gtceu.wire_coil.tooltip_extended_info": "oɟuI snuoᗺ ןıoƆ ʍoɥs oʇ ⟘ℲIHS pןoHㄥ§",
   "block.gtceu.wire_coil.tooltip_heat": "ʞ %dɟ§ :ʎʇıɔɐdɐƆ ʇɐǝH ǝsɐᗺɔ§",
   "block.gtceu.wire_coil.tooltip_parallel_smelter": "%sɟ§ :ןǝןןɐɹɐԀ xɐWϛ§  ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1592,7 +1592,7 @@
   "block.gtceu.white_studs": "White Studs",
   "block.gtceu.wire_coil.tooltip_cracking": "§8Cracking Unit:",
   "block.gtceu.wire_coil.tooltip_energy_cracking": "  §aEnergy Usage: §f%s%%",
-  "block.gtceu.wire_coil.tooltip_energy_smelter": "  §aEnergy Usage: §f%s EU/t §8per recipe",
+  "block.gtceu.wire_coil.tooltip_energy_smelter": "  §aEnergy Usage: §f%s EU/t",
   "block.gtceu.wire_coil.tooltip_extended_info": "§7Hold SHIFT to show Coil Bonus Info",
   "block.gtceu.wire_coil.tooltip_heat": "§cBase Heat Capacity: §f%d K",
   "block.gtceu.wire_coil.tooltip_parallel_smelter": "  §5Max Parallel: §f%s",

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
@@ -225,10 +225,10 @@ public class GTRecipeModifiers {
      * <p>
      * Modifies the recipe in the following order:
      * <ol>
-     * <li>Calculates the maximum parallel as {@code 32 × coilLevel}</li>
+     * <li>Calculates the maximum parallels as {@code 32 × coilLevel}</li>
      * <li>Finds the actual parallel amount that the smelter can do</li>
      * <li>Sets the recipe duration to {@code 128 × 2 × parallels / maxParallels}</li>
-     * <li>Sets the recipe EUt to {@code 4 × (parallels / (8 × coilDiscount))}</li>
+     * <li>Sets the recipe EUt to {@code (4 × maxParallels / (8 × coilDiscount))}</li>
      * <li>Applies {@link OverclockingLogic#NON_PERFECT_OVERCLOCK} to this modified recipe</li>
      * <li>Multiplies the recipe contents by the parallel amount</li>
      * </ol>
@@ -249,7 +249,7 @@ public class GTRecipeModifiers {
         if (parallels == 0) return ModifierFunction.NULL;
 
         int duration = (int) (128 * 2.0 * parallels / maxParallel);
-        long eut = 4 * (long) (parallels / (8.0 * coilMachine.getCoilType().getEnergyDiscount()));
+        long eut = (long) (4 * maxParallel / (8.0 * coilMachine.getCoilType().getEnergyDiscount()));
         ModifierFunction baseModifier = r -> {
             var copy = r.copy();
             EURecipeCapability.putEUContent(copy.tickInputs, new EnergyStack(Math.max(1, eut)));

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/BlockLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/BlockLang.java
@@ -23,7 +23,7 @@ public class BlockLang {
         replace(provider, "block.gtceu.wire_coil.tooltip_heat", "§cBase Heat Capacity: §f%d K");
         replace(provider, "block.gtceu.wire_coil.tooltip_smelter", "§8Multi Smelter:");
         replace(provider, "block.gtceu.wire_coil.tooltip_parallel_smelter", "  §5Max Parallel: §f%s");
-        replace(provider, "block.gtceu.wire_coil.tooltip_energy_smelter", "  §aEnergy Usage: §f%s EU/t §8per recipe");
+        replace(provider, "block.gtceu.wire_coil.tooltip_energy_smelter", "  §aEnergy Usage: §f%s EU/t");
         replace(provider, "block.gtceu.wire_coil.tooltip_pyro", "§8Pyrolyse Oven:");
         replace(provider, "block.gtceu.wire_coil.tooltip_speed_pyro", "  §bProcessing Speed: §f%s%%");
         replace(provider, "block.gtceu.wire_coil.tooltip_cracking", "§8Cracking Unit:");


### PR DESCRIPTION
## What
Fixes #3747 


Changes multi-smelter EU/t math to no longer scale EU/t with current parallel count, fixing an energy exploit.

Also fixes an edge case for custom coils with high discounts, and further clarifies the multi-smelter coil tooltip (since energy cost does not scale with how many recipes are run).

