### PR TITLE
Add the missing CharTyped event listener to ClientScreenHandler

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/mui/base/widget/Interactable.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/base/widget/Interactable.java
@@ -135,11 +135,12 @@ public interface Interactable {
     /**
      * Called when this widget was clicked and mouse is now dragging.
      *
-     * @param mouseX the X coordinate of the mouse.
-     * @param mouseY the Y coordinate of the mouse.
-     * @param button mouse button that drags
-     * @param dragX
-     * @param dragY
+     * @param mouseX current mouse X coordinate relative to the screen
+     * @param mouseY current mouse Y coordinate relative to the screen
+     * @param button mouse button that is held down
+     *               (0 = left button, 1 = right button, 2 = scroll button, 4 and 5 = side buttons)
+     * @param dragX  amount of drag on the X axis (e.g. the distance that has been dragged)
+     * @param dragY  amount of drag on the Y axis (e.g. the distance that has been dragged)
      */
     default void onMouseDrag(double mouseX, double mouseY, int button, double dragX, double dragY) {}
 

--- a/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ClientScreenHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ClientScreenHandler.java
@@ -181,6 +181,20 @@ public class ClientScreenHandler {
 
     // before JEI
     @SubscribeEvent(priority = EventPriority.HIGH)
+    public static void onScreenCharTyped(ScreenEvent.CharacterTyped.Pre event) {
+        int codePoint = event.getCodePoint();
+        int modifiers = event.getModifiers();
+        defaultContext.updateLatestTypedChar(codePoint, modifiers);
+        if (checkGui(event.getScreen())) currentScreen.getContext().updateLatestTypedChar(codePoint, modifiers);
+
+        // vanilla also casts to char here
+        if (doAction(currentScreen, ms -> ms.charTyped((char) codePoint, modifiers))) {
+            event.setCanceled(true);
+        }
+    }
+
+    // before JEI
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onScreenMousePressed(ScreenEvent.MouseButtonPressed.Pre event) {
         int button = event.getButton();
         double mouseX = event.getMouseX();

--- a/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ClientScreenHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ClientScreenHandler.java
@@ -235,7 +235,7 @@ public class ClientScreenHandler {
         if (w == 0) return;
         defaultContext.updateMouseWheel(w);
         if (checkGui(event.getScreen())) currentScreen.getContext().updateMouseWheel(w);
-        checkGui(event.getScreen());
+
         if (doAction(currentScreen, ms -> ms.mouseScrolled(event.getMouseX(), event.getMouseY(), w))) {
             event.setCanceled(true);
         }
@@ -244,10 +244,6 @@ public class ClientScreenHandler {
     // before JEI
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onScreenMouseDragged(ScreenEvent.MouseDragged.Pre event) {
-        checkGui(event.getScreen());
-        if (event.getMouseButton() == -1) {
-            return;
-        }
         if (doAction(currentScreen, ms -> ms.mouseDragged(event.getMouseX(), event.getMouseY(),
                 event.getMouseButton(), event.getDragX(), event.getDragY()))) {
             event.setCanceled(true);

--- a/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ModularScreen.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ModularScreen.java
@@ -483,8 +483,8 @@ public class ModularScreen implements GuiEventListener, Renderable, LayoutElemen
      * Interactable#onCharTyped(char, int)} on every
      * widget under the mouse after gui action listeners have been called.
      *
-     * @param codePoint the character of the pressed key
-     * @param modifiers the key modifiers of the pressed key (see modifiers at {@link InputConstants})
+     * @param codePoint the code point of the typed character
+     * @param modifiers the key modifiers of the typed character (see modifiers at {@link InputConstants})
      * @return true if the action was consumed and further processing should be canceled
      */
     @Override
@@ -509,8 +509,8 @@ public class ModularScreen implements GuiEventListener, Renderable, LayoutElemen
      * Interactable#onMouseScrolled(double, double, double)} on every widget under
      * the mouse after gui action listeners have been called.
      *
-     * @param mouseX mouse x-coordinate
-     * @param mouseY mouse y-coordinate
+     * @param mouseX current mouse X coordinate relative to the screen
+     * @param mouseY current mouse Y coordinate relative to the screen
      * @param delta  the direction and speed of the scroll
      * @return true if the action was consumed and further processing should be canceled
      */
@@ -536,12 +536,12 @@ public class ModularScreen implements GuiEventListener, Renderable, LayoutElemen
      * Interactable#onMouseDrag(double, double, int, double, double)} on every widget
      * under the mouse after gui action listeners have been called.
      *
-     * @param mouseX starting mouse x-coordinate
-     * @param mouseY starting mouse y-coordinate
-     * @param button mouse button that is held down (0 = left button, 1 = right button, 2 = scroll button, 4 and 5 =
-     *               side buttons)
-     * @param dragX  ending mouse y-coordinate
-     * @param dragY  ending mouse y-coordinate
+     * @param mouseX current mouse X coordinate relative to the screen
+     * @param mouseY current mouse Y coordinate relative to the screen
+     * @param button mouse button that is held down
+     *               (0 = left button, 1 = right button, 2 = scroll button, 4 and 5 = side buttons)
+     * @param dragX  the X distance of the drag
+     * @param dragY  the Y distance of the drag
      * @return true if the action was consumed and further processing should be canceled
      */
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/client/mui/screen/viewport/GuiContext.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/mui/screen/viewport/GuiContext.java
@@ -52,6 +52,8 @@ public class GuiContext extends GuiViewportStack {
     private int scanCode;
     @Getter
     private int modifiers;
+    @Getter
+    private int codePoint;
 
     /* Render states */
     @Getter
@@ -100,6 +102,12 @@ public class GuiContext extends GuiViewportStack {
     public void updateLatestKey(int keyCode, int scanCode, int modifiers) {
         this.keyCode = keyCode;
         this.scanCode = scanCode;
+        this.modifiers = modifiers;
+    }
+
+    @ApiStatus.Internal
+    public void updateLatestTypedChar(int codePoint, int modifiers) {
+        this.codePoint = codePoint;
         this.modifiers = modifiers;
     }
 


### PR DESCRIPTION
## What
Added the missing event listener
also clarified some of the mouse methods' parameter descriptions, mainly in `ModularScreen`

## Outcome
`charTyped` is actually called in every case now