### PR TITLE
Spray cans with AE2 IColorableBlockEntity support

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.item;
 
+import appeng.api.implementations.blockentities.IColorableBlockEntity;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.blockentity.IPaintable;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
@@ -204,8 +205,13 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
         if (player == null) {
             return false;
         }
-        if (GTCEu.Mods.isAE2Loaded() && AE2CallWrapper.isAE2Cable(first)) {
-            var collected = AE2CallWrapper.collect(first, limit);
+        if (GTCEu.Mods.isAE2Loaded() && AE2CallWrapper.isColorable(first)) {
+            List<IColorableBlockEntity> collected;
+            if(first instanceof CableBusBlockEntity) {
+                collected = AE2CallWrapper.collect(first, limit).stream().map(i -> (IColorableBlockEntity) i).toList();
+            } else {
+                collected = List.of((IColorableBlockEntity) first);
+            }
             var ae2Color = color == null ? AEColor.TRANSPARENT : AEColor.values()[color.ordinal()];
             for (var c : collected) {
                 if (c.getColor() == ae2Color) {
@@ -479,8 +485,8 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
                     limit, limit * 6);
         }
 
-        static boolean isAE2Cable(BlockEntity be) {
-            return be instanceof CableBusBlockEntity;
+        static boolean isColorable(BlockEntity be) {
+            return be instanceof IColorableBlockEntity;
         }
 
         static boolean ae2CablePredicate(CableBusBlockEntity parent, CableBusBlockEntity child, Direction direction) {

--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.common.item;
 
-import appeng.api.implementations.blockentities.IColorableBlockEntity;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.blockentity.IPaintable;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
@@ -41,6 +40,7 @@ import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.util.TriPredicate;
 
+import appeng.api.implementations.blockentities.IColorableBlockEntity;
 import appeng.api.util.AEColor;
 import appeng.blockentity.networking.CableBusBlockEntity;
 import com.google.common.collect.ImmutableMap;
@@ -207,7 +207,7 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
         }
         if (GTCEu.Mods.isAE2Loaded() && AE2CallWrapper.isColorable(first)) {
             List<IColorableBlockEntity> collected;
-            if(first instanceof CableBusBlockEntity) {
+            if (first instanceof CableBusBlockEntity) {
                 collected = AE2CallWrapper.collect(first, limit).stream().map(i -> (IColorableBlockEntity) i).toList();
             } else {
                 collected = List.of((IColorableBlockEntity) first);

--- a/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/ColorSprayBehaviour.java
@@ -206,11 +206,11 @@ public class ColorSprayBehaviour implements IDurabilityBar, IInteractionItem, IA
             return false;
         }
         if (GTCEu.Mods.isAE2Loaded() && AE2CallWrapper.isColorable(first)) {
-            List<IColorableBlockEntity> collected;
+            Set<? extends IColorableBlockEntity> collected;
             if (first instanceof CableBusBlockEntity) {
-                collected = AE2CallWrapper.collect(first, limit).stream().map(i -> (IColorableBlockEntity) i).toList();
+                collected = AE2CallWrapper.collect(first, limit);
             } else {
-                collected = List.of((IColorableBlockEntity) first);
+                collected = Set.of((IColorableBlockEntity) first);
             }
             var ae2Color = color == null ? AEColor.TRANSPARENT : AEColor.values()[color.ordinal()];
             for (var c : collected) {


### PR DESCRIPTION
## What
Added  support AE2 IColorableBlockEntity for spray cans

## Outcome
Added feature of #4259
Added isColorable func instead of isAE2Cable and support for other IColorableBlockEntity


## Additional Information
Сables are working as before. Other IColorableBlockEntity are painted one block at a time
