### PR TITLE
Fix #3792 Multi-mode machines won't check recipe after mode changes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/fancyconfigurator/MachineModeFancyConfigurator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/fancyconfigurator/MachineModeFancyConfigurator.java
@@ -44,7 +44,7 @@ public class MachineModeFancyConfigurator implements IFancyUIProvider {
         for (int i = 0; i < machine.getRecipeTypes().length; i++) {
             int finalI = i;
             group.addWidget(new ButtonWidget(2, 2 + i * 20, 136, 20, IGuiTexture.EMPTY,
-                    cd -> machine.setActiveRecipeType(finalI)));
+                    cd -> machine.setActiveRecipeTypeAndUpdateTickSubs(finalI)));
             group.addWidget(new ImageWidget(2, 2 + i * 20, 136, 20,
                     () -> new GuiTextureGroup(
                             ResourceBorderTexture.BUTTON_COMMON.copy()

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/fancyconfigurator/MachineModeFancyConfigurator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/fancyconfigurator/MachineModeFancyConfigurator.java
@@ -44,7 +44,7 @@ public class MachineModeFancyConfigurator implements IFancyUIProvider {
         for (int i = 0; i < machine.getRecipeTypes().length; i++) {
             int finalI = i;
             group.addWidget(new ButtonWidget(2, 2 + i * 20, 136, 20, IGuiTexture.EMPTY,
-                    cd -> machine.setActiveRecipeTypeAndUpdateTickSubs(finalI)));
+                    cd -> setActiveRecipeTypeAndUpdateTickSubs(finalI)));
             group.addWidget(new ImageWidget(2, 2 + i * 20, 136, 20,
                     () -> new GuiTextureGroup(
                             ResourceBorderTexture.BUTTON_COMMON.copy()
@@ -61,6 +61,14 @@ public class MachineModeFancyConfigurator implements IFancyUIProvider {
         List<Component> tooltip = new ArrayList<>();
         tooltip.add(Component.literal("Change active Machine Mode"));
         return tooltip;
+    }
+
+    private void setActiveRecipeTypeAndUpdateTickSubs(int activeRecipeType) {
+        boolean needUpdateTickSubs = !machine.keepSubscribing() && activeRecipeType != machine.getActiveRecipeType();
+        machine.setActiveRecipeType(activeRecipeType);
+        if (needUpdateTickSubs) {
+            machine.getRecipeLogic().updateTickSubscription();
+        }
     }
 
     public class MachineModeConfigurator extends WidgetGroup {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -32,17 +32,6 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
     void setActiveRecipeType(int type);
 
     /**
-     * Set the activeRecipeType, and if it changes, schedule the recipe logic.
-     */
-    default void setActiveRecipeTypeAndUpdateTickSubs(int activeRecipeType) {
-        boolean needUpdateTickSubs = !keepSubscribing() && activeRecipeType != getActiveRecipeType();
-        setActiveRecipeType(activeRecipeType);
-        if (needUpdateTickSubs) {
-            getRecipeLogic().updateTickSubscription();
-        }
-    }
-
-    /**
      * Called when recipe logic status changed
      */
     default void notifyStatusChanged(RecipeLogic.Status oldStatus, RecipeLogic.Status newStatus) {}

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -32,6 +32,17 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
     void setActiveRecipeType(int type);
 
     /**
+     * Set the activeRecipeType, and if it changes, schedule the recipe logic.
+     */
+    default void setActiveRecipeTypeAndUpdateTickSubs(int activeRecipeType) {
+        boolean needUpdateTickSubs = activeRecipeType != getActiveRecipeType();
+        setActiveRecipeType(activeRecipeType);
+        if (needUpdateTickSubs) {
+            getRecipeLogic().updateTickSubscription();
+        }
+    }
+
+    /**
      * Called when recipe logic status changed
      */
     default void notifyStatusChanged(RecipeLogic.Status oldStatus, RecipeLogic.Status newStatus) {}

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -35,7 +35,7 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
      * Set the activeRecipeType, and if it changes, schedule the recipe logic.
      */
     default void setActiveRecipeTypeAndUpdateTickSubs(int activeRecipeType) {
-        boolean needUpdateTickSubs = activeRecipeType != getActiveRecipeType();
+        boolean needUpdateTickSubs = !keepSubscribing() && activeRecipeType != getActiveRecipeType();
         setActiveRecipeType(activeRecipeType);
         if (needUpdateTickSubs) {
             getRecipeLogic().updateTickSubscription();


### PR DESCRIPTION
## What

Multi-mode machines won't check recipe after mode changes.

## Implementation Details

Added a method that both call the setter and schedule the recipe logic.

## Outcome

Fixed #3792
