### PR TITLE
Fix crates voiding the inventories of their stack after being placed down

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CrateMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CrateMachine.java
@@ -119,16 +119,11 @@ public class CrateMachine extends MetaMachine implements IUIMachine, IMachineLif
         IMachineLife.super.onMachinePlaced(player, stack);
         CompoundTag tag = stack.getTag();
         if (tag != null) {
-            this.isTaped = tag.contains("taped") && tag.getBoolean("taped");
-            if (isTaped) {
+            if (tag.contains("taped") && tag.getBoolean("taped")) {
                 this.inventory.storage.deserializeNBT(tag.getCompound("inventory"));
             }
-
-            tag.remove("taped");
-            this.isTaped = false;
             setRenderState(getRenderState().setValue(GTMachineModelProperties.IS_TAPED, isTaped));
         }
-        stack.setTag(null);
     }
 
     @Override


### PR DESCRIPTION
## What
exactly as the title describes. before the fix if you have multiple crates in a single stack of items, placing down just one crate would void the items in all the other crates of that stack

## Outcome
Closes https://github.com/GregTechCEu/GregTech-Modern/issues/4008

## Additional Information
relevant behavior before:
https://github.com/user-attachments/assets/57bf5706-3837-4819-a88d-0c2127d48ae7
and after:
https://github.com/user-attachments/assets/c72f4528-920e-48a4-a1b0-c9e9ffd90f85

## Potential Compatibility Issues
i have absolutely no idea why it was editing the stack's nbt before and that was causing the issue so i got rid of that part but if thats crucial for something this pr is very bad