### PR TITLE
Make redstone-related blocks mineable with wrenches

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/mineable/wrench.json
+++ b/src/generated/resources/data/forge/tags/blocks/mineable/wrench.json
@@ -1,6 +1,23 @@
 {
   "values": [
     "gtceu:pump_deck",
-    "#gtceu:mineable/pickaxe_or_wrench"
+    "#gtceu:mineable/pickaxe_or_wrench",
+    "minecraft:piston",
+    "minecraft:piston_head",
+    "minecraft:sticky_piston",
+    "minecraft:observer",
+    "minecraft:redstone_lamp",
+    "minecraft:redstone_block",
+    "minecraft:iron_door",
+    "minecraft:iron_trapdoor",
+    "minecraft:polished_blackstone_pressure_plate",
+    "minecraft:heavy_weighted_pressure_plate",
+    "minecraft:light_weighted_pressure_plate",
+    "minecraft:hopper",
+    "minecraft:dispenser",
+    "minecraft:dropper",
+    "minecraft:lightning_rod",
+    "minecraft:daylight_detector",
+    "minecraft:bell"
   ]
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -47,7 +47,8 @@ public class BlockTagLoader {
                 .add(Blocks.PISTON, Blocks.PISTON_HEAD, Blocks.STICKY_PISTON, Blocks.OBSERVER, Blocks.REDSTONE_LAMP,
                         Blocks.REDSTONE_BLOCK, Blocks.IRON_DOOR, Blocks.IRON_TRAPDOOR,
                         Blocks.POLISHED_BLACKSTONE_PRESSURE_PLATE, Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE,
-                        Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, Blocks.HOPPER);
+                        Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, Blocks.HOPPER, Blocks.DISPENSER, Blocks.DROPPER,
+                        Blocks.LIGHTNING_ROD, Blocks.DAYLIGHT_DETECTOR, Blocks.BELL);
         provider.addTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
                 .addTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -43,7 +43,11 @@ public class BlockTagLoader {
 
         // always add the wrench/pickaxe tag as a valid tag to mineable/wrench etc.
         provider.addTag(CustomTags.MINEABLE_WITH_WRENCH)
-                .addTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH);
+                .addTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
+                .add(Blocks.PISTON, Blocks.PISTON_HEAD, Blocks.STICKY_PISTON, Blocks.OBSERVER, Blocks.REDSTONE_LAMP,
+                        Blocks.REDSTONE_BLOCK, Blocks.IRON_DOOR, Blocks.IRON_TRAPDOOR,
+                        Blocks.POLISHED_BLACKSTONE_PRESSURE_PLATE, Blocks.HEAVY_WEIGHTED_PRESSURE_PLATE,
+                        Blocks.LIGHT_WEIGHTED_PRESSURE_PLATE, Blocks.HOPPER);
         provider.addTag(CustomTags.MINEABLE_WITH_WIRE_CUTTER)
                 .addTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER);
 


### PR DESCRIPTION
## What
Makes blocks like pistons, observers and hoppers mineable with wrenches

## Outcome
Resolves #3521