### PR TITLE
Fix laser and Optical pipe ignoring connections

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/LaserPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/LaserPipeBlockEntity.java
@@ -65,7 +65,7 @@ public class LaserPipeBlockEntity extends PipeBlockEntity<LaserPipeType, LaserPi
         if (cap == GTCapability.CAPABILITY_LASER) {
             if (getLevel().isClientSide())
                 return GTCapability.CAPABILITY_LASER.orEmpty(cap, LazyOptional.of(() -> clientCapability));
-
+            if (side != null && !isConnected(side)) return LazyOptional.empty();
             if (handlers.isEmpty()) {
                 initHandlers();
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/OpticalPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/OpticalPipeBlockEntity.java
@@ -76,7 +76,7 @@ public class OpticalPipeBlockEntity extends PipeBlockEntity<OpticalPipeType, Opt
                 return GTCapability.CAPABILITY_DATA_ACCESS.orEmpty(capability,
                         LazyOptional.of(() -> clientDataHandler));
             }
-
+            if (facing != null && !isConnected(facing)) return LazyOptional.empty();
             if (handlers.isEmpty()) initHandlers();
 
             checkNetwork();
@@ -89,7 +89,7 @@ public class OpticalPipeBlockEntity extends PipeBlockEntity<OpticalPipeType, Opt
                 return GTCapability.CAPABILITY_COMPUTATION_PROVIDER.orEmpty(capability,
                         LazyOptional.of(() -> clientComputationHandler));
             }
-
+            if (facing != null && !isConnected(facing)) return LazyOptional.empty();
             if (handlers.isEmpty()) initHandlers();
 
             checkNetwork();


### PR DESCRIPTION
## What
Fix laser and Optical pipe ignoring connections

## Implementation Details
Add check

## Outcome
Connection is required to work

## Potential Compatibility Issues
Players who exploit this bug need to rearrange