### PR TITLE
Fix scythe not breaking items in an AOE

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
@@ -125,7 +125,6 @@ public class GTToolType {
                     .aoe(2, 2, 2)
                     .behaviors(AOEConfigUIBehavior.INSTANCE, HoeGroundBehavior.INSTANCE, HarvestCropsBehavior.INSTANCE)
                     .canApplyEnchantment(EnchantmentCategory.DIGGER))
-            .constructor(GTHoeItem::new)
             .toolClassNames("scythe")
             .toolClasses(GTToolType.HOE)
             .defaultActions(ToolActions.HOE_DIG)

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolType.java
@@ -113,6 +113,7 @@ public class GTToolType {
                     .durabilityMultiplier(3.0F)
                     .behaviors(AOEConfigUIBehavior.INSTANCE, GrassPathBehavior.INSTANCE,
                             DouseCampfireBehavior.INSTANCE))
+            .constructor(GTShovelItem::new)
             .toolClasses(GTToolType.SHOVEL)
             .defaultActions(ToolActions.SHOVEL_DIG)
             .materialAmount(3 * GTValues.M)
@@ -125,6 +126,7 @@ public class GTToolType {
                     .aoe(2, 2, 2)
                     .behaviors(AOEConfigUIBehavior.INSTANCE, HoeGroundBehavior.INSTANCE, HarvestCropsBehavior.INSTANCE)
                     .canApplyEnchantment(EnchantmentCategory.DIGGER))
+            .constructor(GTHoeItem::new)
             .toolClassNames("scythe")
             .toolClasses(GTToolType.HOE)
             .defaultActions(ToolActions.HOE_DIG)

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -548,21 +548,26 @@ public class ToolHelper {
         return successful;
     }
 
+    /**
+     * Calculates the harvestable blocks, used for tool AoE harvesting
+     *
+     * @param player the player clicking the item
+     * @param stack  the item that was used
+     *
+     * @return listOfBlockPositions or empty list if none
+     */
     public static List<BlockPos> getHarvestableBlocks(ItemStack stack, Player player) {
-        if (!hasBehaviorsTag(stack)) return List.of();
+        final List<BlockPos> NO_BLOCKS = List.of();
+
+        if (!hasBehaviorsTag(stack)) return NO_BLOCKS;
 
         var aoeDefinition = getAoEDefinition(stack);
         if (aoeDefinition.isZero()) {
-            return List.of();
+            return NO_BLOCKS;
         }
 
+        InteractionHand hand = InteractionHand.MAIN_HAND;
         BlockHitResult hitResult = getPlayerDefaultRaytrace(player);
-        var toolType = player.getItemInHand(InteractionHand.MAIN_HAND).getItem() instanceof GTToolItem toolItem ?
-                toolItem.toolType : null;
-        if (toolType == null) return Collections.emptyList();
-        var hand = is(player.getItemInHand(InteractionHand.MAIN_HAND), toolType) ?
-                InteractionHand.MAIN_HAND : null;
-        if (hand == null) return Collections.emptyList();
         UseOnContext context = new UseOnContext(player, hand, hitResult);
         return getHarvestableBlocks(aoeDefinition, context);
     }


### PR DESCRIPTION

## What
- Fixes #3970
- Corrects AoE block breaking behavior for the scythe
- Includes a small cleanup/refactor of getHarvestableBlocks to simplify logic and remove unused checks

## Implementation Details
The cleanup commit does not change tool behavior by itself, it only removes dead or redundant logic.

All changes were tested with multiple GregTech AoE tools, and everything behaved correctly in my tests, but a review is recommended.

