### PR TITLE
Fix color spray not working with `DyeColor` blockstate

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -289,7 +289,7 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
         BlockState state = level.getBlockState(pos);
         for (Property property : state.getProperties()) {
             if (property.getValueClass() == DyeColor.class) {
-                state.setValue(property, color);
+                level.setBlockAndUpdate(state.setValue(property, color));
                 return true;
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -289,7 +289,7 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
         BlockState state = level.getBlockState(pos);
         for (Property property : state.getProperties()) {
             if (property.getValueClass() == DyeColor.class) {
-                level.setBlockAndUpdate(state.setValue(property, color));
+                level.setBlockAndUpdate(pos, state.setValue(property, color));
                 return true;
             }
         }


### PR DESCRIPTION
## What
Spray cans (are supposed to) allow any block with a `DyeColor` blockstate to be painted.
This doesn't work however as the `state.setValue(property, color)` call doesn't actually set the value, it only creates a new `BlockState` object, which you then have to put back into the world with `level.setBlockAndUpdate`. 

## Implementation Details
Added the `level.setBlockAndUpdate` call.

## Outcome
Fixes said behavior.