### PR TITLE
Fix Energy Charge Bar cover StackItem amount

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
@@ -27,7 +27,7 @@ public final class ToolChargeBarRenderer {
     private static final int colorBarRightDurability = FastColor.ARGB32.color(255, 115, 255, 89);
 
     private static final int colorBarLeftDepleted = FastColor.ARGB32.color(255, 122, 0, 0);
-    private static final int colorBarRightDepleted = FastColor.ARGB32.color(255, 255, 27, 27);
+    private static final int colorBarRightDepleted = FastColor.ARGB32.color(255, 0, 255, 0);
 
     public static void render(GuiGraphics graphics, int level, int xPosition, int yPosition, int offset, boolean shadow,
                               int left, int right, boolean doDepletedColor) {
@@ -38,8 +38,8 @@ public final class ToolChargeBarRenderer {
 
         int x = xPosition + 2;
         int y = yPosition + 13 - offset;
-        graphics.fill(RenderType.gui(), x, y, x + 13, y + (shadow ? 2 : 1), 200, colorShadow);
-        DrawUtil.fillHorizontalGradient(graphics, RenderType.gui(), x, y, x + level, y + 1, left, right, 200);
+        graphics.fill(RenderType.gui(), x, y, x + 13, y + (shadow ? 2 : 1), 190, colorShadow);
+        DrawUtil.fillHorizontalGradient(graphics, RenderType.gui(), x, y, x + level, y + 1, left, right, 190);
         // graphics.fill(RenderType.guiOverlay(), x + BAR_W, y, x + BAR_W - level, y - 1, colorBG);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
@@ -38,8 +38,8 @@ public final class ToolChargeBarRenderer {
 
         int x = xPosition + 2;
         int y = yPosition + 13 - offset;
-        graphics.fill(RenderType.guiOverlay(), x, y, x + 13, y + (shadow ? 2 : 1), 400, colorShadow);
-        DrawUtil.fillHorizontalGradient(graphics, RenderType.guiOverlay(), x, y, x + level, y + 1, left, right, 400);
+        graphics.fill(RenderType.gui(), x, y, x + 13, y + (shadow ? 2 : 1), 200, colorShadow);
+        DrawUtil.fillHorizontalGradient(graphics, RenderType.gui(), x, y, x + level, y + 1, left, right, 200);
         // graphics.fill(RenderType.guiOverlay(), x + BAR_W, y, x + BAR_W - level, y - 1, colorBG);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/item/ToolChargeBarRenderer.java
@@ -27,7 +27,7 @@ public final class ToolChargeBarRenderer {
     private static final int colorBarRightDurability = FastColor.ARGB32.color(255, 115, 255, 89);
 
     private static final int colorBarLeftDepleted = FastColor.ARGB32.color(255, 122, 0, 0);
-    private static final int colorBarRightDepleted = FastColor.ARGB32.color(255, 0, 255, 0);
+    private static final int colorBarRightDepleted = FastColor.ARGB32.color(255, 255, 27, 27);
 
     public static void render(GuiGraphics graphics, int level, int xPosition, int yPosition, int offset, boolean shadow,
                               int left, int right, boolean doDepletedColor) {


### PR DESCRIPTION
## What
Resolve #3915 

## Outcome
changed z-offset 400->190 and guiOverlay() -> gui()

before
<img width="583" height="161" alt="image" src="https://github.com/user-attachments/assets/fed2badb-9d59-4cb6-9e3c-3463c6b97ad5" />

after
<img width="652" height="127" alt="image" src="https://github.com/user-attachments/assets/fc3bd135-526a-4eee-ae0d-3774fe2d3d4e" />
