### PR TITLE
Research Data Holder no longer voids recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
@@ -205,7 +205,7 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
                 outputItem = ItemRecipeCapability.CAP.of(contents.get(0).content).getItems()[0];
             }
             if (!outputItem.isEmpty()) {
-                holder.setDataItem(outputItem);
+                holder.setDataItem(outputItem.copy());
             }
             holder.setLocked(false);
             return ActionResult.SUCCESS;


### PR DESCRIPTION
## What
Research Computer's Data holders used to get set with a direct reference to the itemstack that's in the recipe, meaning when you shift click it out of the data holder the recipe would void

https://github.com/user-attachments/assets/eca5305c-402e-41f9-aa1a-e18164545cf3


https://github.com/user-attachments/assets/8c5854eb-bec9-4908-9109-040bd4161084


## Implementation Details
we now copy the item before putting it in the hatch

## Outcome
https://github.com/user-attachments/assets/2b0348ce-4c93-4dfc-b941-d132eb2d2cc7


Closes #3364 