### PR TITLE
fix (steam) multiblocks not resetting progress on powerfail

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -296,6 +296,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                         if (machine.self() instanceof IMultiController && !preventPowerFail) {
                             runAttempt = 0;
                             setStatus(Status.SUSPEND);
+                            regressRecipe();
                         }
                     }
                     runDelay = runAttempt * 60;


### PR DESCRIPTION
## What
fixes #4172

## Implementation Details
The regressRecipe() call checks for machine status WAITING, but when a machine hits powerfail its state changes to SUSPEND so the check fails.
So at this point let's just call it.