### PR TITLE
Fix Machine explosions

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/TieredEnergyMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/TieredEnergyMachine.java
@@ -30,7 +30,7 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
     @Persisted
     @DescSynced
     public final NotifiableEnergyContainer energyContainer;
-    protected TickableSubscription explosionSubs;
+    protected TickableSubscription explosionSub;
     protected ISubscription energyListener;
 
     public TieredEnergyMachine(IMachineBlockEntity holder, int tier, Object... args) {
@@ -61,8 +61,10 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
         // if machine need do check explosion conditions
         if (!isRemote() && ConfigHolder.INSTANCE.machines.shouldWeatherOrTerrainExplosion &&
                 shouldWeatherOrTerrainExplosion()) {
-            energyListener = energyContainer.addChangedListener(this::updateExplosionSubscription);
-            updateExplosionSubscription();
+            explosionSub = subscribeServerTick(this::checkExplosion);
+            checkExplosion();
+            //explosionSub = energyContainer.addChangedListener(this::updateExplosionSubscription);
+            //updateExplosionSubscription();
         }
     }
 
@@ -73,13 +75,17 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
             energyListener.unsubscribe();
             energyListener = null;
         }
+
+        if (explosionSub != null) {
+            explosionSub = null;
+        }
     }
 
     //////////////////////////////////////
     // ******** Explosion ********//
     //////////////////////////////////////
 
-    protected void updateExplosionSubscription() {
+    /*protected void updateExplosionSubscription() {
         if (ConfigHolder.INSTANCE.machines.shouldWeatherOrTerrainExplosion && shouldWeatherOrTerrainExplosion() &&
                 energyContainer.getEnergyStored() > 0) {
             explosionSubs = subscribeServerTick(explosionSubs, this::checkExplosion);
@@ -87,11 +93,13 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
             explosionSubs.unsubscribe();
             explosionSubs = null;
         }
-    }
+    }*/
 
     protected void checkExplosion() {
-        checkWeatherOrTerrainExplosion(tier, tier * 10);
-        updateExplosionSubscription();
+        if (energyContainer.getEnergyStored() > 0) {
+            checkWeatherOrTerrainExplosion(tier, tier * 10);
+        }
+        //updateExplosionSubscription();
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/TieredEnergyMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/TieredEnergyMachine.java
@@ -11,7 +11,6 @@ import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.lowdragmc.lowdraglib.gui.texture.IGuiTexture;
 import com.lowdragmc.lowdraglib.gui.texture.ProgressTexture;
 import com.lowdragmc.lowdraglib.gui.widget.ProgressWidget;
-import com.lowdragmc.lowdraglib.syncdata.ISubscription;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
@@ -31,7 +30,6 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
     @DescSynced
     public final NotifiableEnergyContainer energyContainer;
     protected TickableSubscription explosionSub;
-    protected ISubscription energyListener;
 
     public TieredEnergyMachine(IMachineBlockEntity holder, int tier, Object... args) {
         super(holder, tier);
@@ -58,25 +56,18 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
     @Override
     public void onLoad() {
         super.onLoad();
-        // if machine need do check explosion conditions
         if (!isRemote() && ConfigHolder.INSTANCE.machines.shouldWeatherOrTerrainExplosion &&
                 shouldWeatherOrTerrainExplosion()) {
             explosionSub = subscribeServerTick(this::checkExplosion);
             checkExplosion();
-            //explosionSub = energyContainer.addChangedListener(this::updateExplosionSubscription);
-            //updateExplosionSubscription();
         }
     }
 
     @Override
     public void onUnload() {
         super.onUnload();
-        if (energyListener != null) {
-            energyListener.unsubscribe();
-            energyListener = null;
-        }
-
         if (explosionSub != null) {
+            explosionSub.unsubscribe();
             explosionSub = null;
         }
     }
@@ -84,22 +75,10 @@ public class TieredEnergyMachine extends TieredMachine implements ITieredMachine
     //////////////////////////////////////
     // ******** Explosion ********//
     //////////////////////////////////////
-
-    /*protected void updateExplosionSubscription() {
-        if (ConfigHolder.INSTANCE.machines.shouldWeatherOrTerrainExplosion && shouldWeatherOrTerrainExplosion() &&
-                energyContainer.getEnergyStored() > 0) {
-            explosionSubs = subscribeServerTick(explosionSubs, this::checkExplosion);
-        } else if (explosionSubs != null) {
-            explosionSubs.unsubscribe();
-            explosionSubs = null;
-        }
-    }*/
-
     protected void checkExplosion() {
         if (energyContainer.getEnergyStored() > 0) {
             checkWeatherOrTerrainExplosion(tier, tier * 10);
         }
-        //updateExplosionSubscription();
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IExplosionMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IExplosionMachine.java
@@ -34,7 +34,7 @@ public interface IExplosionMachine extends IMachineFeature {
                 }
             }
         }
-        if (GTValues.RNG.nextInt(10) == 0) {
+        if (GTValues.RNG.nextInt(1000) == 0) {
             if (level.isRainingAt(pos) || level.isRainingAt(pos.east()) || level.isRainingAt(pos.west()) ||
                     level.isRainingAt(pos.north()) || level.isRainingAt(pos.south())) {
                 if (level.isThundering() && GTValues.RNG.nextInt(3) == 0) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IExplosionMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IExplosionMachine.java
@@ -34,7 +34,7 @@ public interface IExplosionMachine extends IMachineFeature {
                 }
             }
         }
-        if (GTValues.RNG.nextInt(1000) == 0) {
+        if (GTValues.RNG.nextInt(10) == 0) {
             if (level.isRainingAt(pos) || level.isRainingAt(pos.east()) || level.isRainingAt(pos.west()) ||
                     level.isRainingAt(pos.north()) || level.isRainingAt(pos.south())) {
                 if (level.isThundering() && GTValues.RNG.nextInt(3) == 0) {


### PR DESCRIPTION
## What
Previously, machines would only gain the explosion subscription if it had a change in energy and it was >50% energy charge on load(which meant first placed machines never got it until they were reloaded from world) and the rain explosion check would only happen during a energy change.
This PR changes it so that a machine with any charge will check for rain explosions.

## Implementation Details
clean up the subscription code.

## Outcome
more frequent explosions