### PR TITLE
Order EMI Machine List manually

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/oreprocessing/GTOreProcessingEmiCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/oreprocessing/GTOreProcessingEmiCategory.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey.ORE;
 import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.*;
+import static com.gregtechceu.gtceu.integration.emi.recipe.GTRecipeEMICategory.sortDefinition;
 
 public class GTOreProcessingEmiCategory extends EmiRecipeCategory {
 
@@ -43,7 +44,10 @@ public class GTOreProcessingEmiCategory extends EmiRecipeCategory {
                 MACERATOR_RECIPES, ORE_WASHER_RECIPES, THERMAL_CENTRIFUGE_RECIPES, CENTRIFUGE_RECIPES,
                 CHEMICAL_BATH_RECIPES, ELECTROMAGNETIC_SEPARATOR_RECIPES, SIFTER_RECIPES
         };
-        for (MachineDefinition machine : GTRegistries.MACHINES) {
+        for (MachineDefinition machine : GTRegistries.MACHINES.values()
+                .stream()
+                .sorted(sortDefinition)
+                .toList()) {
             for (GTRecipeType type : machine.getRecipeTypes()) {
                 for (GTRecipeType validType : validTypes) {
                     if (type == validType && !registeredMachines.contains(machine)) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/GTRecipeEMICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/recipe/GTRecipeEMICategory.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.integration.emi.recipe;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
+import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
@@ -17,6 +18,7 @@ import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
 import dev.emi.emi.api.stack.EmiStack;
 
+import java.util.Comparator;
 import java.util.function.Function;
 
 public class GTRecipeEMICategory extends EmiRecipeCategory {
@@ -42,8 +44,23 @@ public class GTRecipeEMICategory extends EmiRecipeCategory {
         }
     }
 
+    public static Comparator<MachineDefinition> sortDefinition = (a, b) -> {
+        boolean isAMulti = a instanceof MultiblockMachineDefinition;
+        boolean isBMulti = b instanceof MultiblockMachineDefinition;
+        if (isAMulti && !isBMulti) {
+            return 1;
+        } else if (!isAMulti && isBMulti) {
+            return -1;
+        } else {
+            return a.getTier() - b.getTier();
+        }
+    };
+
     public static void registerWorkStations(EmiRegistry registry) {
-        for (MachineDefinition machine : GTRegistries.MACHINES) {
+        for (MachineDefinition machine : GTRegistries.MACHINES.values()
+                .stream()
+                .sorted(sortDefinition)
+                .toList()) {
             for (GTRecipeType type : machine.getRecipeTypes()) {
                 for (GTRecipeCategory category : type.getCategories()) {
                     if (!category.isXEIVisible() && !GTCEu.isDev()) continue;


### PR DESCRIPTION
## What
#3591 broke EMI machine lists by making registries not return items in order of registration like before. This PR manually enforces the ordering of the machines so that the EMI pages are in-order again:

<img width="742" height="955" alt="image" src="https://github.com/user-attachments/assets/07b72055-b0b9-4c5f-b78a-d6475a983260" />


## Implementation Details
This has 100% broken other things too, we just haven't found which ones.
