### PR TITLE
Rename AdjacentFluid overload

### DIFF
--- a/docs/content/Modpacks/Changes/v7.2.0.md
+++ b/docs/content/Modpacks/Changes/v7.2.0.md
@@ -29,9 +29,9 @@ Where the inputs or outputs will be rolled inclusively from min to max.
 ## Rock breaker conditions
 Previously, rock breaker recipes used the `addData("fluidA", ...)` methods.
 
-Now, they work by AdjacentFluidConditions, added with the `adjacentFluid(Fluid...)` methods. See [our other condition builder methods](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java#L894).
+Now, they work by AdjacentFluidConditions, added with the `adjacentFluids(Fluid...)` methods. See [our other condition builder methods](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java#L894).
 
-In a similar vein, recipes that used to have adjacent block requirements, you now need to use `adjacentBlock(Block...)` rather than `addData("blockA")`.
+In a similar vein, recipes that used to have adjacent block requirements, you now need to use `adjacentBlocks(Block...)` rather than `addData("blockA")`.
 
 There also exist methods for tagged fluids, by using `.adjacentFluidTag(ResourceLocation)` and `.adjacentBlockTag(ResourceLocation)`.
 

--- a/docs/content/Modpacks/Changes/v7.2.0.md
+++ b/docs/content/Modpacks/Changes/v7.2.0.md
@@ -33,6 +33,8 @@ Now, they work by AdjacentFluidConditions, added with the `adjacentFluid(Fluid..
 
 In a similar vein, recipes that used to have adjacent block requirements, you now need to use `adjacentBlock(Block...)` rather than `addData("blockA")`.
 
+There also exist methods for tagged fluids, by using `.adjacentFluidTag(ResourceLocation)` and `.adjacentBlockTag(ResourceLocation)`.
+
 ## Recipe Conditions
 We have moved away from the .serialize, .deserialize, .toNetwork and .fromNetwork calls on the RecipeCondition, and we now exclusively use the recipeCondition's codec.  
 See the [Recipe Conditions Page](../Recipes/Recipe-Conditions/)

--- a/docs/content/Modpacks/Changes/v7.2.1.md
+++ b/docs/content/Modpacks/Changes/v7.2.1.md
@@ -5,7 +5,7 @@ title: "Version 7.2.1"
 
 # Updating from `7.2.0` to `7.2.1`
 
-## AdjacentFluid(Tag)
+## AdjacentFluid(Tag) and AdjacentBlock(Tag)
 
 For ease of use for KJS, we have renamed
 
@@ -20,4 +20,4 @@ This way, there's no conflict between
 - `adjacentFluid(ResourceLocation... tagNames)`  
 - `adjacentFluid(Fluid... fluids)`.  
 
-For java, there has been no change since the overloads are unambiguous there.  
+These changes hold for the `.adjacentBlock(tag)` too.

--- a/docs/content/Modpacks/Changes/v7.2.1.md
+++ b/docs/content/Modpacks/Changes/v7.2.1.md
@@ -5,19 +5,16 @@ title: "Version 7.2.1"
 
 # Updating from `7.2.0` to `7.2.1`
 
-## AdjacentFluid(Tag) and AdjacentBlock(Tag)
+## AdjacentFluid() and AdjacentBlock()
 
-For ease of use for KJS, we have renamed
+For ease of use for KJS, we have added overrides for
 
-- `adjacentFluid(ResourceLocation... tagNames)`
+- `adjacentFluid(ResourceLocation... tagNames)` -> `adjacentFluidTag(ResourceLocation... tagNames)`
 
-to
+and
 
-- `adjacentFluidTag(ResourceLocation... tagNames)`.
+- `adjacentFluid(Fluid... fluids)` -> `adjacentFluids(Fluid... fluids)`
 
-This way, there's no conflict between   
+This way, the old `AdjacentFluid(...)` methods still exist, but there also is a clear way to use the kubejs without ambiguous casts / methods.
 
-- `adjacentFluid(ResourceLocation... tagNames)`  
-- `adjacentFluid(Fluid... fluids)`.  
-
-These changes hold for the `.adjacentBlock(tag)` too.
+These changes hold for the `.adjacentBlock()` too.

--- a/docs/content/Modpacks/Changes/v7.2.1.md
+++ b/docs/content/Modpacks/Changes/v7.2.1.md
@@ -1,0 +1,23 @@
+---
+title: "Version 7.2.1"
+---
+
+
+# Updating from `7.2.0` to `7.2.1`
+
+## AdjacentFluid(Tag)
+
+For ease of use for KJS, we have renamed
+
+- `adjacentFluid(ResourceLocation... tagNames)`
+
+to
+
+- `adjacentFluidTag(ResourceLocation... tagNames)`.
+
+This way, there's no conflict between   
+
+- `adjacentFluid(ResourceLocation... tagNames)`  
+- `adjacentFluid(Fluid... fluids)`.  
+
+For java, there has been no change since the overloads are unambiguous there.  

--- a/docs/content/Modpacks/Recipes/Adding-and-Removing-Recipes.md
+++ b/docs/content/Modpacks/Recipes/Adding-and-Removing-Recipes.md
@@ -180,15 +180,15 @@ ServerEvents.recipes(event => {
 
 Rock breaker recipes use AdjacentFluidConditions.
 
-To add a condition, you can use the `adjacentFluid(Fluid...)` methods, see [our other condition builder methods](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java#L894).
+To add a condition, you can use the `adjacentFluids(Fluid...)` methods, see [our other condition builder methods](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java#L894).
 
 ```js title="rock_breaker.js"
 ServerEvents.recipes(event => {
     event.recipes.gtceu.rock_breaker('rhino_jank')
         .notConsumable('minecraft:dirt')
         .itemOutputs('minecraft:dirt')
-        .adjacentFluid('minecraft:water')
-        .adjacentFluid('minecraft:lava')
+        .adjacentFluids('minecraft:water')
+        .adjacentFluids('minecraft:lava')
         .duration(16)
         .EUt(30)
 })

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1153,6 +1153,18 @@ public class GTRecipeBuilder {
         return environmentalHazard(condition, false);
     }
 
+    public final GTRecipeBuilder adjacentFluids(Fluid... fluids) {
+        return adjacentFluids(false, fluids);
+    }
+
+    public final GTRecipeBuilder adjacentFluids(boolean isReverse, Fluid... fluids) {
+        if (fluids.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many fluids, not adding to recipe, id: {}", this.id);
+            return this;
+        }
+        return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
+    }
+
     public final GTRecipeBuilder adjacentFluid(Fluid... fluids) {
         return adjacentFluid(false, fluids);
     }
@@ -1179,6 +1191,20 @@ public class GTRecipeBuilder {
         return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
     }
 
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentFluid(TagKey<Fluid>... tags) {
+        return adjacentFluid(false, tags);
+    }
+
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentFluid(boolean isReverse, TagKey<Fluid>... tags) {
+        if (tags.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many fluids, not adding to recipe, id: {}", this.id);
+            return this;
+        }
+        return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
+    }
+
     public GTRecipeBuilder adjacentFluid(Collection<HolderSet<Fluid>> fluids) {
         return adjacentFluid(fluids, false);
     }
@@ -1191,6 +1217,18 @@ public class GTRecipeBuilder {
         return addCondition(new AdjacentFluidCondition(isReverse, new ArrayList<>(fluids)));
     }
 
+    public GTRecipeBuilder adjacentBlocks(Block... blocks) {
+        return adjacentBlocks(false, blocks);
+    }
+
+    public GTRecipeBuilder adjacentBlocks(boolean isReverse, Block... blocks) {
+        if (blocks.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many blocks, not adding to recipe, id: {}", this.id);
+            return this;
+        }
+        return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
+    }
+
     public GTRecipeBuilder adjacentBlock(Block... blocks) {
         return adjacentBlock(false, blocks);
     }
@@ -1201,6 +1239,20 @@ public class GTRecipeBuilder {
             return this;
         }
         return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
+    }
+
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentBlock(TagKey<Block>... tags) {
+        return adjacentBlock(false, tags);
+    }
+
+    @SafeVarargs
+    public final GTRecipeBuilder adjacentBlock(boolean isReverse, TagKey<Block>... tags) {
+        if (tags.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
+            GTCEu.LOGGER.error("Has too many blocks, not adding to recipe, id: {}", this.id);
+            return this;
+        }
+        return addCondition(AdjacentBlockCondition.fromTags(tags).setReverse(isReverse));
     }
 
     @SafeVarargs

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1166,12 +1166,12 @@ public class GTRecipeBuilder {
     }
 
     @SafeVarargs
-    public final GTRecipeBuilder adjacentFluid(TagKey<Fluid>... tags) {
-        return adjacentFluid(false, tags);
+    public final GTRecipeBuilder adjacentFluidTag(TagKey<Fluid>... tags) {
+        return adjacentFluidTag(false, tags);
     }
 
     @SafeVarargs
-    public final GTRecipeBuilder adjacentFluid(boolean isReverse, TagKey<Fluid>... tags) {
+    public final GTRecipeBuilder adjacentFluidTag(boolean isReverse, TagKey<Fluid>... tags) {
         if (tags.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
             GTCEu.LOGGER.error("Has too many fluids, not adding to recipe, id: {}", this.id);
             return this;
@@ -1204,12 +1204,12 @@ public class GTRecipeBuilder {
     }
 
     @SafeVarargs
-    public final GTRecipeBuilder adjacentBlock(TagKey<Block>... tags) {
-        return adjacentBlock(false, tags);
+    public final GTRecipeBuilder adjacentBlockTag(TagKey<Block>... tags) {
+        return adjacentBlockTag(false, tags);
     }
 
     @SafeVarargs
-    public final GTRecipeBuilder adjacentBlock(boolean isReverse, TagKey<Block>... tags) {
+    public final GTRecipeBuilder adjacentBlockTag(boolean isReverse, TagKey<Block>... tags) {
         if (tags.length > GTUtil.NON_CORNER_NEIGHBOURS.size()) {
             GTCEu.LOGGER.error("Has too many blocks, not adding to recipe, id: {}", this.id);
             return this;

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -89,7 +89,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("cobblestone")
                 .notConsumable(Blocks.COBBLESTONE.asItem())
                 .outputItems(Blocks.COBBLESTONE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VA[ULV])
                 .save(provider);
@@ -97,7 +97,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("stone")
                 .notConsumable(Blocks.STONE.asItem())
                 .outputItems(Blocks.STONE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VA[ULV])
                 .save(provider);
@@ -105,7 +105,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("andesite")
                 .notConsumable(Blocks.ANDESITE.asItem())
                 .outputItems(Blocks.ANDESITE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[MV])
                 .save(provider);
@@ -113,7 +113,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("granite")
                 .notConsumable(Blocks.GRANITE.asItem())
                 .outputItems(Blocks.GRANITE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[MV])
                 .save(provider);
@@ -121,7 +121,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("diorite")
                 .notConsumable(Blocks.DIORITE.asItem())
                 .outputItems(Blocks.DIORITE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[MV])
                 .save(provider);
@@ -129,7 +129,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("obsidian")
                 .notConsumable(dust, Redstone)
                 .outputItems(Blocks.OBSIDIAN.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -137,7 +137,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("basalt")
                 .notConsumable(Blocks.BASALT.asItem())
                 .outputItems(Blocks.BASALT.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -145,7 +145,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("blackstone")
                 .notConsumable(Blocks.BLACKSTONE.asItem())
                 .outputItems(Blocks.BLACKSTONE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -153,7 +153,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("deepslate")
                 .notConsumable(Blocks.DEEPSLATE.asItem())
                 .outputItems(Blocks.DEEPSLATE.asItem())
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[EV])
                 .save(provider);
@@ -161,7 +161,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("marble")
                 .notConsumable(rock, Marble)
                 .outputItems(rock, Marble)
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -169,7 +169,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("basalt")
                 .notConsumable(rock, Basalt)
                 .outputItems(rock, Basalt)
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[HV])
                 .save(provider);
@@ -177,7 +177,7 @@ public class MiscRecipeLoader {
         ROCK_BREAKER_RECIPES.recipeBuilder("red_granite")
                 .notConsumable(rock, GraniteRed)
                 .outputItems(rock, GraniteRed)
-                .adjacentFluid(FluidTags.LAVA, FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.LAVA, FluidTags.WATER)
                 .duration(16)
                 .EUt(VHA[EV])
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -899,11 +899,11 @@ public interface GTRecipeSchema {
             return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
         }
 
-        public GTRecipeJS adjacentFluid(ResourceLocation... tagNames) {
-            return adjacentFluid(false, tagNames);
+        public GTRecipeJS adjacentFluidTag(ResourceLocation... tagNames) {
+            return adjacentFluidTag(false, tagNames);
         }
 
-        public GTRecipeJS adjacentFluid(boolean isReverse, ResourceLocation... tagNames) {
+        public GTRecipeJS adjacentFluidTag(boolean isReverse, ResourceLocation... tagNames) {
             List<TagKey<Fluid>> tags = Arrays.stream(tagNames)
                     .map(id -> TagKey.create(Registries.FLUID, id))
                     .toList();

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -918,11 +918,11 @@ public interface GTRecipeSchema {
             return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
         }
 
-        public GTRecipeJS adjacentBlock(ResourceLocation... tagNames) {
-            return adjacentBlock(false, tagNames);
+        public GTRecipeJS adjacentBlockTag(ResourceLocation... tagNames) {
+            return adjacentBlockTag(false, tagNames);
         }
 
-        public GTRecipeJS adjacentBlock(boolean isReverse, ResourceLocation... tagNames) {
+        public GTRecipeJS adjacentBlockTag(boolean isReverse, ResourceLocation... tagNames) {
             List<TagKey<Block>> tags = Arrays.stream(tagNames)
                     .map(id -> TagKey.create(Registries.BLOCK, id))
                     .toList();

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -891,12 +891,31 @@ public interface GTRecipeSchema {
             return environmentalHazard(condition, false);
         }
 
+        public GTRecipeJS adjacentFluids(Fluid... fluids) {
+            return adjacentFluids(false, fluids);
+        }
+
+        public GTRecipeJS adjacentFluids(boolean isReverse, Fluid... fluids) {
+            return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
+        }
+
         public GTRecipeJS adjacentFluid(Fluid... fluids) {
             return adjacentFluid(false, fluids);
         }
 
         public GTRecipeJS adjacentFluid(boolean isReverse, Fluid... fluids) {
             return addCondition(AdjacentFluidCondition.fromFluids(fluids).setReverse(isReverse));
+        }
+
+        public GTRecipeJS adjacentFluid(ResourceLocation... tagNames) {
+            return adjacentFluid(false, tagNames);
+        }
+
+        public GTRecipeJS adjacentFluid(boolean isReverse, ResourceLocation... tagNames) {
+            List<TagKey<Fluid>> tags = Arrays.stream(tagNames)
+                    .map(id -> TagKey.create(Registries.FLUID, id))
+                    .toList();
+            return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
         }
 
         public GTRecipeJS adjacentFluidTag(ResourceLocation... tagNames) {
@@ -908,6 +927,14 @@ public interface GTRecipeSchema {
                     .map(id -> TagKey.create(Registries.FLUID, id))
                     .toList();
             return addCondition(AdjacentFluidCondition.fromTags(tags).setReverse(isReverse));
+        }
+
+        public GTRecipeJS adjacentBlocks(Block... blocks) {
+            return adjacentBlocks(false, blocks);
+        }
+
+        public GTRecipeJS adjacentBlocks(boolean isReverse, Block... blocks) {
+            return addCondition(AdjacentBlockCondition.fromBlocks(blocks).setReverse(isReverse));
         }
 
         public GTRecipeJS adjacentBlock(Block... blocks) {
@@ -923,6 +950,17 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS adjacentBlockTag(boolean isReverse, ResourceLocation... tagNames) {
+            List<TagKey<Block>> tags = Arrays.stream(tagNames)
+                    .map(id -> TagKey.create(Registries.BLOCK, id))
+                    .toList();
+            return addCondition(AdjacentBlockCondition.fromTags(tags).setReverse(isReverse));
+        }
+
+        public GTRecipeJS adjacentBlock(ResourceLocation... tagNames) {
+            return adjacentBlock(false, tagNames);
+        }
+
+        public GTRecipeJS adjacentBlock(boolean isReverse, ResourceLocation... tagNames) {
             List<TagKey<Block>> tags = Arrays.stream(tagNames)
                     .map(id -> TagKey.create(Registries.BLOCK, id))
                     .toList();

--- a/src/test/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidConditionTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/recipe/condition/AdjacentFluidConditionTest.java
@@ -38,7 +38,7 @@ public class AdjacentFluidConditionTest {
                 .recipeBuilder(GTCEu.id("test_adjacent_fluid_conditions"))
                 .inputItems(new ItemStack(Blocks.COBBLESTONE))
                 .outputItems(new ItemStack(Blocks.STONE))
-                .adjacentFluid(FluidTags.WATER)
+                .adjacentFluidTag(FluidTags.WATER)
                 .EUt(GTValues.VA[GTValues.HV])
                 .duration(8)
                 .buildRawRecipe());
@@ -47,7 +47,7 @@ public class AdjacentFluidConditionTest {
                 .recipeBuilder(GTCEu.id("test_adjacent_fluid_conditions_multiple_fluids"))
                 .inputItems(new ItemStack(Blocks.OAK_WOOD))
                 .outputItems(new ItemStack(Items.CHARCOAL))
-                .adjacentFluid(FluidTags.WATER, FluidTags.LAVA)
+                .adjacentFluidTag(FluidTags.WATER, FluidTags.LAVA)
                 .EUt(GTValues.VA[GTValues.HV])
                 .duration(8)
                 .buildRawRecipe());


### PR DESCRIPTION
## What
Solves #3952

## Outcome
<img width="765" height="614" alt="image" src="https://github.com/user-attachments/assets/40b70ccd-372f-44e3-8643-24c17faa8e3c" />

## Additional Information
I have added 2 new methods (`adjacent[Block/Fluid]Tag` and `adjacent[Block/Fluid]s`) so the old ones still eixst and this isn't API breaking
In the future we shouldn't ship methods with ambiguous builders.

## Potential Compatibility Issues
None since this now adds optional overrides and doesn't remove existing stuff