### PR TITLE
Change bonkHatch.getBonk() to bonkHandler.getbonk() in Custom-Ingredient.md 

### DIFF
--- a/docs/content/Development/Recipe-Logic/Custom-Ingredient.md
+++ b/docs/content/Development/Recipe-Logic/Custom-Ingredient.md
@@ -267,7 +267,7 @@ public class BonkHatchPartMachine extends TieredIOPartMachine {
     protected InteractionResult onHardHammerClick(Player playerIn, InteractionHand hand, Direction gridSide, BlockHitResult hitResult) {
         if(isRemote()) return InteractionResult.SUCCESS;
         if(bonkHandler.addBonk(1, false)){
-            playerIn.sendSystemMessage(Component.literal("Bonk! Total bonk stored: " + bonkHatch.getBonk()));
+            playerIn.sendSystemMessage(Component.literal("Bonk! Total bonk stored: " + bonkHandler.getBonk()));
             return InteractionResult.CONSUME;
         }
         return super.onHardHammerClick(playerIn, hand, gridSide, hitResult);


### PR DESCRIPTION
## What
Fixes the slight typo to reference the correct thing.

## Implementation Details
Fix the typo in docs.

## Outcome
Allows people to actually use the Bonk custom ingredient properly.

## Potential Compatibility Issues
Anyone who has used this typo in their code will have to fix it.
