### PR TITLE
Fix manual mode for item/fluid filter covers and conveyors/pumps

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -28,6 +28,7 @@ import com.gregtechceu.gtceu.client.model.machine.MachineRenderState;
 import com.gregtechceu.gtceu.client.util.ModelUtils;
 import com.gregtechceu.gtceu.common.cover.FluidFilterCover;
 import com.gregtechceu.gtceu.common.cover.ItemFilterCover;
+import com.gregtechceu.gtceu.common.cover.data.ManualIOMode;
 import com.gregtechceu.gtceu.common.item.tool.behavior.ToolModeSwitchBehavior;
 import com.gregtechceu.gtceu.common.machine.owner.MachineOwner;
 import com.gregtechceu.gtceu.common.machine.owner.PlayerOwner;
@@ -745,7 +746,15 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     public Predicate<ItemStack> getItemCapFilter(@Nullable Direction side, IO io) {
         if (side != null) {
             var cover = getCoverContainer().getCoverAtSide(side);
-            if (cover instanceof ItemFilterCover filterCover && filterCover.getFilterMode().filters(io)) {
+            if (cover instanceof ItemFilterCover filterCover) {
+                if (!filterCover.getFilterMode().filters(io)) {
+                    if (filterCover.getAllowFlow() == ManualIOMode.DISABLED) {
+                        return item -> false;
+                    }
+                    if (filterCover.getAllowFlow() == ManualIOMode.UNFILTERED) {
+                        return item -> true;
+                    }
+                }
                 return filterCover.getItemFilter();
             }
         }
@@ -755,7 +764,15 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     public Predicate<FluidStack> getFluidCapFilter(@Nullable Direction side, IO io) {
         if (side != null) {
             var cover = getCoverContainer().getCoverAtSide(side);
-            if (cover instanceof FluidFilterCover filterCover && filterCover.getFilterMode().filters(io)) {
+            if (cover instanceof  FluidFilterCover filterCover) {
+                if (!filterCover.getFilterMode().filters(io)) {
+                    if (filterCover.getAllowFlow() == ManualIOMode.DISABLED) {
+                        return fluid -> false;
+                    }
+                    if (filterCover.getAllowFlow() == ManualIOMode.UNFILTERED) {
+                        return fluid -> true;
+                    }
+                }
                 return filterCover.getFluidFilter();
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -764,7 +764,7 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
     public Predicate<FluidStack> getFluidCapFilter(@Nullable Direction side, IO io) {
         if (side != null) {
             var cover = getCoverContainer().getCoverAtSide(side);
-            if (cover instanceof  FluidFilterCover filterCover) {
+            if (cover instanceof FluidFilterCover filterCover) {
                 if (!filterCover.getFilterMode().filters(io)) {
                     if (filterCover.getAllowFlow() == ManualIOMode.DISABLED) {
                         return fluid -> false;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ConveyorCover.java
@@ -512,10 +512,15 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
         @NotNull
         @Override
         public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-            if (io == IO.OUT && manualIOMode == ManualIOMode.DISABLED) {
-                return stack;
+            if (io == IO.OUT) {
+                if (manualIOMode == ManualIOMode.DISABLED) {
+                    return stack;
+                }
+                if (manualIOMode == ManualIOMode.UNFILTERED) {
+                    return super.insertItem(slot, stack, simulate);
+                }
             }
-            if (manualIOMode == ManualIOMode.FILTERED && !filterHandler.test(stack)) {
+            if (!filterHandler.test(stack)) {
                 return stack;
             }
             return super.insertItem(slot, stack, simulate);
@@ -524,17 +529,19 @@ public class ConveyorCover extends CoverBehavior implements IIOCover, IUICover, 
         @NotNull
         @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            if (io == IO.IN && manualIOMode == ManualIOMode.DISABLED) {
-                return ItemStack.EMPTY;
-            }
-            if (manualIOMode == ManualIOMode.FILTERED) {
-                ItemStack result = super.extractItem(slot, amount, true);
-                if (result.isEmpty() || !filterHandler.test(result)) {
+            if (io == IO.IN) {
+                if (manualIOMode == ManualIOMode.DISABLED) {
                     return ItemStack.EMPTY;
                 }
-                return simulate ? result : super.extractItem(slot, amount, false);
+                if (manualIOMode == ManualIOMode.UNFILTERED) {
+                    return super.extractItem(slot, amount, simulate);
+                }
             }
-            return super.extractItem(slot, amount, simulate);
+            ItemStack result = super.extractItem(slot, amount, true);
+            if (result.isEmpty() || !filterHandler.test(result)) {
+                return ItemStack.EMPTY;
+            }
+            return simulate ? result : super.extractItem(slot, amount, false);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
@@ -20,7 +20,6 @@ import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import lombok.Getter;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
@@ -20,6 +20,7 @@ import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import lombok.Getter;
@@ -103,20 +104,34 @@ public class FluidFilterCover extends CoverBehavior implements IUICover {
 
         @Override
         public int fill(FluidStack resource, FluidAction action) {
-            if ((filterMode == FilterMode.FILTER_EXTRACT) && allowFlow == ManualIOMode.UNFILTERED)
-                return super.fill(resource, action);
-            if (filterMode != FilterMode.FILTER_EXTRACT && getFluidFilter().test(resource))
-                return super.fill(resource, action);
-            return 0;
+            if (filterMode == FilterMode.FILTER_EXTRACT) {
+                if (allowFlow == ManualIOMode.DISABLED) {
+                    return 0;
+                }
+                if (allowFlow == ManualIOMode.UNFILTERED) {
+                    return super.fill(resource, action);
+                }
+            }
+            if (!getFluidFilter().test(resource)) {
+                return 0;
+            }
+            return super.fill(resource, action);
         }
 
         @Override
         public FluidStack drain(FluidStack resource, FluidAction action) {
-            if ((filterMode == FilterMode.FILTER_INSERT) && allowFlow == ManualIOMode.UNFILTERED)
-                return super.drain(resource, action);
-            if (filterMode != FilterMode.FILTER_INSERT && getFluidFilter().test(resource))
-                return super.drain(resource, action);
-            return FluidStack.EMPTY;
+            if (filterMode == FilterMode.FILTER_INSERT) {
+                if (allowFlow == ManualIOMode.DISABLED) {
+                    return FluidStack.EMPTY;
+                }
+                if (allowFlow == ManualIOMode.UNFILTERED) {
+                    return super.drain(resource, action);
+                }
+            }
+            if (!getFluidFilter().test(resource)) {
+                return FluidStack.EMPTY;
+            }
+            return super.drain(resource, action);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
@@ -116,25 +116,35 @@ public class ItemFilterCover extends CoverBehavior implements IUICover {
 
         @Override
         public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-            if ((filterMode == FilterMode.FILTER_EXTRACT) && allowFlow == ManualIOMode.UNFILTERED)
-                return super.insertItem(slot, stack, simulate);
-            if (filterMode != FilterMode.FILTER_EXTRACT && getItemFilter().test(stack)) {
-                return super.insertItem(slot, stack, simulate);
+            if (filterMode == FilterMode.FILTER_EXTRACT) {
+                if (allowFlow == ManualIOMode.DISABLED) {
+                    return stack;
+                }
+                if (allowFlow == ManualIOMode.UNFILTERED) {
+                    return super.insertItem(slot, stack, simulate);
+                }
             }
-            return stack;
+            if (!getItemFilter().test(stack)) {
+                return stack;
+            }
+            return super.insertItem(slot, stack, simulate);
         }
 
         @Override
         public @NotNull ItemStack extractItem(int slot, int amount, boolean simulate) {
+            if (filterMode == FilterMode.FILTER_INSERT) {
+                if (allowFlow == ManualIOMode.DISABLED) {
+                    return ItemStack.EMPTY;
+                }
+                if (allowFlow == ManualIOMode.UNFILTERED) {
+                    return super.extractItem(slot, amount, simulate);
+                }
+            }
             ItemStack result = super.extractItem(slot, amount, true);
-            if (result.isEmpty() && (filterMode == FilterMode.FILTER_INSERT) && allowFlow == ManualIOMode.UNFILTERED) {
-                return super.extractItem(slot, amount, false);
+            if (result.isEmpty() || !getItemFilter().test(result)) {
+                return ItemStack.EMPTY;
             }
-
-            if (filterMode != FilterMode.FILTER_INSERT && getItemFilter().test(result)) {
-                return super.extractItem(slot, amount, false);
-            }
-            return ItemStack.EMPTY;
+            return simulate ? result : super.extractItem(slot, amount, false);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
@@ -19,7 +19,6 @@ import com.gregtechceu.gtceu.api.transfer.fluid.FluidHandlerDelegate;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
 import com.gregtechceu.gtceu.api.transfer.fluid.ModifiableFluidHandlerWrapper;
 import com.gregtechceu.gtceu.common.cover.data.BucketMode;
-import com.gregtechceu.gtceu.common.cover.data.FilterMode;
 import com.gregtechceu.gtceu.common.cover.data.ManualIOMode;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/PumpCover.java
@@ -19,6 +19,7 @@ import com.gregtechceu.gtceu.api.transfer.fluid.FluidHandlerDelegate;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
 import com.gregtechceu.gtceu.api.transfer.fluid.ModifiableFluidHandlerWrapper;
 import com.gregtechceu.gtceu.common.cover.data.BucketMode;
+import com.gregtechceu.gtceu.common.cover.data.FilterMode;
 import com.gregtechceu.gtceu.common.cover.data.ManualIOMode;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 
@@ -369,10 +370,15 @@ public class PumpCover extends CoverBehavior implements IIOCover, IUICover, ICon
 
         @Override
         public int fill(FluidStack resource, FluidAction action) {
-            if (io == IO.OUT && manualIOMode == ManualIOMode.DISABLED) {
-                return 0;
+            if (io == IO.OUT) {
+                if (manualIOMode == ManualIOMode.DISABLED) {
+                    return 0;
+                }
+                if (manualIOMode == ManualIOMode.UNFILTERED) {
+                    return super.fill(resource, action);
+                }
             }
-            if (!filterHandler.test(resource) && manualIOMode == ManualIOMode.FILTERED) {
+            if (!filterHandler.test(resource)) {
                 return 0;
             }
             return super.fill(resource, action);
@@ -380,10 +386,15 @@ public class PumpCover extends CoverBehavior implements IIOCover, IUICover, ICon
 
         @Override
         public FluidStack drain(FluidStack resource, FluidAction action) {
-            if (io == IO.IN && manualIOMode == ManualIOMode.DISABLED) {
-                return FluidStack.EMPTY;
+            if (io == IO.IN) {
+                if (manualIOMode == ManualIOMode.DISABLED) {
+                    return FluidStack.EMPTY;
+                }
+                if (manualIOMode == ManualIOMode.UNFILTERED) {
+                    return super.drain(resource, action);
+                }
             }
-            if (manualIOMode == ManualIOMode.FILTERED && !filterHandler.test(resource)) {
+            if (!filterHandler.test(resource)) {
                 return FluidStack.EMPTY;
             }
             return super.drain(resource, action);


### PR DESCRIPTION
## What
tries to fix many of manual io bugs
see: https://discord.com/channels/701354865217110096/1089296351906504835/1442285824074055731

## Outcome
- all cases of items being pushed/pulled through item filter/conveyor covers from external sources have been fixed for all manual io modes
- this includes item voiding bug due to filter cover's extract method not handling simulate parameter correctly
- attempt to fix auto output + manual io mode bugs, with limitations; for example, auto output + conveyor with filter doesn't respect manual io

## Additional Information
many of these probably needs a bigger code refactor that i'm not knowledgable enough to do such as
- conveyors inheriting filter cover behavior somehow, so handling for both's filters isn't duplicated and missing in places
-` MetaMachine.getItemCapFilter`'s io parameter should probably be changed, it doesn't really make sense with `IO.BOTH/NONE`, it only is used with `IO.IN/OUT` anyway
- refactor other duplicate code probably, like `getItemcCapFilter` is used everywhere in similar ways, bunch of similar `exportToNearby` methods, etc

## Potential Compatibility Issues / Implementation Details
should be no compat issues, tried to not modify current code structure as much as possible
although a bigger cleanup is probably needed later, see above
