### PR TITLE
Fix research station cannot reserach.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
@@ -265,7 +265,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
         for (Direction direction : GTUtil.DIRECTIONS) {
             BlockEntity blockEntity = machine.getLevel().getBlockEntity(machine.getPos().relative(direction));
             if (blockEntity instanceof OpticalPipeBlockEntity) {
-                machine.getLevel().getCapability(GTCapability.CAPABILITY_COMPUTATION_PROVIDER,
+                return machine.getLevel().getCapability(GTCapability.CAPABILITY_COMPUTATION_PROVIDER,
                         blockEntity.getBlockPos(), blockEntity.getBlockState(), blockEntity, direction.getOpposite());
             }
         }


### PR DESCRIPTION
## What
Research station machine  cannot start researching.

## Implementation Details
Add return statement for com.gregtechceu.gtceu.api.machine.trait.NotifiableComputationContainer#getOpticalNetProvider.

## Outcome
Now research station machine can start researching
