### PR TITLE
Fix machines set to disable after current cycle not disabling on powerstall

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -394,7 +394,8 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
             if (this.status == Status.WORKING) {
                 this.totalContinuousRunningTime = 0;
             }
-            if (status == Status.SUSPEND && suspendAfterFinish) {
+            if ((status == Status.WAITING || status == Status.SUSPEND) && suspendAfterFinish) {
+                status = Status.SUSPEND;
                 suspendAfterFinish = false;
             }
             machine.notifyStatusChanged(this.status, status);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -296,7 +296,6 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
                         if (machine.self() instanceof IMultiController && !preventPowerFail) {
                             runAttempt = 0;
                             setStatus(Status.SUSPEND);
-                            regressRecipe();
                         }
                     }
                     runDelay = runAttempt * 60;
@@ -305,7 +304,7 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
         } else {
             setWaiting(conditionResult.reason());
         }
-        if (isWaiting()) {
+        if (isWaiting() || isSuspend()) {
             regressRecipe();
         }
     }


### PR DESCRIPTION
## What
# what.
Honestly I thought this worked when I tested it the last time I was modifying this logic a few months ago, but judging by the file contents and git history it's like it never worked.

Anyway, makes it so that when you use a soft mallet to disable a machine that's trying to powerstall, the mallet _actually disables the machine on its next powerstall_.