### PR TITLE
recipe manager handling refactor

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeManagerHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeManagerHandler.java
@@ -57,8 +57,8 @@ public final class RecipeManagerHandler {
      * @param recipesByID  the recipes stored by their ID
      * @param gtRecipeType the recipe type to add recipes to
      */
-    public static void addToLookup(@NotNull Map<ResourceLocation, Recipe<?>> recipesByID,
-                                   @NotNull GTRecipeType gtRecipeType) {
+    public static void addRecipesToLookup(@NotNull Map<ResourceLocation, Recipe<?>> recipesByID,
+                                          @NotNull GTRecipeType gtRecipeType) {
         var lookup = gtRecipeType.getLookup();
         for (var r : recipesByID.values()) {
             if (r.getType() != gtRecipeType) {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeManagerHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeManagerHandler.java
@@ -1,0 +1,76 @@
+package com.gregtechceu.gtceu.api.recipe.lookup;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Internal class handling adding recipes to GT's lookup system.
+ * <p>
+ * Intended for use by {@link com.gregtechceu.gtceu.core.mixins.RecipeManagerMixin} and
+ * {@link com.gregtechceu.gtceu.integration.kjs.GregTechKubeJSPlugin}
+ */
+@ApiStatus.Internal
+public final class RecipeManagerHandler {
+
+    /**
+     * Adds proxy recipes to an {@link GTRecipeType}'s {@link GTRecipeLookup} and adds them to a list.
+     *
+     * @param recipesByID  the recipes stored by their ID
+     * @param gtRecipeType the recipe type to add the recipes to, which owns the proxy recipes
+     * @param proxyType    the recipeType for the proxy recipes
+     * @param proxyRecipes the list of proxy recipes to populate
+     */
+    public static void addProxyRecipesToLookup(@NotNull Map<ResourceLocation, Recipe<?>> recipesByID,
+                                               @NotNull GTRecipeType gtRecipeType, @NotNull RecipeType<?> proxyType,
+                                               @NotNull List<GTRecipe> proxyRecipes) {
+        var lookup = gtRecipeType.getLookup();
+        proxyRecipes.clear();
+        recipesByID.forEach((id, recipe) -> {
+            if (recipe.getType() != proxyType) {
+                // should not happen
+                GTCEu.LOGGER.warn("Proxy Recipe '{}' with RecipeType '{}' did not match GTRecipeType '{}'.",
+                        recipe.getId(), ForgeRegistries.RECIPE_TYPES.getKey(recipe.getType()),
+                        gtRecipeType.registryName);
+                return;
+            }
+            GTRecipe gtRecipe = gtRecipeType.toGTrecipe(id, recipe);
+            proxyRecipes.add(gtRecipe);
+            lookup.addRecipe(gtRecipe);
+        });
+    }
+
+    /**
+     * Adds recipes to an {@link GTRecipeType}'s {@link GTRecipeLookup}
+     *
+     * @param recipesByID  the recipes stored by their ID
+     * @param gtRecipeType the recipe type to add recipes to
+     */
+    public static void addToLookup(@NotNull Map<ResourceLocation, Recipe<?>> recipesByID,
+                                   @NotNull GTRecipeType gtRecipeType) {
+        var lookup = gtRecipeType.getLookup();
+        for (var r : recipesByID.values()) {
+            if (r.getType() != gtRecipeType) {
+                // should not happen
+                GTCEu.LOGGER.warn("Recipe '{}' with RecipeType '{}' did not match GTRecipeType '{}'.",
+                        r.getId(), ForgeRegistries.RECIPE_TYPES.getKey(r.getType()),
+                        gtRecipeType.registryName);
+                continue;
+            }
+            if (r instanceof GTRecipe recipe) {
+                lookup.addRecipe(recipe);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
@@ -1,16 +1,16 @@
 package com.gregtechceu.gtceu.core.mixins;
 
-import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.api.recipe.lookup.RecipeManagerHandler;
 import com.gregtechceu.gtceu.common.item.armor.PowerlessJetpack;
 
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import com.google.gson.JsonElement;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,11 +19,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
-// only fires if KJS is NOT loaded.
+/**
+ * Only fires if KubeJS is not interacting with GT recipes.
+ */
 @Mixin(RecipeManager.class)
 public abstract class RecipeManagerMixin {
 
@@ -35,36 +35,23 @@ public abstract class RecipeManagerMixin {
     private void gtceu$cloneVanillaRecipes(Map<ResourceLocation, JsonElement> map, ResourceManager resourceManager,
                                            ProfilerFiller profiler, CallbackInfo ci) {
         PowerlessJetpack.FUELS.clear();
-        for (RecipeType<?> recipeType : BuiltInRegistries.RECIPE_TYPE) {
-            if (recipeType instanceof GTRecipeType gtRecipeType) {
-                gtRecipeType.getLookup().removeAllRecipes();
-
-                var proxyRecipes = gtRecipeType.getProxyRecipes();
-                for (Map.Entry<RecipeType<?>, List<GTRecipe>> entry : proxyRecipes.entrySet()) {
-                    var type = entry.getKey();
-                    var recipes = entry.getValue();
-                    recipes.clear();
-                    if (this.recipes.containsKey(type)) {
-                        for (var recipe : this.recipes.get(type).entrySet()) {
-                            recipes.add(gtRecipeType.toGTrecipe(recipe.getKey(), recipe.getValue()));
-                        }
-                    }
-                }
-
-                if (this.recipes.containsKey(gtRecipeType)) {
-                    Stream.concat(
-                            this.recipes.get(gtRecipeType).values().stream(),
-                            proxyRecipes.entrySet().stream()
-                                    .flatMap(entry -> entry.getValue().stream()))
-                            .filter(GTRecipe.class::isInstance)
-                            .map(GTRecipe.class::cast)
-                            .forEach(gtRecipe -> gtRecipeType.getLookup().addRecipe(gtRecipe));
-                } else if (!proxyRecipes.isEmpty()) {
-                    proxyRecipes.values().stream()
-                            .flatMap(List::stream)
-                            .forEach(gtRecipe -> gtRecipeType.getLookup().addRecipe(gtRecipe));
-                }
+        for (RecipeType<?> recipeType : ForgeRegistries.RECIPE_TYPES) {
+            if (!(recipeType instanceof GTRecipeType gtRecipeType)) {
+                continue;
             }
+            gtRecipeType.getLookup().removeAllRecipes();
+            gtRecipeType.getProxyRecipes().forEach((type, list) -> {
+                var recipesByID = recipes.get(type);
+                if (recipesByID == null) {
+                    return;
+                }
+                RecipeManagerHandler.addProxyRecipesToLookup(recipesByID, gtRecipeType, type, list);
+            });
+            var recipesByID = recipes.get(gtRecipeType);
+            if (recipesByID == null) {
+                continue;
+            }
+            RecipeManagerHandler.addToLookup(recipesByID, gtRecipeType);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
@@ -51,7 +51,7 @@ public abstract class RecipeManagerMixin {
             if (recipesByID == null) {
                 continue;
             }
-            RecipeManagerHandler.addToLookup(recipesByID, gtRecipeType);
+            RecipeManagerHandler.addRecipesToLookup(recipesByID, gtRecipeType);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -530,15 +530,15 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
             gtRecipeType.getProxyRecipes().forEach((type, list) -> {
                 RecipeManagerHandler.addProxyRecipesToLookup(recipesByName, gtRecipeType, type, list);
             });
-            RecipeManagerHandler.addToLookup(recipesByName, gtRecipeType);
+            RecipeManagerHandler.addRecipesToLookup(recipesByName, gtRecipeType);
         }
     }
 
     private static void handleGTRecipe(Map<ResourceLocation, Recipe<?>> recipesByName,
                                        GTRecipeSchema.GTRecipeJS gtRecipe) {
-        GTRecipeType gtRecipeType = (GTRecipeType) ForgeRegistries.RECIPE_TYPES.getValue(gtRecipe.type.id);
+        GTRecipeType gtRecipeType = (GTRecipeType) ForgeRegistries.RECIPE_TYPES.getValue(gtRecipe.getType());
         if (gtRecipeType == null) {
-            // should not happen
+            GTCEu.LOGGER.error("Failed to get GTRecipeType from GTRecipe: {}", gtRecipe.getType());
             return;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -47,13 +47,13 @@ import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
 import com.gregtechceu.gtceu.api.pattern.Predicates;
 import com.gregtechceu.gtceu.api.recipe.DummyCraftingContainer;
-import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeSerializer;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
+import com.gregtechceu.gtceu.api.recipe.lookup.RecipeManagerHandler;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder;
@@ -92,7 +92,6 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.ExtendedOutputIte
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 import com.gregtechceu.gtceu.utils.data.RuntimeBlockStateProvider;
 
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
@@ -105,6 +104,7 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import com.mojang.serialization.DataResult;
 import dev.latvian.mods.kubejs.KubeJSPaths;
@@ -133,7 +133,6 @@ import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 import java.util.*;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.KEY;
 import static dev.latvian.mods.kubejs.recipe.schema.minecraft.ShapedRecipeSchema.PATTERN;
@@ -523,39 +522,28 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                 GTRecipeSerializer.SERIALIZER.fromJson(builtRecipe.getId(), builtRecipe.serializeRecipe())));
 
         // clone vanilla recipes for stuff like electric furnaces, etc
-        for (RecipeType<?> recipeType : BuiltInRegistries.RECIPE_TYPE) {
-            if (recipeType instanceof GTRecipeType gtRecipeType) {
-                gtRecipeType.getLookup().removeAllRecipes();
-
-                var proxyRecipes = gtRecipeType.getProxyRecipes();
-                for (Map.Entry<RecipeType<?>, List<GTRecipe>> entry : proxyRecipes.entrySet()) {
-                    var type = entry.getKey();
-                    var recipes = entry.getValue();
-                    recipes.clear();
-                    for (var recipe : recipesByName.entrySet().stream()
-                            .filter(recipe -> recipe.getValue().getType() == type).collect(Collectors.toSet())) {
-                        recipes.add(gtRecipeType.toGTrecipe(recipe.getKey(), recipe.getValue()));
-                    }
-                }
-
-                Stream.concat(
-                        recipesByName.values().stream()
-                                .filter(recipe -> recipe.getType() == gtRecipeType),
-                        proxyRecipes.entrySet().stream()
-                                .flatMap(entry -> entry.getValue().stream()))
-                        .filter(GTRecipe.class::isInstance)
-                        .map(GTRecipe.class::cast)
-                        .forEach(gtRecipe -> gtRecipeType.getLookup().addRecipe(gtRecipe));
+        for (RecipeType<?> recipeType : ForgeRegistries.RECIPE_TYPES) {
+            if (!(recipeType instanceof GTRecipeType gtRecipeType)) {
+                continue;
             }
+            gtRecipeType.getLookup().removeAllRecipes();
+            gtRecipeType.getProxyRecipes().forEach((type, list) -> {
+                RecipeManagerHandler.addProxyRecipesToLookup(recipesByName, gtRecipeType, type, list);
+            });
+            RecipeManagerHandler.addToLookup(recipesByName, gtRecipeType);
         }
     }
 
     private static void handleGTRecipe(Map<ResourceLocation, Recipe<?>> recipesByName,
                                        GTRecipeSchema.GTRecipeJS gtRecipe) {
-        // get the recipe ID without the leading type path
-        GTRecipeBuilder builder = ((GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(gtRecipe.type.id))
-                .recipeBuilder(gtRecipe.idWithoutType());
+        GTRecipeType gtRecipeType = (GTRecipeType) ForgeRegistries.RECIPE_TYPES.getValue(gtRecipe.type.id);
+        if (gtRecipeType == null) {
+            // should not happen
+            return;
+        }
 
+        // get the recipe ID without the leading type path
+        GTRecipeBuilder builder = gtRecipeType.recipeBuilder(gtRecipe.idWithoutType());
         if (gtRecipe.getValue(GTRecipeSchema.DURATION) != null) {
             builder.duration = gtRecipe.getValue(GTRecipeSchema.DURATION).intValue();
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -538,7 +538,8 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                                        GTRecipeSchema.GTRecipeJS gtRecipe) {
         GTRecipeType gtRecipeType = (GTRecipeType) ForgeRegistries.RECIPE_TYPES.getValue(gtRecipe.getType());
         if (gtRecipeType == null) {
-            GTCEu.LOGGER.error("Failed to get GTRecipeType from GTRecipe: {}", gtRecipe.getType());
+            GTCEu.LOGGER.error("Failed to get GTRecipeType from GTRecipe: '{}' with type '{}'", gtRecipe.getId(),
+                    gtRecipe.getType());
             return;
         }
 


### PR DESCRIPTION
## What
Refactors the interactions between `RecipeManager` and recipes (and the KubeJS plugin). The code is a lot simpler now, and makes it easier to change the behavior of `GTRecipeLookup` in the future.

## Implementation Details
I've verified no change in behavior occurs by checking the before and after numbers for recipes added.
