### PR TITLE
Allow tags in shaped recipes to get recycle info

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -98,7 +98,6 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
@@ -663,7 +662,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
             var ingredient = entry.value().kjs$asIngredient();
             var values = ((IngredientAccessor) ingredient).getValues();
-            if (values.length == 0 || values[0] instanceof Ingredient.TagValue) continue;
+            if (values.length == 0) continue;
 
             ItemStack[] stacks = ingredient.getItems();
             ItemStack stack;


### PR DESCRIPTION
## What
now a KJS recipe with .shaped that uses tags actually get considered for recycling info

## Implementation Details
We explicitly disallowed it before? not sure why

## Outcome
closes #3641 


(Do note that in this example, iron plates' first item is create iron sheets, which doesn't have a recycle value in our dev env. So it makes sense we don't have it in the output list)

ServerEvents.recipes(event => {
    event.recipes.gtceu.shaped("minecraft:dirt", [
        "SSS",
        "SMS",
        "III"
    ], {
        M: "#forge:plates/iron",
        S: "#forge:plates/steel",
        I: "#forge:ingots/bronze"
    }).addMaterialInfo()
})



Before:

<img width="410" height="434" alt="image" src="https://github.com/user-attachments/assets/74d9b28f-67aa-4147-8403-de56d1948f42" />
<img width="380" height="283" alt="image" src="https://github.com/user-attachments/assets/74e7cd25-3538-461b-b983-2f2c927efc28" />


After:
<img width="446" height="280" alt="image" src="https://github.com/user-attachments/assets/d37fffed-ddc8-4f6a-a0f1-1a53cac23061" />
<img width="489" height="315" alt="image" src="https://github.com/user-attachments/assets/b0bc8b73-5a87-45cf-bf44-b568c16b1a17" />
