### PR TITLE
fix larger miner crash game

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/LargeMinerLogic.java
@@ -29,6 +29,7 @@ import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Optional;
 
 public class LargeMinerLogic extends MinerLogic {
 
@@ -149,7 +150,7 @@ public class LargeMinerLogic extends MinerLogic {
         fortunePick.enchant(fortuneHolder, getDropCountMultiplier());
         LootParams params = builder.withParameter(LootContextParams.TOOL, fortunePick)
                 .create(LootContextParamSets.BLOCK);
-        LootContext context = new LootContext.Builder(params).create(null);
+        LootContext context = new LootContext.Builder(params).create(Optional.empty());
 
         for (ItemStack outputStack : outputs) {
             if (ChemicalHelper.getPrefix(outputStack.getItem()) == TagPrefix.crushed) {


### PR DESCRIPTION
## What
The large miner crash game.
The parameter of net.minecraft.world.level.storage.loot.LootContext.Builder#create become Optional<ResourceLocation> from ResourceLocation.

## Implementation Details
Change actual parameter null to Optional.empty()

## Outcome
Large miner no longer crash game.