### PR TITLE
Simplify recipeHandle method

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
@@ -71,7 +71,7 @@ public class EURecipeCapability extends RecipeCapability<EnergyStack> {
                 for (var handler : handlers) {
                     // noinspection unchecked
                     eu = (List<Long>) handler.handleRecipe(IO.OUT, recipe, eu, true);
-                    if (eu == null) break;
+                    if (eu == null || eu.isEmpty()) break;
                 }
                 int[] bin = ParallelLogic.adjustMultiplier(eu == null, minMultiplier, multiplier, maxMultiplier);
                 minMultiplier = bin[0];

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -163,7 +163,7 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
             for (var handler : handlers) {
                 // noinspection unchecked
                 copied = (List<FluidIngredient>) handler.handleRecipe(IO.OUT, recipe, copied, true);
-                if (copied == null) break;
+                if (copied == null || copied.isEmpty()) break;
             }
             int[] bin = ParallelLogic.adjustMultiplier(copied == null, minMultiplier, multiplier, maxMultiplier);
             minMultiplier = bin[0];

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -187,7 +187,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
             for (var handler : handlers) {
                 // noinspection unchecked
                 copied = (List<Ingredient>) handler.handleRecipe(IO.OUT, recipe, copied, true);
-                if (copied == null) break;
+                if (copied == null || copied.isEmpty()) break;
             }
             int[] bin = ParallelLogic.adjustMultiplier(copied == null, minMultiplier, multiplier, maxMultiplier);
             minMultiplier = bin[0];

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamEnergyRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamEnergyRecipeHandler.java
@@ -53,7 +53,7 @@ public class SteamEnergyRecipeHandler implements IRecipeHandler<EnergyStack> {
                 }
             }
         }
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
@@ -330,7 +330,7 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
 
         }
 
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -219,7 +219,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
             if (changed && action.execute()) listeners[i].run();
         }
 
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -206,7 +206,7 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         storage.setOnContentsChanged(listener);
         if (changed && !simulate) listener.run();
 
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     private static @Nullable ItemStack getActioned(CustomItemStackHandler storage, int index, List<?> actions) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
@@ -185,7 +185,7 @@ public class RecipeHandlerList {
             var handlerList = getCapability(entry.getKey());
             for (var handler : handlerList) {
                 var left = handler.handleRecipe(io, recipe, entry.getValue(), simulate);
-                if (left == null) {
+                if (left == null || left.isEmpty()) {
                     it.remove();
                     break;
                 } else {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -152,7 +152,7 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IEx
                     outputTanks.addAll(getCapabilitiesFlat(IO.BOTH, FluidRecipeCapability.CAP));
                     for (IRecipeHandler<?> tank : outputTanks) {
                         fillSteam = (List<FluidIngredient>) tank.handleRecipe(IO.OUT, null, fillSteam, false);
-                        if (fillSteam == null) break;
+                        if (fillSteam == null || fillSteam.isEmpty()) break;
                     }
                 }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
@@ -188,7 +188,7 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine implements IMac
                 ingredient.shrink(storage.fill(output, action));
                 if (ingredient.getAmount() <= 0) it.remove();
             }
-            return left.isEmpty() ? null : left;
+            return left;
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -606,7 +606,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
                 }
             }
             if (changed) onContentsChanged();
-            return left.isEmpty() ? null : left;
+            return left;
         }
 
         public @Nullable List<FluidIngredient> handleFluidInternal(List<FluidIngredient> left, boolean simulate) {
@@ -655,7 +655,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
             }
 
             if (changed) onContentsChanged();
-            return left.isEmpty() ? null : left;
+            return left;
         }
 
         @Override


### PR DESCRIPTION
## What
allows recipeHandle from IRecipeHandlers to return either an empty list or null, not just null

## Implementation Details
simple if checks

## Outcome
cleaner code

## Additional Information
addons can simply return the left list at the end instead of needed to null cast when empty as previously