### PR TITLE
no more z fighting

### DIFF
--- a/src/main/resources/assets/gtceu/models/block/machine/large_miner_active.json
+++ b/src/main/resources/assets/gtceu/models/block/machine/large_miner_active.json
@@ -43,7 +43,7 @@
             }
         },
         {
-            "from": [  0,   0, 16 ],
+            "from": [  0,   -0.01, 16 ],
             "to":   [ 16, -16, 32 ],
             "faces": {
                 "down":  { "uv": [0, 0, 16, 16], "texture": "#overlay_pipe", "cullface": "down" }


### PR DESCRIPTION
fix zfighting on the miner overlay for da pipe

before
<img width="617" height="567" alt="image" src="https://github.com/user-attachments/assets/40c69df6-1922-45be-b456-146279926a8b" />



<img width="596" height="407" alt="image" src="https://github.com/user-attachments/assets/3ce59d1e-431f-45f4-95d7-fa07a00218cf" />
after


