### PR TITLE
Correction of translation into Russian

### DIFF
--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -4310,7 +4310,7 @@
     "material.gtceu.hydrofluoric_acid": "Плавиковая кислота",
     "material.gtceu.hydrogen": "Водород",
     "material.gtceu.hydrogen_sulfide": "Сероводород",
-    "material.gtceu.hypochlorous_acid": "Соляная кислота",
+    "material.gtceu.hypochlorous_acid": "Хлорноватистая кислота",
     "material.gtceu.ice": "Лед",
     "material.gtceu.ilmenite": "Ильменит",
     "material.gtceu.impure_naquadria_solution": "Загрязненный раствор наквадрии",


### PR DESCRIPTION
## What
The key string: `“material.gtceu.hypochlorous_acid”` was translated as _“Соляная кислота”_ **(Hydrochloric acid)**, when in fact it is _“Хлорноватистая кислота”_ **(Hypochlorous acid)**.

## Outcome
Fixed translation of key string (see above)

## Additional Information
**Information for quick reference:**
[Hydrochloric acid (wikipedia on russian)](https://ru.wikipedia.org/wiki/%D0%A1%D0%BE%D0%BB%D1%8F%D0%BD%D0%B0%D1%8F_%D0%BA%D0%B8%D1%81%D0%BB%D0%BE%D1%82%D0%B0)

[Hypochlorous acid (wikipedia on russian)](https://ru.wikipedia.org/wiki/%D0%A5%D0%BB%D0%BE%D1%80%D0%BD%D0%BE%D0%B2%D0%B0%D1%82%D0%B8%D1%81%D1%82%D0%B0%D1%8F_%D0%BA%D0%B8%D1%81%D0%BB%D0%BE%D1%82%D0%B0)

[Screenshot -- English-Russian dictionary "Multitran" ](https://www.multitran.com/m.exe?ll1=1&ll2=2&s=Hypochlorous+acid&l1=1&l2=2)
<img width="823" height="201" alt="image" src="https://github.com/user-attachments/assets/8520228e-4da6-4a56-81c2-29f7c509c277" />

[Screenshot -- English-Russian dictionary "Woordhunt"](https://wooordhunt.ru/word/hypochlorous_acid)
<img width="609" height="162" alt="image" src="https://github.com/user-attachments/assets/b8beb9ef-92f0-4945-b9a5-3b32e8a72b8b" />

Screenshot -- Translator of Cambridge Dictionary
<img width="1134" height="317" alt="image" src="https://github.com/user-attachments/assets/b7fc6a8c-be5f-48d6-b2fa-6a26e375cdee" />

[Screenshot -- English-Russian dictionary "Reverso"](https://dictionary.reverso.net/english-russian/Hypochlorous+acid)
<img width="850" height="824" alt="image" src="https://github.com/user-attachments/assets/7caa5fa2-d03f-4274-b59c-039b2f2bc17e" />





