### PR TITLE
Alter test recipe creation to call main recipe registry to get slot counts. Fixes a lot of fluid test issues.

### DIFF
--- a/src/test/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogicTest.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
 
@@ -30,8 +31,8 @@ public class RecipeLogicTest {
 
     @BeforeBatch(batch = "RecipeLogic")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("recipe_logic_test_lcr");
-        CR_RECIPE_TYPE = TestUtils.createRecipeType("recipe_logic_test_cr");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("recipe_logic_test_lcr", GTRecipeTypes.LARGE_CHEMICAL_RECIPES);
+        CR_RECIPE_TYPE = TestUtils.createRecipeType("recipe_logic_test_cr", GTRecipeTypes.CHEMICAL_RECIPES);
 
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_multiblock_recipelogic"))

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/MultipleEnergyHatchTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/MultipleEnergyHatchTest.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.misc.EnergyContainerList;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.EnergyHatchPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
@@ -42,7 +43,8 @@ public class MultipleEnergyHatchTest {
 
     @BeforeBatch(batch = "MultipleEnergyHatch")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("multiple_energy_hatch_lcr_tests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("multiple_energy_hatch_lcr_tests",
+                GTRecipeTypes.LARGE_CHEMICAL_RECIPES);
 
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_multiple_energy_hatch_ev"))

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/OverclockLogicTest.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
 
@@ -37,8 +38,8 @@ public class OverclockLogicTest {
 
     @BeforeBatch(batch = "OverclockLogic")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("overclock_logic_lcr_tests");
-        CR_RECIPE_TYPE = TestUtils.createRecipeType("overclock_logic_cr_tests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("overclock_logic_lcr_tests", GTRecipeTypes.LARGE_CHEMICAL_RECIPES);
+        CR_RECIPE_TYPE = TestUtils.createRecipeType("overclock_logic_cr_tests", GTRecipeTypes.CHEMICAL_RECIPES);
 
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_overclock_logic"))

--- a/src/test/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidConditionTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidConditionTest.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
 
 import net.minecraft.core.BlockPos;
@@ -31,7 +32,8 @@ public class AdjacentFluidConditionTest {
 
     @BeforeBatch(batch = "AdjacentFluidCondition")
     public static void prepare(ServerLevel level) {
-        ROCK_BREAKER_RECIPE_TYPE = TestUtils.createRecipeType("adjacent_fluid_conditions_tests");
+        ROCK_BREAKER_RECIPE_TYPE = TestUtils.createRecipeType("adjacent_fluid_conditions_tests",
+                GTRecipeTypes.ROCK_BREAKER_RECIPES);
         ROCK_BREAKER_RECIPE_TYPE.getLookup().addRecipe(ROCK_BREAKER_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_adjacent_fluid_conditions"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE))

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -135,8 +135,9 @@ public class TestUtils {
 
     /**
      * Creates a dummy recipe type. Safe for use in recipe lookup.
-     * DO NOT USE THIS FOR MACHINE RECIPES.
+     * DO NOT USE THIS FOR MACHINE RECIPES. Use {@link #createRecipeType(String, GTRecipeType)} for that.
      */
+    @Deprecated
     public static GTRecipeType createRecipeType(String name) {
         return createRecipeType(name, 2, 2, 2, 2);
     }

--- a/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
+++ b/src/test/java/com/gregtechceu/gtceu/gametest/util/TestUtils.java
@@ -3,7 +3,9 @@ package com.gregtechceu.gtceu.gametest.util;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.item.IComponentItem;
@@ -118,9 +120,10 @@ public class TestUtils {
 
     /**
      * Creates a dummy recipe type that also includes a basic, HV, 1 tick, cobblestone -> stone recipe
+     * Requires a {@link GTRecipeType} to inherit I/O counts from
      */
-    public static GTRecipeType createRecipeTypeAndInsertRecipe(String name) {
-        GTRecipeType type = createRecipeType(name);
+    public static GTRecipeType createRecipeTypeAndInsertRecipe(String name, GTRecipeType original) {
+        GTRecipeType type = createRecipeType(name, original);
         type.getLookup().addRecipe(type
                 .recipeBuilder(GTCEu.id("test_recipe"))
                 .inputItems(new ItemStack(Items.COBBLESTONE))
@@ -130,10 +133,31 @@ public class TestUtils {
         return type;
     }
 
+    /**
+     * Creates a dummy recipe type. Safe for use in recipe lookup.
+     * DO NOT USE THIS FOR MACHINE RECIPES.
+     */
     public static GTRecipeType createRecipeType(String name) {
         return createRecipeType(name, 2, 2, 2, 2);
     }
 
+    /**
+     * Creates a recipe type for writing test cases.
+     * Requires a {@link GTRecipeType} to inherit I/O counts from.
+     */
+    public static GTRecipeType createRecipeType(String name, GTRecipeType original) {
+        return createRecipeType(name,
+                original.getMaxInputs(ItemRecipeCapability.CAP),
+                original.getMaxOutputs(ItemRecipeCapability.CAP),
+                original.getMaxInputs(FluidRecipeCapability.CAP),
+                original.getMaxOutputs(FluidRecipeCapability.CAP));
+    }
+
+    /**
+     * Creates a recipe type for writing test cases.
+     * Requires setting I/O counts manually.
+     * You probably want to be using {@link #createRecipeType(String, GTRecipeType)}
+     */
     public static GTRecipeType createRecipeType(String name, int maxInputs, int maxOutputs, int maxFluidInputs,
                                                 int maxFluidOutputs) {
         GTRegistries.RECIPE_TYPES.unfreeze();

--- a/src/test/java/com/gregtechceu/gtceu/integration/ae2/machine/PatternBufferTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/integration/ae2/machine/PatternBufferTest.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.FluidHatchPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
@@ -43,7 +44,8 @@ public class PatternBufferTest {
 
     @BeforeBatch(batch = "PatternBuffer")
     public static void prepare(ServerLevel level) {
-        LCR_RECIPE_TYPE = TestUtils.createRecipeTypeAndInsertRecipe("pattern_buffer_tests");
+        LCR_RECIPE_TYPE = TestUtils.createRecipeTypeAndInsertRecipe("pattern_buffer_tests",
+                GTRecipeTypes.LARGE_CHEMICAL_RECIPES);
 
         LCR_RECIPE_TYPE.getLookup().addRecipe(LCR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_recipe_pattern_buffer"))


### PR DESCRIPTION
## What
The automated test case recipe builder creates new recipe lists to use for its machine tests.

However, the constructor for machine blocks checks the recipe registry to decide how many I/O slots to give the machine.

Meaning that if a new recipe list is created with the wrong number of I/O slots, it will cause test files which are run later to hard crash on an AIOOB in structure template/block deserialization.

This fixes that behavior to make one set of tests not break other sets of tests.

## Potential Compatibility Issues
Other people writing test cases will need to use the new version of createRecipeType(String, GTRecipeType) rather than the old one. However, the javadoc does directly say not to use that one anymore.