### PR TITLE
Fixes some cases where handleRecipe() succeeds when it should fail

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/SizedIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/SizedIngredient.java
@@ -98,7 +98,7 @@ public class SizedIngredient extends Ingredient {
             }
             return copied;
         }
-        return SizedIngredient.create(ingredient);
+        return SizedIngredient.create(ingredient, ingredient.getItems()[0].getCount());
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes some cases where handleRecipe() succeeds when it should fail because it was handed an Ingredient that contained a stack of more than 1 item because SizedIngredient.copy() when handed an Ingredient set its amount to 1