### PR TITLE
fix recipe conditions link

### DIFF
--- a/docs/content/Modpacks/Changes/v7.2.0.md
+++ b/docs/content/Modpacks/Changes/v7.2.0.md
@@ -35,7 +35,7 @@ In a similar vein, recipes that used to have adjacent block requirements, you no
 
 ## Recipe Conditions
 We have moved away from the .serialize, .deserialize, .toNetwork and .fromNetwork calls on the RecipeCondition, and we now exclusively use the recipeCondition's codec.  
-See the [Recipe Conditions Page](../Other-Topics/Recipe-Conditions.md)
+See the [Recipe Conditions Page](../Recipes/Recipe-Conditions/)
 
 ## Primitive Pump
 MV output hatches are no longer valid hatches for the Primitive Pump and need to be replaced with either a ULV`(new)` or LV hatch.


### PR DESCRIPTION
## What

Fix recipe conditions link in the v7.2.0 changes document.

## Implementation Details

## Outcome

The link should point to the actual RecipeConditions doc

## Additional Information

## Potential Compatibility Issues

None, docs only change
