### PR TITLE
Generating all ore block -> crushed recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/OreRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/OreRecipeHandler.java
@@ -46,9 +46,7 @@ public final class OreRecipeHandler {
         }
 
         for (TagPrefix ore : ORES.keySet()) {
-            if (ConfigHolder.INSTANCE.worldgen.allUniqueStoneTypes || ORES.get(ore).shouldDropAsItem()) {
-                processOre(provider, ore, property, material);
-            }
+            processOre(provider, ore, property, material);
         }
 
         processRawOre(provider, property, material);


### PR DESCRIPTION
## What
Makes ore block -> crushed recipes for all ore blocks

## Implementation Details
I don't get why you wouldn't generate these recipes
if we generate "too many", it's just a recipe in a tree. If we generate too few, large miners don't work and people with silk touch can't macerate their ores

## Outcome
Large miners work with custom stone types

## Additional Information
Am down to hear counter arguments as to why we wouldn't just do this :P 