### PR TITLE
Add quantum tank missing capacity warning

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/QuantumTankMachineItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/QuantumTankMachineItem.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.item;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
 import com.gregtechceu.gtceu.api.misc.forge.QuantumFluidHandlerItemStack;
 import com.gregtechceu.gtceu.common.machine.storage.QuantumTankMachine;
@@ -18,6 +19,11 @@ public class QuantumTankMachineItem extends MetaMachineItem {
 
     @Override
     public @Nullable ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundTag nbt) {
+        if (!QuantumTankMachine.TANK_CAPACITY.containsKey(getDefinition())) {
+            GTCEu.LOGGER
+                    .error("Quantum tank " + getDefinition().getName() + " does not have a registered TANK_CAPACITY," +
+                            " will have capacity 0.");
+        }
         return new QuantumFluidHandlerItemStack(stack, QuantumTankMachine.TANK_CAPACITY.getLong(getDefinition()));
     }
 }


### PR DESCRIPTION
## What
Warns people when they create a new quantum/supertank without adding the capacity into the array, making a quantum tank of size 0

## Outcome
TFG ran into it, see https://discord.com/channels/701354865217110096/1186025944222269580/1431650435910996058
<img width="1133" height="106" alt="image" src="https://github.com/user-attachments/assets/1386dc96-241d-4fb3-b2e1-6aa895ae6064" />
