### PR TITLE
Fix Robot Arms ignoring Keep Exact behavior when taking input from a Pipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -423,7 +423,8 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
     public boolean shouldRespectDistributionMode() {
         return ((io == IO.IN) ?
                 (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()) instanceof ItemPipeBlockEntity) :
-                (getAdjacentItemHandler() instanceof ItemPipeBlockEntity));
+                (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()
+                        .relative(attachedSide)) instanceof ItemPipeBlockEntity));
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -421,10 +421,9 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
     }
 
     public boolean shouldRespectDistributionMode() {
-        return getDistributionMode() != DistributionMode.INSERT_FIRST &&
-                ((io == IO.IN) ?
-                        (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()) instanceof ItemPipeBlockEntity) :
-                        (getAdjacentItemHandler() instanceof ItemPipeBlockEntity));
+        return ((io == IO.IN) ?
+                (coverHolder.getLevel().getBlockEntity(coverHolder.getPos()) instanceof ItemPipeBlockEntity) :
+                (getAdjacentItemHandler() instanceof ItemPipeBlockEntity));
     }
 
     //////////////////////////////////////
@@ -442,6 +441,7 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
                 DistributionMode.values(), distributionMode, this::setDistributionMode);
 
         distributionSelector.setVisible(shouldRespectDistributionMode());
+        group.addWidget(distributionSelector);
 
         ioModeSwitch = new SwitchWidget(10, 45, 20, 20,
                 (clickData, value) -> {

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -334,11 +334,10 @@ public class ItemNetHandler implements IItemHandlerModifiable {
             case TRANSFER_ANY:
                 return insertIntoDestination(handler, stack, simulate, allowed, ignoreLimit);
             case KEEP_EXACT:
-                if (arm.getFilterHandler().getFilter().supportsAmounts()) {
-                    count = rate - countStack(handler, stack, arm);
-                } else {
-                    count = rate;
+                if (rate == Integer.MAX_VALUE) {
+                    rate = arm.getGlobalTransferLimit();
                 }
+                count = rate - countStack(handler, stack, arm);
                 if (count <= 0) return stack;
                 count = Math.min(allowed, Math.min(stack.getCount(), count));
                 return insertIntoDestination(handler, stack, simulate, count, ignoreLimit);


### PR DESCRIPTION
## What
Robot arms attached to Pipes (either directly attached, or attached to a machine connected to a pipe) and set to Keep Exact transfer mode, do not respect the keep exact count and will continue filling items.

This fixes that.

It does _not_ fix the fact that a Robot Arm attached to a pipe and set to Keep Exact mode when feeding _into_ the pipe, silently completely shuts down the arm. This probably cannot be fixed properly until the UI rework.

## Additional Information
Contains the contents of #3810 and so is either blocked by 3810 or supersedes 3810, depending on which gets accepted first.