### PR TITLE
Add method overload to BlastProperty constructor to use default vacuum freezer settings

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/BlastProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/BlastProperty.java
@@ -75,6 +75,13 @@ public class BlastProperty implements IMaterialProperty {
         this.gasTier = gasTier;
     }
 
+    public BlastProperty(int blastTemperature, GasTier gasTier, int eutOverride, int durationOverride) {
+        this.blastTemperature = blastTemperature;
+        this.gasTier = gasTier;
+        this.EUtOverride = eutOverride;
+        this.durationOverride = durationOverride;
+    }
+
     public BlastProperty(int blastTemperature, GasTier gasTier, int eutOverride, int durationOverride,
                          int vacuumEUtOverride, int vacuumDurationOverride) {
         this.blastTemperature = blastTemperature;


### PR DESCRIPTION
## What
Currently, setting an override for EBF recipe EU/t or duration using BlastProperty requires you to add EU/t and duration overrides for the VF recipe too. This PR adds a new overload that only sets EBF overrides

## Potential Compatibility Issues
None, hopefully