### PR TITLE
Max Parallel Setting on place

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ParallelHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ParallelHatchPartMachine.java
@@ -35,6 +35,7 @@ public class ParallelHatchPartMachine extends TieredPartMachine implements IFanc
     public ParallelHatchPartMachine(IMachineBlockEntity holder, int tier) {
         super(holder, tier);
         this.maxParallel = (int) Math.pow(4, tier - GTValues.EV);
+        this.currentParallel = maxParallel;
     }
 
     public void setCurrentParallel(int parallelAmount) {


### PR DESCRIPTION
## What
makes the parallel hatch default to the max value when first placed instead of 1

## Implementation Details
current = max in ctor

## Outcome
placing loads of parallel hatches is no longer pain