### PR TITLE
Support Bookmarking  multiblock info

### DIFF
--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -4,7 +4,7 @@ registrate = "MC1.20-1.3.11"
 configuration = "2.2.0"
 mixinExtras = "0.5.0-rc.3"
 
-jei = "15.20.0.105"
+jei = "15.20.0.115"
 rei = "12.1.785"
 emi = "1.1.13+1.20.1"
 ae2 = "15.0.18"

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/multipage/MultiblockInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/multipage/MultiblockInfoCategory.java
@@ -5,17 +5,35 @@ import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.machines.GTMultiMachines;
 
+import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.jei.ModularUIRecipeCategory;
 
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.gui.navigation.ScreenPosition;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 
 import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
+import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
+import mezz.jei.api.gui.widgets.ISlottedRecipeWidget;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.helpers.IJeiHelpers;
+import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.IRecipeRegistration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
 public class MultiblockInfoCategory extends ModularUIRecipeCategory<MultiblockInfoWrapper> {
 
     public final static RecipeType<MultiblockInfoWrapper> RECIPE_TYPE = new RecipeType<>(GTCEu.id("multiblock_info"),
@@ -36,6 +54,47 @@ public class MultiblockInfoCategory extends ModularUIRecipeCategory<MultiblockIn
                 .filter(MultiblockMachineDefinition::isRenderXEIPreview)
                 .map(MultiblockInfoWrapper::new)
                 .toList());
+    }
+
+    @Override
+    public void createRecipeExtras(@NotNull IRecipeExtrasBuilder builder, @NotNull MultiblockInfoWrapper recipe,
+                                   @NotNull IFocusGroup focuses) {
+        super.createRecipeExtras(builder, recipe, focuses);
+        List<IRecipeSlotDrawable> slots = new ArrayList<>(builder.getRecipeSlots().getSlots());
+        class ProxyRecipeWidget implements ISlottedRecipeWidget {
+
+            private final ScreenPosition position = new ScreenPosition(0, 0);
+
+            @Override
+            public Optional<RecipeSlotUnderMouse> getSlotUnderMouse(double mouseX, double mouseY) {
+                var parent = recipe.getWidget();
+                var pos = parent.getSelfPosition();
+                var size = parent.getSize();
+                boolean inParent = Widget.isMouseOver(pos.x, pos.y, size.width, size.height, mouseX, mouseY);
+                if (!inParent) return Optional.empty();
+                List<Widget> flatVisibleWidgetCollection = recipe.modularUI.getFlatWidgetCollection();
+                return slots.stream()
+                        .filter(slot -> slot.isMouseOver(mouseX, mouseY))
+                        .findFirst()
+                        .flatMap(slot -> slot.getSlotName().map(name -> {
+                            int index = Integer.parseInt(name.substring(5));
+                            Widget widget = flatVisibleWidgetCollection.get(index);
+                            return new RecipeSlotUnderMouse(slot, 0, 0);
+                        }));
+            }
+
+            @Override
+            public ScreenPosition getPosition() {
+                return position;
+            }
+        }
+
+        builder.addSlottedWidget(new ProxyRecipeWidget(), slots);
+    }
+
+    @Override
+    public @Nullable ResourceLocation getRegistryName(@NotNull MultiblockInfoWrapper recipe) {
+        return recipe.definition.getId();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/multipage/MultiblockInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/multipage/MultiblockInfoCategory.java
@@ -9,7 +9,6 @@ import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.jei.ModularUIRecipeCategory;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
-import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.ScreenPosition;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/multipage/MultiblockInfoCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/multipage/MultiblockInfoCategory.java
@@ -9,6 +9,7 @@ import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.jei.ModularUIRecipeCategory;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.navigation.ScreenPosition;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -67,20 +68,24 @@ public class MultiblockInfoCategory extends ModularUIRecipeCategory<MultiblockIn
 
             @Override
             public Optional<RecipeSlotUnderMouse> getSlotUnderMouse(double mouseX, double mouseY) {
-                var parent = recipe.getWidget();
-                var pos = parent.getSelfPosition();
-                var size = parent.getSize();
+                var panel = recipe.getWidget();
+                var pos = panel.getSelfPosition();
+                var size = panel.getSize();
                 boolean inParent = Widget.isMouseOver(pos.x, pos.y, size.width, size.height, mouseX, mouseY);
                 if (!inParent) return Optional.empty();
-                List<Widget> flatVisibleWidgetCollection = recipe.modularUI.getFlatWidgetCollection();
+                List<Widget> widgets = recipe.modularUI.getFlatWidgetCollection();
                 return slots.stream()
-                        .filter(slot -> slot.isMouseOver(mouseX, mouseY))
-                        .findFirst()
-                        .flatMap(slot -> slot.getSlotName().map(name -> {
+                        .filter(slot -> {
+                            Optional<String> slotName = slot.getSlotName();
+                            if (slotName.isEmpty()) return false;
+                            String name = slotName.get();
                             int index = Integer.parseInt(name.substring(5));
-                            Widget widget = flatVisibleWidgetCollection.get(index);
-                            return new RecipeSlotUnderMouse(slot, 0, 0);
-                        }));
+                            Widget widget = widgets.get(index);
+                            slot.setPosition(widget.getPositionX(), widget.getPositionY());
+                            return slot.isMouseOver(mouseX, mouseY);
+                        })
+                        .findFirst()
+                        .map(slot -> new RecipeSlotUnderMouse(slot, 0, 0));
             }
 
             @Override


### PR DESCRIPTION
## What

[this](https://github.com/mezz/JustEnoughItems/pull/4097) jei pr make that  bookmarking recipe that have no outputs possible,
so we can supoort bookmark multiblock info page now.

and fix a position bug with MultiblockInfoCategory(recipe slot may out of recipe layout's bounds)
## Implementation Details

Use Jei ISlottedRecipeWidget to sync position and make IRecipeIngredientSlot have dynamic position

## Additional Information
All Categories that use ModularUIRecipeCategory have position bug, but my purpose is just to make multiblock info bookmarks, so I haven't fixed the other Categories

**Multiblock info recipe bookmark not being serialized is not a GTM bug, it's a JEI bug**

a preview(enabled extra jei bookmark feature : INGREDIENTS):

<img width="2441" height="1566" alt="e2f72786-eb66-4872-b0ca-9a09d562ec16" src="https://github.com/user-attachments/assets/f3797938-ef44-47af-a384-553357aeb907" />

## Potential Compatibility Issues

When use emi, jemi will cause tooltip preview render bug ;
