### PR TITLE
Fix assembly line cannot read research data from data bank.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
@@ -458,6 +458,8 @@ public class CommonInit {
                 duct.attachCapabilities(event);
             } else if (block instanceof IMachineBlock machine) {
                 machine.attachCapabilities(event);
+            } else if (block instanceof OpticalPipeBlock optical) {
+                optical.attachCapabilities(event);
             }
         }
 


### PR DESCRIPTION
## What
Assembly line cannot read research data from data bank.

## Implementation Details
Attach abilities for optical pipe.

## Outcome
Assembly line can read research data from data bank now.