### PR TITLE
Fix Advanced Energy Detector Cover not working in % mode

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
@@ -72,13 +72,13 @@ public class AdvancedEnergyDetectorCover extends EnergyDetectorCover implements 
         IEnergyInfoProvider energyInfoProvider = getEnergyInfoProvider();
         if (energyInfoProvider == null) return;
 
-        var energyInfo = energyInfoProvider.getEnergyInfo();
-        var isBigInt = energyInfoProvider.supportsBigIntEnergyValues();
+        IEnergyInfoProvider.EnergyInfo energyInfo = energyInfoProvider.getEnergyInfo();
+        boolean isBigInt = energyInfoProvider.supportsBigIntEnergyValues();
 
         if (isBigInt) {
             if (usePercent) {
                 if (energyInfo.capacity().compareTo(BigInteger.ZERO) > 0) {
-                    var ratio = GTMath.ratio(energyInfo.stored(), energyInfo.capacity());
+                    float ratio = GTMath.ratio(energyInfo.stored(), energyInfo.capacity());
                     setRedstoneSignalOutput(computeLatchedRedstoneBetweenValues(ratio * 100, maxValue,
                             minValue, isInverted(), redstoneSignalOutput));
                 } else {
@@ -92,7 +92,7 @@ public class AdvancedEnergyDetectorCover extends EnergyDetectorCover implements 
         } else {
             if (usePercent) {
                 if (energyInfo.capacity().longValue() > 0) {
-                    var ratio = energyInfo.stored().longValue() / energyInfo.capacity().longValue();
+                    float ratio = energyInfo.stored().floatValue() / energyInfo.capacity().floatValue();
                     setRedstoneSignalOutput(computeLatchedRedstoneBetweenValues(ratio * 100, maxValue,
                             minValue, isInverted(), redstoneSignalOutput));
                 } else {


### PR DESCRIPTION
## What
Advanced EU Detector Cover in % mode outputs signal if storage is not full and does not output if storage is full, ignoring upper/lower latch limit settings. #3713 

Because it's doing integer division on current EU / max EU.

So this fixes that and reverts it to floating point division.

## Additional Information
`var`