### PR TITLE
Fix Stone Pressure Plate / Button recipe conflict

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/StoneMachineRecipes.java
@@ -202,6 +202,7 @@ public class StoneMachineRecipes {
                             .stair(Items.POLISHED_BLACKSTONE_STAIRS)
                             .wall(Items.POLISHED_BLACKSTONE_WALL)
                             .pressurePlate(Items.POLISHED_BLACKSTONE_PRESSURE_PLATE)
+                            .button(Items.POLISHED_BLACKSTONE_BUTTON)
                             .material(GTMaterials.Blackstone)
                             .registerAllMaterialInfo()
                             .build(),
@@ -209,7 +210,6 @@ public class StoneMachineRecipes {
                             .stone(Items.POLISHED_BLACKSTONE_BRICKS)
                             .slab(Items.POLISHED_BLACKSTONE_BRICK_SLAB)
                             .stair(Items.POLISHED_BLACKSTONE_BRICK_STAIRS)
-                            .button(Items.POLISHED_BLACKSTONE_BUTTON)
                             .wall(Items.POLISHED_BLACKSTONE_BRICK_WALL)
                             .material(GTMaterials.Blackstone)
                             .registerAllMaterialInfo()
@@ -595,30 +595,6 @@ public class StoneMachineRecipes {
             }
         }
 
-        if (entry.button != null) {
-            if (ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.pressurePlate != null) {
-                VanillaRecipeHelper.addShapedRecipe(provider, "stone_button", new ItemStack(entry.button, 6), "sP",
-                        'P', entry.pressurePlate);
-            }
-
-            if (entry.slab != null) {
-                GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("cut_" + entry.stoneName + "slab_into_button")
-                        .inputItems(entry.slab)
-                        .outputItems(entry.button, 3)
-                        .duration(60)
-                        .EUt(8)
-                        .save(provider);
-            } else {
-                GTRecipeTypes.FORMING_PRESS_RECIPES.recipeBuilder("cut_" + entry.stoneName + "_into_button")
-                        .inputItems(entry.stone)
-                        .notConsumable(GTItems.SHAPE_MOLD_NUGGET)
-                        .outputItems(entry.button, 6)
-                        .duration(60)
-                        .EUt(8)
-                        .save(provider);
-            }
-        }
-
         if (entry.pressurePlate != null) {
 
             if (ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.slab != null) {
@@ -637,6 +613,30 @@ public class StoneMachineRecipes {
                         .save(provider);
             } else if (ConfigHolder.INSTANCE.recipes.removeVanillaBlockRecipes) {
 
+            }
+        }
+
+        if (entry.button != null) {
+            if (ConfigHolder.INSTANCE.recipes.hardRedstoneRecipes && entry.pressurePlate != null) {
+                VanillaRecipeHelper.addShapedRecipe(provider, "stone_button", new ItemStack(entry.button, 6), "sP",
+                        'P', entry.pressurePlate);
+            }
+
+            if (entry.pressurePlate != null) {
+                GTRecipeTypes.CUTTER_RECIPES.recipeBuilder("cut_" + entry.stoneName + "slab_into_button")
+                        .inputItems(entry.pressurePlate)
+                        .outputItems(entry.button, 3)
+                        .duration(60)
+                        .EUt(8)
+                        .save(provider);
+            } else {
+                GTRecipeTypes.FORMING_PRESS_RECIPES.recipeBuilder("cut_" + entry.stoneName + "_into_button")
+                        .inputItems(entry.stone)
+                        .notConsumable(GTItems.SHAPE_MOLD_NUGGET)
+                        .outputItems(entry.button, 6)
+                        .duration(60)
+                        .EUt(8)
+                        .save(provider);
             }
         }
 


### PR DESCRIPTION
## What
[main/WARN] [GregTechCEu/]: Recipe duplicate or conflict found in GTRecipeType gtceu:cutter and was not added. See next lines for details
[main/WARN] [GregTechCEu/]: Attempted to add GTRecipe: gtceu:cutter/cut_stoneslab_into_button_distilled_water
 [main/WARN] [GregTechCEu/]: Which conflicts with: gtceu:cutter/stone_pressure_plate_distilled_water
[main/WARN] [GregTechCEu/]: Recipe duplicate or conflict found in GTRecipeType gtceu:cutter and was not added. See next lines for details
[main/WARN] [GregTechCEu/]: Attempted to add GTRecipe: gtceu:cutter/stone_pressure_plate_water
[main/WARN] [GregTechCEu/]: Which conflicts with: gtceu:cutter/cut_stoneslab_into_button_water
[main/WARN] [GregTechCEu/]: Recipe duplicate or conflict found in GTRecipeType gtceu:cutter and was not added. See next lines for details
[main/WARN] [GregTechCEu/]: Attempted to add GTRecipe: gtceu:cutter/stone_pressure_plate
[main/WARN] [GregTechCEu/]: Which conflicts with: gtceu:cutter/cut_stoneslab_into_button

The Cutter recipes for Stone Buttons and Pressure Plates conflict with each other.
This is because they don't follow the sequencing pattern present in Wooden Pressure Plates and Buttons.

## Implementation Details
Wood cuts from Planks -> Slabs -> Pressure Plates -> Buttons
Stone was trying to cut from Blocks -> Slabs -> [pressure plates and also buttons]
Polished Blackstone avoided this by cutting Pressure plates from Polished Slabs, but buttons from Polished Bricks (despite the vanilla crafting recipe from Polished Blocks, not bricks)

This unifies all three paths and removes the recipe conflict.