### PR TITLE
[MUI2] Center stuff in battery buffer UI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -121,8 +121,9 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                 .child(GTMuiWidgets.createTitleBar(getDefinition(), 172))
                 .child(Flow.row()
                         .height(90)
-                        .padding(5)
-                        .marginBottom(82)
+                        .margin(6)
+                        .marginTop(2)
+                        .height(80)
                         .child(new ProgressWidget()
                                 .texture(GTGuiTextures.PROGRESS_BAR_BOILER_EMPTY_STEEL,
                                         GTGuiTextures.PROGRESS_BAR_BOILER_HEAT, 60)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -122,6 +122,7 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                 .child(Flow.row()
                         .height(90)
                         .padding(5)
+                        .marginBottom(82)
                         .child(new ProgressWidget()
                                 .texture(GTGuiTextures.PROGRESS_BAR_BOILER_EMPTY_STEEL,
                                         GTGuiTextures.PROGRESS_BAR_BOILER_HEAT, 60)
@@ -129,6 +130,7 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                                 .progress(this::getEnergyPercentage)
                                 .marginRight(50)
                                 .size(18, 60)
+                                .verticalCenter()
                                 .addTooltipLine(IKey.dynamic(() -> Component.literal(
                                         "%s/%s EU".formatted(
                                                 GTStringUtils.formatInt(energyContainer.getEnergyStored()),
@@ -138,7 +140,8 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                                 inventorySize, 'B',
                                 slot -> slot.background(GTGuiTextures.SLOT, GTGuiTextures.CHARGER_OVERLAY),
                                 syncManager,
-                                matrix)))
+                                matrix)
+                                .center()))
                 .child(new Column()
                         .coverChildren()
                         .leftRel(1.0f)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -122,6 +122,7 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                 .child(Flow.row()
                         .height(90)
                         .margin(6)
+                        .marginLeft(7)
                         .marginTop(2)
                         .height(80)
                         .child(new ProgressWidget()


### PR DESCRIPTION
## What
The bar and slot group weren't properly centered so now they are

## Outcome
<img width="1856" height="1016" alt="image" src="https://github.com/user-attachments/assets/0d60fc5c-a638-4434-bd8a-42c65b1fcee6" />
<img width="1856" height="1016" alt="image" src="https://github.com/user-attachments/assets/7a8482c5-bd1e-4072-b79f-18667b379025" />
<img width="1856" height="1016" alt="image" src="https://github.com/user-attachments/assets/97f9e81f-0e3f-4802-943e-4dcebc73d7f7" />
