### PR TITLE
(Docs) Fix GTValues.VA being used as a function in material property modification, add reference to coil temps in Material Properties

### DIFF
--- a/docs/content/Modpacks/Materials-and-Elements/Material-Properties.md
+++ b/docs/content/Modpacks/Materials-and-Elements/Material-Properties.md
@@ -29,7 +29,7 @@ Properties can be applied to a material to decide how they behave. An example of
 
 ## `Blast Furnace Properties`
 - `.blastTemp()` is meant to be paired together with `.ingot()`. Will generate a EBF recipe (and an ABS recipe) based on the parameters you give it:
-    1. `int temperature` -> dictates what coil tier it will require (check the coil tooltips for their max temperature).
+    1. `int temperature` -> dictates what coil tier it will require (check the coil tooltips for their max temperature, or visit [Standard Coils](../Other-Topics/Custom-Coils.md#standard-coils)).
         If the temperature is below 1000, it will also generate a PBF recipe.
         If temperature is above 1750, a hot ingot will be generated, this requiring a Vacuum Freezer.
     2. (optional) `string gasTier` -> can be `null` for none, `'low'` for nitrogen, `'mid'` for helium, `'high'` for argon, `'higher'` for neon or `'highest'` for krypton.

--- a/docs/content/Modpacks/Materials-and-Elements/Modifying-Existing-Materials.md
+++ b/docs/content/Modpacks/Materials-and-Elements/Modifying-Existing-Materials.md
@@ -22,7 +22,7 @@ All periodic table elements are present in GT, but some of them don't have any p
         GTMaterials.Selenium.setProperty(PropertyKey.DUST, new $DustProperty());
 
         // Blast Property
-        GTMaterials.Zirconium.setProperty(PropertyKey.BLAST, new $BlastProperty(8000, 'higher', GTValues.VA(GTValues.MV), 8000));
+        GTMaterials.Zirconium.setProperty(PropertyKey.BLAST, new $BlastProperty(8000, 'higher', GTValues.VA[GTValues.MV], 8000));
 
     });
 ```


### PR DESCRIPTION
## What
This PR is intended to fix some slight inaccuracies in the docs, nothing big.

## Implementation Details
Maybe the way the reference to Standard Coils has been "rammed in" too haphazardly. Find it intuitive this way, however, feel free to disagree.

## Outcome
I, and others, don't have to find the coil section at the bottom to know what temps belong to which coil tier.
