### PR TITLE
add descsynced to ItemBusPartMachine storage, FluidHatchPartMachine tanks, and NotifiableFluidTank tanks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -35,6 +35,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
     @Getter
     public final IO capabilityIO;
     @Persisted
+    @DescSynced
     @Getter
     protected final CustomFluidTank[] storages;
     @Getter

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java
@@ -65,6 +65,7 @@ public class FluidHatchPartMachine extends TieredIOPartMachine implements IMachi
     public static final int INITIAL_TANK_CAPACITY_9X = FluidType.BUCKET_VOLUME;
 
     @Persisted
+    @DescSynced
     public final NotifiableFluidTank tank;
     private final int slots;
     @Nullable

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -59,6 +59,7 @@ public class ItemBusPartMachine extends TieredIOPartMachine
             TieredIOPartMachine.MANAGED_FIELD_HOLDER);
     @Getter
     @Persisted
+    @DescSynced
     private final NotifiableItemStackHandler inventory;
     @Nullable
     protected TickableSubscription autoIOSubs;


### PR DESCRIPTION
## What
add descsynced to the mentioned things, for renders to do their thing

## Implementation Details
added descsynced

## Outcome
renders based on item bus or fluid hatch contents should be easier/possible now