### PR TITLE
fix material registration event listener running after Registrate (and before KubeJS)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/fluid/FluidBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/fluid/FluidBuilder.java
@@ -292,9 +292,6 @@ public class FluidBuilder {
                 .setData(ProviderType.LANG, NonNullBiConsumer.noop());
         if (this.hasFluidBlock) {
             builder.block()
-                    .blockstate((ctx, prov) -> prov
-                            .simpleBlock(ctx.getEntry(), prov.models().getBuilder(this.name)
-                                    .texture("particle", this.still)))
                     .color(() -> () -> (state, level, pos, index) -> {
                         return IClientFluidTypeExtensions.of(state.getFluidState())
                                 .getTintColor(state.getFluidState(), level, pos);

--- a/src/main/java/com/gregtechceu/gtceu/api/fluid/FluidBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/fluid/FluidBuilder.java
@@ -96,7 +96,7 @@ public class FluidBuilder {
      * @param temperature the temperature of the fluid in Kelvin
      * @return this;
      */
-    public @NotNull FluidBuilder temperature(int temperature) {
+    public FluidBuilder temperature(int temperature) {
         Preconditions.checkArgument(temperature > 0, "temperature must be > 0");
         this.temperature = temperature;
         return this;
@@ -109,7 +109,7 @@ public class FluidBuilder {
      * @param color the color
      * @return this
      */
-    public @NotNull FluidBuilder color(int color) {
+    public FluidBuilder color(int color) {
         this.color = GTUtil.convertRGBtoARGB(color);
         if (this.color == INFER_COLOR) {
             return disableColor();
@@ -122,7 +122,7 @@ public class FluidBuilder {
      *
      * @return this
      */
-    public @NotNull FluidBuilder disableColor() {
+    public FluidBuilder disableColor() {
         this.isColorEnabled = false;
         return this;
     }
@@ -132,7 +132,7 @@ public class FluidBuilder {
      * @return this
      */
     @Tolerate
-    public @NotNull FluidBuilder density(double density) {
+    public FluidBuilder density(double density) {
         return density(convertToMCDensity(density));
     }
 
@@ -156,7 +156,7 @@ public class FluidBuilder {
      * @param luminosity of the fluid from [0, 16)
      * @return this
      */
-    public @NotNull FluidBuilder luminosity(int luminosity) {
+    public FluidBuilder luminosity(int luminosity) {
         Preconditions.checkArgument(luminosity >= 0 && luminosity < 16, "luminosity must be >= 0 and < 16");
         this.luminosity = luminosity;
         return this;
@@ -166,7 +166,7 @@ public class FluidBuilder {
      * @param mcViscosity the MC viscosity of the fluid
      * @return this
      */
-    public @NotNull FluidBuilder viscosity(int mcViscosity) {
+    public FluidBuilder viscosity(int mcViscosity) {
         Preconditions.checkArgument(mcViscosity >= 0, "viscosity must be >= 0");
         this.viscosity = mcViscosity;
         return this;
@@ -176,7 +176,7 @@ public class FluidBuilder {
      * @param viscosity the viscosity of the fluid in Poise
      * @return this
      */
-    public @NotNull FluidBuilder viscosity(double viscosity) {
+    public FluidBuilder viscosity(double viscosity) {
         return viscosity(convertViscosity(viscosity));
     }
 
@@ -194,7 +194,7 @@ public class FluidBuilder {
      * @param attribute the attribute to add
      * @return this
      */
-    public @NotNull FluidBuilder attribute(@NotNull FluidAttribute attribute) {
+    public FluidBuilder attribute(FluidAttribute attribute) {
         this.attributes.add(attribute);
         return this;
     }
@@ -203,7 +203,7 @@ public class FluidBuilder {
      * @param attributes the attributes to add
      * @return this
      */
-    public @NotNull FluidBuilder attributes(@NotNull FluidAttribute @NotNull... attributes) {
+    public FluidBuilder attributes(FluidAttribute @NotNull... attributes) {
         Collections.addAll(this.attributes, attributes);
         return this;
     }
@@ -213,7 +213,7 @@ public class FluidBuilder {
      * 
      * @return this
      */
-    public @NotNull FluidBuilder customStill() {
+    public FluidBuilder customStill() {
         return textures(true);
     }
 
@@ -221,7 +221,7 @@ public class FluidBuilder {
      * @param hasCustomStill if the fluid has a custom still texture
      * @return this
      */
-    public @NotNull FluidBuilder textures(boolean hasCustomStill) {
+    public FluidBuilder textures(boolean hasCustomStill) {
         this.hasCustomStill = hasCustomStill;
         this.isColorEnabled = false;
         return this;
@@ -232,7 +232,7 @@ public class FluidBuilder {
      * @param hasCustomFlowing if the fluid has a custom flowing texture
      * @return this
      */
-    public @NotNull FluidBuilder textures(boolean hasCustomStill, boolean hasCustomFlowing) {
+    public FluidBuilder textures(boolean hasCustomStill, boolean hasCustomFlowing) {
         this.hasCustomStill = hasCustomStill;
         this.hasCustomFlowing = hasCustomFlowing;
         this.isColorEnabled = false;
@@ -244,7 +244,7 @@ public class FluidBuilder {
      *
      * @return this
      */
-    public @NotNull FluidBuilder block() {
+    public FluidBuilder block() {
         this.hasFluidBlock = true;
         return this;
     }
@@ -254,14 +254,13 @@ public class FluidBuilder {
      *
      * @return this
      */
-    public @NotNull FluidBuilder disableBucket() {
+    public FluidBuilder disableBucket() {
         this.hasBucket = false;
         return this;
     }
 
     @SuppressWarnings("UnstableApiUsage")
-    public @NotNull Supplier<? extends Fluid> build(Material material, @NotNull FluidStorageKey key,
-                                                    GTRegistrate registrate) {
+    public Supplier<? extends Fluid> build(Material material, FluidStorageKey key, GTRegistrate registrate) {
         determineName(material, key);
         determineTextures(material, key);
 
@@ -324,14 +323,14 @@ public class FluidBuilder {
         return builder.register()::getSource;
     }
 
-    private void determineName(@NotNull Material material, @Nullable FluidStorageKey key) {
+    private void determineName(Material material, @Nullable FluidStorageKey key) {
         if (name != null) return;
         if (material.isNull() || key == null) throw new IllegalArgumentException("Fluid must have a name");
         name = key.getRegistryNameFor(material);
     }
 
     @ApiStatus.Internal
-    public void determineTextures(@NotNull Material material, @NotNull FluidStorageKey key) {
+    public void determineTextures(Material material, FluidStorageKey key) {
         if (hasCustomStill || material.isNull()) {
             still = ResourceLocation.fromNamespaceAndPath(material.getModid(), "block/fluids/fluid." + name);
         } else {
@@ -347,7 +346,7 @@ public class FluidBuilder {
         }
     }
 
-    private void determineTemperature(@NotNull Material material) {
+    private void determineTemperature(Material material) {
         if (temperature != INFER_TEMPERATURE) return;
         if (material.isNull()) {
             temperature = ROOM_TEMPERATURE;
@@ -380,7 +379,7 @@ public class FluidBuilder {
         }
     }
 
-    private void determineColor(@NotNull Material material) {
+    private void determineColor(Material material) {
         if (color != INFER_COLOR) return;
         if (isColorEnabled && !material.isNull()) {
             color = GTUtil.convertRGBtoARGB(material.getMaterialRGB());
@@ -396,7 +395,7 @@ public class FluidBuilder {
         };
     }
 
-    private void determineLuminosity(@NotNull Material material) {
+    private void determineLuminosity(Material material) {
         if (luminosity != INFER_LUMINOSITY) return;
         if (state == FluidState.PLASMA) {
             luminosity = 15;
@@ -414,7 +413,7 @@ public class FluidBuilder {
         }
     }
 
-    private void determineViscosity(@NotNull Material material) {
+    private void determineViscosity(Material material) {
         if (viscosity != INFER_VISCOSITY) return;
         viscosity = switch (state) {
             case LIQUID -> {

--- a/src/main/java/com/gregtechceu/gtceu/api/material/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/material/material/Material.java
@@ -36,7 +36,6 @@ import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import dev.latvian.mods.rhino.util.HideFromJS;
 import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -1837,7 +1836,6 @@ public class Material {
          *
          * @return The finalized Material.
          */
-        @HideFromJS
         public Material buildAndRegister() {
             materialInfo.componentList = composition.isEmpty() && this.compositionSupplier != null ?
                     ImmutableList.copyOf(compositionSupplier.stream().map(MaterialStackWrapper::toMatStack)

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -76,7 +76,22 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
      * @return The {@link GTRegistrate} instance
      */
     public static GTRegistrate create(String modId) {
-        return innerCreate(modId, true);
+        return create(modId, true);
+    }
+
+    /**
+     * Get or create a new {@link GTRegistrate} and conditionally register event listeners.
+     * A new {@code GTRegistrate} instance is only made if one doesn't already exist in the cache.
+     * <br>
+     * Note that if you do not allow event listeners to be registered automatically, you <strong>must</strong>
+     * call {@link #registerEventListeners(IEventBus)} yourself with your {@link IEventBus mod event bus}.
+     *
+     * @param modId          The mod ID for which objects will be registered
+     * @param registerEvents Whether to register required event listeners.
+     * @return The {@link GTRegistrate} instance
+     */
+    public static GTRegistrate create(String modId, boolean registerEvents) {
+        return innerCreate(modId, false, registerEvents);
     }
 
     /**
@@ -90,26 +105,28 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
      */
     @ApiStatus.Internal
     public static GTRegistrate createIgnoringListenerErrors(String modId) {
-        return innerCreate(modId, false);
+        return innerCreate(modId, true, false);
     }
 
-    private static GTRegistrate innerCreate(String modId, boolean strict) {
+    private static GTRegistrate innerCreate(String modId, boolean registerEvents, boolean requireValidEventBus) {
         if (EXISTING_REGISTRATES.containsKey(modId)) {
             return EXISTING_REGISTRATES.get(modId);
         }
         var registrate = new GTRegistrate(modId);
-        Optional<IEventBus> modEventBus = ModList.get().getModContainerById(modId).map(ModContainer::getEventBus);
-        if (strict) {
-            modEventBus.ifPresentOrElse(registrate::registerEventListeners, () -> {
-                String message = "# [GTRegistrate] Failed to register eventListeners for mod " + modId +
-                        ", This should be reported to this mod's dev #";
-                String hashtags = "#".repeat(message.length());
-                GTCEu.LOGGER.fatal(hashtags);
-                GTCEu.LOGGER.fatal(message);
-                GTCEu.LOGGER.fatal(hashtags);
-            });
-        } else {
-            registrate.registerEventListeners(modEventBus.orElse(GTCEu.gtModBus));
+        if (registerEvents) {
+            Optional<IEventBus> modEventBus = ModList.get().getModContainerById(modId).map(ModContainer::getEventBus);
+            if (requireValidEventBus) {
+                modEventBus.ifPresentOrElse(registrate::registerEventListeners, () -> {
+                    String message = "# [GTRegistrate] Failed to register eventListeners for mod " + modId +
+                            ", This should be reported to this mod's dev #";
+                    String hashtags = "#".repeat(message.length());
+                    GTCEu.LOGGER.fatal(hashtags);
+                    GTCEu.LOGGER.fatal(message);
+                    GTCEu.LOGGER.fatal(hashtags);
+                });
+            } else {
+                registrate.registerEventListeners(modEventBus.orElse(GTCEu.gtModBus));
+            }
         }
         EXISTING_REGISTRATES.put(modId, registrate);
         return registrate;

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -135,8 +135,8 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
     @Override
     public GTRegistrate registerEventListeners(IEventBus bus) {
         if (!registered.getAndSet(true)) {
-            if (((AbstractRegistrateAccessor) this).getModEventBus() == null) {
-                ((AbstractRegistrateAccessor) this).setModEventBus(bus);
+            if (this.getModEventBus() == null) {
+                this.setModEventBus(bus);
             }
             // recreate the super method so we can register the event listener with LOW priority.
             Consumer<RegisterEvent> onRegister = this::onRegister;

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -235,11 +235,10 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
                 callback -> GTBlockBuilder.create(this, parent, name, callback, factory));
     }
 
-    @Nullable
-    private RegistryEntry<CreativeModeTab, ? extends CreativeModeTab> currentTab;
+    private @Nullable RegistryEntry<CreativeModeTab, ? extends CreativeModeTab> currentTab;
     private static final Map<RegistryEntry<?, ?>, RegistryEntry<CreativeModeTab, ? extends CreativeModeTab>> TAB_LOOKUP = new IdentityHashMap<>();
 
-    public RegistryEntry<CreativeModeTab, ? extends CreativeModeTab> creativeModeTab() {
+    public @Nullable RegistryEntry<CreativeModeTab, ? extends CreativeModeTab> creativeModeTab() {
         return this.currentTab;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -134,26 +134,28 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
 
     @Override
     public GTRegistrate registerEventListeners(IEventBus bus) {
-        if (!registered.getAndSet(true)) {
-            if (this.getModEventBus() == null) {
-                this.setModEventBus(bus);
-            }
-            // recreate the super method so we can register the event listener with LOW priority.
-            Consumer<RegisterEvent> onRegister = this::onRegister;
-            Consumer<RegisterEvent> onRegisterLate = this::onRegisterLate;
-            bus.addListener(EventPriority.LOW, onRegister);
-            bus.addListener(EventPriority.LOWEST, onRegisterLate);
+        if (registered.getAndSet(true)) {
+            // early exit if event listeners are already registered
+            return this;
+        }
+        if (this.getModEventBus() == null) {
+            this.setModEventBus(bus);
+        }
+        // recreate the super method so we can register the event listener with LOW priority.
+        Consumer<RegisterEvent> onRegister = this::onRegister;
+        Consumer<RegisterEvent> onRegisterLate = this::onRegisterLate;
+        bus.addListener(EventPriority.LOW, onRegister);
+        bus.addListener(EventPriority.LOWEST, onRegisterLate);
 
-            // Fired multiple times when ever tabs need contents rebuilt (changing op tab perms for example)
-            bus.addListener(this::onBuildCreativeModeTabContents);
-            // Register events fire multiple times, so clean them up on common setup
-            OneTimeEventReceiver.addModListener(this, FMLCommonSetupEvent.class, $ -> {
-                OneTimeEventReceiver.unregister(this, onRegister, RegisterEvent.class);
-                OneTimeEventReceiver.unregister(this, onRegisterLate, RegisterEvent.class);
-            });
-            if (((AbstractRegistrateAccessor) this).getDoDatagen().get()) {
-                OneTimeEventReceiver.addModListener(this, GatherDataEvent.class, this::onData);
-            }
+        // Fired multiple times when ever tabs need contents rebuilt (changing op tab perms for example)
+        bus.addListener(this::onBuildCreativeModeTabContents);
+        // Register events fire multiple times, so clean them up on common setup
+        OneTimeEventReceiver.addModListener(this, FMLCommonSetupEvent.class, $ -> {
+            OneTimeEventReceiver.unregister(this, onRegister, RegisterEvent.class);
+            OneTimeEventReceiver.unregister(this, onRegisterLate, RegisterEvent.class);
+        });
+        if (((AbstractRegistrateAccessor) this).getDoDatagen().get()) {
+            OneTimeEventReceiver.addModListener(this, GatherDataEvent.class, this::onData);
         }
         return this;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
@@ -100,6 +100,7 @@ import com.gregtechceu.gtceu.utils.input.KeyBind;
 
 import com.lowdragmc.lowdraglib.gui.factory.UIFactory;
 
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.packs.PackType;
@@ -306,7 +307,7 @@ public class CommonInit {
         }
     }
 
-    private static void postInitMaterials() {
+    private static void postInitMaterials(Registry<Material> registry) {
         // Register all material manager registries, for materials with mod ids.
         GTCEuAPI.materialManager.getUsedNamespaces().forEach(namespace -> {
             // Force the material lang generator to be at index 0, so that addons' lang generators can override it.
@@ -342,7 +343,7 @@ public class CommonInit {
 
     @SubscribeEvent
     public static void modifyRegistries(ModifyRegistriesEvent event) {
-        GTRegistries.MATERIALS.addCallback((BakeCallback<Material>) registry -> postInitMaterials());
+        GTRegistries.MATERIALS.addCallback((BakeCallback<Material>) CommonInit::postInitMaterials);
         GTRegistries.MACHINES.addCallback((BakeCallback<MachineDefinition>) GTMachines::bakeRenderStates);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
@@ -175,6 +175,7 @@ public class CommonInit {
         GTRegistrateDatagen.initPre();
 
         GTRegistries.init(modBus);
+        REGISTRATE.registerEventListeners(modBus);
         GTCreativeModeTabs.init();
         GTAttachmentTypes.ATTACHMENT_TYPES.register(modBus);
 

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
@@ -163,10 +163,12 @@ public class CommonInit {
 
     public static void init(final IEventBus modBus) {
         CommonInit.modBus = modBus;
-        modBus.register(CommonInit.class);
         if (GTCEu.Mods.isKubeJSLoaded()) {
-            modBus.addListener(EventPriority.LOWEST, GTKubeJSPlugin::registerKJSMachines);
+            // initialize this before the class's static listeners
+            // so KubeJS materials are registered before the material registry is closed.
+            modBus.addListener(EventPriority.LOW, GTKubeJSPlugin::registerWrappers);
         }
+        modBus.register(CommonInit.class);
 
         UIFactory.register(MachineUIFactory.INSTANCE);
         UIFactory.register(CoverUIFactory.INSTANCE);

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonInit.java
@@ -266,8 +266,8 @@ public class CommonInit {
         GTCEuAPI.materialManager.setFallbackMaterial(GTCEu.MOD_ID, GTMaterials.Aluminium);
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
-    public static void onRegisterEarly(RegisterEvent event) {
+    @SubscribeEvent(priority = EventPriority.LOW)
+    public static void onRegisterLate(RegisterEvent event) {
         // Material event *should* happen before any of the others here
         if (event.getRegistryKey() == GTRegistries.MATERIAL_REGISTRY) {
             // Fire Post-Material event, intended for when Materials need to be iterated over in-full before freezing

--- a/src/main/java/com/gregtechceu/gtceu/common/registry/GTRegistration.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/registry/GTRegistration.java
@@ -8,7 +8,7 @@ import net.minecraft.world.item.CreativeModeTab;
 
 public class GTRegistration {
 
-    public static final GTRegistrate REGISTRATE = GTRegistrate.create(GTCEu.MOD_ID);
+    public static final GTRegistrate REGISTRATE = GTRegistrate.create(GTCEu.MOD_ID, false);
     static {
         GTRegistration.REGISTRATE.defaultCreativeTab((ResourceKey<CreativeModeTab>) null);
     }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/registrate/AbstractRegistrateAccessor.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/registrate/AbstractRegistrateAccessor.java
@@ -1,7 +1,5 @@
 package com.gregtechceu.gtceu.core.mixins.registrate;
 
-import net.neoforged.bus.api.IEventBus;
-
 import com.google.common.collect.ListMultimap;
 import com.tterrag.registrate.AbstractRegistrate;
 import com.tterrag.registrate.providers.ProviderType;
@@ -20,10 +18,4 @@ public interface AbstractRegistrateAccessor {
 
     @Accessor
     NonNullSupplier<Boolean> getDoDatagen();
-
-    @Accessor("modEventBus")
-    IEventBus getModEventBus();
-
-    @Accessor("modEventBus")
-    void setModEventBus(IEventBus modEventBus);
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTKubeJSPlugin.java
@@ -101,9 +101,11 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.CapabilityMapComp
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 import com.gregtechceu.gtceu.utils.data.RuntimeBlockStateProvider;
 
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.SoundType;
@@ -126,21 +128,28 @@ import dev.latvian.mods.kubejs.script.BindingRegistry;
 import dev.latvian.mods.kubejs.script.ConsoleJS;
 import dev.latvian.mods.kubejs.script.TypeWrapperRegistry;
 import dev.latvian.mods.rhino.Wrapper;
+import org.jetbrains.annotations.ApiStatus;
 
 public class GTKubeJSPlugin implements KubeJSPlugin {
 
-    public static void registerKJSMachines(RegisterEvent event) {
-        if (event.getRegistryKey() != GTRegistries.MACHINE_REGISTRY) {
+    @ApiStatus.Internal
+    public static void registerWrappers(RegisterEvent event) {
+        registerWrappers(event, GTRegistries.MACHINE_REGISTRY);
+        registerWrappers(event, GTRegistries.MATERIAL_REGISTRY);
+    }
+
+    private static <T> void registerWrappers(RegisterEvent event, ResourceKey<Registry<T>> registryKey) {
+        if (event.getRegistryKey() != registryKey) {
             return;
         }
-        var objStorage = RegistryObjectStorage.of(GTRegistries.MACHINE_REGISTRY);
-        ResourceLocation registryLoc = GTRegistries.MACHINE_REGISTRY.location();
+        var objStorage = RegistryObjectStorage.of(registryKey);
+        ResourceLocation registryLoc = registryKey.location();
 
         int added = 0;
 
         for (var builder : objStorage) {
             if (builder.dummyBuilder) {
-                // don't actually register it here, the machine builders register themselves with Registrate
+                // don't actually register anything here, the wrapper builders register themselves with Registrate
                 builder.createTransformedObject();
 
                 if (DevProperties.get().logRegistryEventObjects) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/MaterialBuilderWrapper.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/MaterialBuilderWrapper.java
@@ -30,6 +30,7 @@ public class MaterialBuilderWrapper extends BuilderBase<Material> {
     public MaterialBuilderWrapper(ResourceLocation id) {
         super(id);
         this.internal = new Material.Builder(id);
+        this.dummyBuilder = true;
     }
 
     /*
@@ -658,5 +659,14 @@ public class MaterialBuilderWrapper extends BuilderBase<Material> {
     @Override
     public Material createObject() {
         return internal.buildAndRegister();
+    }
+
+    @Override
+    public Material transformObject(Material material) {
+        // this method is called right after `createObject`.
+        // here, you can add things that have to be done after registration
+        // but would be nice to do without using a separate material modification event.
+
+        return super.transformObject(material);
     }
 }


### PR DESCRIPTION
## What
Fix the event listener that closes the registry from further editing being ran before KubeJS has a chance to post its material registration event

## Implementation Details
changed `CommonInit.onRegisterEarly` to use a `LOW` priority and renamed it to `onRegisterLate` so it matches.
Also added a way to create a GTRegistrate without automatically registering its event listerers, so that the LOW priority event listener can be processed before registrate registers all the items/blocks/fluids/etc.

## Outcome
can register materials with KubeJS now

## Additional Information
I also deleted 19 unnecessary `@NotNull`s from FluidBuilder because the warnings were annoying.
Also made KubeJS materials not be registered twice (this crashes!)