### PR TITLE
Set fluid block map colors from material color

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/forge/GTFluidBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/forge/GTFluidBuilder.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.fluids.GTFluid;
 import com.gregtechceu.gtceu.api.fluids.forge.GTFluidImpl;
 import com.gregtechceu.gtceu.api.item.GTBucketItem;
 import com.gregtechceu.gtceu.api.registry.registrate.IGTFluidBuilder;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
@@ -196,6 +197,7 @@ public class GTFluidBuilder<P> extends AbstractBuilder<Fluid, GTFluidImpl.Flowin
         return getOwner().<B, GTFluidBuilder<P>>block(this, sourceName, p -> factory.apply(supplier, p))
                 .properties(p -> BlockBehaviour.Properties.copy(Blocks.WATER).noLootTable())
                 .properties(p -> p.lightLevel(blockState -> fluidType.get().getLightLevel()))
+                .properties(p -> p.mapColor(GTUtil.determineMapColor(material.getMaterialRGB())))
                 .setData(ProviderType.LANG, NonNullBiConsumer.noop())
                 .blockstate((ctx, prov) -> prov.simpleBlock(ctx.getEntry(), prov.models().getBuilder(sourceName)
                         .texture("particle", stillTexture)))


### PR DESCRIPTION
## What
Give fluids a default map color, based on the material color (instead of just inheriting blue from Water.)

## Implementation Details
Also it turns out determineDyeColor was bugged since #3124 - luckily it looks like nothing uses this method.

## Outcome
Oil is now black on Vanilla maps.
Fixes #3660