### PR TITLE
сorrecting EnderCoversTest

### DIFF
--- a/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
@@ -46,7 +46,7 @@ public class EnderCoversTest {
                 IFluidHandler.FluidAction.EXECUTE);
         helper.runAtTickTime(20, () -> {
             helper.assertTrue(TestUtils.isFluidStackEqual(
-                    tank2.getFluidHandlerCap(Direction.UP, false).getFluidInTank(0),
+                    tank2.getFluidHandlerCap(null, false).getFluidInTank(0),
                     new FluidStack(Fluids.WATER, 1000)),
                     "ender fluid link cover didn't transfer fluid");
             helper.succeed();

--- a/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
@@ -30,6 +30,10 @@ import net.minecraftforge.gametest.PrefixGameTestTemplate;
 @GameTestHolder(GTCEu.MOD_ID)
 public class EnderCoversTest {
 
+    public static boolean isTankFluidStackEqual(QuantumTankMachine tank, FluidStack stack) {
+        return tank.getStored().getFluid() == stack.getFluid() && tank.getStoredAmount() == stack.getAmount();
+    }
+
     @GameTest(template = "empty_5x5", batch = "coverTests")
     public static void fluidLinkCoverTest(GameTestHelper helper) {
         QuantumTankMachine tank1 = (QuantumTankMachine) TestUtils.setMachine(helper, new BlockPos(1, 1, 1),
@@ -42,10 +46,10 @@ public class EnderCoversTest {
                 GTItems.COVER_ENDER_FLUID_LINK.asStack(), Direction.UP);
         cover1.setIo(IO.IN);
         cover2.setIo(IO.OUT);
-        tank1.getFluidHandlerCap(Direction.UP, false).fill(new FluidStack(Fluids.WATER, 1000),
+        tank1.getFluidHandlerCap(Direction.UP, false).fill(new FluidStack(Fluids.WATER, 950),
                 IFluidHandler.FluidAction.EXECUTE);
         helper.runAtTickTime(20, () -> {
-            helper.assertTrue(TestUtils.isFluidStackEqual(tank2.getStored(), new FluidStack(Fluids.WATER, 1000)),
+            helper.assertTrue(isTankFluidStackEqual(tank2, new FluidStack(Fluids.WATER, 950)),
                     "ender fluid link cover didn't transfer fluid");
             helper.succeed();
         });

--- a/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/common/cover/EnderCoversTest.java
@@ -30,10 +30,6 @@ import net.minecraftforge.gametest.PrefixGameTestTemplate;
 @GameTestHolder(GTCEu.MOD_ID)
 public class EnderCoversTest {
 
-    public static boolean isTankFluidStackEqual(QuantumTankMachine tank, FluidStack stack) {
-        return tank.getStored().getFluid() == stack.getFluid() && tank.getStoredAmount() == stack.getAmount();
-    }
-
     @GameTest(template = "empty_5x5", batch = "coverTests")
     public static void fluidLinkCoverTest(GameTestHelper helper) {
         QuantumTankMachine tank1 = (QuantumTankMachine) TestUtils.setMachine(helper, new BlockPos(1, 1, 1),
@@ -46,10 +42,12 @@ public class EnderCoversTest {
                 GTItems.COVER_ENDER_FLUID_LINK.asStack(), Direction.UP);
         cover1.setIo(IO.IN);
         cover2.setIo(IO.OUT);
-        tank1.getFluidHandlerCap(Direction.UP, false).fill(new FluidStack(Fluids.WATER, 950),
+        tank1.getFluidHandlerCap(Direction.UP, false).fill(new FluidStack(Fluids.WATER, 1000),
                 IFluidHandler.FluidAction.EXECUTE);
         helper.runAtTickTime(20, () -> {
-            helper.assertTrue(isTankFluidStackEqual(tank2, new FluidStack(Fluids.WATER, 950)),
+            helper.assertTrue(TestUtils.isFluidStackEqual(
+                    tank2.getFluidHandlerCap(Direction.UP, false).getFluidInTank(0),
+                    new FluidStack(Fluids.WATER, 1000)),
                     "ender fluid link cover didn't transfer fluid");
             helper.succeed();
         });


### PR DESCRIPTION
## What
The test is working better now

## Outcome
It is correct to use fluidHandlerCap instead of getStored() (because tank.getStored always 1000mb when the fluid is inside)