### PR TITLE
Solve UnsupportedOperationException on world creation/loading

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistry.java
@@ -145,6 +145,14 @@ public abstract class GTRegistry<K, V> implements Iterable<V> {
         return Collections.unmodifiableMap(keyToValue);
     }
 
+    public void clear() {
+        if (frozen) {
+            throw new IllegalArgumentException("Registry is frozen!");
+        }
+        keyToValue.clear();
+        valueToKey.clear();
+    }
+
     @Nullable
     public V get(K key) {
         return keyToValue.get(key);

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockFluidLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockFluidLoader.java
@@ -46,7 +46,7 @@ public class BedrockFluidLoader extends SimpleJsonResourceReloadListener {
         if (GTRegistries.BEDROCK_FLUID_DEFINITIONS.isFrozen()) {
             GTRegistries.BEDROCK_FLUID_DEFINITIONS.unfreeze();
         }
-        GTRegistries.BEDROCK_FLUID_DEFINITIONS.registry().clear();
+        GTRegistries.BEDROCK_FLUID_DEFINITIONS.clear();
 
         GTBedrockFluids.init();
         AddonFinder.getAddons().forEach(IGTAddon::registerFluidVeins);

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/BedrockOreLoader.java
@@ -48,7 +48,7 @@ public class BedrockOreLoader extends SimpleJsonResourceReloadListener {
         if (GTRegistries.BEDROCK_ORE_DEFINITIONS.isFrozen()) {
             GTRegistries.BEDROCK_ORE_DEFINITIONS.unfreeze();
         }
-        GTRegistries.BEDROCK_ORE_DEFINITIONS.registry().clear();
+        GTRegistries.BEDROCK_ORE_DEFINITIONS.clear();
 
         AddonFinder.getAddons().forEach(IGTAddon::registerBedrockOreVeins);
         ModLoader.get().postEvent(

--- a/src/main/java/com/gregtechceu/gtceu/data/loader/GTOreLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/loader/GTOreLoader.java
@@ -51,7 +51,7 @@ public class GTOreLoader extends SimpleJsonResourceReloadListener {
         if (GTRegistries.ORE_VEINS.isFrozen()) {
             GTRegistries.ORE_VEINS.unfreeze();
         }
-        GTRegistries.ORE_VEINS.registry().clear();
+        GTRegistries.ORE_VEINS.clear();
 
         GTOres.init();
         AddonFinder.getAddons().forEach(IGTAddon::registerOreVeins);


### PR DESCRIPTION
## What
https://github.com/GregTechCEu/GregTech-Modern/pull/3591 reworked GTRegistry, and in doing so broke world loading because the .registry() returns an immutable view

## Implementation Details
This adds a clear() function to registries, which is then used in the places that .registry().clear() was used before

## Outcome
Closes #3758 
Allows us to create worlds again

## Additional Information
We really should not allow such big / multi-scoped PRs, and they should be reviewed thoroughly regardless
