### PR TITLE
Prevent clientside state mutations in QuarkTechSuite helmet

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
@@ -87,7 +87,7 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
 
         boolean ret = false;
         if (type == ArmorItem.Type.HELMET) {
-            
+
             if (!world.isClientSide) {
                 ret = supplyAir(item, player) || supplyFood(item, player);
                 removeNegativeEffects(item, player);

--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
@@ -87,9 +87,11 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
 
         boolean ret = false;
         if (type == ArmorItem.Type.HELMET) {
-            ret = supplyAir(item, player) || supplyFood(item, player);
-
-            removeNegativeEffects(item, player);
+            
+            if (!world.isClientSide) {
+                ret = supplyAir(item, player) || supplyFood(item, player);
+                removeNegativeEffects(item, player);
+            }
 
             boolean nightVision = data.contains("nightVision") && data.getBoolean("nightVision");
             if (toggleTimer == 0 && KeyBind.ARMOR_MODE_SWITCH.isKeyDown(player)) {


### PR DESCRIPTION
## What
The QuarkTechSuite helmet calls functions to modify the gamestate during both logical sides in the onArmorTick. This can cause a number of issues and is generally discouraged.

## Outcome
This PR limits the mutations (food, air, negative effects) to the serverside only.

## Additional Information
I ran into this when making a mixin for this bug: https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/1640

I noticed supplyFood gets called during the clientside ticks as well as the serverside ticks, and the clientside ticks can't properly check if the player is in a PlayerRevive:bleeding state or not.

While that is all a mod compatibility stuff that brings it to light the actual bug in GTm is a standalone latent bug.

I worked around the bug in https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/216 by checking for clientside in the mixin and not running supplyFood at all on clientside, which worked fine.