### PR TITLE
Miner block replacement

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1862,6 +1862,7 @@
   "config.gtceu.option.renderGrowingPlants": "sʇuɐןԀbuıʍoɹ⅁ɹǝpuǝɹ",
   "config.gtceu.option.renderer": "ɹǝɹǝpuǝɹ",
   "config.gtceu.option.replaceMinedBlocksWith": "ɥʇıMsʞɔoןᗺpǝuıWǝɔɐןdǝɹ",
+  "config.gtceu.option.replaceWithCobbleVersion": "uoısɹǝΛǝןqqoƆɥʇıMǝɔɐןdǝɹ",
   "config.gtceu.option.requireGTToolsForBlocks": "sʞɔoןᗺɹoℲsןoo⟘⟘⅁ǝɹınbǝɹ",
   "config.gtceu.option.rngDamageElectricTools": "sןoo⟘ɔıɹʇɔǝןƎǝbɐɯɐᗡbuɹ",
   "config.gtceu.option.rubberTreeSpawnChance": "ǝɔuɐɥƆuʍɐdSǝǝɹ⟘ɹǝqqnɹ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1862,6 +1862,7 @@
   "config.gtceu.option.renderGrowingPlants": "renderGrowingPlants",
   "config.gtceu.option.renderer": "renderer",
   "config.gtceu.option.replaceMinedBlocksWith": "replaceMinedBlocksWith",
+  "config.gtceu.option.replaceWithCobbleVersion": "replaceWithCobbleVersion",
   "config.gtceu.option.requireGTToolsForBlocks": "requireGTToolsForBlocks",
   "config.gtceu.option.rngDamageElectricTools": "rngDamageElectricTools",
   "config.gtceu.option.rubberTreeSpawnChance": "rubberTreeSpawnChance",

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -46,6 +46,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.grower.AbstractTreeGrower;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.WoodType;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
@@ -1164,6 +1165,7 @@ public class GTBlocks {
             GTCEu.id("block/casings/signs/machine_casing_stripes_b"));
 
     public static Table<StoneBlockType, StoneTypes, BlockEntry<Block>> STONE_BLOCKS;
+    public static Map<TagPrefix, Supplier<BlockState>> COBBLE_BLOCKS = new HashMap<>();
 
     public static BlockEntry<Block> RED_GRANITE;
     public static BlockEntry<Block> MARBLE;
@@ -1238,6 +1240,12 @@ public class GTBlocks {
             }
         }
         STONE_BLOCKS = builder.build();
+
+        STONE_BLOCKS.row(StoneBlockType.COBBLE).forEach((ore, block) -> {
+            if (ore.generateBlocks) {
+                GTBlocks.registerCobbleBlock(ore.getTagPrefix(), block::getDefaultState);
+            }
+        });
 
         RED_GRANITE = STONE_BLOCKS.get(StoneBlockType.STONE, StoneTypes.RED_GRANITE);
         MARBLE = STONE_BLOCKS.get(StoneBlockType.STONE, StoneTypes.MARBLE);
@@ -1372,9 +1380,18 @@ public class GTBlocks {
         };
     }
 
+    public static void registerCobbleBlock(TagPrefix orePrefix, Supplier<BlockState> state) {
+        COBBLE_BLOCKS.put(orePrefix, state);
+    }
+
+    public static void removeCobbleBlock(TagPrefix orePrefix) {
+        COBBLE_BLOCKS.remove(orePrefix);
+    }
+
     public static void init() {
         // Decor Blocks
         generateStoneBlocks();
+        initializeCobbleReplacements();
 
         // Procedural Blocks
         REGISTRATE.creativeModeTab(() -> GTCreativeModeTabs.MATERIAL_BLOCK);
@@ -1401,6 +1418,23 @@ public class GTBlocks {
 
         // GCYM
         GCYMBlocks.init();
+    }
+
+    private static void initializeCobbleReplacements() {
+        // replacement blocks for mc based stone types
+        registerCobbleBlock(TagPrefix.ore, Blocks.COBBLESTONE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreDeepslate, Blocks.COBBLED_DEEPSLATE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreAndesite, Blocks.ANDESITE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreDiorite, Blocks.DIORITE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreGranite, Blocks.GRANITE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreSand, Blocks.SAND::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreGravel, Blocks.GRAVEL::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreRedSand, Blocks.RED_SAND::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreBasalt, Blocks.BASALT::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreBlackstone, Blocks.BLACKSTONE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreEndstone, Blocks.END_STONE::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreNetherrack, Blocks.NETHERRACK::defaultBlockState);
+        registerCobbleBlock(TagPrefix.oreTuff, Blocks.TUFF::defaultBlockState);
     }
 
     public static boolean doMetalPipe(Material material) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.common.machine.trait.miner;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.IMiner;
 import com.gregtechceu.gtceu.api.capability.recipe.*;
+import com.gregtechceu.gtceu.api.item.MaterialBlockItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
@@ -176,7 +177,16 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         this.pipeLength = 0;
     }
 
-    private static BlockState findMiningReplacementBlock(Level level) {
+    private static BlockState findMiningReplacementBlock(Level level, BlockPos pos) {
+        if (ConfigHolder.INSTANCE.machines.replaceWithCobbleVersion) {
+            BlockState oreState = level.getBlockState(pos);
+            if (oreState.getBlock().asItem() instanceof MaterialBlockItem matBlockItem) {
+                var prefix = matBlockItem.tagPrefix;
+                if (!GTBlocks.COBBLE_BLOCKS.containsKey(prefix)) return Blocks.COBBLESTONE.defaultBlockState();
+                return GTBlocks.COBBLE_BLOCKS.get(prefix).get();
+            }
+        }
+
         try {
             return BlockStateParser.parseForBlock(level.holderLookup(Registries.BLOCK),
                     ConfigHolder.INSTANCE.machines.replaceMinedBlocksWith, false).blockState();
@@ -422,10 +432,11 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         if (handler != null) {
             if (GTTransferUtils.addItemsToItemHandler(handler, true, blockDrops)) {
                 GTTransferUtils.addItemsToItemHandler(handler, false, blockDrops);
-                world.setBlock(blocksToMine.getFirst(), findMiningReplacementBlock(world), 3);
-                mineX = blocksToMine.getFirst().getX();
-                mineZ = blocksToMine.getFirst().getZ();
-                mineY = blocksToMine.getFirst().getY();
+                var pos = blocksToMine.getFirst();
+                world.setBlock(pos, findMiningReplacementBlock(world, pos), 3);
+                mineX = pos.getX();
+                mineZ = pos.getZ();
+                mineY = pos.getY();
                 blocksToMine.removeFirst();
                 onMineOperation();
 

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -480,6 +480,11 @@ public class ConfigHolder {
                 "This does nothing if enableCleanroom is false.", "Default: false" })
         public boolean cleanMultiblocks = false;
         @Configurable
+        @Configurable.Comment({
+                "Whether the miner should attempt to replace the block mined with a cobbled version of the ore",
+                "Default: true" })
+        public boolean replaceWithCobbleVersion = true;
+        @Configurable
         @Configurable.Comment({ "Block to replace mined ores with in the miner and multiblock miner.",
                 "Default: minecraft:cobblestone" })
         public String replaceMinedBlocksWith = "minecraft:cobblestone";


### PR DESCRIPTION
## What
adds a config to allow the miner to replace the mined ore with a specific block closer to the stone type of the ore, instead of just cobblestone

## Implementation Details
map and defaults for the mc block stone types

## Outcome
no more ugly blobs of cobblestone in the end and nether

## Additional Information
addons should be able to add map entries using the method in GTBlocks

## Potential Compatibility Issues
old behavior can be toggle by turning the config false