### PR TITLE
Implement creating Chanced and Ranged NBTPredicateIngredients

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -490,7 +490,7 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipeBuilder inputItemNbtPredicate(ItemStack stack, NBTPredicate predicate) {
-        if (missingIngredientError(0, true, ItemRecipeCapability.CAP, input::isEmpty)) {
+        if (missingIngredientError(0, true, ItemRecipeCapability.CAP, stack::isEmpty)) {
             return this;
         }
         gatherMaterialInfoFromStack(stack);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -464,12 +464,12 @@ public class GTRecipeBuilder {
         return inputItems(machine.asStack(count));
     }
 
-    public GTRecipeBuilder inputItemsRanged(IntProviderIngredient provider) {
+    public GTRecipeBuilder inputItemRanged(IntProviderIngredient provider) {
         return inputItems(provider);
     }
 
     public GTRecipeBuilder inputItemsRanged(ItemStack input, IntProvider intProvider) {
-        return inputItemsRanged(IntProviderIngredient.of(input, intProvider));
+        return inputItemRanged(IntProviderIngredient.of(input, intProvider));
     }
 
     public GTRecipeBuilder inputItemsRanged(Item input, IntProvider intProvider) {
@@ -618,12 +618,12 @@ public class GTRecipeBuilder {
         return output(ItemRecipeCapability.CAP, ingredient);
     }
 
-    public GTRecipeBuilder outputItemsRanged(IntProviderIngredient provider) {
+    public GTRecipeBuilder outputItemRanged(IntProviderIngredient provider) {
         return outputItems(provider);
     }
 
     public GTRecipeBuilder outputItemsRanged(ItemStack output, IntProvider intProvider) {
-        return outputItemsRanged(IntProviderIngredient.of(output, intProvider));
+        return outputItemRanged(IntProviderIngredient.of(output, intProvider));
     }
 
     public GTRecipeBuilder outputItemsRanged(Item input, IntProvider intProvider) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -771,19 +771,19 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedInput (ItemStack stack, int chance, int tierChanceBoost){
+    public GTRecipeBuilder chancedInput(ItemStack stack, int chance, int tierChanceBoost) {
         return chancedInput(Ingredient.of(stack), chance, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedInput (FluidStack stack, int chance, int tierChanceBoost){
+    public GTRecipeBuilder chancedInput(FluidStack stack, int chance, int tierChanceBoost) {
         return chancedInput(FluidIngredient.of(stack), chance, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedOutput (ItemStack stack, int chance, int tierChanceBoost){
+    public GTRecipeBuilder chancedOutput(ItemStack stack, int chance, int tierChanceBoost) {
         return chancedOutput(Ingredient.of(stack), chance, tierChanceBoost);
     }
 
-    public GTRecipeBuilder chancedOutput (FluidStack stack, int chance, int tierChanceBoost){
+    public GTRecipeBuilder chancedOutput(FluidStack stack, int chance, int tierChanceBoost) {
         return chancedOutput(FluidIngredient.of(stack), chance, tierChanceBoost);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -464,8 +464,12 @@ public class GTRecipeBuilder {
         return inputItems(machine.asStack(count));
     }
 
+    public GTRecipeBuilder inputItemsRanged(IntProviderIngredient provider) {
+        return inputItems(provider);
+    }
+
     public GTRecipeBuilder inputItemsRanged(ItemStack input, IntProvider intProvider) {
-        return inputItems(IntProviderIngredient.of(input, intProvider));
+        return inputItemsRanged(IntProviderIngredient.of(input, intProvider));
     }
 
     public GTRecipeBuilder inputItemsRanged(Item input, IntProvider intProvider) {
@@ -614,8 +618,12 @@ public class GTRecipeBuilder {
         return output(ItemRecipeCapability.CAP, ingredient);
     }
 
+    public GTRecipeBuilder outputItemsRanged(IntProviderIngredient provider) {
+        return outputItems(provider);
+    }
+
     public GTRecipeBuilder outputItemsRanged(ItemStack output, IntProvider intProvider) {
-        return outputItems(IntProviderIngredient.of(output, intProvider));
+        return outputItemsRanged(IntProviderIngredient.of(output, intProvider));
     }
 
     public GTRecipeBuilder outputItemsRanged(Item input, IntProvider intProvider) {
@@ -707,7 +715,7 @@ public class GTRecipeBuilder {
         return notConsumable(IntCircuitIngredient.of(configuration));
     }
 
-    public GTRecipeBuilder chancedInput(ItemStack stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedInput(Ingredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -721,7 +729,7 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedInput(FluidStack stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedInput(FluidIngredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -735,7 +743,7 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(ItemStack stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedOutput(Ingredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -749,7 +757,7 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(FluidStack stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedOutput(FluidIngredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -761,6 +769,22 @@ public class GTRecipeBuilder {
         this.chance = lastChance;
         this.tierChanceBoost = lastTierChanceBoost;
         return this;
+    }
+
+    public GTRecipeBuilder chancedInput (ItemStack stack, int chance, int tierChanceBoost){
+        return chancedInput(Ingredient.of(stack), chance, tierChanceBoost);
+    }
+
+    public GTRecipeBuilder chancedInput (FluidStack stack, int chance, int tierChanceBoost){
+        return chancedInput(FluidIngredient.of(stack), chance, tierChanceBoost);
+    }
+
+    public GTRecipeBuilder chancedOutput (ItemStack stack, int chance, int tierChanceBoost){
+        return chancedOutput(Ingredient.of(stack), chance, tierChanceBoost);
+    }
+
+    public GTRecipeBuilder chancedOutput (FluidStack stack, int chance, int tierChanceBoost){
+        return chancedOutput(FluidIngredient.of(stack), chance, tierChanceBoost);
     }
 
     public GTRecipeBuilder chancedOutput(TagPrefix tag, Material mat, int chance, int tierChanceBoost) {
@@ -974,12 +998,16 @@ public class GTRecipeBuilder {
         return input(FluidRecipeCapability.CAP, ingredients.toArray(FluidIngredient[]::new));
     }
 
-    public GTRecipeBuilder inputFluidsRanged(FluidStack input, IntProvider intProvider) {
-        return inputFluidsRanged(FluidIngredient.of(input), intProvider);
+    public GTRecipeBuilder inputFluidsRanged(IntProviderFluidIngredient provider) {
+        return inputFluids(provider);
     }
 
     protected GTRecipeBuilder inputFluidsRanged(FluidIngredient input, IntProvider intProvider) {
-        return inputFluids(IntProviderFluidIngredient.of(input, intProvider));
+        return inputFluidsRanged(IntProviderFluidIngredient.of(input, intProvider));
+    }
+
+    public GTRecipeBuilder inputFluidsRanged(FluidStack input, IntProvider intProvider) {
+        return inputFluidsRanged(FluidIngredient.of(input), intProvider);
     }
 
     public GTRecipeBuilder inputFluids(FluidIngredient... inputs) {
@@ -999,12 +1027,16 @@ public class GTRecipeBuilder {
         return output(FluidRecipeCapability.CAP, outputs);
     }
 
-    public GTRecipeBuilder outputFluidsRanged(FluidStack output, IntProvider intProvider) {
-        return outputFluidsRanged(FluidIngredient.of(output), intProvider);
+    public GTRecipeBuilder outputFluidsRanged(IntProviderFluidIngredient provider) {
+        return outputFluids(provider);
     }
 
     protected GTRecipeBuilder outputFluidsRanged(FluidIngredient output, IntProvider intProvider) {
-        return outputFluids(IntProviderFluidIngredient.of(output, intProvider));
+        return outputFluidsRanged(IntProviderFluidIngredient.of(output, intProvider));
+    }
+
+    public GTRecipeBuilder outputFluidsRanged(FluidStack output, IntProvider intProvider) {
+        return outputFluidsRanged(FluidIngredient.of(output), intProvider);
     }
 
     //////////////////////////////////////

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateTest.java
@@ -1,25 +1,71 @@
 package com.gregtechceu.gtceu.api.recipe.ingredient;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.ingredient.nbtpredicate.NBTPredicate;
 
+import com.gregtechceu.gtceu.gametest.util.TestUtils;
+import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.BeforeBatch;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
 import static com.gregtechceu.gtceu.api.recipe.ingredient.nbtpredicate.NBTPredicates.*;
-import static com.gregtechceu.gtceu.api.recipe.ingredient.nbtpredicate.NBTPredicates.eq;
+import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.CHEMICAL_RECIPES;
+import static com.gregtechceu.gtceu.gametest.util.TestUtils.getMetaMachine;
 
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class NBTPredicateTest {
+    private static GTRecipeType CR_RECIPE_TYPE;
 
     @BeforeBatch(batch = "NBTPredicateTest")
-    public static void prepare(ServerLevel level) {}
+    public static void prepare(ServerLevel level) {
+        CR_RECIPE_TYPE = TestUtils.createRecipeType("nbt_predicate_ingredient_cr_tests", CHEMICAL_RECIPES);
+        CR_RECIPE_TYPE.getLookup().addRecipe(
+                CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test")
+                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
+                        .outputItems(new ItemStack(Items.COAL))
+                        .EUt(GTValues.V[GTValues.HV])
+                        .duration(5)
+                        .buildRawRecipe());
+/*
+        CR_RECIPE_TYPE.getLookup().addRecipe(
+                CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_chanced")
+                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
+                        .outputItems(new ItemStack(Items.COAL))
+                        .EUt(GTValues.V[GTValues.HV])
+                        .duration(5)
+                        .buildRawRecipe());
+
+        CR_RECIPE_TYPE.getLookup().addRecipe(
+                CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_ranged")
+                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
+                        .outputItems(new ItemStack(Items.COAL))
+                        .EUt(GTValues.V[GTValues.HV])
+                        .duration(5)
+                        .buildRawRecipe());
+
+        CR_RECIPE_TYPE.getLookup().addRecipe(
+                CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_chanced_ranged")
+                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
+                        .outputItems(new ItemStack(Items.COAL))
+                        .EUt(GTValues.V[GTValues.HV])
+                        .duration(5)
+                        .buildRawRecipe());
+ */
+    }
 
     @GameTest(template = "empty", batch = "NBTPredicateTest")
     public static void NBTPredicateEqualsTest(GameTestHelper helper) {
@@ -175,5 +221,46 @@ public class NBTPredicateTest {
         helper.assertFalse(lte("num", 9).test(tag),
                 "Less-or-equal NBTPredicate  succeeded with empty tag");
         helper.succeed();
+    }
+
+
+    @GameTest(template = "singleblock_chem_reactor", batch = "NBTPredicateTest")
+    public static void NBTPredicateMachineCRTestSucceeds(GameTestHelper helper) {
+        SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
+                helper.getBlockEntity(new BlockPos(0, 1, 0)));
+
+        machine.setRecipeType(CR_RECIPE_TYPE);
+        NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP).get(0);
+        NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
+
+        var inputStack = new ItemStack(Items.FEATHER);
+        inputStack.getOrCreateTag().putString("foo", "bar");
+        itemIn.setStackInSlot(0, inputStack);
+        helper.runAfterDelay(10, () -> {
+            helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)), "NBT Predicate test didn't run when it should have.");
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = "singleblock_chem_reactor", batch = "NBTPredicateTest")
+    public static void NBTPredicateMachineCRTestDoesntSucceed(GameTestHelper helper) {
+        SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
+                helper.getBlockEntity(new BlockPos(0, 1, 0)));
+
+        machine.setRecipeType(CR_RECIPE_TYPE);
+        NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP).get(0);
+        NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
+
+        var inputStack = new ItemStack(Items.FEATHER);
+        inputStack.getOrCreateTag().putString("foo", "baz");
+        itemIn.setStackInSlot(0, inputStack);
+        helper.runAfterDelay(10, () -> {
+            helper.assertFalse(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)), "NBT Predicate test ran when it shouldn't have.");
+            helper.succeed();
+        });
     }
 }

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateTest.java
@@ -8,8 +8,8 @@ import com.gregtechceu.gtceu.api.machine.SimpleTieredMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.ingredient.nbtpredicate.NBTPredicate;
-
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.BeforeBatch;
 import net.minecraft.gametest.framework.GameTest;
@@ -19,7 +19,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
@@ -30,6 +29,7 @@ import static com.gregtechceu.gtceu.gametest.util.TestUtils.getMetaMachine;
 @PrefixGameTestTemplate(false)
 @GameTestHolder(GTCEu.MOD_ID)
 public class NBTPredicateTest {
+
     private static GTRecipeType CR_RECIPE_TYPE;
 
     @BeforeBatch(batch = "NBTPredicateTest")
@@ -56,7 +56,7 @@ public class NBTPredicateTest {
         CR_RECIPE_TYPE.getLookup().addRecipe(
                 CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_ranged")
                         .inputItemRanged(new IntProviderIngredient(new NBTPredicateIngredient(
-                                new ItemStack(Items.FEATHER), eq("bash", "bar")), UniformInt.of(0,4)))
+                                new ItemStack(Items.FEATHER), eq("bash", "bar")), UniformInt.of(0, 4)))
                         .outputItems(new ItemStack(Items.COBBLESTONE))
                         .EUt(GTValues.V[GTValues.HV])
                         .duration(4)
@@ -66,7 +66,7 @@ public class NBTPredicateTest {
                 CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_chanced_ranged")
                         .chance(4000)
                         .inputItemRanged(new IntProviderIngredient(new NBTPredicateIngredient(
-                                new ItemStack(Items.FEATHER), eq("bash", "botch")), UniformInt.of(0,4)))
+                                new ItemStack(Items.FEATHER), eq("bash", "botch")), UniformInt.of(0, 4)))
                         .chance(10000)
                         .outputItems(new ItemStack(Items.DEEPSLATE))
                         .EUt(GTValues.V[GTValues.HV])
@@ -230,7 +230,6 @@ public class NBTPredicateTest {
         helper.succeed();
     }
 
-
     @GameTest(template = "singleblock_chem_reactor", batch = "NBTPredicateTest")
     public static void NBTPredicateMachineCRTestSucceeds(GameTestHelper helper) {
         SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
@@ -246,7 +245,8 @@ public class NBTPredicateTest {
         inputStack.getOrCreateTag().putString("foo", "bar");
         itemIn.setStackInSlot(0, inputStack);
         helper.runAfterDelay(10, () -> {
-            helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)), "NBT Predicate test didn't run when it should have.");
+            helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)),
+                    "NBT Predicate test didn't run when it should have.");
             helper.succeed();
         });
     }
@@ -266,7 +266,8 @@ public class NBTPredicateTest {
         inputStack.getOrCreateTag().putString("foo", "baz");
         itemIn.setStackInSlot(0, inputStack);
         helper.runAfterDelay(10, () -> {
-            helper.assertFalse(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)), "NBT Predicate test ran when it shouldn't have.");
+            helper.assertFalse(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)),
+                    "NBT Predicate test ran when it shouldn't have.");
             helper.succeed();
         });
     }
@@ -282,15 +283,15 @@ public class NBTPredicateTest {
         NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
                 .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
 
-        var inputStack = new ItemStack(Items.FEATHER, 15); //one short, a chance roll needs to fail
+        var inputStack = new ItemStack(Items.FEATHER, 15); // one short, a chance roll needs to fail
         inputStack.getOrCreateTag().putString("bin", "bar");
         itemIn.setStackInSlot(0, inputStack);
-        helper.runAfterDelay(4*16+1, () -> {
+        helper.runAfterDelay(4 * 16 + 1, () -> {
             helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.CHARCOAL)),
                     "NBT Predicate Chanced test ran the wrong recipe!");
             helper.assertTrue(itemOut.getStackInSlot(0).getCount() == 16,
-                    "NBT Predicate Chanced test didn't complete enough recipe runs, completed ["+
-                    itemOut.getStackInSlot(0).getCount()+"], not [16]");
+                    "NBT Predicate Chanced test didn't complete enough recipe runs, completed [" +
+                            itemOut.getStackInSlot(0).getCount() + "], not [16]");
             helper.assertFalse(itemIn.getStackInSlot(0).getCount() == 15,
                     "NBT Predicate Chanced test didn't consume items");
             helper.assertFalse(itemIn.getStackInSlot(0).isEmpty(),
@@ -310,15 +311,15 @@ public class NBTPredicateTest {
         NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
                 .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
 
-        var inputStack = new ItemStack(Items.FEATHER, 63); //one short, a range needs to roll not max
+        var inputStack = new ItemStack(Items.FEATHER, 63); // one short, a range needs to roll not max
         inputStack.getOrCreateTag().putString("bash", "bar");
         itemIn.setStackInSlot(0, inputStack);
-        helper.runAfterDelay(4*16+1, () -> {
+        helper.runAfterDelay(4 * 16 + 1, () -> {
             helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COBBLESTONE)),
                     "NBT Predicate Ranged test ran the wrong recipe!");
             helper.assertTrue(itemOut.getStackInSlot(0).getCount() == 16,
-                    "NBT Predicate Ranged test didn't complete enough recipe runs, completed ["+
-                    itemOut.getStackInSlot(0).getCount()+"], not [16]");
+                    "NBT Predicate Ranged test didn't complete enough recipe runs, completed [" +
+                            itemOut.getStackInSlot(0).getCount() + "], not [16]");
             helper.assertFalse(itemIn.getStackInSlot(0).getCount() == 15,
                     "NBT Predicate Ranged test didn't consume items");
             helper.assertFalse(itemIn.getStackInSlot(0).isEmpty(),
@@ -338,15 +339,15 @@ public class NBTPredicateTest {
         NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
                 .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
 
-        var inputStack = new ItemStack(Items.FEATHER, 63); //one short, a chance or range needs to not max
+        var inputStack = new ItemStack(Items.FEATHER, 63); // one short, a chance or range needs to not max
         inputStack.getOrCreateTag().putString("bash", "botch");
         itemIn.setStackInSlot(0, inputStack);
-        helper.runAfterDelay(4*16+1, () -> {
+        helper.runAfterDelay(4 * 16 + 1, () -> {
             helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.DEEPSLATE)),
                     "NBT Predicate Chanced Ranged test ran the wrong recipe!");
             helper.assertTrue(itemOut.getStackInSlot(0).getCount() == 16,
-                    "NBT Predicate Chanced Ranged test didn't complete enough recipe runs, completed ["+
-                    itemOut.getStackInSlot(0).getCount()+"], not [16]");
+                    "NBT Predicate Chanced Ranged test didn't complete enough recipe runs, completed [" +
+                            itemOut.getStackInSlot(0).getCount() + "], not [16]");
             helper.assertFalse(itemIn.getStackInSlot(0).getCount() == 15,
                     "NBT Predicate Chanced Ranged test didn't consume items");
             helper.assertFalse(itemIn.getStackInSlot(0).isEmpty(),

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateTest.java
@@ -16,8 +16,10 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
@@ -40,31 +42,36 @@ public class NBTPredicateTest {
                         .EUt(GTValues.V[GTValues.HV])
                         .duration(5)
                         .buildRawRecipe());
-/*
+
         CR_RECIPE_TYPE.getLookup().addRecipe(
                 CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_chanced")
-                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
-                        .outputItems(new ItemStack(Items.COAL))
+                        .chance(4000)
+                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("bin", "bar"))
+                        .chance(10000)
+                        .outputItems(new ItemStack(Items.CHARCOAL))
                         .EUt(GTValues.V[GTValues.HV])
-                        .duration(5)
+                        .duration(4)
                         .buildRawRecipe());
 
         CR_RECIPE_TYPE.getLookup().addRecipe(
                 CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_ranged")
-                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
-                        .outputItems(new ItemStack(Items.COAL))
+                        .inputItemRanged(new IntProviderIngredient(new NBTPredicateIngredient(
+                                new ItemStack(Items.FEATHER), eq("bash", "bar")), UniformInt.of(0,4)))
+                        .outputItems(new ItemStack(Items.COBBLESTONE))
                         .EUt(GTValues.V[GTValues.HV])
-                        .duration(5)
+                        .duration(4)
                         .buildRawRecipe());
 
         CR_RECIPE_TYPE.getLookup().addRecipe(
                 CR_RECIPE_TYPE.recipeBuilder("nbt_predicate_test_chanced_ranged")
-                        .inputItemNbtPredicate(new ItemStack(Items.FEATHER), eq("foo", "bar"))
-                        .outputItems(new ItemStack(Items.COAL))
+                        .chance(4000)
+                        .inputItemRanged(new IntProviderIngredient(new NBTPredicateIngredient(
+                                new ItemStack(Items.FEATHER), eq("bash", "botch")), UniformInt.of(0,4)))
+                        .chance(10000)
+                        .outputItems(new ItemStack(Items.DEEPSLATE))
                         .EUt(GTValues.V[GTValues.HV])
-                        .duration(5)
+                        .duration(4)
                         .buildRawRecipe());
- */
     }
 
     @GameTest(template = "empty", batch = "NBTPredicateTest")
@@ -260,6 +267,90 @@ public class NBTPredicateTest {
         itemIn.setStackInSlot(0, inputStack);
         helper.runAfterDelay(10, () -> {
             helper.assertFalse(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COAL)), "NBT Predicate test ran when it shouldn't have.");
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = "singleblock_chem_reactor", batch = "NBTPredicateTest")
+    public static void NBTPredicateMachineCRTestChanced(GameTestHelper helper) {
+        SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
+                helper.getBlockEntity(new BlockPos(0, 1, 0)));
+
+        machine.setRecipeType(CR_RECIPE_TYPE);
+        NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP).get(0);
+        NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
+
+        var inputStack = new ItemStack(Items.FEATHER, 15); //one short, a chance roll needs to fail
+        inputStack.getOrCreateTag().putString("bin", "bar");
+        itemIn.setStackInSlot(0, inputStack);
+        helper.runAfterDelay(4*16+1, () -> {
+            helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.CHARCOAL)),
+                    "NBT Predicate Chanced test ran the wrong recipe!");
+            helper.assertTrue(itemOut.getStackInSlot(0).getCount() == 16,
+                    "NBT Predicate Chanced test didn't complete enough recipe runs, completed ["+
+                    itemOut.getStackInSlot(0).getCount()+"], not [16]");
+            helper.assertFalse(itemIn.getStackInSlot(0).getCount() == 15,
+                    "NBT Predicate Chanced test didn't consume items");
+            helper.assertFalse(itemIn.getStackInSlot(0).isEmpty(),
+                    "NBT Predicate Chanced test consumed too many items");
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = "singleblock_chem_reactor", batch = "NBTPredicateTest")
+    public static void NBTPredicateMachineCRTestRanged(GameTestHelper helper) {
+        SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
+                helper.getBlockEntity(new BlockPos(0, 1, 0)));
+
+        machine.setRecipeType(CR_RECIPE_TYPE);
+        NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP).get(0);
+        NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
+
+        var inputStack = new ItemStack(Items.FEATHER, 63); //one short, a range needs to roll not max
+        inputStack.getOrCreateTag().putString("bash", "bar");
+        itemIn.setStackInSlot(0, inputStack);
+        helper.runAfterDelay(4*16+1, () -> {
+            helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.COBBLESTONE)),
+                    "NBT Predicate Ranged test ran the wrong recipe!");
+            helper.assertTrue(itemOut.getStackInSlot(0).getCount() == 16,
+                    "NBT Predicate Ranged test didn't complete enough recipe runs, completed ["+
+                    itemOut.getStackInSlot(0).getCount()+"], not [16]");
+            helper.assertFalse(itemIn.getStackInSlot(0).getCount() == 15,
+                    "NBT Predicate Ranged test didn't consume items");
+            helper.assertFalse(itemIn.getStackInSlot(0).isEmpty(),
+                    "NBT Predicate Ranged test consumed too many items");
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = "singleblock_chem_reactor", batch = "NBTPredicateTest")
+    public static void NBTPredicateMachineCRTestChancedRanged(GameTestHelper helper) {
+        SimpleTieredMachine machine = (SimpleTieredMachine) getMetaMachine(
+                helper.getBlockEntity(new BlockPos(0, 1, 0)));
+
+        machine.setRecipeType(CR_RECIPE_TYPE);
+        NotifiableItemStackHandler itemIn = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP).get(0);
+        NotifiableItemStackHandler itemOut = (NotifiableItemStackHandler) machine
+                .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).get(0);
+
+        var inputStack = new ItemStack(Items.FEATHER, 63); //one short, a chance or range needs to not max
+        inputStack.getOrCreateTag().putString("bash", "botch");
+        itemIn.setStackInSlot(0, inputStack);
+        helper.runAfterDelay(4*16+1, () -> {
+            helper.assertTrue(ItemStack.isSameItemSameTags(itemOut.getStackInSlot(0), new ItemStack(Items.DEEPSLATE)),
+                    "NBT Predicate Chanced Ranged test ran the wrong recipe!");
+            helper.assertTrue(itemOut.getStackInSlot(0).getCount() == 16,
+                    "NBT Predicate Chanced Ranged test didn't complete enough recipe runs, completed ["+
+                    itemOut.getStackInSlot(0).getCount()+"], not [16]");
+            helper.assertFalse(itemIn.getStackInSlot(0).getCount() == 15,
+                    "NBT Predicate Chanced Ranged test didn't consume items");
+            helper.assertFalse(itemIn.getStackInSlot(0).isEmpty(),
+                    "NBT Predicate Chanced Ranged test consumed too many items");
             helper.succeed();
         });
     }


### PR DESCRIPTION
## What
Implements tests for NBTPredicateIngredients in machine recipes so that we can make sure they actually work, and actually work with 

To enable this:
* Fixes a bug where NBTPIs cannot be the first ingredient added to a recipe
* Adds genericized .itemInputRanged() and .chancedInput() functions to the internal recipe builder, allowing them to accept more complex Ingredients rather than only ItemStacks.