### PR TITLE
Fixes multiblock rendering issues on world load

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -228,6 +228,12 @@ public class MetaMachine implements IEnhancedManaged, IToolable, ITickSubscripti
                 this.isPainted() != renderState.getValue(GTMachineModelProperties.IS_PAINTED)) {
             setRenderState(renderState.setValue(GTMachineModelProperties.IS_PAINTED, this.isPainted()));
         }
+
+        // Force model data refresh on client when BlockEntity finishes loading,
+        // in case the chunk was rendered before this BlockEntity was available
+        if (isRemote()) {
+            scheduleRenderUpdate();
+        }
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/part/MultiblockPartMachine.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeHandlerList;
 import com.gregtechceu.gtceu.client.model.machine.MachineRenderState;
 
 import com.lowdragmc.lowdraglib.syncdata.annotation.DescSynced;
+import com.lowdragmc.lowdraglib.syncdata.annotation.RequireRerender;
 import com.lowdragmc.lowdraglib.syncdata.annotation.UpdateListener;
 import com.lowdragmc.lowdraglib.syncdata.field.ManagedFieldHolder;
 
@@ -38,6 +39,7 @@ public class MultiblockPartMachine extends MetaMachine implements IMultiPart {
             MetaMachine.MANAGED_FIELD_HOLDER);
 
     @DescSynced
+    @RequireRerender
     @UpdateListener(methodName = "onControllersUpdated")
     protected final Set<BlockPos> controllerPositions = new ObjectOpenHashSet<>(8);
     protected final SortedSet<IMultiController> controllers = new ReferenceLinkedOpenHashSet<>(8);

--- a/src/main/java/com/gregtechceu/gtceu/client/model/machine/multipart/MultiPartBakedModel.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/machine/multipart/MultiPartBakedModel.java
@@ -122,7 +122,9 @@ public class MultiPartBakedModel implements IDynamicBakedModel {
         BlockPos pos = modelData.get(MODEL_DATA_POS);
 
         var machine = (level == null || pos == null) ? null : MetaMachine.getMachine(level, pos);
-        if (machine == null) return IDynamicBakedModel.super.getRenderTypes(state, rand, modelData);
+        // When machine is null (BE not loaded yet), use the default model's render types
+        // to ensure we still render something instead of being invisible
+        if (machine == null) return defaultModel.getRenderTypes(state, rand, modelData);
 
         var renderTypeSets = new LinkedList<ChunkRenderTypeSet>();
         var selectors = getSelectors(machine.getRenderState());


### PR DESCRIPTION
## What

Addresses an issue where multiblocks sometimes fail to render correctly after initial chunk loading due to the block entity not being fully initialized when the chunk is first rendered.

## Implementation Details

Forces a model data refresh on the client side when a block entity finishes loading to ensure correct rendering of multiblocks, especially in cases where the chunk was rendered before the block entity was fully available. Also, it avoids returning null model render types, which could cause the block to be invisible, by instead returning the render types of the default model.

## Outcome

Fixes #4276
