### PR TITLE
Fix NPE in GUI preview when machine model is replaced by a resource pack

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockEntityWithBERModelRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockEntityWithBERModelRenderer.java
@@ -53,9 +53,11 @@ public class BlockEntityWithBERModelRenderer<T extends BlockEntity> implements B
             Level level = blockEntity.getLevel();
             BlockPos pos = blockEntity.getBlockPos();
 
+            ModelData modelData;
             // noinspection DataFlowIssue,UnstableApiUsage
-            ModelData modelData = level.getModelDataManager().getAt(pos);
-            if (modelData == null) modelData = ModelData.EMPTY;
+            if (level.getModelDataManager() == null || (modelData = level.getModelDataManager().getAt(pos)) == null) {
+                modelData = ModelData.EMPTY;
+            }
 
             long randomSeed = blockState.getSeed(pos);
             RandomSource random = RandomSource.create();


### PR DESCRIPTION
## What
Fixes an NPE in the preview pane of machine GUIs when a machine model has been replaced by a resource pack

## Implementation Details
Replacing a machine model in a resource pack causes the BER to take the `else` path in https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/client/renderer/BlockEntityWithBERModelRenderer.java#L52

## Outcome
Fixes a crash