### PR TITLE
Validate KubeJS recipes to ensure no invalid/missing ingredients

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -457,6 +457,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS notConsumable(TagPrefix orePrefix, Material material) {
+            validateItems("not consumable", orePrefix);
+
             int lastChance = this.chance;
             this.chance = 0;
             inputItems(orePrefix, material);
@@ -815,6 +817,14 @@ public interface GTRecipeSchema {
         }
 
         private void validateItems(String type, OutputItem... items) {
+            for (var item : items) {
+                if (item.isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
+                }
+            }
+        }
+
+        private void validateItems(String type, TagPrefix... items) {
             for (var item : items) {
                 if (item.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -794,7 +794,7 @@ public interface GTRecipeSchema {
 
         private void validateItems(@NotNull String type, InputItem... items) {
             for (var stack : items) {
-                if (stack.isEmpty()) {
+                if (stack == null || stack.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -792,7 +792,7 @@ public interface GTRecipeSchema {
         // ********** VALIDATION ***********//
         //////////////////////////////////////
 
-        private void validateItems(String type, InputItem... items) {
+        private void validateItems(@NotNull String type, InputItem... items) {
             for (var stack : items) {
                 if (stack.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
@@ -800,42 +800,46 @@ public interface GTRecipeSchema {
             }
         }
 
-        private void validateItems(String type, ItemStack... stacks) {
+        private void validateItems(@NotNull String type, ItemStack... stacks) {
             for (var stack : stacks) {
-                if (stack.isEmpty()) {
+                if (stack == null || stack.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
                 }
             }
         }
 
-        private void validateItems(String type, Ingredient... ingredients) {
+        private void validateItems(@NotNull String type, Ingredient... ingredients) {
             for (var ingredient : ingredients) {
-                if (ingredient.isEmpty()) {
+                if (ingredient == null || ingredient.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
                 }
             }
         }
 
-        private void validateItems(String type, OutputItem... items) {
+        private void validateItems(@NotNull String type, OutputItem... items) {
             for (var item : items) {
-                if (item.item.isEmpty()) {
+                if (item == null || item.item == null || item.item.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
                 }
             }
         }
 
-        private void validateItems(String type, TagPrefix... items) {
+        private void validateItems(@NotNull String type, TagPrefix... items) {
             for (var item : items) {
-                if (item.isEmpty()) {
+                if (item == null || item.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
                 }
             }
         }
 
-        private void validateFluids(String type, GTRecipeComponents.FluidIngredientJS... ingredients) {
-            for (var ingredient : ingredients) {
-                for (var stack : ingredient.ingredient().getStacks()) {
-                    if (stack.isEmpty()) {
+        private void validateFluids(@NotNull String type, GTRecipeComponents.FluidIngredientJS... fluids) {
+            for (var fluid : fluids) {
+                if (fluid == null || fluid.ingredient() == null || fluid.ingredient().getStacks() == null) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
+                }
+
+                for (var stack : fluid.ingredient().getStacks()) {
+                    if (stack == null || stack.isEmpty()) {
                         throw new RecipeExceptionJS(
                                 String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
                     }
@@ -843,9 +847,9 @@ public interface GTRecipeSchema {
             }
         }
 
-        private void validateFluids(String type, FluidStackJS... stacks) {
+        private void validateFluids(@NotNull String type, FluidStackJS... stacks) {
             for (var stack : stacks) {
-                if (stack.getFluidStack().isEmpty()) {
+                if (stack == null || stack.getFluidStack() == null || stack.getFluidStack().isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -29,6 +29,7 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.ExtendedOutputIte
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
+import dev.latvian.mods.kubejs.KubeJS;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -818,7 +819,7 @@ public interface GTRecipeSchema {
 
         private void validateItems(String type, OutputItem... items) {
             for (var item : items) {
-                if (item.isEmpty()) {
+                if (item.item.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
                 }
             }
@@ -834,8 +835,12 @@ public interface GTRecipeSchema {
 
         private void validateFluids(String type, GTRecipeComponents.FluidIngredientJS... ingredients) {
             for (var ingredient : ingredients) {
-                if (ingredient.ingredient().isEmpty()) {
-                    throw new RecipeExceptionJS(String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
+                for (var stack : ingredient.ingredient().getStacks()) {
+                    if (stack.isEmpty()) {
+                        throw new RecipeExceptionJS(
+                                String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id)
+                        );
+                    }
                 }
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -264,6 +264,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS inputItems(InputItem... inputs) {
+            validateItems("input", inputs);
+
             for (var stack : inputs) {
                 // test simple item that have pure singular material stack
                 var matStack = ChemicalHelper.getMaterialStack(stack.ingredient.getItems()[0].getItem());
@@ -286,6 +288,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS inputItems(ItemStack... inputs) {
+            validateItems("input", inputs);
+
             for (ItemStack itemStack : inputs) {
                 // test simple item that have pure singular material stack
                 var matStack = ChemicalHelper.getMaterialStack(itemStack);
@@ -365,10 +369,12 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS inputItemsRanged(Ingredient ingredient, int min, int max) {
+            validateItems("ranged input", ingredient);
             return input(ItemRecipeCapability.CAP, new ExtendedOutputItem(ingredient, 1, UniformInt.of(min, max)));
         }
 
         public GTRecipeJS inputItemsRanged(ItemStack stack, int min, int max) {
+            validateItems("ranged input", stack);
             return input(ItemRecipeCapability.CAP, new ExtendedOutputItem(stack, UniformInt.of(min, max)));
         }
 
@@ -389,6 +395,7 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS outputItems(ExtendedOutputItem... outputs) {
+            validateItems("output", outputs);
             for (ExtendedOutputItem itemStack : outputs) {
                 if (itemStack.isEmpty()) {
                     throw new RecipeExceptionJS(String.format("Output items is empty, id: %s", id));
@@ -426,10 +433,12 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS outputItemsRanged(Ingredient ingredient, int min, int max) {
+            validateItems("ranged output", ingredient);
             return output(ItemRecipeCapability.CAP, new ExtendedOutputItem(ingredient, 1, UniformInt.of(min, max)));
         }
 
         public GTRecipeJS outputItemsRanged(ItemStack stack, int min, int max) {
+            validateItems("ranged output", stack);
             return output(ItemRecipeCapability.CAP, new ExtendedOutputItem(stack, UniformInt.of(min, max)));
         }
 
@@ -438,6 +447,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS notConsumable(InputItem itemStack) {
+            validateItems("not consumable", itemStack);
+
             int lastChance = this.chance;
             this.chance = 0;
             inputItems(itemStack);
@@ -454,6 +465,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS notConsumableFluid(GTRecipeComponents.FluidIngredientJS fluid) {
+            validateFluids("not consumable", fluid);
+
             int lastChance = this.chance;
             this.chance = 0;
             inputFluids(fluid);
@@ -469,6 +482,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS chancedInput(InputItem stack, int chance, int tierChanceBoost) {
+            validateItems("chanced input", stack);
+
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
                         String.format("Chance cannot be less or equal to 0 or more than %s, Actual: %s, id: %s",
@@ -486,6 +501,8 @@ public interface GTRecipeSchema {
 
         public GTRecipeJS chancedFluidInput(GTRecipeComponents.FluidIngredientJS stack, int chance,
                                             int tierChanceBoost) {
+            validateFluids("chanced input", stack);
+
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
                         String.format("Chance cannot be less or equal to 0 or more than %s, Actual: %s, id: %s",
@@ -502,6 +519,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS chancedOutput(ExtendedOutputItem stack, int chance, int tierChanceBoost) {
+            validateItems("chanced output", stack);
+
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
                         String.format("Chance cannot be less or equal to 0 or more than %s, Actual: %s, id: %s",
@@ -527,9 +546,7 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS chancedOutput(ExtendedOutputItem stack, String fraction, int tierChanceBoost) {
-            if (stack.isEmpty()) {
-                return this;
-            }
+            validateItems("chanced output", stack);
 
             String[] split = fraction.split("/");
             if (split.length > 2) {
@@ -600,6 +617,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS chancedFluidOutput(FluidStackJS stack, int chance, int tierChanceBoost) {
+            validateFluids("chanced output", stack);
+
             if (0 >= chance || chance > ChanceLogic.getMaxChancedValue()) {
                 throw new RecipeExceptionJS(
                         String.format("Chance cannot be less or equal to 0 or more than %s, Actual: %s, id: %s",
@@ -616,6 +635,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS chancedFluidOutput(FluidStackJS stack, String fraction, int tierChanceBoost) {
+            validateFluids("chanced output", stack);
+
             if (stack.getAmount() == 0) {
                 return this;
             }
@@ -724,6 +745,8 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS inputFluids(GTRecipeComponents.FluidIngredientJS... inputs) {
+            validateFluids("input", inputs);
+
             for (var fluidIng : inputs) {
                 for (var stack : fluidIng.ingredient().getStacks()) {
                     var mat = ChemicalHelper.getMaterial(stack.getFluid());
@@ -741,12 +764,14 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS inputFluidsRanged(FluidStackJS input, IntProvider range) {
+            validateFluids("ranged input", input);
             FluidStack stack = new FluidStack(input.getFluid(), (int) input.getAmount(), input.getNbt());
             return input(FluidRecipeCapability.CAP,
                     IntProviderFluidIngredient.of(FluidIngredient.of(stack), range));
         }
 
         public GTRecipeJS outputFluids(FluidStackJS... outputs) {
+            validateFluids("output", outputs);
             return output(FluidRecipeCapability.CAP, (Object[]) outputs);
         }
 
@@ -755,9 +780,62 @@ public interface GTRecipeSchema {
         }
 
         public GTRecipeJS outputFluidsRanged(FluidStackJS output, IntProvider range) {
+            validateFluids("ranged output", output);
             FluidStack stack = new FluidStack(output.getFluid(), (int) output.getAmount(), output.getNbt());
             return output(FluidRecipeCapability.CAP,
                     IntProviderFluidIngredient.of(FluidIngredient.of(stack), range));
+        }
+
+        //////////////////////////////////////
+        // ********** VALIDATION ***********//
+        //////////////////////////////////////
+
+        private void validateItems(String type, InputItem... items) {
+            for (var stack : items) {
+                if (stack.isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
+                }
+            }
+        }
+
+        private void validateItems(String type, ItemStack... stacks) {
+            for (var stack : stacks) {
+                if (stack.isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
+                }
+            }
+        }
+
+        private void validateItems(String type, Ingredient... ingredients) {
+            for (var ingredient : ingredients) {
+                if (ingredient.isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
+                }
+            }
+        }
+
+        private void validateItems(String type, OutputItem... items) {
+            for (var item : items) {
+                if (item.isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s item (recipe ID: %s)", type, id));
+                }
+            }
+        }
+
+        private void validateFluids(String type, GTRecipeComponents.FluidIngredientJS... ingredients) {
+            for (var ingredient : ingredients) {
+                if (ingredient.ingredient().isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
+                }
+            }
+        }
+
+        private void validateFluids(String type, FluidStackJS... stacks) {
+            for (var stack : stacks) {
+                if (stack.getFluidStack().isEmpty()) {
+                    throw new RecipeExceptionJS(String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
+                }
+            }
         }
 
         //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -29,7 +29,6 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.ExtendedOutputIte
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
-import dev.latvian.mods.kubejs.KubeJS;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -838,8 +837,7 @@ public interface GTRecipeSchema {
                 for (var stack : ingredient.ingredient().getStacks()) {
                     if (stack.isEmpty()) {
                         throw new RecipeExceptionJS(
-                                String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id)
-                        );
+                                String.format("Invalid or empty %s fluid (recipe ID: %s)", type, id));
                     }
                 }
             }


### PR DESCRIPTION
## What

Adds validation and descriptive error messages when an item or fluid is invalid/empty in the recipe IO of recipes added through KubeJS.

**Keep in mind this will cause recipe loading to fail in situations where inputs or outputs were set to items or fluids that don't exist.** This is by design, as there was no validation in those cases previously.

## Potential Compatibility Issues

While initial tests were successful, this should still be tested in the context of some larger modpacks if possible, to ensure nothing breaks in potential edge cases.