### PR TITLE
Fix Partial NBT not matching

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/PartialNBTItemStackMapIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/PartialNBTItemStackMapIngredient.java
@@ -41,7 +41,7 @@ public class PartialNBTItemStackMapIngredient extends ItemStackMapIngredient {
 
     @Override
     protected int hash() {
-        return ItemStackHashStrategy.comparingAllButCount().hashCode(stack) * 31;
+        return ItemStackHashStrategy.comparingItem().hashCode(stack) * 31;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/StrictNBTItemStackMapIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/StrictNBTItemStackMapIngredient.java
@@ -41,7 +41,7 @@ public class StrictNBTItemStackMapIngredient extends ItemStackMapIngredient {
 
     @Override
     protected int hash() {
-        return ItemStackHashStrategy.comparingAllButCount().hashCode(stack) * 31;
+        return ItemStackHashStrategy.comparingItem().hashCode(stack) * 31;
     }
 
     @Override


### PR DESCRIPTION
## What
#3273 changed the Strict and Partial NBTItemStackMapIngredients to use the hashfunction `comparingAllButCount()` instead of `comparingItem()` 
This would mean that two items with matching partialNBT (say, `{'foo':1}` and `{'foo':1,'bar':2}`) to not have the same hash. Since we then use a Object2ObjectOpenHashMap() in GTRecipeLookup/Branch, the hashmap's .get() never calls the .equals function, doesn't return the other partialNBT, and therefore the crafts never succeed.

This partially reverts that PR to use `comparingItem()` again, so that they match again and recipe logic works again.

## Outcome
Partial NBT crafts work again, which ATM9 and TFG heavily rely on