### PR TITLE
Set default fluids to the rock breaker recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -35,7 +35,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.tags.FluidTags;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.material.Fluid;
@@ -415,9 +414,6 @@ public class GTRecipeTypes {
             .setProgressBar(GuiTextures.PROGRESS_BAR_MACERATE, LEFT_TO_RIGHT)
             .setIconSupplier(() -> GTMachines.ROCK_CRUSHER[GTValues.LV].asStack())
             .setSteamProgressBar(GuiTextures.PROGRESS_BAR_MACERATE_STEAM, LEFT_TO_RIGHT)
-            .prepareBuilder(recipeBuilder -> {
-                recipeBuilder.addCondition(AdjacentFluidCondition.fromTags(FluidTags.LAVA, FluidTags.WATER));
-            })
             .setUiBuilder((recipe, widgetGroup) -> {
                 List<HolderSet<Fluid>> fluids = new ArrayList<>();
                 for (RecipeCondition condition : recipe.conditions) {
@@ -429,18 +425,23 @@ public class GTRecipeTypes {
                     return;
                 }
 
-                int xOffset = 0;
+                int xOffset = 35;
+                int yOffset = 0;
+                int i = 0;
                 for (HolderSet<Fluid> set : fluids) {
                     if (set.size() == 0) {
                         continue;
                     }
                     List<FluidEntryList> slots = Collections.singletonList(FluidHolderSetList.of(set, 1000, null));
                     TankWidget tank = new TankWidget(new CycleFluidEntryHandler(slots),
-                            widgetGroup.getSize().width - 30 - xOffset, widgetGroup.getSize().height - 30, false, false)
+                            widgetGroup.getSize().width - 30 - xOffset, widgetGroup.getSize().height - 30 + yOffset,
+                            false, false)
                             .setBackground(GuiTextures.FLUID_SLOT).setShowAmount(false);
                     widgetGroup.addWidget(tank);
 
-                    xOffset += 20;
+                    i++;
+                    xOffset = 20 * (2 - (i % 3)) - 5;
+                    yOffset = 20 * (i / 3);
                 }
             })
             .setSound(GTSoundEntries.FIRE);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -25,6 +25,7 @@ import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
 import com.gregtechceu.gtceu.common.recipe.condition.*;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+import com.gregtechceu.gtceu.utils.GTUtil;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -91,7 +92,6 @@ public class GTRecipeBuilder {
     public ResourceLocation id;
     @Setter
     public GTRecipeType recipeType;
-    @Setter
     public int duration = 100;
     @Setter
     public boolean perTick;
@@ -213,6 +213,14 @@ public class GTRecipeBuilder {
     public GTRecipeBuilder addCondition(RecipeCondition condition) {
         conditions.add(condition);
         recipeType.setMinRecipeConditions(conditions.size());
+        return this;
+    }
+
+    public GTRecipeBuilder duration(int duration) {
+        if (duration < 0) {
+            GTCEu.LOGGER.error("Recipe duration must be non negative, id: {}", this.id);
+        }
+        this.duration = Math.max(duration, 0);
         return this;
     }
 
@@ -1145,19 +1153,29 @@ public class GTRecipeBuilder {
         return environmentalHazard(condition, false);
     }
 
-    public GTRecipeBuilder adjacentFluid(Fluid... fluids) {
+    public final GTRecipeBuilder adjacentFluid(Fluid... fluids) {
         return adjacentFluid(false, fluids);
     }
 
-    public GTRecipeBuilder adjacentFluid(boolean isReverse, Fluid... fluids) {
+    public final GTRecipeBuilder adjacentFluid(boolean isReverse, Fluid... fluids) {
+        if (fluids.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many fluids, not adding to recipe, id: {}", this.id);
+            return this;
+        }
         return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
     }
 
-    public GTRecipeBuilder adjacentFluid(TagKey<Fluid>... tags) {
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentFluid(TagKey<Fluid>... tags) {
         return adjacentFluid(false, tags);
     }
 
-    public GTRecipeBuilder adjacentFluid(boolean isReverse, TagKey<Fluid>... tags) {
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentFluid(boolean isReverse, TagKey<Fluid>... tags) {
+        if (tags.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many fluids, not adding to recipe, id: {}", this.id);
+            return this;
+        }
         return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
     }
 
@@ -1166,6 +1184,10 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipeBuilder adjacentFluid(Collection<HolderSet<Fluid>> fluids, boolean isReverse) {
+        if (fluids.size() > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many fluids, not adding to recipe, id: {}", this.id);
+            return this;
+        }
         return addCondition(new AdjacentFluidCondition(isReverse, new ArrayList<>(fluids)));
     }
 
@@ -1174,14 +1196,24 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipeBuilder adjacentBlock(boolean isReverse, Block... blocks) {
+        if (blocks.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many blocks, not adding to recipe, id: {}", this.id);
+            return this;
+        }
         return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
     }
 
-    public GTRecipeBuilder adjacentBlock(TagKey<Block>... tags) {
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentBlock(TagKey<Block>... tags) {
         return adjacentBlock(false, tags);
     }
 
-    public GTRecipeBuilder adjacentBlock(boolean isReverse, TagKey<Block>... tags) {
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentBlock(boolean isReverse, TagKey<Block>... tags) {
+        if (tags.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many blocks, not adding to recipe, id: {}", this.id);
+            return this;
+        }
         return addCondition(AdjacentBlockCondition.fromTags(tags).setReverse(isReverse));
     }
 
@@ -1190,6 +1222,10 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipeBuilder adjacentBlock(Collection<HolderSet<Block>> blocks, boolean isReverse) {
+        if (blocks.size() > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many blocks, not adding to recipe, id: {}", this.id);
+            return this;
+        }
         return addCondition(new AdjacentBlockCondition(isReverse, new ArrayList<>(blocks)));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 
 import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.tags.FluidTags;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -88,6 +89,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("cobblestone")
                 .notConsumable(Blocks.COBBLESTONE.asItem())
                 .outputItems(Blocks.COBBLESTONE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VA[ULV])
                 .save(provider);
@@ -95,6 +97,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("stone")
                 .notConsumable(Blocks.STONE.asItem())
                 .outputItems(Blocks.STONE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VA[ULV])
                 .save(provider);
@@ -102,6 +105,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("andesite")
                 .notConsumable(Blocks.ANDESITE.asItem())
                 .outputItems(Blocks.ANDESITE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[MV])
                 .save(provider);
@@ -109,6 +113,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("granite")
                 .notConsumable(Blocks.GRANITE.asItem())
                 .outputItems(Blocks.GRANITE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[MV])
                 .save(provider);
@@ -116,6 +121,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("diorite")
                 .notConsumable(Blocks.DIORITE.asItem())
                 .outputItems(Blocks.DIORITE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[MV])
                 .save(provider);
@@ -123,6 +129,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("obsidian")
                 .notConsumable(dust, Redstone)
                 .outputItems(Blocks.OBSIDIAN.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -130,6 +137,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("basalt")
                 .notConsumable(Blocks.BASALT.asItem())
                 .outputItems(Blocks.BASALT.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -137,6 +145,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("blackstone")
                 .notConsumable(Blocks.BLACKSTONE.asItem())
                 .outputItems(Blocks.BLACKSTONE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -144,6 +153,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("deepslate")
                 .notConsumable(Blocks.DEEPSLATE.asItem())
                 .outputItems(Blocks.DEEPSLATE.asItem())
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[EV])
                 .save(provider);
@@ -151,6 +161,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("marble")
                 .notConsumable(rock, Marble)
                 .outputItems(rock, Marble)
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -158,6 +169,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("basalt")
                 .notConsumable(rock, Basalt)
                 .outputItems(rock, Basalt)
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -165,6 +177,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("red_granite")
                 .notConsumable(rock, GraniteRed)
                 .outputItems(rock, GraniteRed)
+                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[EV])
                 .save(provider);


### PR DESCRIPTION
## What
Manually sets the default fluids to all our rock breaker recipes rather than through the builder, also fixed up the emi ui a tad

## Outcome
no need to remove the condition if you want different fluids in kjs
