### PR TITLE
Remove unnecessary third argument in the holder of the Example Turbine.

### DIFF
--- a/docs/content/Modpacks/Examples/Multiblocks/Example_Turbine.md
+++ b/docs/content/Modpacks/Examples/Multiblocks/Example_Turbine.md
@@ -46,7 +46,7 @@ Below is an example of a multiblock using the LargeTurbineMachine class for maki
 === "Java"
     ```java title="MultiMachines.java"
     public static final MultiblockMachineDefinition HYPER_GAS_TURBINE = REGISTRATE
-            .multiblock("hyper_gas_turbine", (holder) -> new LargeTurbineMachine(holder, GTValues.LuV, 4)) // The value shows one rotor holder tier above the recommended minimum rotor holder. The tier of rotor holder provides a boost based on the efficiency stat.
+            .multiblock("hyper_gas_turbine", (holder) -> new LargeTurbineMachine(holder, GTValues.LuV)) // The value shows one rotor holder tier above the recommended minimum rotor holder. The tier of rotor holder provides a boost based on the efficiency stat.
             .rotationState(RotationState.NON_Y_AXIS)
             .recipeType(GTRecipeTypes.GAS_TURBINE_FUELS)
             .recipeModifiers(GTRecipeModifiers.OC_NON_PERFECT_SUBTICK, GTRecipeModifiers.BATCH_MODE, LargeTurbineMachine::recipeModifier)


### PR DESCRIPTION
.multiblock("hyper_gas_turbine", (holder) -> new LargeTurbineMachine(holder, GTValues.LuV, 4)) -> .multiblock("hyper_gas_turbine", (holder) -> new LargeTurbineMachine(holder, GTValues.LuV))