### PR TITLE
Add to 7.0.0 rtui patch notes, and add Ambiguous Methods docs page

### DIFF
--- a/docs/content/Modpacks/Changes/v7.0.0.md
+++ b/docs/content/Modpacks/Changes/v7.0.0.md
@@ -5,6 +5,17 @@ title: "Version 7.0.0"
 
 # Updating from `1.6.4` to `7.0.0`
 
+## Custom UIs
+
+In your custom `.rtui` files, you need to rename the following references:  
+
+  - `phantom_fluid_slot` -> `gtm_phantom_fluid_slot`  
+  - `phantom_item_slot` -> `gtm_phantom_item_slot`  
+  - `item_slot` -> `gtm_item_slot`  
+  - `fluid_slot` -> `gtm_fluid_slot`  
+  - `container` -> `gtm_container`  
+
+This can be done in any NBT editor of choice, e.g. IntelliJ's built-in one or [webNBT](https://irath96.github.io/webNBT/).
 
 ## Models
 

--- a/docs/content/Modpacks/Changes/v7.0.0.md
+++ b/docs/content/Modpacks/Changes/v7.0.0.md
@@ -15,7 +15,7 @@ In your custom `.rtui` files, you need to rename the following references:
   - `fluid_slot` -> `gtm_fluid_slot`  
   - `container` -> `gtm_container`  
 
-This can be done in any NBT editor of choice, e.g. IntelliJ's built-in one or [webNBT](https://irath96.github.io/webNBT/).
+This can be done in any NBT editor of choice, e.g. [webNBT](https://irath96.github.io/webNBT/).
 
 ## Models
 

--- a/docs/content/Modpacks/Examples/Superheated_Pyrolyzing_Oven.md
+++ b/docs/content/Modpacks/Examples/Superheated_Pyrolyzing_Oven.md
@@ -19,7 +19,7 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeTypes('pyrolyse_oven')
             .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_PERFECT,GTRecipeModifiers.BATCH_MODE, (machine, recipe) =>
-            GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe)])
+                GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe)])
             .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
             .pattern(definition => FactoryBlockPattern.start()
                 .aisle("BBCCCBB", "BBCDCBB", "BBCCCBB", "BBCCCBB", "BBEEEBB", "BBEEEBB")

--- a/docs/content/Modpacks/Examples/Superheated_Pyrolyzing_Oven.md
+++ b/docs/content/Modpacks/Examples/Superheated_Pyrolyzing_Oven.md
@@ -18,8 +18,14 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
             .machine((holder) => new CoilWorkableElectricMultiblockMachine(holder))
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeTypes('pyrolyse_oven')
-            .recipeModifiers([GTRecipeModifiers.PARALLEL_HATCH, GTRecipeModifiers.OC_PERFECT,GTRecipeModifiers.BATCH_MODE, (machine, recipe) =>
-                GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe)])
+            .recipeModifiers(
+                [
+                    GTRecipeModifiers.PARALLEL_HATCH, 
+                    GTRecipeModifiers.OC_PERFECT,
+                    GTRecipeModifiers.BATCH_MODE, 
+                    (machine, recipe) => GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe)
+                ]
+            )
             .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
             .pattern(definition => FactoryBlockPattern.start()
                 .aisle("BBCCCBB", "BBCDCBB", "BBCCCBB", "BBCCCBB", "BBEEEBB", "BBEEEBB")

--- a/docs/content/Modpacks/Other-Topics/Ambiguous-Methods.md
+++ b/docs/content/Modpacks/Other-Topics/Ambiguous-Methods.md
@@ -1,0 +1,56 @@
+---
+title: Ambiguous Methods
+---
+
+Sometimes in KJS, you run into ambiguous methods when calling functions. 
+This happens when there's multiple overloads (e.g. methods with the same name but different types) and KubeJS isn't sure which function to call with your arguments.
+
+For example, when you do:
+```js
+
+GTCEuStartupEvents.registry('gtceu:machine', event => {
+    event.create('unboxinator', 'multiblock')
+        .tooltips(Component.literal("I am a multiblock"))
+    // Rest of the multiblock
+})
+```
+
+you'd get the error:
+```
+Error in 'GTCEuStartupEvents.registry': The choice of Java method com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder.tooltips matching JavaScript argument types (net.minecraft.network.chat.MutableComponent) is ambiguous; candidate methods are: 
+    class com.gregtechceu.gtceu.api.registry.registrate.MachineBuilder tooltips(java.util.List)
+    class com.gregtechceu.gtceu.api.registry.registrate.MachineBuilder tooltips(net.minecraft.network.chat.Component[])
+```
+
+In this case, there's ambiguity between the following 2 java functions:
+```java
+    public MachineBuilder<DEFINITION> tooltips(@Nullable Component... components) {
+        return tooltips(Arrays.asList(components));
+    }
+
+    public MachineBuilder<DEFINITION> tooltips(List<? extends @Nullable Component> components) {
+        tooltips.addAll(components.stream().filter(Objects::nonNull).toList());
+        return this;
+    }
+```
+
+You would want to select one of the two, and this can be done in the following way:
+```js
+GTCEuStartupEvents.registry('gtceu:machine', event => {
+    event.create('unboxinator', 'multiblock')
+        ["tooltips(java.util.List)"]([Component.literal("I am a multiblock")])
+        // Rest of the multiblock
+})
+```
+or
+```js
+GTCEuStartupEvents.registry('gtceu:machine', event => {
+    event.create('unboxinator', 'multiblock')
+        ["tooltips(net.minecraft.network.chat.Component[])"]([Component.literal("I am a multiblock")])
+        // Rest of the multiblock
+})
+```
+
+Because of the way javascript indexing works, `.foo` and `["foo"]` are the same thing, so you can just keep chaning your functions afterward, since it's just a "normal" builder method, just called in a more specific way.
+!!! Note
+    Generics don't exist in compiled code, so e.g. a call to `memoize(Supplier<T> delegate)` would turn into `["memoize(Supplier)"](...)`


### PR DESCRIPTION
## What
- Adds documentation for the 1.6.4->7.0.0 chance of .rtui files as per #2941
- Adds a page on KJS ambiguous overrides
- Changes indentation on superheated pyrolyzing oven page


## Implementation Details
Maybe we don't want the overrides docs, since it's a KJS thing rather than a GTM thing? But I feel it's specific, helpful, and not-known enough to be included here. Tar and phoenix (contributor not dev) agreed here: https://discord.com/channels/701354865217110096/1089296351906504835/1416776978320588842


## Outcome
<img width="490" height="338" alt="image" src="https://github.com/user-attachments/assets/8f8af4d5-3909-4cc1-ba47-bdf614c04189" />

<img width="643" height="1090" alt="image" src="https://github.com/user-attachments/assets/21e2529d-9d0f-4f8f-b681-b31aaf7d3dbc" />

<img width="507" height="279" alt="image" src="https://github.com/user-attachments/assets/2221a2ff-bd63-48c1-a588-590e75201218" />
