### PR TITLE
KubeJS Duration Check

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/GTValues.java
@@ -36,6 +36,15 @@ public class GTValues {
     public static final int L = 144;
     public static final RandomSource RNG = RandomSource.createThreadSafe();
 
+    // shortcut for various lengths of time in ticks
+    public static final long SECONDS = 20;
+    public static final long MINUTES = 60 * SECONDS;
+    public static final long HOURS = 60 * MINUTES;
+    public static final long DAYS = 24 * HOURS;
+    public static final long WEEKS = 7 * DAYS;
+    public static final long MONTHS = 30 * DAYS;
+    public static final long YEARS = 365 * DAYS;
+
     /**
      * The Item WildCard Tag. Even shorter than the "-1" of the past
      */

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -548,7 +548,12 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         // get the recipe ID without the leading type path
         GTRecipeBuilder builder = gtRecipeType.recipeBuilder(gtRecipe.idWithoutType());
         if (gtRecipe.getValue(GTRecipeSchema.DURATION) != null) {
-            builder.duration = gtRecipe.getValue(GTRecipeSchema.DURATION).intValue();
+            int duration = gtRecipe.getValue(GTRecipeSchema.DURATION).intValue();
+            if (duration <= 0) {
+                GTCEu.LOGGER.error("Duration must be a positive value, skipping recipe id: {}", gtRecipe.getId());
+                return;
+            }
+            builder.duration = duration;
         }
         if (gtRecipe.getValue(GTRecipeSchema.DATA) != null) {
             builder.data = gtRecipe.getValue(GTRecipeSchema.DATA);


### PR DESCRIPTION
## What
Skips the recipe from registering if the duration is non positive, led to a crash in overclocking logic
also added several constants to GTValues for various amounts of time in ticks(seconds, minutes, hours etc)

## Implementation Details
non positive check and log and return

## Outcome
no more bug