### PR TITLE
Fix UI not opening on steam boilers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
@@ -315,7 +315,7 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
                 return InteractionResult.SUCCESS;
             }
         }
-        return InteractionResult.sidedSuccess(world.isClientSide);
+        return IInteractedMachine.super.onUse(state, world, pos, player, hand, hit);
     }
 
     //////////////////////////////////////


### PR DESCRIPTION
## What
Solar and Solid boilers didn't open their UI anymore

## Implementation Details
caused by #3519
By always returning SUCCESS or CONSUME, we always consumed the input event, never letting it open the UI. Calling super returns PASS which does open the UI

## Outcome
They now open their UIs again

