### PR TITLE
[MUI] add UI builder option to multis

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -14,6 +14,7 @@ import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
+import com.gregtechceu.gtceu.api.mui.factory.PanelFactory;
 import com.gregtechceu.gtceu.api.pattern.BlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -480,6 +481,11 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
     @Override
     public MultiblockMachineBuilder allowCoverOnFront(boolean allowCoverOnFront) {
         return (MultiblockMachineBuilder) super.allowCoverOnFront(allowCoverOnFront);
+    }
+
+    @Override
+    public MultiblockMachineBuilder UI(PanelFactory ui) {
+        return (MultiblockMachineBuilder) super.UI(ui);
     }
 
     @Override


### PR DESCRIPTION
## What
Changed MachineDefinition without also changing MultiblockMachineDefinition award

## Outcome
EBF: .UI(GTMuiPanels.TEST_PANEL)

https://github.com/user-attachments/assets/c7a7de43-407d-4702-8741-1b103a6f2e6f


## Additional Information
We really should switch this to a MUI-widget-style getThis() based builder so that our subclass doesn't have to override *every single function*
