### PR TITLE
Fix Ender Redstone Link Covers on non-default channels

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/misc/virtualregistry/entries/VirtualRedstone.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/virtualregistry/entries/VirtualRedstone.java
@@ -24,10 +24,8 @@ public class VirtualRedstone extends VirtualEntry {
         return members.values().intStream().max().orElse(0);
     }
 
-    public UUID addMember() {
-        UUID uuid = UUID.randomUUID();
+    public void addMember(UUID uuid) {
         members.put(uuid, (short) 0);
-        return uuid;
     }
 
     public void setSignal(UUID uuid, int signal) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderRedstoneLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderRedstoneLinkCover.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.common.cover.ender;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.misc.virtualregistry.EntryTypes;
-import com.gregtechceu.gtceu.api.misc.virtualregistry.VirtualEnderRegistry;
 import com.gregtechceu.gtceu.api.misc.virtualregistry.VirtualEntry;
 import com.gregtechceu.gtceu.api.misc.virtualregistry.entries.VirtualRedstone;
 
@@ -34,9 +33,8 @@ public class EnderRedstoneLinkCover extends AbstractEnderLinkCover<VirtualRedsto
     public EnderRedstoneLinkCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide) {
         super(definition, coverHolder, attachedSide);
         if (!isRemote()) {
-            storage = VirtualEnderRegistry.getInstance().getOrCreateEntry(getOwner(), EntryTypes.ENDER_REDSTONE,
-                    getChannelName());
-            uuid = storage.addMember();
+            uuid = UUID.randomUUID();
+            setVirtualEntry();
         } else uuid = null;
     }
 
@@ -57,7 +55,9 @@ public class EnderRedstoneLinkCover extends AbstractEnderLinkCover<VirtualRedsto
 
     @Override
     protected void setEntry(VirtualEntry entry) {
+        if (storage != null) storage.removeMember(uuid);
         storage = (VirtualRedstone) entry;
+        storage.addMember(uuid);
     }
 
     @Override


### PR DESCRIPTION
## What
Before, only the default (FFFFFFFF) channel would work for redstone links.
Now, non-default channels should also work.

## Implementation Details
* Move the add/remove member logic to EnderRedstoneLinkCover.setEntry
* Move UUID generation to EnderRedstoneLinkCover initialisation

These changes should ensure that the VirtualRedstone members map is consistently updated when covers are updated.

## Additional Information
I am not an expert in LDLib, so may have missed something subtle - I did see the ["Using @Persisted fields in initialization code"](https://low-drag-mc.github.io/LowDragMC-Doc/ldlib/SyncData/#using-persisted-fields-in-initialization-code) warning in the docs, but so far saving/loading the game and loading/unloading the chunks seems to be working ok.