### PR TITLE
Add missing particles to item/fluid passthrough and laser hatches

### DIFF
--- a/src/main/resources/assets/gtceu/models/block/machine/part/fluid_passthrough_hatch.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/part/fluid_passthrough_hatch.json
@@ -2,6 +2,7 @@
     "credit": "Made with Blockbench",
     "parent": "block/block",
     "textures": {
+        "particle": "#side",
         "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
         "overlay_pipe_in": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
         "overlay_fluid_hatch_input": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",

--- a/src/main/resources/assets/gtceu/models/block/machine/part/item_passthrough_hatch.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/part/item_passthrough_hatch.json
@@ -2,6 +2,7 @@
     "credit": "Made with Blockbench",
     "parent": "block/block",
     "textures": {
+        "particle": "#side",
         "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
         "overlay_pipe_in": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
         "overlay_item_hatch_input": "gtceu:block/overlay/machine/overlay_item_hatch_input",

--- a/src/main/resources/assets/gtceu/models/block/machine/part/laser_source_hatch.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/part/laser_source_hatch.json
@@ -2,6 +2,7 @@
     "credit": "Made with Blockbench",
     "parent": "block/block",
     "textures": {
+        "particle": "#side",
         "overlay_laser": "gtceu:block/overlay/machine/overlay_laser_base",
         "overlay_laser_source": "gtceu:block/overlay/machine/overlay_laser_source",
         "overlay_laser_source_emissive": "gtceu:block/overlay/machine/overlay_laser_source_emissive"

--- a/src/main/resources/assets/gtceu/models/block/machine/part/laser_target_hatch.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/part/laser_target_hatch.json
@@ -2,6 +2,7 @@
     "credit": "Made with Blockbench",
     "parent": "block/block",
     "textures": {
+        "particle": "#side",
         "overlay_laser": "gtceu:block/overlay/machine/overlay_laser_base",
         "overlay_laser_target": "gtceu:block/overlay/machine/overlay_laser_target",
         "overlay_laser_target_emissive": "gtceu:block/overlay/machine/overlay_laser_target_emissive"


### PR DESCRIPTION
## What
Add block-break particles to
* Item passthrough hatches
* Fluid passthrough hatches
* Laser source hatches
* Laser target hatches

## Outcome
Fixes: #3801