### PR TITLE
Fix GTValues.VHA[LV] value

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -48,7 +48,7 @@ public class GTValues {
     /**
      * The Voltage Tiers. Use this Array instead of the old named Voltage Variables
      */
-    public static final long[] V = new long[] { 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608,
+    public static final long[] V = { 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608,
             33554432, 134217728, 536870912, 2147483648L };
 
     /**
@@ -60,19 +60,19 @@ public class GTValues {
     /**
      * The Voltage Tiers adjusted for cable loss. Use this for recipe EU/t to avoid full-amp recipes
      */
-    public static final int[] VA = new int[] { 7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320,
+    public static final int[] VA = { 7, 30, 120, 480, 1920, 7680, 30720, 122880, 491520, 1966080, 7864320,
             31457280, 125829120, 503316480, 2013265920 };
 
     /**
      * The Voltage Tiers adjusted for cable loss, divided by 2.
      */
-    public static final int[] VHA = { 7, 16, 60, 240, 960, 3840, 15360, 61440, 245760, 983040, 3932160, 15728640,
+    public static final int[] VHA = { 4, 16, 60, 240, 960, 3840, 15360, 61440, 245760, 983040, 3932160, 15728640,
             62914560, 251658240, 1006632960 };
 
     /**
      * The Voltage Tiers. Use this Array instead of the old named Voltage Variables
      */
-    public static final long[] VEX = new long[] { 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608,
+    public static final long[] VEX = { 8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152, 8388608,
             33554432, 134217728, 536870912, 2147483648L, 8589934592L, 34359738368L, 137438953472L, 549755813888L,
             2199023255552L, 8796093022208L, 35184372088832L, 140737488355328L, 562949953421312L, 2251799813685248L,
             9007199254740992L, 36028797018963968L, 144115188075855872L, 576460752303423488L, 2305843009213693952L,

--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -66,7 +66,7 @@ public class GTValues {
     /**
      * The Voltage Tiers adjusted for cable loss, divided by 2.
      */
-    public static final int[] VHA = { 4, 16, 60, 240, 960, 3840, 15360, 61440, 245760, 983040, 3932160, 15728640,
+    public static final int[] VHA = { 3, 15, 60, 240, 960, 3840, 15360, 61440, 245760, 983040, 3932160, 15728640,
             62914560, 251658240, 1006632960 };
 
     /**


### PR DESCRIPTION
## What
GTValues.VHA is "The Voltage Tiers adjusted for cable loss, divided by 2.".

V[LV] is 8
VA[LV] is 7
VHA[LV] used to be 7, but this should be either 3 or 4. Since making it 4 would not account for cable loss (and thus running 2 VHA[LV] recipes would take the full amp + burn the cable), I have opted to make it 3. Feel free to fight this out in the comments

Also, VHA[MV] used to be 16 when it should have been 15 for the same reason.


## Implementation Details
Also changed all 4 arrays to use the same creation mechanic `new int[] x = { ... }`

## Potential Compatibility Issues
Balancing chance :caught:

