### PR TITLE
Use manual tag checking instead of IsSameItemSameTags

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -119,7 +119,7 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
                             break;
                         }
                     } else if (obj instanceof ItemStack stack1) {
-                        if (ItemStack.isSameItemSameTags(stack, stack1)) {
+                        if (GTUtil.isSameItemSameTags(stack, stack1)) {
                             isEqual = true;
                             break;
                         }

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.widget.PhantomSlotWidget;
 import com.gregtechceu.gtceu.api.gui.widget.ToggleButtonWidget;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 
@@ -157,7 +158,7 @@ public class SimpleItemFilter implements ItemFilter {
             if (ignoreNbt && ItemStack.isSameItem(candidate, itemStack)) {
                 totalCount += candidate.getCount();
             }
-            if (!ignoreNbt && ItemStack.isSameItemSameTags(candidate, itemStack)) {
+            if (!ignoreNbt && GTUtil.isSameItemSameTags(candidate, itemStack)) {
                 totalCount += candidate.getCount();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/gui/widget/TankWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/gui/widget/TankWidget.java
@@ -10,6 +10,7 @@ import com.gregtechceu.gtceu.integration.xei.entry.fluid.FluidTagList;
 import com.gregtechceu.gtceu.integration.xei.handlers.fluid.CycleFluidEntryHandler;
 import com.gregtechceu.gtceu.integration.xei.handlers.fluid.CycleFluidStackHandler;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.gui.editor.annotation.Configurable;
 import com.lowdragmc.lowdraglib.gui.editor.annotation.LDLRegister;
@@ -532,7 +533,7 @@ public class TankWidget extends Widget implements IRecipeIngredientSlot, IConfig
 
                 if (filledResult.isEmpty()) {
                     filledResult = remainingStack.copy();
-                } else if (ItemStack.isSameItemSameTags(filledResult, remainingStack)) {
+                } else if (GTUtil.isSameItemSameTags(filledResult, remainingStack)) {
                     if (filledResult.getCount() < filledResult.getMaxStackSize())
                         filledResult.grow(1);
                     else
@@ -578,7 +579,7 @@ public class TankWidget extends Widget implements IRecipeIngredientSlot, IConfig
 
                 if (drainedResult.isEmpty()) {
                     drainedResult = remainingStack.copy();
-                } else if (ItemStack.isSameItemSameTags(drainedResult, remainingStack)) {
+                } else if (GTUtil.isSameItemSameTags(drainedResult, remainingStack)) {
                     if (drainedResult.getCount() < drainedResult.getMaxStackSize())
                         drainedResult.grow(1);
                     else

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -11,6 +11,7 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
 import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
@@ -30,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
@@ -135,8 +135,7 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                     int outputStorageLimit = 0;
                     for (int slot = 0; slot < storage.getSlots(); ++slot) {
                         ItemStack stack = storage.getStackInSlot(slot);
-                        if (stack.isEmpty() || (ItemStack.isSameItem(stack, output) &&
-                                Objects.equals(stack.getTag(), output.getTag()))) {
+                        if (stack.isEmpty() || GTUtil.isSameItemSameTags(stack, output)) {
                             outputStorageLimit += storage.getSlotLimit(slot) - stack.getCount();
                         }
                     }
@@ -177,8 +176,7 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                 } else { // IO.OUT
                     ItemStack output = items[0].copyWithCount(amount);
                     // Only try this slot if not visited or if visited with the same type of item
-                    if (visited[slot] == null || (ItemStack.isSameItem(visited[slot], output) &&
-                            Objects.equals(visited[slot].getTag(), output.getTag()))) {
+                    if (visited[slot] == null || GTUtil.isSameItemSameTags(visited[slot], output)) {
                         if (count < output.getMaxStackSize() && count < storage.getSlotLimit(slot)) {
                             var remainder = getActioned(storage, slot, recipe.ingredientActions);
                             if (remainder == null) remainder = storage.insertItem(slot, output, simulate);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
@@ -134,7 +135,8 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                     int outputStorageLimit = 0;
                     for (int slot = 0; slot < storage.getSlots(); ++slot) {
                         ItemStack stack = storage.getStackInSlot(slot);
-                        if (stack.isEmpty() || ItemStack.isSameItemSameTags(stack, output)) {
+                        if (stack.isEmpty() || (ItemStack.isSameItem(stack, output) &&
+                                Objects.equals(stack.getTag(), output.getTag()))) {
                             outputStorageLimit += storage.getSlotLimit(slot) - stack.getCount();
                         }
                     }
@@ -175,7 +177,8 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                 } else { // IO.OUT
                     ItemStack output = items[0].copyWithCount(amount);
                     // Only try this slot if not visited or if visited with the same type of item
-                    if (visited[slot] == null || ItemStack.isSameItemSameTags(visited[slot], output)) {
+                    if (visited[slot] == null || (ItemStack.isSameItem(visited[slot], output) &&
+                            Objects.equals(visited[slot].getTag(), output.getTag()))) {
                         if (count < output.getMaxStackSize() && count < storage.getSlotLimit(slot)) {
                             var remainder = getActioned(storage, slot, recipe.ingredientActions);
                             if (remainder == null) remainder = storage.insertItem(slot, output, simulate);

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.pattern.error.SinglePredicateError;
 import com.gregtechceu.gtceu.api.pattern.predicates.SimplePredicate;
 import com.gregtechceu.gtceu.api.pattern.util.PatternMatchContext;
 import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.utils.BlockInfo;
 
@@ -649,7 +650,7 @@ public class BlockPattern {
                 if (rt != null) {
                     return rt;
                 }
-            } else if (candidates.stream().anyMatch(candidate -> ItemStack.isSameItemSameTags(candidate, stack)) &&
+            } else if (candidates.stream().anyMatch(candidate -> GTUtil.isSameItemSameTags(candidate, stack)) &&
                     !stack.isEmpty() && stack.getItem() instanceof BlockItem) {
                         return IntObjectPair.of(i, handler);
                     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookup.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.MapIngredientTypeManag
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.item.armor.PowerlessJetpack;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.ItemStack;
@@ -145,7 +146,7 @@ public class GTRecipeLookup {
             if (index > 0) {
                 for (ItemStack unique : uniqueItems) {
                     if (unique == null) break;
-                    else if (ItemStack.isSameItemSameTags(input, unique)) {
+                    else if (GTUtil.isSameItemSameTags(input, unique)) {
                         continue main;
                     }
                 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/StrictNBTItemStackMapIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/StrictNBTItemStackMapIngredient.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.recipe.lookup.ingredient.item;
 
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.AbstractMapIngredient;
 import com.gregtechceu.gtceu.core.mixins.forge.StrictNBTIngredientAccessor;
+import com.gregtechceu.gtceu.utils.GTUtil;
 import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 
 import net.minecraft.world.item.ItemStack;
@@ -55,7 +56,7 @@ public class StrictNBTItemStackMapIngredient extends ItemStackMapIngredient {
             }
             if (this.nbtIngredient != null) {
                 if (other.nbtIngredient != null) {
-                    return ItemStack.isSameItemSameTags(((StrictNBTIngredientAccessor) nbtIngredient).getStack(),
+                    return GTUtil.isSameItemSameTags(((StrictNBTIngredientAccessor) nbtIngredient).getStack(),
                             ((StrictNBTIngredientAccessor) other.nbtIngredient).getStack());
                 } else {
                     this.nbtIngredient.test(other.stack);

--- a/src/main/java/com/gregtechceu/gtceu/client/util/RenderUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/RenderUtil.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.utils.GTMatrixUtils;
+import com.gregtechceu.gtceu.utils.GTUtil;
 import com.gregtechceu.gtceu.utils.ResearchManager;
 
 import com.lowdragmc.lowdraglib.gui.util.DrawerHelper;
@@ -298,7 +299,7 @@ public class RenderUtil {
                 ItemStack[] items = ItemRecipeCapability.CAP.of(outputs.get(0).content).getItems();
                 if (items.length > 0) {
                     ItemStack output = items[0];
-                    if (!output.isEmpty() && !ItemStack.isSameItemSameTags(output, stack)) {
+                    if (!output.isEmpty() && !GTUtil.isSameItemSameTags(output, stack)) {
                         originalMethod.call(entity, level, output, x, y, seed, z);
                         return true;
                     }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -20,6 +20,7 @@ import com.gregtechceu.gtceu.common.blockentity.ItemPipeBlockEntity;
 import com.gregtechceu.gtceu.common.cover.data.DistributionMode;
 import com.gregtechceu.gtceu.common.cover.data.ManualIOMode;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
+import com.gregtechceu.gtceu.utils.GTUtil;
 import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
@@ -280,7 +281,7 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
             int slotIndex = itemInfo.slots.getInt(i);
             ItemStack extractedStack = sourceInventory.extractItem(slotIndex, itemsLeftToExtract, true);
             if (!extractedStack.isEmpty() &&
-                    ItemStack.isSameItemSameTags(resultStack, extractedStack)) {
+                    GTUtil.isSameItemSameTags(resultStack, extractedStack)) {
                 totalExtractedCount += extractedStack.getCount();
                 itemsLeftToExtract -= extractedStack.getCount();
             }
@@ -312,7 +313,7 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
             int slotIndex = itemInfo.slots.getInt(i);
             ItemStack extractedStack = sourceInventory.extractItem(slotIndex, itemsLeftToExtract, false);
             if (!extractedStack.isEmpty() &&
-                    ItemStack.isSameItemSameTags(resultStack, extractedStack)) {
+                    GTUtil.isSameItemSameTags(resultStack, extractedStack)) {
                 itemsLeftToExtract -= extractedStack.getCount();
             }
             if (itemsLeftToExtract == 0) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedItemVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedItemVoidingCover.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.cover.filter.SimpleItemFilter;
 import com.gregtechceu.gtceu.api.gui.widget.EnumSelectorWidget;
 import com.gregtechceu.gtceu.api.gui.widget.IntInputWidget;
 import com.gregtechceu.gtceu.common.cover.data.VoidingMode;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
@@ -73,7 +74,7 @@ public class AdvancedItemVoidingCover extends ItemVoidingCover {
 
             for (int slot = 0; slot < handler.getSlots(); slot++) {
                 ItemStack is = handler.getStackInSlot(slot);
-                if (!is.isEmpty() && ItemStack.isSameItemSameTags(is, itemInfo.itemStack)) {
+                if (!is.isEmpty() && GTUtil.isSameItemSameTags(is, itemInfo.itemStack)) {
                     ItemStack extracted = handler.extractItem(slot, itemToVoidAmount, false);
 
                     if (!extracted.isEmpty()) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/HarvestCropsBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/HarvestCropsBehavior.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.api.item.tool.aoe.AoESymmetrical;
 import com.gregtechceu.gtceu.api.item.tool.behavior.IToolBehavior;
 import com.gregtechceu.gtceu.common.data.item.GTToolActions;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -92,7 +93,7 @@ public class HarvestCropsBehavior implements IToolBehavior {
                 var drops = Block.getDrops(blockState, (ServerLevel) level, pos, null);
                 boolean removedSeed = false;
                 for (ItemStack drop : drops) {
-                    if (!removedSeed && ItemStack.isSameItemSameTags(drop, seed)) {
+                    if (!removedSeed && GTUtil.isSameItemSameTags(drop, seed)) {
                         drop.shrink(1);
                         removedSeed = true;
                         if (drop.isEmpty()) continue;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeChestMachine.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.widget.PhantomSlotWidget;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
 import com.lowdragmc.lowdraglib.gui.texture.ResourceBorderTexture;
@@ -156,7 +157,7 @@ public class CreativeChestMachine extends QuantumChestMachine {
 
         @Override
         public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-            if (!stored.isEmpty() && ItemStack.isSameItemSameTags(stored, stack)) return ItemStack.EMPTY;
+            if (!stored.isEmpty() && GTUtil.isSameItemSameTags(stored, stack)) return ItemStack.EMPTY;
             return stack;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumChestMachine.java
@@ -21,6 +21,7 @@ import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import com.lowdragmc.lowdraglib.gui.editor.Icons;
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup;
@@ -389,7 +390,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
                             }
                         }))
                 .addWidget(new PhantomSlotWidget(lockedItem, 0, 58, 41,
-                        stack -> stored.isEmpty() || ItemStack.isSameItemSameTags(stack, stored))
+                        stack -> stored.isEmpty() || GTUtil.isSameItemSameTags(stack, stored))
                         .setMaxStackSize(1))
                 .addWidget(new ToggleButtonWidget(4, 41, 18, 18,
                         GuiTextures.BUTTON_ITEM_OUTPUT, this::isAutoOutputItems, this::setAutoOutputItems)
@@ -446,7 +447,7 @@ public class QuantumChestMachine extends TieredMachine implements IAutoOutputIte
     protected class ItemCache extends MachineTrait implements IItemHandlerModifiable {
 
         private final Predicate<ItemStack> filter = i -> !isLocked() ||
-                ItemStack.isSameItemSameTags(i, getLockedItem());
+                GTUtil.isSameItemSameTags(i, getLockedItem());
 
         public ItemCache(MetaMachine holder) {
             super(holder);

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemNetHandler.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.common.cover.ItemFilterCover;
 import com.gregtechceu.gtceu.common.cover.RobotArmCover;
 import com.gregtechceu.gtceu.common.cover.data.FilterMode;
 import com.gregtechceu.gtceu.utils.FacingPos;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -353,7 +354,7 @@ public class ItemNetHandler implements IItemHandlerModifiable {
             ItemStack slot = handler.getStackInSlot(i);
             if (slot.isEmpty()) continue;
             if (ignoreNBT && !ItemStack.isSameItem(stack, slot)) continue;
-            if (!ignoreNBT && !ItemStack.isSameItemSameTags(stack, slot)) continue;
+            if (!ignoreNBT && !GTUtil.isSameItemSameTags(stack, slot)) continue;
             if (arm.getFilterHandler().getFilter().test(slot)) {
                 count += slot.getCount();
             }

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -604,6 +604,10 @@ public class GTUtil {
         });
     }
 
+    public static boolean isSameItemSameTags(ItemStack s1, ItemStack s2) {
+        return (ItemStack.isSameItem(s1, s2) && Objects.equals(s1.getTag(), s2.getTag()));
+    }
+
     public static <T> T getLast(List<T> list) {
         return list.get(list.size() - 1);
     }

--- a/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/OverlayedItemHandler.java
@@ -56,7 +56,7 @@ public class OverlayedItemHandler {
             initSlot(i);
             // if it's the same item or there is no item in the slot
             ItemStack slotKey = this.slots[i].getItemStack();
-            if (slotKey.isEmpty() || ItemStack.isSameItemSameTags(slotKey, stack)) {
+            if (slotKey.isEmpty() || GTUtil.isSameItemSameTags(slotKey, stack)) {
                 // if the slot is not full
                 int canInsertUpTo = Math.min(this.slots[i].getSlotLimit() - this.slots[i].getCount(),
                         stack.getMaxStackSize());
@@ -140,7 +140,7 @@ public class OverlayedItemHandler {
         }
 
         public void setItemStack(@NotNull ItemStack itemStack) {
-            if (!ItemStack.isSameItemSameTags(this.itemStack, itemStack)) {
+            if (!GTUtil.isSameItemSameTags(this.itemStack, itemStack)) {
                 this.itemStack = itemStack;
                 this.slotLimit = Math.min(itemStack.getMaxStackSize(), slotLimit);
             }


### PR DESCRIPTION
## What
IsSameItemSameTags is a slow operation cause it checks if the item stack capabilities are the same on both stacks, which the forge impl is slow, so we opt with manually comparing if the tags are the same instead

## Implementation Details
boolean tweaking

## Outcome
comparing stacks in the recipe handler should be faster
partial fix for #4205 
