### PR TITLE
Refactor OR and XOR chance logic rolls to multiply outputs for Guaranteed Rolls rather than adding

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -99,7 +99,7 @@ public class RecipeRunner {
             // add chanced contents to the recipe content map
             if (!chancedContents.isEmpty()) {
                 var cache = this.chanceCaches.get(cap);
-                chancedContents = logic.roll(chancedContents, function, recipeTier, chanceTier, cache,
+                chancedContents = logic.roll(cap, chancedContents, function, recipeTier, chanceTier, cache,
                         recipe.getTotalRuns());
 
                 for (Content cont : chancedContents) {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -53,7 +53,7 @@ public abstract class ChanceLogic {
                 int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                 int totalChance = times * newChance;
                 int guaranteed = totalChance / maxChance;
-                if (guaranteed > 0) builder.add(entry.copy(cap, ContentModifier.multiplier(guaranteed)));
+                if (guaranteed > 0) builder.add(entry.copyChanced(cap, ContentModifier.multiplier(guaranteed)));
                 newChance = totalChance % maxChance;
 
                 int cached = getCachedChance(entry, cache);
@@ -218,7 +218,7 @@ public abstract class ChanceLogic {
                     int totalChance = times * newChance;
                     int guaranteed = totalChance / 10000;
                     if (guaranteed > 0) {
-                        builder.add(entry.copy(cap, ContentModifier.multiplier(guaranteed)));
+                        builder.add(entry.copyChanced(cap, ContentModifier.multiplier(guaranteed)));
                         nonGuaranteedTimes -= guaranteed;
                     }
                 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/chance/logic/ChanceLogic.java
@@ -2,8 +2,10 @@ package com.gregtechceu.gtceu.api.recipe.chance.logic;
 
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.recipe.chance.boost.ChanceBoostFunction;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
+import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 
 import net.minecraft.network.chat.Component;
@@ -37,10 +39,10 @@ public abstract class ChanceLogic {
     public static final ChanceLogic OR = new ChanceLogic("or") {
 
         @Override
-        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                         @NotNull ChanceBoostFunction boostFunction,
-                                                         int recipeTier, int chanceTier,
-                                                         @Nullable Object2IntMap<?> cache, int times) {
+        public @Unmodifiable List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                                         @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction, int recipeTier,
+                                                         int chanceTier, @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
             for (Content entry : chancedEntries) {
                 int maxChance = entry.maxChance;
@@ -51,7 +53,7 @@ public abstract class ChanceLogic {
                 int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
                 int totalChance = times * newChance;
                 int guaranteed = totalChance / maxChance;
-                if (guaranteed > 0) builder.addAll(Collections.nCopies(guaranteed, entry));
+                if (guaranteed > 0) builder.add(entry.copy(cap, ContentModifier.multiplier(guaranteed)));
                 newChance = totalChance % maxChance;
 
                 int cached = getCachedChance(entry, cache);
@@ -83,10 +85,10 @@ public abstract class ChanceLogic {
     public static final ChanceLogic AND = new ChanceLogic("and") {
 
         @Override
-        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                         @NotNull ChanceBoostFunction boostFunction,
-                                                         int recipeTier, int chanceTier,
-                                                         @Nullable Object2IntMap<?> cache, int times) {
+        public @Unmodifiable List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                                         @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction, int recipeTier,
+                                                         int chanceTier, @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
             for (int i = 0; i < times; ++i) {
                 boolean failed = false;
@@ -123,10 +125,10 @@ public abstract class ChanceLogic {
     public static final ChanceLogic FIRST = new ChanceLogic("first") {
 
         @Override
-        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                         @NotNull ChanceBoostFunction boostFunction,
-                                                         int recipeTier, int chanceTier,
-                                                         @Nullable Object2IntMap<?> cache, int times) {
+        public @Unmodifiable List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                                         @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction, int recipeTier,
+                                                         int chanceTier, @Nullable Object2IntMap<?> cache, int times) {
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
             for (int i = 0; i < times; ++i) {
                 Content selected = null;
@@ -163,10 +165,10 @@ public abstract class ChanceLogic {
     public static final ChanceLogic XOR = new ChanceLogic("xor") {
 
         @Override
-        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                         @NotNull ChanceBoostFunction boostFunction,
-                                                         int recipeTier, int chanceTier,
-                                                         @Nullable Object2IntMap<?> cache, int times) {
+        public @Unmodifiable List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                                         @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction, int recipeTier,
+                                                         int chanceTier, @Nullable Object2IntMap<?> cache, int times) {
             // Have to set up a system where all chances are set to be out of 10000
             IntList chancesOutOfTenThousand = new IntArrayList();
 
@@ -208,7 +210,21 @@ public abstract class ChanceLogic {
 
             // Use the new, normalized list for the logic
             ImmutableList.Builder<Content> builder = ImmutableList.builder();
-            for (int i = 0; i < times; ++i) {
+            // for high run counts: calculate guaranteed rolls
+            int nonGuaranteedTimes = times;
+            if (times > 1) {
+                for (Content entry : normalizedEntries) {
+                    int newChance = getChance(entry, boostFunction, recipeTier, chanceTier);
+                    int totalChance = times * newChance;
+                    int guaranteed = totalChance / 10000;
+                    if (guaranteed > 0) {
+                        builder.add(entry.copy(cap, ContentModifier.multiplier(guaranteed)));
+                        nonGuaranteedTimes -= guaranteed;
+                    }
+                }
+            }
+            // roll for non-guaranteed
+            for (int i = 0; i < nonGuaranteedTimes; ++i) {
                 Content selected = null;
                 int maxChance = getMaxChancedValue();
                 for (Content entry : normalizedEntries) {
@@ -245,10 +261,10 @@ public abstract class ChanceLogic {
     public static final ChanceLogic NONE = new ChanceLogic("none") {
 
         @Override
-        public @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
-                                                         @NotNull ChanceBoostFunction boostFunction,
-                                                         int recipeTier, int chanceTier,
-                                                         @Nullable Object2IntMap<?> cache, int times) {
+        public @Unmodifiable List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                                         @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+                                                         @NotNull ChanceBoostFunction boostFunction, int recipeTier,
+                                                         int chanceTier, @Nullable Object2IntMap<?> cache, int times) {
             return Collections.emptyList();
         }
 
@@ -329,11 +345,11 @@ public abstract class ChanceLogic {
      * @param times          the number of times to roll
      * @return a list of the produced outputs, empty if roll fails
      */
-    public abstract @Unmodifiable List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+    public abstract @Unmodifiable List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                                              @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
                                                               @NotNull ChanceBoostFunction boostFunction,
-                                                              int recipeTier,
-                                                              int chanceTier, @Nullable Object2IntMap<?> cache,
-                                                              int times);
+                                                              int recipeTier, int chanceTier,
+                                                              @Nullable Object2IntMap<?> cache, int times);
 
     /**
      * Roll the chance and attempt to produce the output
@@ -346,10 +362,11 @@ public abstract class ChanceLogic {
      * @return a list of the produced outputs
      */
     @Unmodifiable
-    public List<@NotNull Content> roll(@NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
+    public List<@NotNull Content> roll(RecipeCapability<?> cap,
+                                       @NotNull @Unmodifiable List<@NotNull Content> chancedEntries,
                                        @NotNull ChanceBoostFunction boostFunction, int recipeTier, int chanceTier,
                                        int times) {
-        return roll(chancedEntries, boostFunction, recipeTier, chanceTier, null, times);
+        return roll(cap, chancedEntries, boostFunction, recipeTier, chanceTier, null, times);
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/content/Content.java
@@ -55,12 +55,29 @@ public class Content {
                 .apply(instance, Content::new));
     }
 
+    /**
+     * Directly copies a Content.
+     */
     public Content copy(RecipeCapability<?> capability) {
         return new Content(capability.copyContent(content), chance, maxChance, tierChanceBoost);
     }
 
+    /**
+     * Applies a {@link ContentModifier} to a Content. Does not apply the Modifier if the Content has a Chance.
+     */
     public Content copy(RecipeCapability<?> capability, @NotNull ContentModifier modifier) {
         if (modifier == ContentModifier.IDENTITY || chance < maxChance) {
+            return copy(capability);
+        } else {
+            return new Content(capability.copyContent(content, modifier), chance, maxChance, tierChanceBoost);
+        }
+    }
+
+    /**
+     * Applies a {@link ContentModifier} to a Content. Even if the content has a Chance.
+     */
+    public Content copyChanced(RecipeCapability<?> capability, @NotNull ContentModifier modifier) {
+        if (modifier == ContentModifier.IDENTITY) {
             return copy(capability);
         } else {
             return new Content(capability.copyContent(content, modifier), chance, maxChance, tierChanceBoost);


### PR DESCRIPTION
## What
Fixes #4205 for OR and XOR logics. Does not alter AND.

## Implementation Details
Swaps OR's guaranteed roller from using Collections.nCopies() for its Guaranteed Rolls, to in stead use ContentModifier.multiply(). As a result, the ContentList returned will contain only one or two copies of every item, rather than 25,000.

Also implements Guaranteed Rolls logic to XOR, using the same method as on OR. XOR will still do more rolls than OR because there are multiple ingredients in play.

This does not make any alterations to AND or FIRST. FIRST is deprecated, and AND is ... I genuinely don't know what to do with AND. AND logic math is weird and doesn't work the way most people would want it to, and that makes it hard to give it guaranteed rolls. That also said though, AND will likely generate so many fails in its rolls that it won't generate lists of 25,000 items anyway.

## Potential Compatibility Issues
Changes the method signature for ChanceLogic.roll() to include the RecipeCapability of the ingredients being rolled for. As far as we know, noone has their own ChanceLogics that they create or call upon so this _shouldn't_ be an issue, but it technically could be.
