### PR TITLE
Improvements to Sodalite and Lazurite

### DIFF
--- a/src/generated/resources/data/forge/tags/items/enchanting_fuels.json
+++ b/src/generated/resources/data/forge/tags/items/enchanting_fuels.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "gtceu:lazurite_gem",
+    "gtceu:sodalite_gem"
+  ]
+}

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -623,5 +623,11 @@ public class MiscRecipeLoader {
                 .inputItems(Blocks.CHISELED_BOOKSHELF.asItem())
                 .outputItems(dust, Wood, 6)
                 .duration(100).EUt(2).save(provider);
+
+        // Lazurite and Sodalite to dye
+        VanillaRecipeHelper.addShapelessRecipe(provider, "lazurite_to_dye", new ItemStack(Items.BLUE_DYE),
+                new MaterialEntry(gem, Lazurite));
+        VanillaRecipeHelper.addShapelessRecipe(provider, "sodalite_to_dye", new ItemStack(Items.BLUE_DYE),
+                new MaterialEntry(gem, Sodalite));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/ItemTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/ItemTagLoader.java
@@ -189,5 +189,10 @@ public class ItemTagLoader {
 
         provider.addTag(CustomTags.TOOLS_IGNITER)
                 .addTag(ItemTags.CREEPER_IGNITERS);
+
+        // Add sodalite and lazurite as enchanting fuels
+        provider.addTag(Tags.Items.ENCHANTING_FUELS)
+                .add(GTMaterialItems.MATERIAL_ITEMS.get(gem, Lazurite).get())
+                .add(GTMaterialItems.MATERIAL_ITEMS.get(gem, Sodalite).get());
     }
 }


### PR DESCRIPTION
## What
Add Lazurite and Sodalite to enchanting fuels tag
Add recipes to craft Lazurite and Sodalite into blue dye

## Outcome
Lazurite and Sodalite now act similarly to Lapis as was in 1.12
fixes #4296 

## Potential Compatibility Issues
none
