### PR TITLE
Fix toggling Advanced Energy Detector Cover between EU and % modes causing values to decrement

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
@@ -182,8 +182,10 @@ public class AdvancedEnergyDetectorCover extends EnergyDetectorCover implements 
             // This needs to be after setting the maximum, because otherwise the converted value would be
             // limited to 100.
             if (wasPercent) {
-                minValueInput.setValue(GTMath.clamp((long) ((minValue / 100.0) * energyCapacity), 0, energyCapacity));
-                maxValueInput.setValue(GTMath.clamp((long) ((maxValue / 100.0) * energyCapacity), 0, energyCapacity));
+                minValueInput.setValue(
+                        GTMath.clamp((long) Math.ceil((minValue / 100.0) * energyCapacity), 0, energyCapacity));
+                maxValueInput.setValue(
+                        GTMath.clamp((long) Math.ceil((maxValue / 100.0) * energyCapacity), 0, energyCapacity));
             }
         }
     }


### PR DESCRIPTION
## What
https://discord.com/channels/701354865217110096/1089296351906504835/1436099680613433439

Fixes Adv EU Detector Cover (when attached to a machine block that is not a battery buffer) decrementing its set values when toggling between EU and % modes

## Implementation Details
A floating point division gets cast to long and floored and so it decrements.

What if it just doesn't get floored