### PR TITLE
Fix Tree Felling happening for Logged off Players

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/TreeFellingHelper.java
@@ -89,7 +89,7 @@ public class TreeFellingHelper {
             while (iterator.hasNext()) {
                 var helper = iterator.next();
                 if (event.level == helper.player.level()) {
-                    if (helper.orderedBlocks.isEmpty() || helper.tool.isEmpty() ||
+                    if (helper.player.isRemoved() || helper.orderedBlocks.isEmpty() || helper.tool.isEmpty() ||
                             !(hasBehaviorsTag(helper.player.getMainHandItem()) &&
                                     getBehaviorsTag(helper.player.getMainHandItem()).getBoolean(TREE_FELLING_KEY))) {
                         iterator.remove();


### PR DESCRIPTION
## What
Currently there seems to be a small memory leak in the Tree Felling logic, that keeps instances from players that have logged off. This means that the tree continues to get chopped, the stale player instance gets durability damage and all, and this data is never saved. Its not important since the instance eventually is cleared like normal.

## Implementation Details
Check if player has been removed from the game to remove the felling instance.

## Outcome
Memory leak no longer happens, and tree felling stops the next tick after player logs off.

Should I make another PR for 1.21?