### PR TITLE
Add flag to disable create compat

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -136,7 +136,7 @@ public class CommonProxy {
         GTSoundEntries.init();
         GTDamageTypes.init();
         GTPlaceholders.initPlaceholders();
-        if (GTCEu.Mods.isCreateLoaded()) {
+        if (ConfigHolder.INSTANCE.compat.createCompat && GTCEu.Mods.isCreateLoaded()) {
             GTCreateIntegration.init();
         }
         if (GTCEu.Mods.isAE2Loaded()) {

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -196,6 +196,10 @@ public class ConfigHolder {
         @Configurable.Comment({ "Whether dimension markers should show the dimension tier value.", "Default: false" })
         public boolean showDimensionTier = false;
 
+        @Configurable
+        @Configurable.Comment({ "Whether Create compatibility will be available.", "Default: true" })
+        public boolean createCompat = true;
+
         public static class EnergyCompatConfig {
 
             @Configurable


### PR DESCRIPTION
## What
Adds a config flag to disable our Computer Cover Create compatability

## Potential Compatibility Issues
Resolves issues with older create versions
