### PR TITLE
Make Jade Provider not show %s Fluid Cell

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
@@ -224,7 +224,7 @@ public class RecipeOutputProvider extends CapabilityBlockProvider<RecipeLogic> {
     }
 
     private Component getItemName(ItemStack stack) {
-        return ComponentUtils.wrapInSquareBrackets(stack.getItem().getDescription()).withStyle(ChatFormatting.WHITE);
+        return stack.getDisplayName().copy().withStyle(ChatFormatting.WHITE);
     }
 
     private Component getFluidName(FluidStack stack) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
@@ -10,7 +10,6 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
-import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.integration.jade.GTElementHelper;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -26,7 +25,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
@@ -51,8 +49,6 @@ public class RecipeOutputProvider extends CapabilityBlockProvider<RecipeLogic> {
     public RecipeOutputProvider() {
         super(GTCEu.id("recipe_output_info"));
     }
-
-    private static final Item empty_cell = Ingredient.of(GTItems.FLUID_CELL).getItems()[0].getItem();
 
     @Override
     protected @Nullable RecipeLogic getCapability(Level level, BlockPos pos, @Nullable Direction side) {
@@ -194,12 +190,7 @@ public class RecipeOutputProvider extends CapabilityBlockProvider<RecipeLogic> {
                     item.setCount(1);
                 }
                 text.append(Component.translatable("gtceu.gui.content.times_item",
-                        (item.getItem().equals(empty_cell) ?
-                                ComponentUtils.wrapInSquareBrackets(
-                                        Component.translatable(item.getItem().getDescription().getString(),
-                                                FluidStack.loadFluidStackFromNBT(item.getTagElement("Fluid"))
-                                                        .getDisplayName())) :
-                                getItemName(item)))
+                        getItemName(item))
                         .withStyle(ChatFormatting.WHITE));
 
                 iTooltip.add(helper.smallItem(item));

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
@@ -10,6 +10,7 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
+import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.integration.jade.GTElementHelper;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -25,6 +26,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.ComponentUtils;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
@@ -49,6 +51,8 @@ public class RecipeOutputProvider extends CapabilityBlockProvider<RecipeLogic> {
     public RecipeOutputProvider() {
         super(GTCEu.id("recipe_output_info"));
     }
+
+    private static final Item empty_cell = Ingredient.of(GTItems.FLUID_CELL).getItems()[0].getItem();
 
     @Override
     protected @Nullable RecipeLogic getCapability(Level level, BlockPos pos, @Nullable Direction side) {
@@ -190,7 +194,12 @@ public class RecipeOutputProvider extends CapabilityBlockProvider<RecipeLogic> {
                     item.setCount(1);
                 }
                 text.append(Component.translatable("gtceu.gui.content.times_item",
-                        getItemName(item))
+                        (item.getItem().equals(empty_cell) ?
+                                ComponentUtils.wrapInSquareBrackets(
+                                        Component.translatable(item.getItem().getDescription().getString(),
+                                                FluidStack.loadFluidStackFromNBT(item.getTagElement("Fluid"))
+                                                        .getDisplayName())) :
+                                getItemName(item)))
                         .withStyle(ChatFormatting.WHITE));
 
                 iTooltip.add(helper.smallItem(item));


### PR DESCRIPTION
## What
<img width="427" height="94" alt="_s fluid cell" src="https://github.com/user-attachments/assets/50f25b71-7176-4fd7-b938-92b5a0838885" />

Fixes the %s

However the way I've done this horrifies me and I don't think it will work for if you try to make a recipe that outputs any of the other Fluid Cells other than the basic one, so I really hope someone can think of a better way of doing this than this 
