### PR TITLE
Fix representative recipes not generating

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jei/recipe/GTRecipeJEICategory.java
@@ -26,6 +26,7 @@ import mezz.jei.api.registration.IRecipeRegistration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -52,12 +53,26 @@ public class GTRecipeJEICategory extends ModularUIRecipeCategory<GTRecipe> {
     }
 
     public static void registerRecipes(IRecipeRegistration registration) {
+        List<GTRecipeCategory> subCategories = new ArrayList<>();
+        // run main categories first
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
             if (!category.shouldRegisterDisplays()) continue;
             var type = category.getRecipeType();
-            if (category == type.getCategory()) type.buildRepresentativeRecipes();
+            if (category == type.getCategory()) {
+                type.buildRepresentativeRecipes();
+            } else {
+                subCategories.add(category);
+                continue;
+            }
             var wrapped = List.copyOf(type.getRecipesInCategory(category));
             registration.addRecipes(TYPES.apply(category), wrapped);
+        }
+        // run subcategories
+        for (GTRecipeCategory subCategory : subCategories) {
+            if (!subCategory.shouldRegisterDisplays()) continue;
+            var type = subCategory.getRecipeType();
+            var wrapped = List.copyOf(type.getRecipesInCategory(subCategory));
+            registration.addRecipes(TYPES.apply(subCategory), wrapped);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/rei/recipe/GTRecipeREICategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/rei/recipe/GTRecipeREICategory.java
@@ -23,6 +23,8 @@ import me.shedaniel.rei.api.common.util.EntryStacks;
 import me.shedaniel.rei.plugin.common.BuiltinPlugin;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 
 public class GTRecipeREICategory extends ModularUIDisplayCategory<GTRecipeDisplay> {
@@ -45,12 +47,28 @@ public class GTRecipeREICategory extends ModularUIDisplayCategory<GTRecipeDispla
     }
 
     public static void registerDisplays(DisplayRegistry registry) {
+        List<GTRecipeCategory> subCategories = new ArrayList<>();
+        // run main categories first
         for (GTRecipeCategory category : GTRegistries.RECIPE_CATEGORIES) {
             if (!category.shouldRegisterDisplays()) continue;
             var type = category.getRecipeType();
-            if (category == type.getCategory()) type.buildRepresentativeRecipes();
+            if (category == type.getCategory()) {
+                type.buildRepresentativeRecipes();
+            } else {
+                subCategories.add(category);
+                continue;
+            }
             var identifier = CATEGORIES.apply(category);
             type.getRecipesInCategory(category).stream()
+                    .map(r -> new GTRecipeDisplay(r, identifier))
+                    .forEach(registry::add);
+        }
+        // run subcategories
+        for (GTRecipeCategory subCategory : subCategories) {
+            if (!subCategory.shouldRegisterDisplays()) continue;
+            var type = subCategory.getRecipeType();
+            var identifier = CATEGORIES.apply(subCategory);
+            type.getRecipesInCategory(subCategory).stream()
                     .map(r -> new GTRecipeDisplay(r, identifier))
                     .forEach(registry::add);
         }


### PR DESCRIPTION
## What
When #3591 migrated the registries from lists to maps, there was no more guarantee that the main category was build before any subcategory when registering all recipes from the categories to xei

## Implementation Details
run through each recipe category twice, once for all main categories and once for all sub categories

## Outcome
representative recipes are visible again