### PR TITLE
Fix Tooltip Rendering inside mui UIs

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
@@ -74,7 +74,7 @@ public class RichTextCompiler {
                 text = key.getFormatted();
             } else if (!(o instanceof IDrawable)) {
                 if (o instanceof MutableComponent component) {
-                    text = component.copy().withStyle(component.getStyle());
+                    text = component.copy();
                 }
 
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
@@ -13,6 +13,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ public class RichTextCompiler {
                 lines.add(line);
                 continue;
             }
-            Component text = null;
+            MutableComponent text = null;
             if (o instanceof IKey key) {
                 if (key == IKey.EMPTY) continue;
                 if (key == IKey.SPACE) {
@@ -72,7 +73,10 @@ public class RichTextCompiler {
                 }
                 text = key.getFormatted();
             } else if (!(o instanceof IDrawable)) {
-                text = Component.literal(String.valueOf(o));
+                if (o instanceof MutableComponent component) {
+                    text = component.copy().withStyle(component.getStyle());
+                }
+
             }
             if (text != null) {
                 compileString(text.getString());

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
@@ -79,10 +79,9 @@ public class RichTextCompiler {
 
             }
             if (text != null) {
-                if(text.getStyle() != Style.EMPTY) {
+                if (text.getStyle() != Style.EMPTY) {
                     addLineElement(text);
-                }
-                else {
+                } else {
                     compileString(text.getString());
                 }
                 continue;

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
@@ -79,7 +79,12 @@ public class RichTextCompiler {
 
             }
             if (text != null) {
-                compileString(text.getString());
+                if(text.getStyle() != Style.EMPTY) {
+                    addLineElement(text);
+                }
+                else {
+                    compileString(text.getString());
+                }
                 continue;
             }
             if (!(o instanceof IIcon)) {

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/text/RichTextCompiler.java
@@ -251,6 +251,11 @@ public class RichTextCompiler {
             o = styleBuilder.toString() + o;
             this.formatting.parseFrom(s2); // parse formatting from current string
         }
+        if (o instanceof Component c) {
+            x += fr.width(c.getString());
+            h = Math.max(h, fr.lineHeight);
+        }
+
         this.currentLine.add(o);
     }
 


### PR DESCRIPTION
fixes the component text rendering inside of the itemSlots so it renders properly

before
<img width="2278" height="319" alt="image" src="https://github.com/user-attachments/assets/729c0a79-5884-4b8a-a197-43912b656b4c" />

after
<img width="1105" height="411" alt="image" src="https://github.com/user-attachments/assets/ddeedc0d-2544-4ab6-b75f-563c3a8ffb5c" />
