### PR TITLE
Mark AppearanceBlock as deprecated and replace references to it

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/ActiveBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/ActiveBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.Property;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -17,7 +18,7 @@ import static com.gregtechceu.gtceu.api.block.property.GTBlockStateProperties.AC
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class ActiveBlock extends AppearanceBlock {
+public class ActiveBlock extends Block {
 
     public ActiveBlock(Properties properties) {
         super(properties);
@@ -50,8 +51,8 @@ public class ActiveBlock extends AppearanceBlock {
     }
 
     @Override
-    public BlockState getBlockAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
-                                         BlockState sourceState, BlockPos sourcePos) {
+    public BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
+                                    @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
         return defaultBlockState();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/block/AppearanceBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/AppearanceBlock.java
@@ -8,6 +8,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import org.jetbrains.annotations.Nullable;
 
+/// @deprecated Use normal Block class instead - replace `AppearanceBlock::getBlockAppearance` with `Block::getAppearance`
+@Deprecated(forRemoval = true)
 public class AppearanceBlock extends Block implements IAppearance {
 
     public AppearanceBlock(Properties properties) {

--- a/src/main/java/com/gregtechceu/gtceu/api/block/AppearanceBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/AppearanceBlock.java
@@ -8,7 +8,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import org.jetbrains.annotations.Nullable;
 
-/// @deprecated Use normal Block class instead - replace `AppearanceBlock::getBlockAppearance` with `Block::getAppearance`
+/// @deprecated Use normal Block class instead - replace `AppearanceBlock::getBlockAppearance` with
+/// `Block::getAppearance`
 @Deprecated(forRemoval = true)
 public class AppearanceBlock extends Block implements IAppearance {
 

--- a/src/main/java/com/gregtechceu/gtceu/api/block/IAppearance.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/IAppearance.java
@@ -7,6 +7,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import org.jetbrains.annotations.Nullable;
 
+@Deprecated(forRemoval = true)
 public interface IAppearance {
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/block/MaterialBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MaterialBlock.java
@@ -57,7 +57,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class MaterialBlock extends AppearanceBlock {
+public class MaterialBlock extends Block {
 
     public final TagPrefix tagPrefix;
     public final Material material;

--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -351,7 +351,7 @@ public class MetaMachineBlock extends Block implements IMachineBlock {
 
     @Override
     public BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
-                                        @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
+                                    @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
         var machine = getMachine(level, pos);
         if (machine != null) {
             return machine.getBlockAppearance(state, level, pos, side, sourceState, sourcePos);

--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -60,7 +60,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @SuppressWarnings("deprecation")
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
-public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
+public class MetaMachineBlock extends Block implements IMachineBlock {
 
     @Getter
     public final MachineDefinition definition;
@@ -350,13 +350,13 @@ public class MetaMachineBlock extends AppearanceBlock implements IMachineBlock {
     }
 
     @Override
-    public BlockState getBlockAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
-                                         BlockState sourceState, BlockPos sourcePos) {
+    public BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
+                                        @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
         var machine = getMachine(level, pos);
         if (machine != null) {
             return machine.getBlockAppearance(state, level, pos, side, sourceState, sourcePos);
         }
-        return super.getBlockAppearance(state, level, pos, side, sourceState, sourcePos);
+        return super.getAppearance(state, level, pos, side, sourceState, sourcePos);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -73,7 +73,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<NodeDataType>, NodeDataType,
-        WorldPipeNetType extends LevelPipeNet<NodeDataType, ? extends PipeNet<NodeDataType>>> extends AppearanceBlock
+        WorldPipeNetType extends LevelPipeNet<NodeDataType, ? extends PipeNet<NodeDataType>>> extends Block
                                implements EntityBlock, IBlockRendererProvider, SimpleWaterloggedBlock {
 
     public final PipeType pipeType;
@@ -444,15 +444,15 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     @Override
-    public BlockState getBlockAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
-                                         BlockState sourceState, BlockPos sourcePos) {
+    public BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
+                                         @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
         var pipe = getPipeTile(level, pos);
         if (pipe != null) {
             var appearance = pipe.getCoverContainer().getBlockAppearance(state, level, pos, side, sourceState,
                     sourcePos);
             if (appearance != null) return appearance;
         }
-        return super.getBlockAppearance(state, level, pos, side, sourceState, sourcePos);
+        return super.getAppearance(state, level, pos, side, sourceState, sourcePos);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -445,7 +445,7 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
 
     @Override
     public BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
-                                         @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
+                                    @Nullable BlockState sourceState, @Nullable BlockPos sourcePos) {
         var pipe = getPipeTile(level, pos);
         if (pipe != null) {
             var appearance = pipe.getCoverContainer().getBlockAppearance(state, level, pos, side, sourceState,

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/ICoverable.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/ICoverable.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public interface ICoverable extends ITickSubscription, IAppearance {
+public interface ICoverable extends ITickSubscription {
 
     Level getLevel();
 

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/ICoverable.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/ICoverable.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.api.capability;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.block.IAppearance;
 import com.gregtechceu.gtceu.api.blockentity.ITickSubscription;
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
@@ -266,7 +265,6 @@ public interface ICoverable extends ITickSubscription {
     }
 
     @Nullable
-    @Override
     default BlockState getBlockAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
                                           BlockState sourceState, BlockPos sourcePos) {
         if (hasCover(side)) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -94,7 +94,7 @@ import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.getBehaviorsTag;
  */
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
-public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscription, IAppearance, IToolGridHighlight,
+public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscription, IToolGridHighlight,
                          IFancyTooltip, IPaintable, IRedstoneSignalMachine {
 
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(MetaMachine.class);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -677,7 +677,6 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
 
     public void animateTick(RandomSource random) {}
 
-    @Override
     @NotNull
     public BlockState getBlockAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side,
                                          BlockState sourceState, BlockPos sourcePos) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.api.machine;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.block.IAppearance;
 import com.gregtechceu.gtceu.api.block.MetaMachineBlock;
 import com.gregtechceu.gtceu.api.block.property.GTBlockStateProperties;
 import com.gregtechceu.gtceu.api.blockentity.IPaintable;

--- a/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.common.block;
 
 import com.gregtechceu.gtceu.api.GTValues;
-import com.gregtechceu.gtceu.api.block.AppearanceBlock;
 import com.gregtechceu.gtceu.api.machine.multiblock.IBatteryData;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 

--- a/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
 
 import lombok.Getter;
+import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;

--- a/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class BatteryBlock extends AppearanceBlock {
+public class BatteryBlock extends Block {
 
     @Getter
     private final IBatteryData data;

--- a/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/BatteryBlock.java
@@ -10,9 +10,9 @@ import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
 
 import lombok.Getter;
-import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;


### PR DESCRIPTION
## What
The AppearanceBlock class is an unneeded block class as the fabric/forge API difference is no longer relevant.