### PR TITLE
Fix turbines crashing when interacting with active rotor holders

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
@@ -223,8 +223,10 @@ public class RotorHolderPartMachine extends TieredPartMachine
     public InteractionResult onUse(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand,
                                    BlockHitResult hit) {
         if (!isRemote() && getRotorSpeed() > 0 && !player.isCreative()) {
-            player.hurt(GTDamageTypes.TURBINE.source(level),
-                    TurbineRotorBehaviour.getBehaviour(getRotorStack()).getDamage(getRotorStack()));
+            TurbineRotorBehaviour behaviour = TurbineRotorBehaviour.getBehaviour(getRotorStack());
+            if (behaviour != null) {
+                player.hurt(GTDamageTypes.TURBINE.source(level), behaviour.getDamage(getRotorStack()));
+            }
             return InteractionResult.FAIL;
         }
         return InteractionResult.PASS;


### PR DESCRIPTION
Fixed #3984

When the rotor is broken, the remaining speed won't be immediately 0, so there's an edge case that the rotor behavoir probably null.