### PR TITLE
Slightly increase Large Turbine energy output and fuel burn

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeTurbineMachine.java
@@ -136,7 +136,7 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
      * Recipe is fast parallelized up to {@code (baseEUt * power) / recipeEUt} times.
      * Duration is then multiplied by the holder efficiency.
      * </p>
-     * 
+     *
      * @param machine a {@link LargeTurbineMachine}
      * @param recipe  recipe
      * @return A {@link ModifierFunction} for the given Turbine Multiblock and recipe
@@ -156,9 +156,15 @@ public class LargeTurbineMachine extends WorkableElectricMultiblockMachine imple
         if (EUt.isEmpty() || turbineMaxVoltage <= EUt.voltage() || holderEfficiency <= 0) return ModifierFunction.NULL;
 
         // get the amount of parallel required to match the desired output voltage
+        // Max Parallel is Ceilinged not Floored to ensure the output voltage is actually met,
+        // at the cost of slightly increased fuel
         int maxParallel = (int) (turbineMaxVoltage / EUt.getTotalEU());
+        if (turbineMaxVoltage % EUt.getTotalEU() != 0) maxParallel++;
+
         int actualParallel = ParallelLogic.getParallelAmountFast(turbineMachine, recipe, maxParallel);
-        double eutMultiplier = turbineMachine.productionBoost() * actualParallel;
+        double eutMultiplier = (maxParallel == actualParallel) ?
+                turbineMachine.productionBoost() * turbineMaxVoltage / EUt.voltage() :
+                turbineMachine.productionBoost() * actualParallel;
 
         return ModifierFunction.builder()
                 .inputModifier(ContentModifier.multiplier(actualParallel))


### PR DESCRIPTION
## What
Large Turbines output somewhat less energy than their turbine power, and their UI, claim they should be able to.

This is because their actual max output is reduced to the _floor_ of the max parallel count (since generators produce energy by doing parallels)

## Implementation Details
The max parallel count is changed to the ceiling, however the max EU/t output is now the actual calculated max power value.

## Outcome
Before:
<img width="546" height="313" alt="image" src="https://github.com/user-attachments/assets/77deae88-8146-4bd6-b4b0-fc52a607fc18" />
After:
<img width="548" height="321" alt="image" src="https://github.com/user-attachments/assets/459e7947-0725-498c-9962-3e6ae06a1d46" />


## Additional Information
All Large Turbines will now output slightly more energy when fully spun up (i.e. the amount of energy their UI claims they're supposed to output), but also all consume an additional 1 unit of fuel per cycle. This is technically a slight nerf to turbine fuel efficiency in exchange for a slight buff to power output, but since turbines already have increased fuel efficiency from rotors and rotor holders this isn't a major loss (and furthermore the fuel loss is larger with weaker rotors and smaller with stronger rotors).