### PR TITLE
Fix multiblock controller rotation overlay logic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -534,7 +534,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
 
         if (toolTypes.contains(GTToolType.WRENCH)) {
             if (!player.isShiftKeyDown()) {
-                if (isFacingValid(side)) {
+                if (isFacingValid(side) || (allowExtendedFacing() && hasFrontFacing() side == getFrontFacing()) {
                     return GuiTextures.TOOL_FRONT_FACING_ROTATION;
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -534,7 +534,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
 
         if (toolTypes.contains(GTToolType.WRENCH)) {
             if (!player.isShiftKeyDown()) {
-                if (isFacingValid(side) || (allowExtendedFacing() && hasFrontFacing() side == getFrontFacing()) {
+                if (isFacingValid(side) || (allowExtendedFacing() && hasFrontFacing() && side == getFrontFacing())) {
                     return GuiTextures.TOOL_FRONT_FACING_ROTATION;
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -533,7 +533,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
         }
 
         if (toolTypes.contains(GTToolType.WRENCH)) {
-            if (player.isShiftKeyDown()) {
+            if (!player.isShiftKeyDown()) {
                 if (isFacingValid(side)) {
                     return GuiTextures.TOOL_FRONT_FACING_ROTATION;
                 }


### PR DESCRIPTION
## What
This fixes #4098 and unifies the multiblock controller's rotation overlay behavior with the singleblock machine's overlay (when holding a wrench and not sneaking/sneaking)

The singleblock logic is [here](https://github.com/jkieberking/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleTieredMachine.java#L456-L464)

## Outcome

**not sneaking**
EBF:
<img width="2552" height="1076" alt="image" src="https://github.com/user-attachments/assets/83ce8041-0e23-4c58-a353-45535516ddbb" />

LCR:
<img width="2555" height="1075" alt="image" src="https://github.com/user-attachments/assets/32615285-b112-433c-a233-0d1cb0203501" />

Electrolyzer:
<img width="2547" height="1072" alt="image" src="https://github.com/user-attachments/assets/b381c9ae-ee92-4d54-858c-a2fcfd1106b9" />


**sneaking**

EBF:
<img width="2559" height="1079" alt="image" src="https://github.com/user-attachments/assets/317f898d-925b-4e18-b3e8-4d96371a708b" />

LCR
<img width="2555" height="1079" alt="image" src="https://github.com/user-attachments/assets/8b76551f-4af3-4cea-995a-c53b4160b8f6" />

Electrolyzer:
<img width="2549" height="1071" alt="image" src="https://github.com/user-attachments/assets/c232a1d3-c9b2-4eab-8bc2-b44b9706e597" />
