### PR TITLE
Fix ore veins with only one layer causing crashes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTLayerPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/GTLayerPattern.java
@@ -34,19 +34,24 @@ public class GTLayerPattern {
         this.layers = layers;
     }
 
-    public Layer rollNext(@Nullable Layer previous, RandomSource random) {
+    public @Nullable Layer rollNext(@Nullable Layer previous, RandomSource random) {
+        if (layers.isEmpty()) return null;
+        if (layers.size() == 1) return layers.get(0);
+
         int totalWeight = 0;
-        for (Layer layer : layers)
-            if (layer != previous)
-                totalWeight += layer.weight;
+        for (Layer layer : layers) {
+            if (layer != previous) totalWeight += layer.weight;
+        }
+        // totalWeight should be >0 here but better be safe than sorry
+        if (totalWeight <= 0) return null;
+
         int rolled = random.nextInt(totalWeight);
 
         for (Layer layer : layers) {
-            if (layer == previous)
-                continue;
+            if (layer == previous) continue;
+
             rolled -= layer.weight;
-            if (rolled < 0)
-                return layer;
+            if (rolled < 0) return layer;
         }
         return null;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
@@ -123,7 +123,17 @@ public class LayeredVeinGenerator extends VeinGenerator {
                         GTLayerPattern.Layer next = layerPattern.rollNext(
                                 resolvedLayers.isEmpty() ? null : resolvedLayers.get(resolvedLayers.size() - 1),
                                 random);
-                        float offset = random.nextFloat() * .5f + .5f;
+
+                        float offset = random.nextFloat() * 0.5f + 0.5f;
+                        // insert the previous layer if this one is null (e.g. invalid)
+                        if (next == null) {
+                            if (resolvedLayers.isEmpty()) {
+                                continue;
+                            }
+                            resolvedLayers.add(resolvedLayers.get(resolvedLayers.size() - 1));
+                            layerDiameterOffsets.add(offset);
+                            continue;
+                        }
                         for (int i = 0; i < next.minSize + random.nextInt(1 + next.maxSize - next.minSize); i++) {
                             resolvedLayers.add(next);
                             layerDiameterOffsets.add(offset);

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
@@ -118,6 +118,8 @@ public class LayeredVeinGenerator extends VeinGenerator {
                 for (int zOffset = 0; zOffset < length; zOffset++) {
                     float sizeFractionZ = zOffset * 2f / length - 1;
                     float zSizeSqr = sizeFractionZ * sizeFractionZ;
+                    // OPTIMIZATION: all values in layerDiameterOffsets are in the [0,1] range, so
+                    // check if the size is >1 before doing any of that math
                     if (xSizeSqr + ySizeSqr + zSizeSqr > 1)
                         continue;
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/LayeredVeinGenerator.java
@@ -75,7 +75,9 @@ public class LayeredVeinGenerator extends VeinGenerator {
         if (patternPool.isEmpty())
             return Map.of();
 
-        GTLayerPattern layerPattern = patternPool.get(random.nextInt(patternPool.size()));
+        // minor optimization, usually only one layer pool exists
+        GTLayerPattern layerPattern = patternPool.size() == 1 ?
+                patternPool.get(0) : patternPool.get(random.nextInt(patternPool.size()));
 
         int size = entry.clusterSize().sample(random);
         float density = entry.density();
@@ -101,23 +103,29 @@ public class LayeredVeinGenerator extends VeinGenerator {
 
         for (int xOffset = 0; xOffset < width; xOffset++) {
             float sizeFractionX = xOffset * 2f / width - 1;
-            if ((sizeFractionX * sizeFractionX) > 1)
+            float xSizeSqr = sizeFractionX * sizeFractionX;
+            if (xSizeSqr > 1)
                 continue;
 
             for (int yOffset = 0; yOffset < height; yOffset++) {
                 float sizeFractionY = yOffset * 2f / height - 1;
-                if ((sizeFractionX * sizeFractionX) + (sizeFractionY * sizeFractionY) > 1)
+                float ySizeSqr = sizeFractionY * sizeFractionY;
+                if (xSizeSqr + ySizeSqr > 1)
                     continue;
                 if (level.isOutsideBuildHeight(yMin + yOffset))
                     continue;
 
                 for (int zOffset = 0; zOffset < length; zOffset++) {
                     float sizeFractionZ = zOffset * 2f / length - 1;
+                    float zSizeSqr = sizeFractionZ * sizeFractionZ;
+                    if (xSizeSqr + ySizeSqr + zSizeSqr > 1)
+                        continue;
 
                     int layerIndex = layerCoordinate == 0 ? zOffset : layerCoordinate == 1 ? xOffset : yOffset;
-                    if (slantyCoordinate != layerCoordinate)
+                    if (slantyCoordinate != layerCoordinate) {
                         layerIndex += Mth.floor(
                                 slantyCoordinate == 0 ? zOffset : slantyCoordinate == 1 ? xOffset : yOffset) * slope;
+                    }
 
                     while (layerIndex >= resolvedLayers.size()) {
                         GTLayerPattern.Layer next = layerPattern.rollNext(
@@ -140,8 +148,7 @@ public class LayeredVeinGenerator extends VeinGenerator {
                         }
                     }
 
-                    if ((sizeFractionX * sizeFractionX) + (sizeFractionY * sizeFractionY) +
-                            (sizeFractionZ * sizeFractionZ) > 1 * layerDiameterOffsets.getFloat(layerIndex))
+                    if (xSizeSqr + ySizeSqr + zSizeSqr > layerDiameterOffsets.getFloat(layerIndex))
                         continue;
 
                     GTLayerPattern.Layer layer = resolvedLayers.get(layerIndex);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTOres.java
@@ -387,7 +387,6 @@ public class GTOres {
             .layeredVeinGenerator(generator -> generator
                     .withLayerPattern(() -> GTLayerPattern.builder(OVERWORLD_RULES)
                             .layer(l -> l.weight(3).mat(Coal).size(2, 4))
-                            .layer(l -> l.weight(3).mat(Coal).size(2, 4))
                             .build()))
             .surfaceIndicatorGenerator(indicator -> indicator
                     .surfaceRock(Coal)));


### PR DESCRIPTION
## What
Fixes #2696
Also removed the duplicate layer on the coal vein as it's no longer required

## Implementation Details
Check if only a single layer is defined and if true, don't even try to pick one randomly.
Also did some minor optimizations in the layered vein generator code

## Outcome
no more crash