### PR TITLE
Rename firstdark maven

### DIFF
--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -14,7 +14,7 @@ repositories {
 
     maven { // LDLib, Shimmer
         name = "FirstDarkDev Maven"
-        url = "https://maven.firstdarkdev.xyz/snapshots"
+        url = "https://maven.firstdark.dev/snapshots"
     }
 
     exclusiveContent { // Create, Ponder, Flywheel


### PR DESCRIPTION
## What
Chore to rename the maven to the new name for firstdark, as per HypherionSA's request.

<img width="455" height="602" alt="image" src="https://github.com/user-attachments/assets/cf9118f8-ceba-4565-b646-14007ae02c65" />