### PR TITLE
Remove hatch duplication on Research Computer, add Error for when that happens

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
@@ -196,6 +196,14 @@ public class RecipeHandlerList {
         return copy;
     }
 
+    public List<IRecipeHandler<?>> getHandlersFlat() {
+        List<IRecipeHandler<?>> handlerList = new ArrayList<>();
+        for (var handlerEntry : getHandlerMap().entrySet()) {
+            handlerList.addAll(handlerEntry.getValue());
+        }
+        return handlerList;
+    }
+
     private record Subscription(List<ISubscription> subs) implements ISubscription {
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
@@ -12,7 +12,6 @@ import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDisplayUIMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockDisplayText;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
-import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.ActionResult;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -64,7 +63,6 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
                     return;
                 }
                 this.objectHolder = iObjectHolder;
-                addHandlerList(RecipeHandlerList.of(IO.IN, iObjectHolder.getAsHandler()));
             }
 
             part.self().holder.self()


### PR DESCRIPTION
## What
Remove a duplicate addHandlerList call and add warnings for duplicates in the future

## Outcome
No longer double register the handlerList of the object holder
if you do:
```
[19:25:12] [Thread-17/ERROR] [GregTechCEu/]: Do not add the same handler twice, as this could cause duplication bugs! Handler com.gregtechceu.gtceu.common.machine.multiblock.part.ObjectHolderMachine$ObjectHolderHandler in List com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList
```

Also adds a RecipeHandlerList::getHandlersFlat helper method