### PR TITLE
Fix XEI display for recipes with IO and TickIO of the same ingredient type

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTRecipeWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTRecipeWidget.java
@@ -354,50 +354,72 @@ public class GTRecipeWidget extends WidgetGroup {
 
     public void collectStorage(Table<IO, RecipeCapability<?>, Object> extraTable,
                                Table<IO, RecipeCapability<?>, List<Content>> extraContents, GTRecipe recipe) {
-        Map<RecipeCapability<?>, List<Object>> inputCapabilities = new Object2ObjectLinkedOpenHashMap<>();
         for (var entry : recipe.inputs.entrySet()) {
             RecipeCapability<?> cap = entry.getKey();
             List<Content> contents = entry.getValue();
 
             extraContents.put(IO.IN, cap, contents);
-            inputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe, IO.IN));
         }
         for (var entry : recipe.tickInputs.entrySet()) {
             RecipeCapability<?> cap = entry.getKey();
             List<Content> contents = entry.getValue();
 
-            extraContents.put(IO.IN, cap, contents);
-            inputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe, IO.IN));
+            if (extraContents.get(IO.IN, cap) == null) {
+                extraContents.put(IO.IN, cap, contents);
+            } else {
+                ArrayList<Content> fullContents = new ArrayList<>(extraContents.get(IO.IN, cap));
+                fullContents.addAll(contents);
+                extraContents.put(IO.IN, cap, fullContents);
+            }
         }
-        for (var entry : inputCapabilities.entrySet()) {
-            while (entry.getValue().size() < recipe.recipeType.getMaxInputs(entry.getKey())) entry.getValue().add(null);
-            var container = entry.getKey().createXEIContainer(entry.getValue());
-            if (container != null) {
-                extraTable.put(IO.IN, entry.getKey(), container);
+        if (extraContents.containsRow(IO.IN)) {
+            Map<RecipeCapability<?>, List<Object>> inputCapabilities = new Object2ObjectLinkedOpenHashMap<>();
+            for (var entry : extraContents.row(IO.IN).entrySet()) {
+                RecipeCapability<?> cap = entry.getKey();
+                inputCapabilities.put(cap, cap.createXEIContainerContents(entry.getValue(), recipe, IO.IN));
+            }
+
+            for (var entry : inputCapabilities.entrySet()) {
+                while (entry.getValue().size() < recipe.recipeType.getMaxInputs(entry.getKey()))
+                    entry.getValue().add(null);
+                var container = entry.getKey().createXEIContainer(entry.getValue());
+                if (container != null) {
+                    extraTable.put(IO.IN, entry.getKey(), container);
+                }
             }
         }
 
-        Map<RecipeCapability<?>, List<Object>> outputCapabilities = new Object2ObjectLinkedOpenHashMap<>();
         for (var entry : recipe.outputs.entrySet()) {
             RecipeCapability<?> cap = entry.getKey();
             List<Content> contents = entry.getValue();
 
             extraContents.put(IO.OUT, cap, contents);
-            outputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe, IO.OUT));
         }
         for (var entry : recipe.tickOutputs.entrySet()) {
             RecipeCapability<?> cap = entry.getKey();
             List<Content> contents = entry.getValue();
 
-            extraContents.put(IO.OUT, cap, contents);
-            outputCapabilities.put(cap, cap.createXEIContainerContents(contents, recipe, IO.OUT));
+            if (extraContents.get(IO.OUT, cap) == null) {
+                extraContents.put(IO.OUT, cap, contents);
+            } else {
+                ArrayList<Content> fullContents = new ArrayList<>(extraContents.get(IO.IN, cap));
+                fullContents.addAll(contents);
+                extraContents.put(IO.OUT, cap, fullContents);
+            }
         }
-        for (var entry : outputCapabilities.entrySet()) {
-            while (entry.getValue().size() < recipe.recipeType.getMaxOutputs(entry.getKey()))
-                entry.getValue().add(null);
-            var container = entry.getKey().createXEIContainer(entry.getValue());
-            if (container != null) {
-                extraTable.put(IO.OUT, entry.getKey(), container);
+        if (extraContents.containsRow(IO.OUT)) {
+            Map<RecipeCapability<?>, List<Object>> outputCapabilities = new Object2ObjectLinkedOpenHashMap<>();
+            for (var entry : extraContents.row(IO.OUT).entrySet()) {
+                RecipeCapability<?> cap = entry.getKey();
+                outputCapabilities.put(cap, cap.createXEIContainerContents(entry.getValue(), recipe, IO.OUT));
+            }
+            for (var entry : outputCapabilities.entrySet()) {
+                while (entry.getValue().size() < recipe.recipeType.getMaxOutputs(entry.getKey()))
+                    entry.getValue().add(null);
+                var container = entry.getKey().createXEIContainer(entry.getValue());
+                if (container != null) {
+                    extraTable.put(IO.OUT, entry.getKey(), container);
+                }
             }
         }
     }


### PR DESCRIPTION
## What
If a recipe is defined that has both Input/Output and TickInput/Output of the same RecipeCapability, the TickInput/Output list overwrites the Input/Output list in the XEI container display, and so only the Tick contents are displayed in EMI.

## Outcome
fixes #4136 
<img width="369" height="249" alt="image" src="https://github.com/user-attachments/assets/5c84a277-a047-49b3-9b98-20bc3b7c6343" />
