### PR TITLE
Fix dupes of Carbon dust and Coal dust

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
@@ -367,7 +367,7 @@ public class UnknownCompositionMaterials {
                 .dust(0)
                 .color(0xa4a4a4).secondaryColor(0x767676).iconSet(ROUGH)
                 .flags(FLAMMABLE, EXPLOSIVE, NO_SMELTING, NO_SMASHING)
-                .components(Saltpeter, 2, Sulfur, 1, Coal, 3)
+                .components(Saltpeter, 2, Sulfur, 1, Carbon, 3)
                 .buildAndRegister();
 
         Oilsands = new Material.Builder(GTCEu.id("oilsands"))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/MixerRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/MixerRecipes.java
@@ -268,7 +268,7 @@ public class MixerRecipes {
         MIXER_RECIPES.recipeBuilder("gunpowder_from_carbon").duration(400).EUt(VA[ULV])
                 .inputItems(dust, Saltpeter, 2)
                 .inputItems(dust, Sulfur)
-                .inputItems(dust, Carbon, 3)
+                .inputItems(dust, Carbon, 6)
                 .circuitMeta(1)
                 .outputItems(dust, Gunpowder, 6)
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/MixerRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/MixerRecipes.java
@@ -268,7 +268,7 @@ public class MixerRecipes {
         MIXER_RECIPES.recipeBuilder("gunpowder_from_carbon").duration(400).EUt(VA[ULV])
                 .inputItems(dust, Saltpeter, 2)
                 .inputItems(dust, Sulfur)
-                .inputItems(dust, Carbon, 6)
+                .inputItems(dust, Carbon, 3)
                 .circuitMeta(1)
                 .outputItems(dust, Gunpowder, 6)
                 .save(provider);


### PR DESCRIPTION
## What
Fix dupes of carbon dust and coal dust
Resolve #3742 

## Implementation Details
Now 2 Saltpeter dust + Sulfur dust + 6 Carbon dust -> gunpowder instead of 2 Saltpeter dust + Sulfur dust + 3 Carbon dust