### PR TITLE
Make HPCA coolant a tag instead of a fluid

### DIFF
--- a/src/generated/resources/data/gtceu/tags/fluids/hpca_coolants.json
+++ b/src/generated/resources/data/gtceu/tags/fluids/hpca_coolants.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "gtceu:pcb_coolant"
+  ]
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -41,6 +41,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.server.TickTask;
@@ -63,6 +64,8 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+
+import static com.gregtechceu.gtceu.data.recipe.CustomTags.HPCA_COOLANTS;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -495,18 +498,20 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                 // try to partially utilize active coolers to stabilize to zero
                 double temperatureToDecrease = Math.min(temperatureChange, maxActiveCooling);
                 int coolantToDrain = Math.max(1, (int) (maxCoolantDrain * (temperatureToDecrease / maxActiveCooling)));
-                FluidStack coolantStack = GTTransferUtils.drainFluidAccountNotifiableList(coolantTank,
-                        getCoolantStack(coolantToDrain), IFluidHandler.FluidAction.EXECUTE);
-                if (!coolantStack.isEmpty()) {
-                    int coolantDrained = coolantStack.getAmount();
-                    if (coolantDrained == coolantToDrain) {
-                        // successfully stabilized to zero
-                        return 0;
-                    } else {
-                        // coolant requirement was only partially met, cool proportional to fluid amount drained
-                        // a * (b / c)
-                        temperatureChange -= temperatureToDecrease * (1.0 * coolantDrained / coolantToDrain);
-                    }
+                int remainingCoolant = coolantToDrain;
+                for (var fluid : BuiltInRegistries.FLUID.getTagOrEmpty(HPCA_COOLANTS)) {
+                    FluidStack remaining = GTTransferUtils.drainFluidAccountNotifiableList(coolantTank,
+                            new FluidStack(fluid.get(), remainingCoolant), IFluidHandler.FluidAction.EXECUTE);
+                    remainingCoolant -= remaining.getAmount();
+                    if (remainingCoolant <= 0) break;
+                } ;
+                if (remainingCoolant == 0) {
+                    // successfully stabilized to zero
+                    return 0;
+                } else {
+                    // coolant requirement was only partially met, cool proportional to fluid amount drained
+                    // a * (b / c)
+                    temperatureChange -= temperatureToDecrease * (1.0 * remainingCoolant / coolantToDrain);
                 }
             }
             return temperatureChange;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -486,7 +486,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                     remainingCoolant -= drained.getAmount();
                     if (remainingCoolant <= 0) break;
                 }
-                if (remainingCoolant == 0) {
+                if (remainingCoolant <= 0) {
                     // coolant requirement was fully met
                     temperatureChange -= maxActiveCooling;
                 } else {
@@ -506,7 +506,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                     remainingCoolant -= drained.getAmount();
                     if (remainingCoolant <= 0) break;
                 }
-                if (remainingCoolant == 0) {
+                if (remainingCoolant <= 0) {
                     // successfully stabilized to zero
                     return 0;
                 } else {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -481,16 +481,21 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
             }
             if (forceCoolWithActive || maxActiveCooling <= temperatureChange) {
                 // try to fully utilize active coolers
-                FluidStack coolantStack = GTTransferUtils.drainFluidAccountNotifiableList(coolantTank,
-                        getCoolantStack(maxCoolantDrain), IFluidHandler.FluidAction.EXECUTE);
-                if (!coolantStack.isEmpty()) {
-                    long coolantDrained = coolantStack.getAmount();
-                    if (coolantDrained == maxCoolantDrain) {
+                int remainingCoolant = maxCoolantDrain;
+                for (var fluid : BuiltInRegistries.FLUID.getTagOrEmpty(HPCA_COOLANTS)) {
+                    FluidStack drained = GTTransferUtils.drainFluidAccountNotifiableList(coolantTank,
+                            new FluidStack(fluid.get(), remainingCoolant), IFluidHandler.FluidAction.EXECUTE);
+                    remainingCoolant -= drained.getAmount();
+                    if (remainingCoolant <= 0) break;
+                }
+                if (remainingCoolant != 0) {
+                    if (remainingCoolant == maxCoolantDrain) {
                         // coolant requirement was fully met
                         temperatureChange -= maxActiveCooling;
                     } else {
                         // coolant requirement was only partially met, cool proportional to fluid amount drained
                         // a * (b / c)
+                        int coolantDrained = maxCoolantDrain - remainingCoolant;
                         temperatureChange -= maxActiveCooling * (1.0 * coolantDrained / maxCoolantDrain);
                     }
                 }
@@ -500,33 +505,22 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                 int coolantToDrain = Math.max(1, (int) (maxCoolantDrain * (temperatureToDecrease / maxActiveCooling)));
                 int remainingCoolant = coolantToDrain;
                 for (var fluid : BuiltInRegistries.FLUID.getTagOrEmpty(HPCA_COOLANTS)) {
-                    FluidStack remaining = GTTransferUtils.drainFluidAccountNotifiableList(coolantTank,
+                    FluidStack drained = GTTransferUtils.drainFluidAccountNotifiableList(coolantTank,
                             new FluidStack(fluid.get(), remainingCoolant), IFluidHandler.FluidAction.EXECUTE);
-                    remainingCoolant -= remaining.getAmount();
+                    remainingCoolant -= drained.getAmount();
                     if (remainingCoolant <= 0) break;
-                } ;
+                }
                 if (remainingCoolant == 0) {
                     // successfully stabilized to zero
                     return 0;
                 } else {
                     // coolant requirement was only partially met, cool proportional to fluid amount drained
                     // a * (b / c)
-                    temperatureChange -= temperatureToDecrease * (1.0 * remainingCoolant / coolantToDrain);
+                    int coolantDrained = ( coolantToDrain - remainingCoolant );
+                    temperatureChange -= temperatureToDecrease * (1.0 * coolantDrained / coolantToDrain);
                 }
             }
             return temperatureChange;
-        }
-
-        /**
-         * Get the coolant stack for this HPCA. Eventually this could be made more diverse with different
-         * coolants from different Active Cooler components, but currently it is just a fixed Fluid.
-         */
-        public FluidStack getCoolantStack(int amount) {
-            return new FluidStack(getCoolant(), amount);
-        }
-
-        private Fluid getCoolant() {
-            return GTMaterials.PCBCoolant.getFluid();
         }
 
         /**

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -19,7 +19,6 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
 import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
 import com.gregtechceu.gtceu.api.transfer.fluid.FluidHandlerList;
-import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
@@ -48,7 +47,6 @@ import net.minecraft.server.TickTask;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
@@ -488,16 +486,14 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                     remainingCoolant -= drained.getAmount();
                     if (remainingCoolant <= 0) break;
                 }
-                if (remainingCoolant != 0) {
-                    if (remainingCoolant == maxCoolantDrain) {
-                        // coolant requirement was fully met
-                        temperatureChange -= maxActiveCooling;
-                    } else {
-                        // coolant requirement was only partially met, cool proportional to fluid amount drained
-                        // a * (b / c)
-                        int coolantDrained = maxCoolantDrain - remainingCoolant;
-                        temperatureChange -= maxActiveCooling * (1.0 * coolantDrained / maxCoolantDrain);
-                    }
+                if (remainingCoolant == 0) {
+                    // coolant requirement was fully met
+                    temperatureChange -= maxActiveCooling;
+                } else {
+                    // coolant requirement was only partially met, cool proportional to fluid amount drained
+                    // a * (b / c)
+                    int coolantDrained = maxCoolantDrain - remainingCoolant;
+                    temperatureChange -= maxActiveCooling * (1.0 * coolantDrained / maxCoolantDrain);
                 }
             } else if (temperatureChange > 0) {
                 // try to partially utilize active coolers to stabilize to zero
@@ -516,7 +512,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                 } else {
                     // coolant requirement was only partially met, cool proportional to fluid amount drained
                     // a * (b / c)
-                    int coolantDrained = ( coolantToDrain - remainingCoolant );
+                    int coolantDrained = (coolantToDrain - remainingCoolant);
                     temperatureChange -= temperatureToDecrease * (1.0 * coolantDrained / coolantToDrain);
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/CustomTags.java
@@ -215,4 +215,6 @@ public class CustomTags {
     public static final TagKey<Fluid> MOLTEN_FLUIDS = TagUtil.createFluidTag("molten");
     public static final TagKey<Fluid> LIQUID_FLUIDS = TagUtil.createFluidTag("liquid");
     public static final TagKey<Fluid> PLASMA_FLUIDS = TagUtil.createFluidTag("plasmatic");
+
+    public static final TagKey<Fluid> HPCA_COOLANTS = TagUtil.createModFluidTag("hpca_coolants");
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/FluidTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/FluidTagLoader.java
@@ -11,5 +11,6 @@ public class FluidTagLoader {
 
     public static void init(RegistrateTagsProvider.IntrinsicImpl<Fluid> provider) {
         provider.addTag(CustomTags.LIGHTER_FLUIDS).add(GTMaterials.Butane.getFluid(), GTMaterials.Propane.getFluid());
+        provider.addTag(CustomTags.HPCA_COOLANTS).add(GTMaterials.PCBCoolant.getFluid());
     }
 }


### PR DESCRIPTION
## What
Use a tag instead of a hardcoded fluid

## Implementation Details
I haven't used the HPCA and don't 100% understand it so please look over the actual logic part well and check if the changes make sense. I think they do

## Outcome
You can now use multiple fluids as coolant for the HPCA, as dictated by the "gtceu:hpca_coolant"  tag


## Potential Compatibility Issues
Might break people's setups if they used mixins to target the getCoolant function? L bozo use the new tag system