### PR TITLE
parity between centrifuging oilsands dust and oilsands ore

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
@@ -50,7 +50,7 @@ public class SeparationRecipes {
         CENTRIFUGE_RECIPES.recipeBuilder("oilsands_ore_separation")
                 .inputItems(ore, Oilsands)
                 .chancedOutput(new ItemStack(Blocks.SAND), 7500, 0)
-                .outputFluids(Oil.getFluid(2000))
+                .outputFluids(OilHeavy.getFluid(2000))
                 .duration(200).EUt(30).save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("oilsands_dust_separation")


### PR DESCRIPTION
## What
changes oilsands ore separation to produce heavy oil instead of oil, so that it has parity with oilsands dust

## Outcome
resolves #3877 

## Additional Information
![it works](https://i.imgur.com/0DjbmXI.png)

## Potential Compatibility Issues
could annoy people that rely on it
