### PR TITLE
Fix Jade provider displaying no energy for addon steam machines consuming 1mB/t

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -92,13 +92,12 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
                     if (blockEntity instanceof MetaMachineBlockEntity mbe) {
                         var machine = mbe.getMetaMachine();
                         if (machine instanceof SimpleSteamMachine ssm) {
-                            EUt = (long) (EUt * ssm.getConversionRate());
+                            EUt = (long) Math.ceil(EUt * ssm.getConversionRate());
                             isSteam = true;
                         } else if (machine instanceof SteamParallelMultiblockMachine smb) {
-                            EUt = (long) (EUt * smb.getConversionRate());
+                            EUt = (long) Math.ceil(EUt * smb.getConversionRate());
                             isSteam = true;
                         }
-                        if (EUt == 0) EUt = 1; //
                     }
 
                     MutableComponent text;

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -88,18 +88,19 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
                 var isInput = recipeInfo.getBoolean("isInput");
                 boolean isSteam = false;
 
-                if (blockEntity instanceof MetaMachineBlockEntity mbe) {
-                    var machine = mbe.getMetaMachine();
-                    if (machine instanceof SimpleSteamMachine ssm) {
-                        EUt = (long) (EUt * ssm.getConversionRate());
-                        isSteam = true;
-                    } else if (machine instanceof SteamParallelMultiblockMachine smb) {
-                        EUt = (long) (EUt * smb.getConversionRate());
-                        isSteam = true;
-                    }
-                }
-
                 if (EUt > 0) {
+                    if (blockEntity instanceof MetaMachineBlockEntity mbe) {
+                        var machine = mbe.getMetaMachine();
+                        if (machine instanceof SimpleSteamMachine ssm) {
+                            EUt = (long) (EUt * ssm.getConversionRate());
+                            isSteam = true;
+                        } else if (machine instanceof SteamParallelMultiblockMachine smb) {
+                            EUt = (long) (EUt * smb.getConversionRate());
+                            isSteam = true;
+                        }
+                        if (EUt == 0) EUt = 1; //
+                    }
+
                     MutableComponent text;
 
                     if (isSteam) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/RecipeLogicInfoProvider.java
@@ -4,9 +4,11 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.steam.SimpleSteamMachine;
 import com.gregtechceu.gtceu.api.machine.steam.SteamMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
+import com.gregtechceu.gtceu.common.machine.multiblock.steam.SteamParallelMultiblockMachine;
 import com.gregtechceu.gtceu.integration.jade.provider.RecipeLogicProvider;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -50,13 +52,20 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<RecipeLogic>
                     // do not show energy usage on machines that do not use energy
                     return;
                 }
-                String formatted = FormattingUtil.formatNumbers(EUt.getTotalEU()) + TextStyleClass.INFO;
                 Component text = null;
 
                 if (blockEntity instanceof IMachineBlockEntity machineBlockEntity) {
                     var machine = machineBlockEntity.getMetaMachine();
+                    long MBt = 0;
+                    if (machine instanceof SimpleSteamMachine ssm) {
+                        MBt = (long) (EUt.getTotalEU() * ssm.getConversionRate());
+                    } else if (machine instanceof SteamParallelMultiblockMachine smb) {
+                        MBt = (long) (EUt.getTotalEU() * smb.getConversionRate());
+                    }
+                    if (MBt == 0) MBt = 1;
                     if (machine instanceof SteamMachine) {
-                        text = Component.translatable("gtceu.jade.fluid_use", formatted)
+                        text = Component.translatable("gtceu.jade.fluid_use",
+                                FormattingUtil.formatNumbers(MBt) + TextStyleClass.INFO)
                                 .withStyle(ChatFormatting.GREEN);
                     }
                 }
@@ -71,7 +80,7 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<RecipeLogic>
                             .append(GTValues.VNF[tier])
                             .append(Component.translatable("gtceu.universal.padded_parentheses",
                                     (Component.translatable("gtceu.recipe.eu.total",
-                                            formatted)))
+                                            FormattingUtil.formatNumbers(EUt.getTotalEU()) + TextStyleClass.INFO)))
                                     .withStyle(ChatFormatting.WHITE));
                 }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/top/provider/RecipeLogicInfoProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/top/provider/RecipeLogicInfoProvider.java
@@ -58,11 +58,10 @@ public class RecipeLogicInfoProvider extends CapabilityInfoProvider<RecipeLogic>
                     var machine = machineBlockEntity.getMetaMachine();
                     long MBt = 0;
                     if (machine instanceof SimpleSteamMachine ssm) {
-                        MBt = (long) (EUt.getTotalEU() * ssm.getConversionRate());
+                        MBt = (long) Math.ceil(EUt.getTotalEU() * ssm.getConversionRate());
                     } else if (machine instanceof SteamParallelMultiblockMachine smb) {
-                        MBt = (long) (EUt.getTotalEU() * smb.getConversionRate());
+                        MBt = (long) Math.ceil(EUt.getTotalEU() * smb.getConversionRate());
                     }
-                    if (MBt == 0) MBt = 1;
                     if (machine instanceof SteamMachine) {
                         text = Component.translatable("gtceu.jade.fluid_use",
                                 FormattingUtil.formatNumbers(MBt) + TextStyleClass.INFO)


### PR DESCRIPTION
## What
If a Steam Machine is defined that has an energy ratio of 0.5 Steam : 1 EU, and it runs a recipe that would only consume 1EU/t, the recipe logic clamps the energy consumption to 1mB/t but Jade does 0.5*1, gets 0, and doesn't display energy at all.
<img width="573" height="621" alt="image" src="https://github.com/user-attachments/assets/d2a19cbf-2995-4979-850f-04a8108d21fd" />

This is actually a bug exposed by Frontiers because those conditions don't happen in normal gtm following last year's steam multiblock rebalance.

## Implementation Details
Moves the EUt > 0 check before the Steam check, then if the steam math would reduce the EU/t to 0 it floors it to 1.
Also applies this change to TOP, along with making the TOP provider actually do the math on EU/t->MB/t since it didn't do that.