### PR TITLE
TestUtils documentation

### DIFF
--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/InputSeparationTest.java
@@ -29,7 +29,7 @@ public class InputSeparationTest {
 
     @BeforeBatch(batch = "InputSeparation")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("input_separation_tests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("input_separation_tests", 3, 3, 3, 3);
         // Force insert the recipe into the manager.
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_multiblock_input_separation"))

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -11,25 +11,93 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.fluids.FluidStack;
 
 import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.ELECTRIC;
 
 public class TestUtils {
 
-    // Compares two itemstacks' items and amounts
-    // DOES NOT CHECK TAGS OR NBT ETC!
+    /**
+     * Compares two itemstacks' items and amounts
+     * DOES NOT CHECK TAGS OR NBT ETC!
+     * 
+     * @return {@code true} if items and amounts are equal
+     */
     public static boolean isItemStackEqual(ItemStack stack1, ItemStack stack2) {
         return ItemStack.isSameItem(stack1, stack2) && stack1.getCount() == stack2.getCount();
     }
 
-    // Forces a structure check on multiblocks after being placed, to avoid having to wait ticks.
-    // Ideally this doesn't need to happen, but it seems not doing this makes the multiblock tests flakey
+    /**
+     * Compares two itemstacks and a range.
+     * 
+     * @return {@code true} if items are equal, and if stack2's amount is within range.
+     */
+    public static boolean isItemStackWithinRange(ItemStack stack1, ItemStack stack2, int min, int max) {
+        return ItemStack.isSameItem(stack1, stack2) && isItemWithinRange(stack2, min, max);
+    }
+
+    /**
+     * Compares an int representing an itemstack's size with a number of batches, parallels, and runs.
+     * Intended to test if an IntProvider is being rolled correctly for a batch, or if it is returning a single value
+     * multiplied.
+     * This test can trigger false positives from bad luck and should be run more than once to reduce the odds of bad
+     * luck.
+     * 
+     * @return {@code true} if the size is an exact multiple of the total run count. TRUE INDICATES FAILURE.
+     */
+    public static boolean isStackSizeExactlyEvenMultiple(int size, int batches, int parallels, int runs) {
+        return size % (batches * parallels * runs) == 0;
+    }
+
+    /**
+     * Compares two fluidstacks' fluids and amounts
+     * DOES NOT CHECK TAGS OR NBT ETC!
+     * 
+     * @return {@code true} if fluids and amounts are equal
+     */
+    public static boolean isFluidStackEqual(FluidStack stack1, FluidStack stack2) {
+        return stack1.isFluidEqual(stack2) && stack1.getAmount() == stack2.getAmount();
+    }
+
+    /**
+     * Compares two fluidstacks and a range.
+     * 
+     * @return {@code true} if items are equal, and if stack2's amount is within range.
+     */
+    public static boolean isFluidStackWithinRange(FluidStack stack1, FluidStack stack2, int min, int max) {
+        return stack1.isFluidEqual(stack2) && isFluidWithinRange(stack2, min, max);
+    }
+
+    /**
+     * compares an ItemStack with a range
+     * 
+     * @return {@code true} if the ItemStack's count is within range
+     */
+    public static boolean isItemWithinRange(ItemStack stack, int min, int max) {
+        return stack.getCount() <= max && stack.getCount() >= min;
+    }
+
+    /**
+     * compares a FluidStack with a range
+     * 
+     * @return {@code true} if the FluidStack's amount is within range
+     */
+    public static boolean isFluidWithinRange(FluidStack stack, int min, int max) {
+        return stack.getAmount() <= max && stack.getAmount() >= min;
+    }
+
+    /**
+     * Forces a structure check on multiblocks after being placed, to avoid having to wait ticks.
+     * Ideally this doesn't need to happen, but it seems not doing this makes the multiblock tests flakey
+     */
     public static void formMultiblock(MultiblockControllerMachine controller) {
         controller.getPattern().checkPatternAt(controller.getMultiblockState(), false);
         controller.onStructureFormed();
     }
 
-    // Creates a dummy recipe type that also includes a basic, HV, 1 tick, cobblestone -> stone recipe
+    /**
+     * Creates a dummy recipe type that also includes a basic, HV, 1 tick, cobblestone -> stone recipe
+     */
     public static GTRecipeType createRecipeTypeAndInsertRecipe(String name) {
         GTRecipeType type = createRecipeType(name);
         type.getLookup().addRecipe(type

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -69,7 +69,7 @@ public class TestUtils {
     }
 
     /**
-     * compares an ItemStack with a range
+     * Compares an ItemStack with a range
      * 
      * @return {@code true} if the ItemStack's count is within range
      */
@@ -78,7 +78,7 @@ public class TestUtils {
     }
 
     /**
-     * compares a FluidStack with a range
+     * Compares a FluidStack with a range
      * 
      * @return {@code true} if the FluidStack's amount is within range
      */


### PR DESCRIPTION
## What
Swaps the comments on TestUtils methods over to Javadocs.
Adds a bunch more test functions to be used on ranged ingredients and Fluid ingredients

Also fixes a warning message that gets thrown by InputSeparationTest related to having more ingredients than the recipe type allows.