### PR TITLE
[MUI2] Fix Tiled UITextures not drawing correctly

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/TiledUITexture.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/TiledUITexture.java
@@ -2,6 +2,8 @@ package com.gregtechceu.gtceu.api.mui.drawable;
 
 import com.gregtechceu.gtceu.client.mui.screen.viewport.GuiContext;
 
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.resources.ResourceLocation;
 
 import com.google.gson.JsonObject;
@@ -26,6 +28,7 @@ public class TiledUITexture extends UITexture {
             super.draw(context, x, y, width, height);
             return;
         }
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
         GuiDraw.drawTiledTexture(context.getLastGraphicsPose(), this.location, x, y, width, height,
                 this.u0, this.v0, this.u1, this.v1,
                 this.imageWidth, this.imageHeight, 0);

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/TiledUITexture.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/drawable/TiledUITexture.java
@@ -2,11 +2,11 @@ package com.gregtechceu.gtceu.api.mui.drawable;
 
 import com.gregtechceu.gtceu.client.mui.screen.viewport.GuiContext;
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.resources.ResourceLocation;
 
 import com.google.gson.JsonObject;
+import com.mojang.blaze3d.systems.RenderSystem;
 
 public class TiledUITexture extends UITexture {
 


### PR DESCRIPTION
## What
Fixes tiled UITextures not being drawn correctly in certain situations. (found by having a tiled texture as a widget be the first widget in a flow)

## Implementation Details
Call `RenderSystem.setShader(GameRenderer::getPositionTexShader)` just like what's done in `UITexture` and `AdaptableUITexture`

## Outcome
Tiled UITextures are now drawn correctly