### PR TITLE
Fix AdjacencyBlockCondition

### DIFF
--- a/docs/content/Modpacks/Changes/v7.2.0.md
+++ b/docs/content/Modpacks/Changes/v7.2.0.md
@@ -27,5 +27,7 @@ Previously, rock breaker recipes used the `addData("fluidA", ...)` methods.
 
 Now, they work by AdjacentFluidConditions, added with the `adjacentFluid(Fluid...)` methods. See [our other condition builder methods](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java#L894).
 
+In a similar vein, recipes that used to have adjacent block requirements, you now need to use `adjacentBlock(Block...)` rather than `addData("blockA")`.
+
 ## Recipe Conditions
 We have moved away from the .serialize, .deserialize, .toNetwork and .fromNetwork calls on the RecipeCondition, and we now exclusively use the codecs registered in GTRecipeConditions.

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/ConditionSerializeUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/ConditionSerializeUtils.java
@@ -4,12 +4,12 @@ import com.gregtechceu.gtceu.api.registry.GTRegistries;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
-import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluids;
 
 import java.util.ArrayList;
@@ -20,20 +20,23 @@ import java.util.stream.Collectors;
 public class ConditionSerializeUtils {
 
     /**
-     * Encode a list of HolderSet<Fluids> to a string encoding
-     * 
-     * @param fluids the List<HolderSet<Fluids>> to be encoded
-     * @return A string, where HolderSets are separated by |'s and elements of the HolderSet are separated by ,
+     * Encode a List<HolderSet<T>> to a string encoding.
+     * HolderSets are separated by '|', and elements of a direct HolderSet are separated by ','.
+     *
+     * @param items       The list of HolderSet<T> to be encoded.
+     * @param registryKey The ResourceKey of the registry (e.g., Registries.FLUID, Registries.BLOCK).
+     * @return A string encoding.
      */
-    public static String encodeFluids(List<HolderSet<Fluid>> fluids) {
+    public static <T> String encodeHolderSets(List<HolderSet<T>> items,
+                                              ResourceKey<? extends Registry<T>> registryKey) {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
 
-        for (HolderSet<Fluid> holderSet : fluids) {
+        for (HolderSet<T> holderSet : items) {
             if (!first) {
                 sb.append("|");
             }
-            sb.append(encodeHolderSet(holderSet));
+            sb.append(encodeSingleHolderSet(holderSet, registryKey));
             first = false;
         }
 
@@ -41,96 +44,112 @@ public class ConditionSerializeUtils {
     }
 
     /**
-     * Encode a HolderSet<Fluids> to a string encoding
-     * The encoding is a string, where if it's a tag, it's encoded as #+location,
-     * and if it's a list, elements of the HolderSet are separated by ,
+     * Encode a single HolderSet<T> to a string.
+     * If it's a tag, it's encoded as #+location.
+     * If it's a direct list, elements are separated by ','.
      *
-     * @param holderSet the HolderSet<Fluids> to be encoded
-     * @return the encoded string
+     * @param holderSet   The HolderSet<T> to be encoded.
+     * @param registryKey The ResourceKey of the registry.
+     * @return The encoded string.
      */
-    public static String encodeHolderSet(HolderSet<Fluid> holderSet) {
+    public static <T> String encodeSingleHolderSet(HolderSet<T> holderSet,
+                                                   ResourceKey<? extends Registry<T>> registryKey) {
+        Registry<T> vanillaRegistry = GTRegistries.builtinRegistry().registry(registryKey).get();
         return holderSet.unwrap().map(
                 // Case 1: Tag
                 tagKey -> "#" + tagKey.location(),
                 // Case 2: Direct list of holders
                 holders -> holders.stream()
-                        .map(holder -> getStringFromHolder(holder))
+                        .map(holder -> getStringFromHolder(holder)) // Pass forgeRegistry
                         .collect(Collectors.joining(",")));
     }
 
     /**
-     * Encode a Holder<Fluid> into a String.
-     * 
-     * @param holder the Holder<Fluid> to be encoded
-     * @return a string encoding, as # + location if it's a tagkey, or the location if it's a registry entry.
+     * Encode a Holder<T> into a String.
+     *
+     * @param holder The Holder<T> to be encoded.
+     * @return A string encoding (location or #+tag_location).
+     * @throws RuntimeException if the holder cannot be serialized.
      */
-    public static String getStringFromHolder(Holder<Fluid> holder) {
-        // Case 1: If the holder has a registry key, use it
-        Optional<ResourceKey<Fluid>> keyOpt = holder.unwrapKey();
+    public static <T> String getStringFromHolder(Holder<T> holder) {
+        Optional<ResourceKey<T>> keyOpt = holder.unwrapKey();
         if (keyOpt.isPresent()) {
             return keyOpt.get().location().toString();
         }
 
-        // Case 2: If the holder is tagged, return the first tag with a '#' prefix
-        Optional<TagKey<Fluid>> tagOpt = holder.tags().findFirst();
+        Optional<TagKey<T>> tagOpt = holder.tags().findFirst();
         if (tagOpt.isPresent()) {
             return "#" + tagOpt.get().location().toString();
         }
-
-        throw new RuntimeException("could not deserialize holder: " + holder);
+        throw new RuntimeException("Could not serialize holder: " + holder);
     }
 
     /**
-     * Decode a FluidString into a List<HolderSet<Fluid>>
-     * The encoding is a string, where if it's a tag, it's encoded as #+location,
-     * and if it's a list, elements of the HolderSet are separated by ,
-     * 
-     * @param fluidString the string encoding
-     * @return The decoded list
+     * Decode a string into a List<HolderSet<T>>.
+     *
+     * @param encodedString The string encoding.
+     * @param registryKey   The ResourceKey of the registry.
+     * @return The decoded list of HolderSet<T>.
      */
-    public static List<HolderSet<Fluid>> decodeFluids(String fluidString) {
-        List<HolderSet<Fluid>> result = new ArrayList<>();
-        for (String token : fluidString.split("\\|")) {
+    public static <T> List<HolderSet<T>> decodeHolderSets(String encodedString,
+                                                          ResourceKey<? extends Registry<T>> registryKey) {
+        List<HolderSet<T>> result = new ArrayList<>();
+        for (String token : encodedString.split("\\|")) {
             if (!token.isBlank()) {
-                result.add(decodeHolderSet(token));
+                result.add(decodeSingleHolderSet(token, registryKey));
             }
         }
         return result;
     }
 
     /**
-     * Decode a string into a HolderSet<Fluid>
-     * The encoding is a string, where if it's a tag, it's encoded as #+location,
-     * and if it's a list, elements of the HolderSet are separated by ,
-     * 
-     * @param encodedSet the encoded set
-     * @return The decoded list
+     * Decode a string into a HolderSet<T>.
+     *
+     * @param encodedSet  The encoded set string.
+     * @param registryKey The ResourceKey of the registry.
+     * @return The decoded HolderSet<T>.
+     * @throws RuntimeException if an unknown ID is encountered.
      */
-    public static HolderSet<Fluid> decodeHolderSet(String encodedSet) {
+    public static <T> HolderSet<T> decodeSingleHolderSet(String encodedSet,
+                                                         ResourceKey<? extends Registry<T>> registryKey) {
         encodedSet = encodedSet.trim();
         if (encodedSet.isEmpty()) {
             return HolderSet.direct(List.of());
         }
 
+        Registry<T> registry = GTRegistries.builtinRegistry().registry(registryKey).get(); // Use the helper
+
         // Case 1: Tag-based holder set
         if (encodedSet.startsWith("#")) {
             ResourceLocation tagId = new ResourceLocation(encodedSet.substring(1));
-            TagKey<Fluid> tagKey = TagKey.create(Registries.FLUID, tagId);
-            return GTRegistries.builtinRegistry().registry(Registries.FLUID).get().getOrCreateTag(tagKey);
+            TagKey<T> tagKey = TagKey.create(registryKey, tagId);
+            return registry.getOrCreateTag(tagKey);
         }
 
-        // Case 2: Direct list of fluids
+        // Case 2: Direct list of items
         String[] parts = encodedSet.split(",");
-        List<Holder<Fluid>> holders = new ArrayList<>();
+        List<Holder<T>> holders = new ArrayList<>();
         for (String part : parts) {
             ResourceLocation rl = new ResourceLocation(part.trim());
-            Fluid fluid = GTRegistries.builtinRegistry().registry(Registries.FLUID).get().get(rl);
-            if (fluid != null && fluid != Fluids.EMPTY) {
-                holders.add(BuiltInRegistries.FLUID.wrapAsHolder(fluid));
+            T item = registry.get(rl);
+            if (item != null && item != getDefaultEmptyValue(registryKey)) { // Use a generic default empty check
+                holders.add(registry.wrapAsHolder(item));
             } else {
-                throw new RuntimeException("Unknown fluid id: " + rl);
+                throw new RuntimeException("Unknown ID for registry " + registryKey.location() + ": " + rl);
             }
         }
         return HolderSet.direct(holders);
+    }
+
+    // Helper to get the default "empty" value for a registry type
+    private static <T> T getDefaultEmptyValue(ResourceKey<? extends Registry<T>> registryKey) {
+        // Compare ResourceLocation directly instead of ResourceKey objects
+        if (registryKey.location().equals(Registries.FLUID.location())) {
+            return (T) Fluids.EMPTY;
+        } else if (registryKey.location().equals(Registries.BLOCK.location())) {
+            return (T) Blocks.AIR;
+        }
+        throw new IllegalArgumentException(
+                "Unsupported registry type for default value lookup: " + registryKey.location());
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/ConditionSerializeUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/condition/ConditionSerializeUtils.java
@@ -23,12 +23,10 @@ public class ConditionSerializeUtils {
      * Encode a List<HolderSet<T>> to a string encoding.
      * HolderSets are separated by '|', and elements of a direct HolderSet are separated by ','.
      *
-     * @param items       The list of HolderSet<T> to be encoded.
-     * @param registryKey The ResourceKey of the registry (e.g., Registries.FLUID, Registries.BLOCK).
+     * @param items The list of HolderSet<T> to be encoded.
      * @return A string encoding.
      */
-    public static <T> String encodeHolderSets(List<HolderSet<T>> items,
-                                              ResourceKey<? extends Registry<T>> registryKey) {
+    public static <T> String encodeHolderSets(List<HolderSet<T>> items) {
         StringBuilder sb = new StringBuilder();
         boolean first = true;
 
@@ -36,7 +34,7 @@ public class ConditionSerializeUtils {
             if (!first) {
                 sb.append("|");
             }
-            sb.append(encodeSingleHolderSet(holderSet, registryKey));
+            sb.append(encodeHolderSet(holderSet));
             first = false;
         }
 
@@ -48,19 +46,16 @@ public class ConditionSerializeUtils {
      * If it's a tag, it's encoded as #+location.
      * If it's a direct list, elements are separated by ','.
      *
-     * @param holderSet   The HolderSet<T> to be encoded.
-     * @param registryKey The ResourceKey of the registry.
+     * @param holderSet The HolderSet<T> to be encoded.
      * @return The encoded string.
      */
-    public static <T> String encodeSingleHolderSet(HolderSet<T> holderSet,
-                                                   ResourceKey<? extends Registry<T>> registryKey) {
-        Registry<T> vanillaRegistry = GTRegistries.builtinRegistry().registry(registryKey).get();
+    public static <T> String encodeHolderSet(HolderSet<T> holderSet) {
         return holderSet.unwrap().map(
                 // Case 1: Tag
                 tagKey -> "#" + tagKey.location(),
                 // Case 2: Direct list of holders
                 holders -> holders.stream()
-                        .map(holder -> getStringFromHolder(holder)) // Pass forgeRegistry
+                        .map(holder -> getStringFromHolder(holder))
                         .collect(Collectors.joining(",")));
     }
 
@@ -79,7 +74,7 @@ public class ConditionSerializeUtils {
 
         Optional<TagKey<T>> tagOpt = holder.tags().findFirst();
         if (tagOpt.isPresent()) {
-            return "#" + tagOpt.get().location().toString();
+            return "#" + tagOpt.get().location();
         }
         throw new RuntimeException("Could not serialize holder: " + holder);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
@@ -47,7 +47,7 @@ public class AdjacentBlockCondition extends RecipeCondition {
 
     public void setBlocks(@NotNull List<HolderSet<Block>> blocks) {
         this.blocks = blocks;
-        this.blockString = encodeHolderSets(blocks, Registries.BLOCK);
+        this.blockString = encodeHolderSets(blocks);
     }
 
     public List<HolderSet<Block>> getBlocks() {

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentBlockCondition.java
@@ -9,13 +9,11 @@ import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderSet;
-import net.minecraft.core.RegistryCodecs;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -24,35 +22,53 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+
+import static com.gregtechceu.gtceu.api.recipe.condition.ConditionSerializeUtils.decodeHolderSets;
+import static com.gregtechceu.gtceu.api.recipe.condition.ConditionSerializeUtils.encodeHolderSets;
 
 @NoArgsConstructor
 public class AdjacentBlockCondition extends RecipeCondition {
 
     // spotless:off
-    private static final Codec<List<HolderSet<Block>>> BLOCK_CODEC = ExtraCodecs.lazyInitializedCodec(
-            () -> RegistryCodecs.homogeneousList(Registries.BLOCK).listOf()
-    );
-
-    public static final Codec<AdjacentBlockCondition> CODEC = RecordCodecBuilder.create(instance -> RecipeCondition.isReverse(instance).and(
-            BLOCK_CODEC.fieldOf("blocks").forGetter(AdjacentBlockCondition::getBlocks)
-    ).apply(instance, AdjacentBlockCondition::new));
+    public static final Codec<AdjacentBlockCondition> CODEC =
+            RecordCodecBuilder.create(instance -> RecipeCondition.isReverse(instance).and(
+                    Codec.STRING.fieldOf("blockString").forGetter(AdjacentBlockCondition::getBlockString)
+            ).apply(instance, AdjacentBlockCondition::new));
     // spotless:on
 
     @Getter
-    @Setter
-    private @NotNull List<HolderSet<Block>> blocks = new ArrayList<>();
+    private @NotNull String blockString = "";
+
+    private @Nullable List<HolderSet<Block>> blocks = null;
+
+    public void setBlocks(@NotNull List<HolderSet<Block>> blocks) {
+        this.blocks = blocks;
+        this.blockString = encodeHolderSets(blocks, Registries.BLOCK);
+    }
+
+    public List<HolderSet<Block>> getBlocks() {
+        if (blocks == null) {
+            blocks = decodeHolderSets(getBlockString(), Registries.BLOCK);
+        }
+        return blocks;
+    }
 
     public AdjacentBlockCondition(@NotNull List<HolderSet<Block>> blocks) {
-        this.blocks.addAll(blocks);
+        setBlocks(blocks);
     }
 
     public AdjacentBlockCondition(boolean isReverse, @NotNull List<HolderSet<Block>> blocks) {
         super(isReverse);
-        this.blocks.addAll(blocks);
+        setBlocks(blocks);
+    }
+
+    public AdjacentBlockCondition(boolean isReverse, String blockString) {
+        super(isReverse);
+        this.blockString = blockString;
     }
 
     public static AdjacentBlockCondition fromBlocks(Collection<Block> blocks) {
@@ -113,7 +129,7 @@ public class AdjacentBlockCondition extends RecipeCondition {
     }
 
     public @NotNull List<HolderSet<Block>> getOrInitBlocks(@NotNull GTRecipe recipe) {
-        if (this.blocks.isEmpty() || (recipe.data.contains("blockA") && recipe.data.contains("blockB"))) {
+        if (getBlocks().isEmpty() || (recipe.data.contains("blockA") && recipe.data.contains("blockB"))) {
             List<HolderSet<Block>> blocks = new ArrayList<>();
 
             Block blockA = BuiltInRegistries.BLOCK.get(new ResourceLocation(recipe.data.getString("blockA")));
@@ -124,9 +140,9 @@ public class AdjacentBlockCondition extends RecipeCondition {
             if (!blockB.defaultBlockState().isAir()) {
                 blocks.add(HolderSet.direct(blockB.builtInRegistryHolder()));
             }
-            this.blocks = blocks;
+            setBlocks(blocks);
         }
-        return this.blocks;
+        return getBlocks();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
@@ -10,6 +10,7 @@ import com.gregtechceu.gtceu.utils.GTUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
@@ -26,8 +27,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-import static com.gregtechceu.gtceu.api.recipe.condition.ConditionSerializeUtils.decodeFluids;
-import static com.gregtechceu.gtceu.api.recipe.condition.ConditionSerializeUtils.encodeFluids;
+import static com.gregtechceu.gtceu.api.recipe.condition.ConditionSerializeUtils.decodeHolderSets;
+import static com.gregtechceu.gtceu.api.recipe.condition.ConditionSerializeUtils.encodeHolderSets;
 
 @NoArgsConstructor
 public class AdjacentFluidCondition extends RecipeCondition {
@@ -46,12 +47,12 @@ public class AdjacentFluidCondition extends RecipeCondition {
 
     public void setFluids(@NotNull List<HolderSet<Fluid>> fluids) {
         this.fluids = fluids;
-        this.fluidString = encodeFluids(fluids);
+        this.fluidString = encodeHolderSets(fluids, Registries.FLUID);
     }
 
     public List<HolderSet<Fluid>> getFluids() {
         if (fluids == null) {
-            fluids = decodeFluids(getFluidString());
+            fluids = decodeHolderSets(getFluidString(), Registries.FLUID);
         }
         return fluids;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidCondition.java
@@ -47,7 +47,7 @@ public class AdjacentFluidCondition extends RecipeCondition {
 
     public void setFluids(@NotNull List<HolderSet<Fluid>> fluids) {
         this.fluids = fluids;
-        this.fluidString = encodeHolderSets(fluids, Registries.FLUID);
+        this.fluidString = encodeHolderSets(fluids);
     }
 
     public List<HolderSet<Fluid>> getFluids() {

--- a/src/test/java/com/gregtechceu/gtceu/api/cover/MonitorCoverTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/cover/MonitorCoverTest.java
@@ -33,7 +33,7 @@ public class MonitorCoverTest {
                 "energy",
                 "energyCapacity"));
         cover.setUpdateInterval(1);
-        helper.runAtTickTime(2, () -> {
+        helper.runAtTickTime(5, () -> {
             TestUtils.assertEqual(helper, cover.getText(),
                     "Energy: 0/" + machine.energyContainer.getEnergyCapacity() + " EU");
             helper.succeed();
@@ -49,7 +49,7 @@ public class MonitorCoverTest {
         cover.getFormatStringLines()
                 .add("{if 1 {combine test 1 2 3 lol {repeat 5 \"a \"}} \"if placeholder failed somehow\"}");
         cover.setUpdateInterval(1);
-        helper.runAtTickTime(2, () -> {
+        helper.runAtTickTime(5, () -> {
             TestUtils.assertEqual(helper, cover.getText(), "test 1 2 3 lol a a a a a ");
             helper.succeed();
         });


### PR DESCRIPTION
## What
AdjacencyBlockCondition suffered the same problems that the AdjacencyFluidCondition had.
This generalizes the solution that we implemented for the fluid condition and lets us used it for the block condition too

Also:
 - Added tests for both and cleaned up the serialization tests
 - Added docs for AdjacencyBlockCondition in our patch notes
 - Changed the placeholder tests to a bigger timeout since they were flakey

## Implementation Details
Lots of generic slop

## Outcome
Block conditions work now
https://discord.com/channels/701354865217110096/1089296351906504835/1411249233901785118

## Additional Information
I am not adding block condition visuals, that's based on recipetype for now anyways, not condition