### PR TITLE
Fix recipe search for Ranged Fluid Ingredients on 0 roll

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredient.java
@@ -19,6 +19,7 @@ import com.mojang.serialization.JsonOps;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Allows a {@link FluidIngredient} to be created with a ranged {@code amount}, which will be randomly rolled upon
@@ -160,6 +161,11 @@ public class IntProviderFluidIngredient extends FluidIngredient {
 
     public static IntProviderFluidIngredient of(FluidStack inner, int min, int max) {
         return IntProviderFluidIngredient.of(FluidIngredient.of(inner), UniformInt.of(min, max));
+    }
+
+    @Override
+    public boolean test(@Nullable FluidStack stack) {
+        return inner.test(stack);
     }
 
     /**


### PR DESCRIPTION
## What
If a recipe contains a Ranged Fluid Input, that ingredient's amount is being incorrectly rolled during recipe lookup by FluidIngredient.test(). If one of these input ingredients rolls a 0, that causes recipe search to fail to match.

By creating an override IPFI.test(), it no longer does the misplaced roll and no longer trips the failure.