### PR TITLE
Ranged Ingredient backported fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IRangedIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IRangedIngredient.java
@@ -1,0 +1,43 @@
+package com.gregtechceu.gtceu.api.recipe.ingredient;
+
+import com.gregtechceu.gtceu.api.GTValues;
+
+import net.minecraft.util.RandomSource;
+import net.minecraft.util.valueproviders.IntProvider;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface IRangedIngredient {
+
+    IntProvider getCountProvider();
+
+    int getSampledCount();
+
+    void setSampledCount(int count);
+
+    /**
+     * If this ingredient has not yet had its count rolled, rolls it and returns the roll.
+     * If it has, returns the existing roll.
+     * Passthrough method, invokes {@code rollSampledCount()} using the threadsafe {@link GTValues#RNG}.
+     *
+     * @return the amount rolled
+     */
+    default int rollSampledCount() {
+        return rollSampledCount(GTValues.RNG);
+    }
+
+    int rollSampledCount(@NotNull RandomSource random);
+
+    /**
+     * @return the average roll of this ranged amount
+     */
+    default double getMidRoll() {
+        return ((getCountProvider().getMaxValue() + getCountProvider().getMinValue()) / 2.0);
+    }
+
+    default boolean isRolled() {
+        return getSampledCount() != -1;
+    }
+
+    void reset();
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredient.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  * and either an {@link IntProvider} or {@code int, int} range bounds (inclusive).
  * Functions similarly to {@link IntProviderIngredient}.
  */
-public class IntProviderFluidIngredient extends FluidIngredient {
+public class IntProviderFluidIngredient extends FluidIngredient implements IRangedIngredient {
 
     public static final Codec<IntProviderFluidIngredient> CODEC = ExtraCodecs.JSON
             .xmap(IntProviderFluidIngredient::fromJson, IntProviderFluidIngredient::toJson);
@@ -39,6 +39,7 @@ public class IntProviderFluidIngredient extends FluidIngredient {
     /**
      * The last result of {@link IntProviderFluidIngredient#getSampledCount()}. -1 if not rolled.
      */
+    @Getter
     @Setter
     protected int sampledCount = -1;
     /**
@@ -92,7 +93,7 @@ public class IntProviderFluidIngredient extends FluidIngredient {
     @Override
     public FluidStack[] getStacks() {
         if (fluidStacks == null) {
-            int cachedAmount = getSampledCount(GTValues.RNG);
+            int cachedAmount = rollSampledCount(GTValues.RNG);
             if (cachedAmount == 0) {
                 return EMPTY_STACK_ARRAY;
             }
@@ -123,24 +124,11 @@ public class IntProviderFluidIngredient extends FluidIngredient {
      * If this ingredient has not yet had its {@link IntProviderFluidIngredient#sampledCount} rolled, rolls it and
      * returns the roll.
      * If it has, returns the existing roll.
-     * Passthrough method, invokes {@link IntProviderFluidIngredient#getSampledCount(RandomSource)} using the threadsafe
-     * {@link GTValues#RNG}.
-     *
-     * @return the amount rolled
-     */
-    public int getSampledCount() {
-        return getSampledCount(GTValues.RNG);
-    }
-
-    /**
-     * If this ingredient has not yet had its {@link IntProviderFluidIngredient#sampledCount} rolled, rolls it and
-     * returns the roll.
-     * If it has, returns the existing roll.
      *
      * @param random {@link RandomSource}, must be threadsafe, usually called using {@link GTValues#RNG}.
      * @return the amount rolled
      */
-    public int getSampledCount(@NotNull RandomSource random) {
+    public int rollSampledCount(@NotNull RandomSource random) {
         if (sampledCount == -1) {
             sampledCount = countProvider.sample(random);
         }
@@ -162,7 +150,7 @@ public class IntProviderFluidIngredient extends FluidIngredient {
     /**
      * Resets the random roll on this ingredient
      */
-    public void reroll() {
+    public void reset() {
         sampledCount = -1;
         fluidStacks = null;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredient.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
  * and an {@link IntProvider}.
  * Functions similarly to {@link IntProviderFluidIngredient}.
  */
-public class IntProviderIngredient extends Ingredient {
+public class IntProviderIngredient extends Ingredient implements IRangedIngredient {
 
     public static final ResourceLocation TYPE = GTCEu.id("int_provider");
     public static final ItemStack[] EMPTY_STACK_ARRAY = new ItemStack[0];
@@ -41,8 +41,9 @@ public class IntProviderIngredient extends Ingredient {
     @Getter
     protected final IntProvider countProvider;
     /**
-     * The last result of {@link IntProviderIngredient#getSampledCount(RandomSource)}. -1 if not rolled.
+     * The last result of {@link IntProviderIngredient#rollSampledCount(RandomSource)}. -1 if not rolled.
      */
+    @Getter
     @Setter
     protected int sampledCount = -1;
     /**
@@ -99,7 +100,7 @@ public class IntProviderIngredient extends Ingredient {
     @Override
     public ItemStack @NotNull [] getItems() {
         if (itemStacks == null) {
-            int cachedCount = getSampledCount();
+            int cachedCount = rollSampledCount();
             if (cachedCount == 0) {
                 return EMPTY_STACK_ARRAY;
             }
@@ -125,19 +126,6 @@ public class IntProviderIngredient extends Ingredient {
     }
 
     /**
-     * If this ingredient has not yet had its {@link IntProviderIngredient#sampledCount} rolled, rolls it and
-     * returns the roll.
-     * If it has, returns the existing roll.
-     * Passthrough method, invokes {@link IntProviderIngredient#getSampledCount(RandomSource)} using the threadsafe
-     * {@link GTValues#RNG}.
-     *
-     * @return the amount rolled
-     */
-    public int getSampledCount() {
-        return getSampledCount(GTValues.RNG);
-    }
-
-    /**
      * If this ingredient has not yet had its {@link IntProviderIngredient#sampledCount} rolled, rolls it and returns
      * the roll.
      * If it has, returns the existing roll.
@@ -145,7 +133,7 @@ public class IntProviderIngredient extends Ingredient {
      * @param random {@link RandomSource}, must be threadsafe, usually called using {@link GTValues#RNG}.
      * @return the count rolled
      */
-    public int getSampledCount(@NotNull RandomSource random) {
+    public int rollSampledCount(@NotNull RandomSource random) {
         if (sampledCount == -1) {
             sampledCount = countProvider.sample(random);
         }
@@ -153,16 +141,9 @@ public class IntProviderIngredient extends Ingredient {
     }
 
     /**
-     * @return the average roll of this ranged amount
-     */
-    public double getMidRoll() {
-        return ((countProvider.getMaxValue() + countProvider.getMinValue()) / 2.0);
-    }
-
-    /**
      * Resets the random roll on this ingredient
      */
-    public void reroll() {
+    public void reset() {
         sampledCount = -1;
         itemStacks = null;
     }

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredientTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredientTest.java
@@ -215,7 +215,7 @@ public class IntProviderFluidIngredientTest {
                 "IntProviderFluidIngredient should have fluid equal to what it was made with");
         helper.assertTrue(stacks[0].isFluidStackIdentical(ingredient.getStacks()[0]),
                 "IntProviderFluidIngredient.getStacks shouldn't change between getStacks calls");
-        ingredient.reroll();
+        ingredient.reset();
         helper.assertFalse(stacks[0].isFluidStackIdentical(ingredient.getStacks()[0]),
                 "IntProviderFluidIngredient.getStacks should have changed after rerolling");
         helper.succeed();

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredientTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredientTest.java
@@ -272,7 +272,7 @@ public class IntProviderFluidIngredientTest {
         // get the result of each roll independently
         int[] addedRolls = new int[runs];
 
-        helper.runAfterDelay(4, () -> {
+        helper.runAfterDelay(2, () -> {
             if (machine.getRecipeLogic().getLastRecipe().getOutputContents(FluidRecipeCapability.CAP).get(0)
                     .getContent() instanceof IntProviderFluidIngredient ingredient) {
                 ingredient.setSampledCount(0);
@@ -295,14 +295,14 @@ public class IntProviderFluidIngredientTest {
         // check the results of all rolls together
         helper.runAfterDelay(runs * 2 + 1, () -> {
             FluidStack results = fluidOut.getFluidInTank(0);
-            helper.assertTrue(TestUtils.isFluidWithinRange(results, runs, runs * 9),
-                    "Sabotaged Singleblock CR didn't produce correct number of fluids, produced [" +
-                            results.getAmount() + "] not [" + runs + "-" + (runs * 9) + "]");
-            helper.assertFalse((results.getAmount() == runs * 9),
-                    "Sabotaged Singleblock CR rolled max value on every roll (how??)");
             helper.assertFalse((results.getAmount() == runs * 0),
                     "Sabotaged Singleblock CR rolled min value on every roll! " +
                             "This is the failure this sabotage was intended to induce.");
+            helper.assertFalse((results.getAmount() == runs * 9),
+                    "Sabotaged Singleblock CR rolled max value on every roll (how??)");
+            helper.assertTrue(TestUtils.isFluidWithinRange(results, runs, runs * 9),
+                    "Sabotaged Singleblock CR didn't produce correct number of fluids, produced [" +
+                            results.getAmount() + "] not [" + runs + "-" + (runs * 9) + "]");
 
             // check if all the rolls were equal, but not min/max
             int[] rolls = new int[runs];

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredientTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredientTest.java
@@ -11,6 +11,7 @@ import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMa
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.FluidHatchPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ParallelHatchPartMachine;
@@ -66,10 +67,11 @@ public class IntProviderIngredientTest {
 
     @BeforeBatch(batch = "RangedIngredients")
     public static void prepare(ServerLevel level) {
-        CR_RECIPE_TYPE = TestUtils.createRecipeType("ranged_ingredient_cr_tests", 2, 2, 3, 2);
-        LCR_RECIPE_TYPE = TestUtils.createRecipeType("ranged_ingredient_lcr_tests", 3, 3, 5, 4);
-        CENTRIFUGE_RECIPE_TYPE = TestUtils.createRecipeType("ranged_ingredient_centrifuge_tests", 2, 6, 1, 6);
-
+        CR_RECIPE_TYPE = TestUtils.createRecipeType("ranged_ingredient_cr_tests", GTRecipeTypes.CHEMICAL_RECIPES);
+        LCR_RECIPE_TYPE = TestUtils.createRecipeType("ranged_ingredient_lcr_tests",
+                GTRecipeTypes.LARGE_CHEMICAL_RECIPES);
+        CENTRIFUGE_RECIPE_TYPE = TestUtils.createRecipeType("ranged_ingredient_centrifuge_tests",
+                GTRecipeTypes.CENTRIFUGE_RECIPES);
         CR_RECIPE_TYPE.getLookup().addRecipe(CR_RECIPE_TYPE
                 .recipeBuilder(GTCEu.id("test_ranged_input_item_cr"))
                 .inputItemsRanged(CR_IN, UniformInt.of(0, 9))
@@ -263,7 +265,7 @@ public class IntProviderIngredientTest {
         // get the result of each roll independently
         int[] addedRolls = new int[runs];
 
-        helper.runAfterDelay(4, () -> {
+        helper.runAfterDelay(2, () -> {
             if (machine.getRecipeLogic().getLastRecipe().getOutputContents(ItemRecipeCapability.CAP).get(0)
                     .getContent() instanceof IntProviderIngredient ingredient) {
                 ingredient.setSampledCount(0);
@@ -286,14 +288,15 @@ public class IntProviderIngredientTest {
         // check the results of all rolls together
         helper.runAfterDelay(runs * 2 + 1, () -> {
             ItemStack results = itemOut.getStackInSlot(0);
-            helper.assertTrue(TestUtils.isItemWithinRange(results, runs, runs * 9),
-                    "Sabotaged Singleblock CR didn't produce correct number of items, produced [" +
-                            results.getCount() + "] not [" + runs + "-" + (runs * 9) + "]");
-            helper.assertFalse((results.getCount() == runs * 9),
-                    "Sabotaged Singleblock CR rolled max value on every roll (how??)");
             helper.assertFalse((results.getCount() == runs * 0),
                     "Sabotaged Singleblock CR rolled min value on every roll! " +
                             "This is the failure this sabotage was intended to induce.");
+            helper.assertFalse((results.getCount() == runs * 9),
+                    "Sabotaged Singleblock CR rolled max value on every roll (how??)");
+
+            helper.assertTrue(TestUtils.isItemWithinRange(results, runs, runs * 9),
+                    "Sabotaged Singleblock CR didn't produce correct number of items, produced [" +
+                            results.getCount() + "] not [" + runs + "-" + (runs * 9) + "]");
 
             // check if all the rolls were equal, but not min/max
             int[] rolls = new int[runs];

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredientTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredientTest.java
@@ -208,7 +208,7 @@ public class IntProviderIngredientTest {
                 "IntProviderIngredient should have item equal to what it was made with");
         helper.assertTrue(TestUtils.areItemStacksEqual(stacks, ingredient.getItems()),
                 "IntProviderIngredient.getItems shouldn't change between getStacks calls");
-        ingredient.reroll();
+        ingredient.reset();
         helper.assertFalse(TestUtils.areItemStacksEqual(stacks, ingredient.getItems()),
                 "IntProviderIngredient.getItems should have changed after rerolling");
         helper.succeed();


### PR DESCRIPTION
## What
Backports a few minor fixes and an API unification for Ranged Ingredients and their tests, from the 1.21 branch.

Notably:

- Ranged Ingredients are now unified under the new interface IRangedIngredient. Functionally unchanged but API conformity.
- The getSampledCount() function has been refactored into a simple @ Getter rather than being what triggers the ranged roll
- Ranged Ingredient Sabotage tests were written slightly wrong and had an incorrect _success_ case, incorrect sabotage timing, and on failure could misreport why they failed.