### PR TITLE
Make fuel jetpacks work on servers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/PowerlessJetpack.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/PowerlessJetpack.java
@@ -96,11 +96,14 @@ public class PowerlessJetpack implements IArmorLogic, IJetpack, IItemHUDProvider
         if (toggleTimer > 0) toggleTimer--;
         data.putByte("toggleTimer", toggleTimer);
 
-        if (currentFuel.isEmpty())
-            findNewRecipe(stack);
-
         performFlying(player, jetpackEnabled, hoverMode, stack);
-        data.putShort("burnTimer", (short) burnTimer);
+
+        if (!world.isClientSide) {
+            if (currentFuel.isEmpty())
+                findNewRecipe(stack);
+
+            data.putShort("burnTimer", (short) burnTimer);
+        }
     }
 
     @Override
@@ -162,8 +165,8 @@ public class PowerlessJetpack implements IArmorLogic, IJetpack, IItemHUDProvider
 
     @Override
     public boolean canUseEnergy(ItemStack stack, int amount) {
-        if (currentFuel.isEmpty()) return false;
         if (burnTimer > 0) return true;
+        if (currentFuel.isEmpty()) return false;
         var ret = FluidUtil.getFluidHandler(stack)
                 .map(h -> h.drain(Integer.MAX_VALUE, FluidAction.SIMULATE))
                 .map(drained -> drained.getAmount() >= currentFuel.getAmount())


### PR DESCRIPTION
[bugfix]

## What
Currently fuel jetpacks don't work on multiplayer unless you go to singleplayer first and then join a server. This PR fixes that.

## Bug cause
PowerlessJetpack.FUELS doesn't get populated when connecting to a server because injectRuntimeRecipes never runs clientSide, so addRecipe doesn't get called. This caused currentFuel to always be empty, making canUseEnergy always return false.

## Implementation Details
This commit checks against burnTimer first in canUseEnergy, rather than currentFuel first, because burnTimer is properly synced via NBT. clientSide still doesn't know about currentFuel or FUELS but it doesn't need to know.

Additionally I added !isClientSide check around findNewRecipe and data.putShort "burnTimer" since the client doesn't need to do those things.

## Additional Information
The workaround of going to singleplayer first worked because FUELS is static and sticks around after exiting the world and going to multiplayer.
An alternative solution to this bug would be to populate FUELS during clientside, and/or sync currentFuel via NBT.
Electric jetpacks don't have this bug.

Fixes https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/590