### PR TITLE
Fix tooltip claiming item/fluid pipes were modified with wire cutters

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -471,4 +471,8 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
         }
         return drops;
     }
+
+    public GTToolType getPipeTuneTool() {
+        return GTToolType.WRENCH;
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
@@ -2,7 +2,6 @@ package com.gregtechceu.gtceu.api.item;
 
 import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
-import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;

--- a/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.item;
 
 import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -43,7 +44,8 @@ public class PipeBlockItem extends BlockItem {
                                 TooltipFlag isAdvanced) {
         super.appendHoverText(stack, level, tooltip, isAdvanced);
         if (GTUtil.isShiftDown()) {
-            tooltip.add(Component.translatable("gtceu.tool_action.wire_cutter.connect"));
+            var tool = getBlock().getPipeTuneTool();
+            tooltip.add(Component.translatable("gtceu.tool_action." + tool.name + ".connect"));
         } else {
             tooltip.add(Component.translatable("gtceu.tool_action.show_tooltips"));
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
@@ -3,8 +3,6 @@ package com.gregtechceu.gtceu.api.item;
 import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
-import com.gregtechceu.gtceu.common.block.FluidPipeBlock;
-import com.gregtechceu.gtceu.common.block.ItemPipeBlock;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -45,14 +43,7 @@ public class PipeBlockItem extends BlockItem {
                                 TooltipFlag isAdvanced) {
         super.appendHoverText(stack, level, tooltip, isAdvanced);
         if (GTUtil.isShiftDown()) {
-            String tool;
-            if (stack.getItem() instanceof MaterialPipeBlockItem i &&
-                    ((i.getBlock() instanceof ItemPipeBlock) || (i.getBlock() instanceof FluidPipeBlock))) {
-                tool = "wrench";
-            } else {
-                tool = "wire_cutter";
-            }
-            tooltip.add(Component.translatable("gtceu.tool_action." + tool + ".connect"));
+            tooltip.add(Component.translatable("gtceu.tool_action.wire_cutter.connect"));
         } else {
             tooltip.add(Component.translatable("gtceu.tool_action.show_tooltips"));
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/PipeBlockItem.java
@@ -3,6 +3,8 @@ package com.gregtechceu.gtceu.api.item;
 import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
+import com.gregtechceu.gtceu.common.block.FluidPipeBlock;
+import com.gregtechceu.gtceu.common.block.ItemPipeBlock;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -43,7 +45,14 @@ public class PipeBlockItem extends BlockItem {
                                 TooltipFlag isAdvanced) {
         super.appendHoverText(stack, level, tooltip, isAdvanced);
         if (GTUtil.isShiftDown()) {
-            tooltip.add(Component.translatable("gtceu.tool_action.wire_cutter.connect"));
+            String tool;
+            if (stack.getItem() instanceof MaterialPipeBlockItem i &&
+                    ((i.getBlock() instanceof ItemPipeBlock) || (i.getBlock() instanceof FluidPipeBlock))) {
+                tool = "wrench";
+            } else {
+                tool = "wire_cutter";
+            }
+            tooltip.add(Component.translatable("gtceu.tool_action." + tool + ".connect"));
         } else {
             tooltip.add(Component.translatable("gtceu.tool_action.show_tooltips"));
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/block/CableBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/CableBlock.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.WireProperties;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.common.blockentity.CableBlockEntity;
@@ -146,5 +147,10 @@ public class CableBlock extends MaterialPipeBlock<Insulation, WireProperties, Le
                 }
             }
         }
+    }
+
+    @Override
+    public GTToolType getPipeTuneTool() {
+        return GTToolType.WIRE_CUTTER;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/block/LaserPipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/LaserPipeBlock.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.blockentity.PipeBlockEntity;
 import com.gregtechceu.gtceu.api.capability.forge.GTCapability;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.client.renderer.block.PipeBlockRenderer;
@@ -111,5 +112,10 @@ public class LaserPipeBlock extends PipeBlock<LaserPipeType, LaserPipeProperties
     public boolean canPipeConnectToBlock(IPipeNode<LaserPipeType, LaserPipeProperties> selfTile, Direction side,
                                          @Nullable BlockEntity tile) {
         return tile != null && tile.getCapability(GTCapability.CAPABILITY_LASER, side.getOpposite()).isPresent();
+    }
+
+    @Override
+    public GTToolType getPipeTuneTool() {
+        return GTToolType.WIRE_CUTTER;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/block/OpticalPipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/OpticalPipeBlock.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.PipeBlock;
 import com.gregtechceu.gtceu.api.blockentity.PipeBlockEntity;
 import com.gregtechceu.gtceu.api.capability.forge.GTCapability;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.client.model.PipeModel;
 import com.gregtechceu.gtceu.client.renderer.block.PipeBlockRenderer;
@@ -113,5 +114,10 @@ public class OpticalPipeBlock extends PipeBlock<OpticalPipeType, OpticalPipeProp
         if (tile == null) return false;
         if (tile.getCapability(GTCapability.CAPABILITY_DATA_ACCESS, side.getOpposite()).isPresent()) return true;
         return tile.getCapability(GTCapability.CAPABILITY_COMPUTATION_PROVIDER, side.getOpposite()).isPresent();
+    }
+
+    @Override
+    public GTToolType getPipeTuneTool() {
+        return GTToolType.WIRE_CUTTER;
     }
 }


### PR DESCRIPTION
## What
exactly what it says on the tin, the Hold Shift tooltip on Item and Fluid pipes claims that you use Wire Cutters to change their sides when in reality you use a Wrench