### PR TITLE
fix conveyor mode button

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -423,7 +423,8 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
     public boolean shouldRespectDistributionMode() {
         return ((io == IO.IN) ?
                 (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()) instanceof ItemPipeBlockEntity) :
-                (getAdjacentItemHandler() instanceof ItemPipeBlockEntity));
+                (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()
+                        .relative(attachedSide)) instanceof ItemPipeBlockEntity));
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -421,10 +421,9 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
     }
 
     public boolean shouldRespectDistributionMode() {
-        return getDistributionMode() != DistributionMode.INSERT_FIRST &&
-                ((io == IO.IN) ?
-                        (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()) instanceof ItemPipeBlockEntity) :
-                        (getAdjacentItemHandler() instanceof ItemPipeBlockEntity));
+        return ((io == IO.IN) ?
+                (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()) instanceof ItemPipeBlockEntity) :
+                (getAdjacentItemHandler() instanceof ItemPipeBlockEntity));
     }
 
     //////////////////////////////////////
@@ -442,6 +441,7 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
                 DistributionMode.values(), distributionMode, this::setDistributionMode);
 
         distributionSelector.setVisible(shouldRespectDistributionMode());
+        group.addWidget(distributionSelector);
 
         ioModeSwitch = new SwitchWidget(10, 45, 20, 20,
                 (clickData, value) -> {


### PR DESCRIPTION
## What
#3568 changed how the UI for Conveyor Covers gets drawn and inadvertently never re-added the toggle button for Priority/RoundRobin/PriorityRoundRobin to the UI. (Also the check for whether or not to show the button had a state, which was also the default state, in which the button would become hidden with no way to un-hide it.)

## Effects
The button exists again.