### PR TITLE
Update sound registration to use ExampleMod.id

### DIFF
--- a/docs/content/Modpacks/Other-Topics/Custom-Sounds.md
+++ b/docs/content/Modpacks/Other-Topics/Custom-Sounds.md
@@ -17,7 +17,7 @@ import static com.examplemod.common.registry.ExampleRegistration.REGISTRATE;
 
 public class ExampleSound {
 
-    public static final SoundEntry MICROVERSE = REGISTRATE.sound("microverse").build();
+    public static final SoundEntry MICROVERSE = REGISTRATE.sound(ExampleMod.id("microverse")).build();
 
     public static void init() {}
 }


### PR DESCRIPTION
## What
Example was broken and forgot to cast the sound into a mod ID.