### PR TITLE
[DOCS] [1.20.1] Use mike for multi-version support

### DIFF
--- a/.github/workflows/deploy-pages-1201.yml
+++ b/.github/workflows/deploy-pages-1201.yml
@@ -1,4 +1,4 @@
-name: Publish docs via GitHub Pages
+name: Publish 1.20.1 docs via GitHub Pages
 on:
   workflow_dispatch:
   push:
@@ -35,14 +35,11 @@ jobs:
         with:
           key: 'mkdocs-cache'
           path: './docs/.cache'
-      - name: Build static files
-        id: mkdocs
-        run: mkdocs build
-      - name: Upload pages as artifact
-        id: artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './docs/site/'
+      - name: Deploy 1.20.1 pages to gh-pages branch
+        run: mike deploy 1.20.1 --push
+      - name: Ensure 1.20.1 is the default version
+        run: mike set-default 1.20.1 --push
+
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pages-1201.yml
+++ b/.github/workflows/deploy-pages-1201.yml
@@ -39,15 +39,3 @@ jobs:
         run: mike deploy 1.20.1 --push
       - name: Ensure 1.20.1 is the default version
         run: mike set-default 1.20.1 --push
-
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,14 +1,12 @@
-name: Publish 1.20.1 docs via GitHub Pages
+name: Publish docs via GitHub Pages
 on:
   workflow_dispatch:
   push:
-    branches: [1.20.1]
+    branches: ["1.20.1", "1.21"]
     paths: ['docs/**']
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: 'pages'
@@ -18,24 +16,25 @@ jobs:
   build:
     name: build docs
     runs-on: ubuntu-latest
+    env:
+      GIT_COMMITTER_NAME: ci-bot
+      GIT_COMMITTER_EMAIL: ci-bot@example.com
+      GIT_AUTHOR_NAME: ci-bot
+      GIT_AUTHOR_EMAIL: ci-bot@example.com
     defaults:
       run:
         working-directory: './docs'
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: '1.20.1'
-          sparse-checkout: './docs'
+          ref: '${{ github.ref_name }}'
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: 'pip'
       - run: pip install -r ./requirements.txt
-      - uses: actions/cache@v4
-        with:
-          key: 'mkdocs-cache'
-          path: './docs/.cache'
-      - name: Deploy 1.20.1 pages to gh-pages branch
-        run: mike deploy 1.20.1 --push
+      - name: Deploy pages to gh-pages branch
+        run: mike deploy "${{ github.ref_name }}" --push
       - name: Ensure 1.20.1 is the default version
         run: mike set-default 1.20.1 --push

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -16,11 +16,6 @@ jobs:
   build:
     name: build docs
     runs-on: ubuntu-latest
-    env:
-      GIT_COMMITTER_NAME: ci-bot
-      GIT_COMMITTER_EMAIL: ci-bot@example.com
-      GIT_AUTHOR_NAME: ci-bot
-      GIT_AUTHOR_EMAIL: ci-bot@example.com
     defaults:
       run:
         working-directory: './docs'
@@ -33,7 +28,10 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -r ./requirements.txt
+      - name: Install packages
+        run: pip install -r ./requirements.txt
+      - name: Set git username and password
+        run: git config user.name 'github-actions[bot]'; git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: Deploy pages to gh-pages branch
         run: mike deploy "${{ github.ref_name }}" --push
       - name: Ensure 1.20.1 is the default version

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,3 +79,7 @@ mkdocs serve
 The following plugins for MkDocs are being used:
 - https://squidfunk.github.io/mkdocs-material/
 - https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin
+
+## Serving final site
+The final site that gets displayed is in the "gh-pages" branch. Both the 1.20.1 and 1.21.1 workflows push to this branch, and a dropdown will appear on the site.
+Be very careful running any kind of mike command locally (mike deploy, mike set-default etc) since these will make commits to gh-pages, which might update the live site.

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@ The following plugins for MkDocs are being used:
 - https://squidfunk.github.io/mkdocs-material/
 - https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin
 
-## Serving final site
-The final site that gets displayed is in the "gh-pages" branch. Both the 1.20.1 and 1.21.1 workflows push to this branch, and a dropdown will appear on the site.
-Be very careful running any kind of mike command locally (mike deploy, mike set-default etc) since these will make commits to gh-pages, which might update the live site.
+## Deployment
+The hosted documentation is found on the `gh-pages` branch of the repository. [Mike](https://github.com/jimporter/mike) is used to deploy both the 1.20.1 and 1.21.1 documentation on the same site through Github Actions.
+
+When working on the docs locally, the plain `mkdocs` commands should be used to view the changes made to the version of the docs you are currently working on, like the previously mentioned `mkdocs serve`.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -5,8 +5,7 @@ hide:
 title: Home
 ---
 
-
-# Welcome to GregTech CEu Modern's Documentation!
+# Welcome to GregTech CEu Modern's Documentation for 1.20.1!
 
 GregTech CEu Modern is a port of [GregTech Community Edition Unofficial](https://github.com/GregTechCEu/GregTech)
 to modern Minecraft versions.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -47,6 +47,8 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/bWSWuYvURP

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs-material
 mkdocs-awesome-pages-plugin
+mike


### PR DESCRIPTION
## What
Uses mike for multi-version support for docs.

## Implementation Details
This means instead of uploading zip files, our pipeline will push to the gh-pages branch, and that will be served. this way the 1.20.1 and 1.21.1 pipeline can independently update and push their changes

## Outcome
Versioned docs, see 

https://github.com/user-attachments/assets/4767a72c-80c1-4510-b15c-9618291c0801


## Additional Information
When both of these PRs are merged, we need to change the pages API to reflect gh-pages rather than uploaded artifacts. This is a setting in github.

Needs to wait for the 1.21 PR that's coming