### PR TITLE
Rework element creation docs

### DIFF
--- a/docs/content/Modpacks/Materials-and-Elements/02-Element-Creation.md
+++ b/docs/content/Modpacks/Materials-and-Elements/02-Element-Creation.md
@@ -4,26 +4,29 @@ title: Element Creation
 
 
 ## Element Creation
-
+!!! Note
+    You can add only elements that are not yet present on the periodic table.
+    For those elements, see GTElements.
 Elements are the base of GT materials. Registering an element WILL NOT add any items.
-To make a new element(NOTE: you can add only elements that are NOT present on the periodic table),
-write an `event.create()` call in the registry function like in the example below.
-Inside the parentheses the following parameters are introduced:
-
-1.  Element Name -> use '' or "" to write the element name.
-2.  Proton Count(use -1 if it is not an element that will get a material).
-3.  Neutron Count(use -1 if it is not an element that will get a material).
-4.  Half Life Seconds(decay stuff. Use -1 if you don't need to use decay).
-5.  Material to decay to(more decay stuff. Use null).
-6.  Atomic Symbol(what will be displayed as in chemical formulas) -> use '' or "" to write the atomic symbol.
-7.  Is isotope(ex. Uranium 235 and Uranium 238. Use false if you are not making an isotope)
-
-When a material will be created from this element, the above properties will affect the auto-generated recipes.
 
 ```js
 GTCEuStartupEvents.registry('gtceu:element', event => {
-   event.create('test_element', 27, 177, -1, null, 'test', false) // (1)
+   event.create('test_element')
+        .protons(27)
+        .neutrons(177)
+        .halfLifeSeconds(-1)
+        .decayTo(null)
+        .symbol('test')
+        .isIsotope(false)
 })
 ```
 
-1. Element Name, Protons, Neutrons, Half Life Seconds, Decay To, Atomic Symbol, Is Isotope
+1.  `.create(String name)` ->  The element name.
+2.  `.protons(int protons)` -> Proton Count. Use `-1` if it is not an element that will get a material.
+3.  `.neutrons(int neutrons)` -> Neutron Count. Use `-1` if it is not an element that will get a material.
+4.  `.halfLifeSeconds(int seconds)` -> Half Life Decay in Seconds. After N seconds, half of the material will have decayed. Use `-1` if your element doesn't decay.
+5.  `.decayTo(Material material)` -> Material to decay to. Use `null` if your element doesn't decay.
+6.  `.symbol(String symbol)` -> Atomic Symbol, which will be displayed as in chemical formulas.
+7.  `.isIsotope(boolean isotope)` -> Whether the element is an isotope, e.g. Uranium 235 and Uranium 238.
+
+When a material will be created from this element, the above properties will affect the auto-generated recipes.

--- a/docs/content/Modpacks/Materials-and-Elements/02-Element-Creation.md
+++ b/docs/content/Modpacks/Materials-and-Elements/02-Element-Creation.md
@@ -22,8 +22,8 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
 ```
 
 1.  `.create(String name)` ->  The element name.
-2.  `.protons(int protons)` -> Proton Count. Use `-1` if it is not an element that will get a material.
-3.  `.neutrons(int neutrons)` -> Neutron Count. Use `-1` if it is not an element that will get a material.
+2.  `.protons(int protons)` -> Proton Count. Use `-1` if it is an element that will not get a material.
+3.  `.neutrons(int neutrons)` -> Neutron Count. Use `-1` if it is an element that will not get a material
 4.  `.halfLifeSeconds(int seconds)` -> Half Life Decay in Seconds. After N seconds, half of the material will have decayed. Use `-1` if your element doesn't decay.
 5.  `.decayTo(Material material)` -> Material to decay to. Use `null` if your element doesn't decay.
 6.  `.symbol(String symbol)` -> Atomic Symbol, which will be displayed as in chemical formulas.


### PR DESCRIPTION
## What
The docs were outdated, this fixes that
<img width="845" height="1072" alt="image" src="https://github.com/user-attachments/assets/4355ea5f-29be-41b7-835b-9d90de669d3f" />