### PR TITLE
Fix ender link cover textures and translations

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2002,6 +2002,8 @@
   "cover.ender_fluid_link.tooltip.channel_name": "ʇxǝʇ ʇnduı ɥʇıʍ ǝɯɐu ןǝuuɐɥɔ ʇǝS",
   "cover.ender_fluid_link.tooltip.clear_button": "uoıʇdıɹɔsǝp ןǝuuɐɥɔ ɹɐǝןƆ",
   "cover.ender_fluid_link.tooltip.list_button": "ʇsıן ןǝuuɐɥɔ ʍoɥS",
+  "cover.ender_item_link.title": "ʞuıꞀ ɯǝʇI ɹǝpuƎ",
+  "cover.ender_redstone_link.title": "ʞuıꞀ ǝuoʇspǝᴚ ɹǝpuƎ",
   "cover.filter.blacklist.disabled": "ʇsıןǝʇıɥM",
   "cover.filter.blacklist.enabled": "ʇsıןʞɔɐןᗺ",
   "cover.filter.mode.filter_both": "ʇɔɐɹʇxƎ/ʇɹǝsuI ɹǝʇןıℲ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2002,6 +2002,8 @@
   "cover.ender_fluid_link.tooltip.channel_name": "Set channel name with input text",
   "cover.ender_fluid_link.tooltip.clear_button": "Clear channel description",
   "cover.ender_fluid_link.tooltip.list_button": "Show channel list",
+  "cover.ender_item_link.title": "Ender Item Link",
+  "cover.ender_redstone_link.title": "Ender Redstone Link",
   "cover.filter.blacklist.disabled": "Whitelist",
   "cover.filter.blacklist.enabled": "Blacklist",
   "cover.filter.mode.filter_both": "Filter Insert/Extract",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -469,6 +469,8 @@ public class LangHandler {
         provider.add("cover.machine_controller.mode.cover_west", "Control Cover (West)");
         provider.add("cover.machine_controller.mode.null", "Control Nothing");
         provider.add("cover.ender_fluid_link.title", "Ender Fluid Link");
+        provider.add("cover.ender_item_link.title", "Ender Item Link");
+        provider.add("cover.ender_redstone_link.title", "Ender Redstone Link");
         provider.add("cover.ender_fluid_link.iomode.enabled", "I/O Enabled");
         provider.add("cover.ender_fluid_link.iomode.disabled", "I/O Disabled");
         provider.add("cover.ender_fluid_link.tooltip.channel_description", "Set channel description with input text");

--- a/src/main/resources/assets/gtceu/textures/block/cover/ender_item_link.png.mcmeta
+++ b/src/main/resources/assets/gtceu/textures/block/cover/ender_item_link.png.mcmeta
@@ -1,0 +1,5 @@
+{
+   "animation":{
+      "frametime":4
+   }
+}

--- a/src/main/resources/assets/gtceu/textures/block/cover/ender_item_link_emissive.png.mcmeta
+++ b/src/main/resources/assets/gtceu/textures/block/cover/ender_item_link_emissive.png.mcmeta
@@ -1,0 +1,5 @@
+{
+   "animation":{
+      "frametime":4
+   }
+}

--- a/src/main/resources/assets/gtceu/textures/block/cover/ender_redstone_link.png.mcmeta
+++ b/src/main/resources/assets/gtceu/textures/block/cover/ender_redstone_link.png.mcmeta
@@ -1,0 +1,5 @@
+{
+   "animation":{
+      "frametime":4
+   }
+}

--- a/src/main/resources/assets/gtceu/textures/block/cover/ender_redstone_link_emissive.png.mcmeta
+++ b/src/main/resources/assets/gtceu/textures/block/cover/ender_redstone_link_emissive.png.mcmeta
@@ -1,0 +1,5 @@
+{
+   "animation":{
+      "frametime":4
+   }
+}


### PR DESCRIPTION
## What
Fixes ender item and redstone link covers' textures and UI title translations

## Outcome
yay they no longer look like they're extremely buggy (they are probably)