### PR TITLE
Fix MUI not being reopened properly

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ClientScreenHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/mui/screen/ClientScreenHandler.java
@@ -85,11 +85,6 @@ public class ClientScreenHandler {
     }
 
     @SubscribeEvent
-    public static void onCloseScreen(ScreenEvent.Closing event) {
-        onGuiChanged(event.getScreen(), null);
-    }
-
-    @SubscribeEvent
     public static void onInitScreenPost(ScreenEvent.Init.Post event) {
         defaultContext.updateScreenArea(event.getScreen().width, event.getScreen().height);
         if (validateGui(event.getScreen())) {


### PR DESCRIPTION
## What
Fixes MUI not reopening properly, particularly when returning from looking at a recipe from EMI/XEI

## Implementation Details
Simply deletes the gui close event listener, as it calls `onGuiChanged()` twice after the gui open event is fired.
`onGuiChanged()` being called twice erroneously set the current screen to null, meaning that the mui screen couldn't be reopened
1.12 MUI also doesn't have a gui close event listener as well, though I don't know if there was a reason that this gui close event listener was needed

## Outcome
MUI now reopens properly when returning from another screen like EMI/XEI