### PR TITLE
fix offsets bugging out when there are multiple faces passed to a FluidAreaRender

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/FluidAreaRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/FluidAreaRender.java
@@ -99,22 +99,21 @@ public class FluidAreaRender extends DynamicRender<IFluidRenderMulti, FluidAreaR
             return;
         }
 
-        poseStack.pushPose();
-        var pose = poseStack.last().pose();
-
         var fluidRenderType = ItemBlockRenderTypes.getRenderLayer(cachedFluid.defaultFluidState());
         var consumer = buffer.getBuffer(RenderTypeHelper.getEntityRenderType(fluidRenderType, false));
 
         for (RelativeDirection face : this.drawFaces) {
+            poseStack.pushPose();
+            var pose = poseStack.last().pose();
+
             var dir = face.getRelative(machine.self().getFrontFacing(), machine.self().getUpwardsFacing(),
                     machine.self().isFlipped());
             if (dir.getAxis() != Direction.Axis.Y) dir = dir.getOpposite();
 
             fluidBlockRenderer.drawPlane(dir, machine.getFluidOffsets(), pose, consumer, cachedFluid,
                     RenderUtil.FluidTextureType.STILL, packedOverlay, machine.self().getPos());
+            poseStack.popPose();
         }
-
-        poseStack.popPose();
     }
 
     private Optional<Fluid> getFixedFluid() {


### PR DESCRIPTION
## What
FluidAreaRenders bug out and apply their offsets repeatedly to themselves if there are multiple RelativeDirections passed in as faces.

## Implementation Details
Moves poseStack push and pop into the for loop instead of outside it.

## Outcome
FluidAreaRenders render correctly if given a drawFaces list longer than 1.

## Additional Information
Before fix:
<img width="2560" height="1403" alt="2025-09-04_00 14 48" src="https://github.com/user-attachments/assets/c88f7942-66a0-48b2-a1a0-d746ce11fd0d" />

After fix:
<img width="2494" height="1371" alt="2025-09-04_00 25 01" src="https://github.com/user-attachments/assets/1fda8849-c700-4bf0-a0c3-0d1ea9631313" />
