### PR TITLE
[MUI2] Fix image & adaptable sizing in GTGuiTextures

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTGuiTextures.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTGuiTextures.java
@@ -47,7 +47,7 @@ public class GTGuiTextures {
     // BACKGROUNDS
     public static final UITexture BACKGROUND = UITexture.builder()
             .location(GTCEu.MOD_ID, "textures/gui/base/background.png")
-            .imageSize(176, 166)
+            .imageSize(16, 16)
             .adaptable(3)
             .name(IDs.STANDARD_BACKGROUND)
             .canApplyTheme()
@@ -90,21 +90,19 @@ public class GTGuiTextures {
     // DISPLAYS
     public static final UITexture DISPLAY = new UITexture.Builder()
             .location(GTCEu.MOD_ID, "textures/gui/base/display.png")
-            .imageSize(143, 75)
-            .adaptable(2)
+            .imageSize(182, 117)
             .canApplyTheme()
             .build();
 
     public static final UITexture DISPLAY_BRONZE = new UITexture.Builder()
             .location(GTCEu.MOD_ID, "textures/gui/base/display_bronze.png")
-            .imageSize(143, 75)
-            .adaptable(2)
+            .imageSize(162, 121)
             .build();
 
     public static final UITexture DISPLAY_STEEL = new UITexture.Builder()
             .location(GTCEu.MOD_ID, "textures/gui/base/display_steel.png")
-            .imageSize(143, 75)
-            .adaptable(2)
+            .imageSize(162, 121)
+            .adaptable(1)
             .build();
 
     // todo primitive display?
@@ -322,7 +320,7 @@ public class GTGuiTextures {
 
     public static final UITexture BUTTON = new UITexture.Builder()
             .location(GTCEu.MOD_ID, "textures/gui/widget/button.png")
-            .imageSize(18, 18)
+            .imageSize(32, 32)
             .adaptable(2)
             .name(IDs.STANDARD_BUTTON)
             .canApplyTheme()


### PR DESCRIPTION
## What
some of the images had an incorrect width+height or an incorrect amount of border listed (adaptable). this pr corrects that

## Outcome
Should fix the bullet point ``adaptive textures do not properly work as a background`` line in https://github.com/GregTechCEu/GregTech-Modern/issues/4032. They seemingly do work fine(ish), but the background texture was declared wrong.

## Additional Information
example before:
<img width="441" height="390" alt="image" src="https://github.com/user-attachments/assets/66069297-c24b-4d87-ac8d-f067e7f60927" />
same ui after:
<img width="413" height="374" alt="image" src="https://github.com/user-attachments/assets/89da2328-4fa1-462d-9bce-e8e1b0a5130f" />
i have no idea whats going on in the top left and bottom right here but its almost certainly outside the scope of this pr. very spooky