### PR TITLE
Fixes "shiny" material set double plates.

### DIFF
--- a/src/main/resources/assets/gtceu/models/item/material_sets/shiny/plate_double.json
+++ b/src/main/resources/assets/gtceu/models/item/material_sets/shiny/plate_double.json
@@ -3,6 +3,6 @@
 	"textures": {
         "layer0": "gtceu:item/material_sets/shiny/plate_double",
         "layer1": "gtceu:item/material_sets/shiny/plate_double_secondary",
-		"layer3": "gtceu:item/material_sets/shiny/plate_double_overlay"
+		"layer2": "gtceu:item/material_sets/shiny/plate_double_overlay"
 	}
 }


### PR DESCRIPTION
## What
- Fixes the `shiny` material set's double plates having an extra overlay sprite.

## Outcome
- Moves overlay sprite on the model for `shiny`'s double plates from `layer3` to `layer2`, removing the accidental single plate overlay sprite.

## Additional Information
<img width="1680" height="1050" alt="2025-11-21_16 43 13" src="https://github.com/user-attachments/assets/4373ba0d-fd3d-4938-8919-ee9eb1b6540e" />

*Fixed double plates; highlight is 1px thinner, as was presumably intended.*

- This PR was, unfortunately, only able to be tested as a resourcepack containing the fixed model (Due to my utter lack of ability to code), but it's only a single model change so it *should* work fine? I hope? Please?