### PR TITLE
Fix GT Capes not rendering in multiplayer

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -4742,7 +4742,7 @@
   "item.gtceu.tool.behavior.block_rotation": "sʞɔoןᗺ sǝʇɐʇoᴚɟ§ :ɔıuɐɥɔǝWᄅ§",
   "item.gtceu.tool.behavior.crop_harvesting": "sdoɹƆ sʇsǝʌɹɐHɟ§ :ɹǝʇsǝʌɹɐHɐ§",
   "item.gtceu.tool.behavior.damage_boost": "%s ʇsuıɐbɐ ǝbɐɯɐp ɐɹʇxƎɟ§ :ʇsooᗺ ǝbɐɯɐᗡㄣ§",
-  "item.gtceu.tool.behavior.dowse_campfire": "sǝɹıɟdɯɐƆ sǝsʍoᗡɟ§ :ɹǝʇɥbıɟǝɹıℲ§",
+  "item.gtceu.tool.behavior.dowse_campfire": "sǝɹıɟdɯɐƆ sǝsʍoᗡɟ§ :ɹǝʇɥbıɟǝɹıℲƖ§",
   "item.gtceu.tool.behavior.grass_path": "sɥʇɐԀ ssɐɹ⅁ sǝʇɐǝɹƆɟ§ :ɹǝdɐɔspuɐꞀǝ§",
   "item.gtceu.tool.behavior.ground_tilling": "punoɹ⅁ sןןı⟘ɟ§ :ɹǝɯɹɐℲǝ§",
   "item.gtceu.tool.behavior.plunger": "spınןℲ suıɐɹᗡɟ§ :ɹǝqɯnןԀ6§",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -4742,7 +4742,7 @@
   "item.gtceu.tool.behavior.block_rotation": "§2Mechanic: §fRotates Blocks",
   "item.gtceu.tool.behavior.crop_harvesting": "§aHarvester: §fHarvests Crops",
   "item.gtceu.tool.behavior.damage_boost": "§4Damage Boost: §fExtra damage against %s",
-  "item.gtceu.tool.behavior.dowse_campfire": "§Firefighter: §fDowses Campfires",
+  "item.gtceu.tool.behavior.dowse_campfire": "§1Firefighter: §fDowses Campfires",
   "item.gtceu.tool.behavior.grass_path": "§eLandscaper: §fCreates Grass Paths",
   "item.gtceu.tool.behavior.ground_tilling": "§eFarmer: §fTills Ground",
   "item.gtceu.tool.behavior.plunger": "§9Plumber: §fDrains Fluids",

--- a/src/main/java/com/gregtechceu/gtceu/api/cosmetics/CapeRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cosmetics/CapeRegistry.java
@@ -11,7 +11,6 @@ import net.minecraft.nbt.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.saveddata.SavedData;
 import net.minecraftforge.common.MinecraftForge;
 
@@ -275,30 +274,27 @@ public class CapeRegistry extends SavedData {
     }
 
     // For loading capes when the player logs in, so that it's synced to the clients.
-    public static void loadCurrentCapesOnLogin(Player player) {
-        if (player instanceof ServerPlayer serverPlayer) {
-            UUID uuid = player.getUUID();
-            // sync to others
-            GTNetwork.sendToAll(new SPacketNotifyCapeChange(uuid, CURRENT_CAPES.get(uuid)));
-            // sync to the one who's logging in
-            for (ServerPlayer otherPlayer : serverPlayer.getServer().getPlayerList().getPlayers()) {
-                uuid = otherPlayer.getUUID();
-                GTNetwork.sendToPlayer(serverPlayer, new SPacketNotifyCapeChange(uuid, CURRENT_CAPES.get(uuid)));
-            }
+    public static void loadCurrentCapesOnLogin(ServerPlayer serverPlayer) {
+        UUID uuid = serverPlayer.getUUID();
+        // sync to others
+        GTNetwork.sendToAll(new SPacketNotifyCapeChange(uuid, CURRENT_CAPES.get(uuid)));
+        // sync to the one who's logging in
+        for (ServerPlayer otherPlayer : serverPlayer.getServer().getPlayerList().getPlayers()) {
+            uuid = otherPlayer.getUUID();
+            GTNetwork.sendToPlayer(serverPlayer, new SPacketNotifyCapeChange(uuid, CURRENT_CAPES.get(uuid)));
         }
     }
 
     // Runs on login and gives the player all free capes & capes they've already unlocked.
-    public static void detectNewCapes(Player player) {
-        if (player instanceof ServerPlayer) {
-            var playerCapes = UNLOCKED_CAPES.get(player.getUUID());
+    public static void detectNewCapes(ServerPlayer serverPlayer) {
+            var playerCapes = UNLOCKED_CAPES.get(serverPlayer.getUUID());
             if (playerCapes == null || !new HashSet<>(playerCapes).containsAll(FREE_CAPES)) {
                 for (ResourceLocation cape : FREE_CAPES) {
-                    unlockCape(player.getUUID(), cape);
+                    unlockCape(serverPlayer.getUUID(), cape);
                 }
                 save();
             }
-        }
+
     }
 
     private static final Comparator<ResourceLocation> SET_COMPARATOR = (o1, o2) -> {

--- a/src/main/java/com/gregtechceu/gtceu/api/cosmetics/CapeRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cosmetics/CapeRegistry.java
@@ -287,14 +287,13 @@ public class CapeRegistry extends SavedData {
 
     // Runs on login and gives the player all free capes & capes they've already unlocked.
     public static void detectNewCapes(ServerPlayer serverPlayer) {
-            var playerCapes = UNLOCKED_CAPES.get(serverPlayer.getUUID());
-            if (playerCapes == null || !new HashSet<>(playerCapes).containsAll(FREE_CAPES)) {
-                for (ResourceLocation cape : FREE_CAPES) {
-                    unlockCape(serverPlayer.getUUID(), cape);
-                }
-                save();
+        var playerCapes = UNLOCKED_CAPES.get(serverPlayer.getUUID());
+        if (playerCapes == null || !new HashSet<>(playerCapes).containsAll(FREE_CAPES)) {
+            for (ResourceLocation cape : FREE_CAPES) {
+                unlockCape(serverPlayer.getUUID(), cape);
             }
-
+            save();
+        }
     }
 
     private static final Comparator<ResourceLocation> SET_COMPARATOR = (o1, o2) -> {

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.client;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.cosmetics.event.RegisterGTCapesEvent;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
@@ -30,6 +31,7 @@ import com.gregtechceu.gtceu.common.data.GTParticleTypes;
 import com.gregtechceu.gtceu.common.entity.GTBoat;
 import com.gregtechceu.gtceu.common.machine.owner.MachineOwner;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+import com.gregtechceu.gtceu.forge.ForgeCommonEventListener;
 import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
 import com.gregtechceu.gtceu.integration.map.cache.client.GTClientCache;
 import com.gregtechceu.gtceu.integration.map.ftbchunks.FTBChunksPlugin;
@@ -71,6 +73,7 @@ public class ClientProxy extends CommonProxy {
             ClientCacheManager.registerClientCache(GTClientCache.instance, "gtceu");
             Layers.registerLayer(OreRenderLayer::new, "ore_veins");
             Layers.registerLayer(FluidRenderLayer::new, "bedrock_fluids");
+            ForgeCommonEventListener.registerCapes(new RegisterGTCapesEvent());
         }
         initializeDynamicRenders();
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -192,7 +192,7 @@ public class LangHandler {
         provider.add("item.gtceu.tool.behavior.crop_harvesting", "§aHarvester: §fHarvests Crops");
         provider.add("item.gtceu.tool.behavior.plunger", "§9Plumber: §fDrains Fluids");
         provider.add("item.gtceu.tool.behavior.block_rotation", "§2Mechanic: §fRotates Blocks");
-        provider.add("item.gtceu.tool.behavior.dowse_campfire", "§Firefighter: §fDowses Campfires");
+        provider.add("item.gtceu.tool.behavior.dowse_campfire", "§1Firefighter: §fDowses Campfires");
         provider.add("item.gtceu.tool.behavior.damage_boost", "§4Damage Boost: §fExtra damage against %s");
         provider.add("item.gtceu.tool.behavior.prospecting.ore", "Found ore: %s");
         provider.add("item.gtceu.tool.behavior.prospecting.air", "Found an air pocket");

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -82,7 +82,6 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.*;
-import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;

--- a/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/ForgeCommonEventListener.java
@@ -82,6 +82,7 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.*;
+import net.minecraftforge.event.entity.EntityJoinLevelEvent;
 import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
@@ -317,15 +318,14 @@ public class ForgeCommonEventListener {
         if (player instanceof ServerPlayer serverPlayer) {
             GTNetwork.sendToPlayer(serverPlayer, new SPacketSendWorldID());
 
-            if (!ConfigHolder.INSTANCE.gameplay.environmentalHazards)
-                return;
-
-            ServerLevel level = serverPlayer.serverLevel();
-            var data = EnvironmentalHazardSavedData.getOrCreate(level);
-            GTNetwork.sendToPlayer(serverPlayer, new SPacketSyncLevelHazards(data.getHazardZones()));
+            if (ConfigHolder.INSTANCE.gameplay.environmentalHazards) {
+                ServerLevel level = serverPlayer.serverLevel();
+                var data = EnvironmentalHazardSavedData.getOrCreate(level);
+                GTNetwork.sendToPlayer(serverPlayer, new SPacketSyncLevelHazards(data.getHazardZones()));
+            }
+            CapeRegistry.detectNewCapes(serverPlayer);
+            CapeRegistry.loadCurrentCapesOnLogin(serverPlayer);
         }
-        CapeRegistry.detectNewCapes(player);
-        CapeRegistry.loadCurrentCapesOnLogin(player);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
## What
Capes didn't work in multiplayer. 
Because they were only registered on serverStart, not on client load. (This load order issue briefly turned this into another Heisenbug, in which if a player loaded into a singleplayer world then their cape **would** render in multiplayer, but only for them.)

Also, the per-player cape unlocked registry also didn't work in multiplayer, because the call to send the cape registry would only happen if Environmental Hazards were configured to True, because of an inappropriately early return call.

Fixes both of these so now you can actually have a cape in multiplayer.


Also totally unrelated to these bugs, also fixes a one line random lang issue where GT Shovels had the effect "irefighter" rather than "Firefighter". I kinda just shoved this one in because it's a one character change and I needed somewhere to put it.