### PR TITLE
Fix Jade showing all singleblock generators as producing at LV

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
+import com.gregtechceu.gtceu.api.machine.SimpleGeneratorMachine;
 import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.steam.SimpleSteamMachine;
@@ -64,6 +65,8 @@ public class RecipeLogicProvider extends CapabilityBlockProvider<RecipeLogic> {
     public static long getVoltage(RecipeLogic capability) {
         long voltage = -1;
         if (capability.machine instanceof SimpleTieredMachine machine) {
+            voltage = GTValues.V[machine.getTier()];
+        } else if (capability.machine instanceof SimpleGeneratorMachine machine) {
             voltage = GTValues.V[machine.getTier()];
         } else if (capability.machine instanceof WorkableElectricMultiblockMachine machine) {
             voltage = machine.getParts().stream()


### PR DESCRIPTION
## What
Singleblock generators always show their output as being relative to their fuel's recipe's base burn value (usually LV). 
<img width="943" height="243" alt="image" src="https://github.com/user-attachments/assets/c9d930b1-ed97-4d49-b724-ee55a5f0b265" />

## Implementation Details
#4002 included a check for SimpleTieredMachine but singleblock generators are actually SimpleGeneratorMachine

## Outcome
Singleblock generators show their output relative to their actual voltage
<img width="944" height="231" alt="image" src="https://github.com/user-attachments/assets/6ce40ffd-5b8e-439d-af8c-827a8d3e72f4" />
