### PR TITLE
Removal of redundant OC call.

### DIFF
--- a/docs/content/Modpacks/Examples/Example_Coil_Multiblock.md
+++ b/docs/content/Modpacks/Examples/Example_Coil_Multiblock.md
@@ -21,7 +21,6 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
             .recipeModifiers(
                 [
                     GTRecipeModifiers.PARALLEL_HATCH, 
-                    GTRecipeModifiers.OC_PERFECT,
                     GTRecipeModifiers.BATCH_MODE, 
                     (machine, recipe) => GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe)
                 ]
@@ -64,7 +63,6 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(GTRecipeTypes.PYROLYSE_RECIPES)
             .recipeModifiers(GTRecipeModifiers.PARALLEL_HATCH,
-                GTRecipeModifiers.ELECTRIC_OVERCLOCK.apply(OverclockingLogic.PERFECT_OVERCLOCK),
                 (machine, recipe) -> GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe))
             .appearanceBlock(GTBlocks.CASING_STEEL_SOLID)
             .pattern(definition -> FactoryBlockPattern.start()
@@ -101,6 +99,9 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
     "block.gtceu.superheated_pyrolyzing_oven": "Superheated Pyrolyzing Oven",
 }
 ```
+
+
+
 
 
 

--- a/docs/content/Modpacks/Examples/Example_Coil_Multiblock.md
+++ b/docs/content/Modpacks/Examples/Example_Coil_Multiblock.md
@@ -20,8 +20,7 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
             .recipeTypes('pyrolyse_oven')
             .recipeModifiers(
                 [
-                    GTRecipeModifiers.PARALLEL_HATCH, 
-                    GTRecipeModifiers.BATCH_MODE, 
+                    GTRecipeModifiers.PARALLEL_HATCH,  
                     (machine, recipe) => GTRecipeModifiers.pyrolyseOvenOverclock(machine, recipe)
                 ]
             )
@@ -99,10 +98,5 @@ Below is an example of a multiblock using the CoilWorkableElectricMultiblockMach
     "block.gtceu.superheated_pyrolyzing_oven": "Superheated Pyrolyzing Oven",
 }
 ```
-
-
-
-
-
 
 


### PR DESCRIPTION
## What
Fixes the incorrect example of calling both pyrolyseOvenOverclock and OC_PERFECT. As the oven overclock already includes non_perfect_oc_subtick.