### PR TITLE
Alter Jade/TOP provider to display machine voltage tier by machine tier rather than by recipe/overclock tier

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/TieredIOPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/TieredIOPartMachine.java
@@ -24,7 +24,6 @@ public class TieredIOPartMachine extends TieredPartMachine implements IControlla
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(TieredIOPartMachine.class,
             MultiblockPartMachine.MANAGED_FIELD_HOLDER);
 
-    @Getter
     protected final IO io;
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/TieredIOPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/TieredIOPartMachine.java
@@ -24,6 +24,7 @@ public class TieredIOPartMachine extends TieredPartMachine implements IControlla
     protected static final ManagedFieldHolder MANAGED_FIELD_HOLDER = new ManagedFieldHolder(TieredIOPartMachine.class,
             MultiblockPartMachine.MANAGED_FIELD_HOLDER);
 
+    @Getter
     protected final IO io;
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -62,11 +62,11 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
     }
 
     public static long getVoltage(RecipeLogic capability) {
-        long tier = -1;
+        long voltage = -1;
         if (capability.machine instanceof SimpleTieredMachine machine) {
-            tier = GTValues.V[machine.getTier()];
+            voltage = GTValues.V[machine.getTier()];
         } else if (capability.machine instanceof WorkableElectricMultiblockMachine machine) {
-            tier = machine.getParts().stream()
+            voltage = machine.getParts().stream()
                     .filter(EnergyHatchPartMachine.class::isInstance)
                     .map(EnergyHatchPartMachine.class::cast)
                     .mapToLong(dynamo -> GTValues.V[dynamo.getTier()])
@@ -74,8 +74,8 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
                     .orElse(-1);
         }
         // default display as LV, this shouldn't happen because a machine is either electric or steam
-        if (tier == -1) tier = 32;
-        return tier;
+        if (voltage == -1) voltage = 32;
+        return voltage;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -70,13 +70,9 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
         } else if (capability.machine instanceof WorkableElectricMultiblockMachine machine) {
             for (Object part : machine.getParts()) { // multiblock generator tier is set by constructor not hatches
                 if (part instanceof EnergyHatchPartMachine dynamo) {
-                    if (dynamo.getIo() == IO.OUT) {
-                        tier = GTValues.V[dynamo.getTier()];
-                    }
+                    long newtier = GTValues.V[dynamo.getTier()];
+                    if (newtier > tier) tier = newtier;
                 }
-            }
-            if (tier == -1) { // multiblock machine tier is set by energy hatches
-                tier = GTValues.V[machine.getTier()];
             }
         }
         // default display as LV, this shouldn't happen because a machine is either electric or steam

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -4,10 +4,14 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.steam.SimpleSteamMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.client.util.TooltipHelper;
+import com.gregtechceu.gtceu.common.machine.multiblock.part.EnergyHatchPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -46,16 +50,38 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
         var recipeInfo = new CompoundTag();
         var recipe = capability.getLastRecipe();
         if (recipe != null) {
+            long voltage = getVoltage(capability);
             var EUt = RecipeHelper.getRealEUtWithIO(recipe);
 
             recipeInfo.putLong("EUt", EUt.getTotalEU());
-            recipeInfo.putLong("voltage", EUt.voltage());
+            recipeInfo.putLong("voltage", voltage);
             recipeInfo.putBoolean("isInput", EUt.isInput());
         }
 
         if (!recipeInfo.isEmpty()) {
             data.put("Recipe", recipeInfo);
         }
+    }
+
+    public static long getVoltage(RecipeLogic capability) {
+        long tier = -1;
+        if (capability.machine instanceof SimpleTieredMachine machine) {
+            tier = GTValues.V[machine.getTier()];
+        } else if (capability.machine instanceof WorkableElectricMultiblockMachine machine) {
+            for (Object part : machine.getParts()) { // multiblock generator tier is set by constructor not hatches
+                if (part instanceof EnergyHatchPartMachine dynamo) {
+                    if (dynamo.getIo() == IO.OUT) {
+                        tier = GTValues.V[dynamo.getTier()];
+                    }
+                }
+            }
+            if (tier == -1) { // multiblock machine tier is set by energy hatches
+                tier = GTValues.V[machine.getTier()];
+            }
+        }
+        // default display as LV, this shouldn't happen because a machine is either electric or steam
+        if (tier == -1) tier = 32;
+        return tier;
     }
 
     @Override
@@ -88,7 +114,7 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
                     } else {
                         var voltage = recipeInfo.getLong("voltage");
                         var tier = GTUtil.getTierByVoltage(voltage);
-                        float minAmperage = (float) EUt / GTValues.V[tier];
+                        float minAmperage = (float) EUt / voltage;
 
                         text = Component
                                 .translatable("gtceu.jade.amperage_use",

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -67,12 +67,12 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
         if (capability.machine instanceof SimpleTieredMachine machine) {
             tier = GTValues.V[machine.getTier()];
         } else if (capability.machine instanceof WorkableElectricMultiblockMachine machine) {
-            for (Object part : machine.getParts()) { // multiblock generator tier is set by constructor not hatches
-                if (part instanceof EnergyHatchPartMachine dynamo) {
-                    long newtier = GTValues.V[dynamo.getTier()];
-                    if (newtier > tier) tier = newtier;
-                }
-            }
+            tier = machine.getParts().stream()
+                    .filter(EnergyHatchPartMachine.class::isInstance)
+                    .map(EnergyHatchPartMachine.class::cast)
+                    .mapToLong(dynamo -> GTValues.V[dynamo.getTier()])
+                    .max()
+                    .orElse(-1);
         }
         // default display as LV, this shouldn't happen because a machine is either electric or steam
         if (tier == -1) tier = 32;

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -49,11 +49,10 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
         var recipeInfo = new CompoundTag();
         var recipe = capability.getLastRecipe();
         if (recipe != null) {
-            long voltage = getVoltage(capability);
             var EUt = RecipeHelper.getRealEUtWithIO(recipe);
 
             recipeInfo.putLong("EUt", EUt.getTotalEU());
-            recipeInfo.putLong("voltage", voltage);
+            recipeInfo.putLong("voltage", getVoltage(capability));
             recipeInfo.putBoolean("isInput", EUt.isInput());
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
-import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.steam.SimpleSteamMachine;

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/RecipeLogicInfoProvider.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.steam.SteamMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
+import com.gregtechceu.gtceu.integration.jade.provider.RecipeLogicProvider;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -61,13 +62,13 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<RecipeLogic>
                 }
 
                 if (text == null) {
-                    var tier = GTUtil.getTierByVoltage(EUt.voltage());
+                    var tier = GTUtil.getTierByVoltage(RecipeLogicProvider.getVoltage(capability));
                     String minAmperage = FormattingUtil
                             .formatNumber2Places((float) (EUt.getTotalEU()) / GTValues.V[tier]) + TextStyleClass.INFO;
 
                     text = Component.translatable("gtceu.jade.amperage_use", minAmperage).withStyle(ChatFormatting.RED)
                             .append(Component.translatable("gtceu.jade.at").withStyle(ChatFormatting.GREEN))
-                            .append(GTValues.VNF[GTUtil.getTierByVoltage(EUt.voltage())])
+                            .append(GTValues.VNF[tier])
                             .append(Component.translatable("gtceu.universal.padded_parentheses",
                                     (Component.translatable("gtceu.recipe.eu.total",
                                             formatted)))


### PR DESCRIPTION
## What
When Jade/TOP tries to display the power tier a machine is running at, it pulls the voltage from the recipe. However, this does not properly show what tier of power the machine is actually consuming or emitting, or the amperage it consumes or emits. This is most visible on Large Turbines while spinning up, which will tick up their displayed voltage tier every time it hits 1A of the next, rather than displaying the output at the actual dynamo tier.

This alters that to show machine power consumption as the actual amps produced/consumed at the voltage of the (highest present if multiple) energy or dynamo hatch. For singleblock machines performing multi-amp recipes, this would also cause them to display the correct amperage @ voltage.

## Outcome
LCR with 2 HV energy hatches:
<img width="598" height="313" alt="image" src="https://github.com/user-attachments/assets/4c6e3883-4b74-4606-b13e-9dcc5bd38e9d" />
Large Turbine with 16A EV Dynamo:
<img width="612" height="117" alt="image" src="https://github.com/user-attachments/assets/b3c45ab2-1543-4a90-8c01-9daea03f422c" />
Same Large Turbine with 2A UV Dynamo:
<img width="633" height="116" alt="image" src="https://github.com/user-attachments/assets/f13a451b-8fd7-460a-b6ba-49f035f6e5d5" />


