### PR TITLE
Update the Configuration mod repository URL

### DIFF
--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -25,7 +25,7 @@ repositories {
         }
     }
     exclusiveContent { // Configuration
-        forRepository { maven { url = "https://api.repsy.io/mvn/toma/public/" } }
+        forRepository { maven { url = "https://repo.repsy.io/mvn/toma/public/" } }
         filter { includeGroup('dev.toma.configuration') }
     }
     exclusiveContent { // FTB mods


### PR DESCRIPTION
## What
This updates the URL from Configuration mod maven repository. Solution from https://github.com/Toma1O6/Configuration/issues/23

## Implementation Details
Changed `repositories.gradle` file replacing `https://api.repsy.io/mvn/toma/public/` with `https://repo.repsy.io/mvn/toma/public/`.