### PR TITLE
Add recipes for netherite tools

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/SmithingTransformRecipeMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/SmithingTransformRecipeMixin.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.SmithingTransformRecipe;
@@ -32,19 +33,23 @@ public class SmithingTransformRecipeMixin {
     private void gtceu$gtToolSmithingTransform1(Container container, RegistryAccess registryAccess,
                                                 CallbackInfoReturnable<ItemStack> cir,
                                                 @Share("newTag") LocalRef<CompoundTag> sharedTag) {
-        var newTag = container.getItem(1).getTag().copy();
-        var output = this.result.copy();
-        if (output.getItem() instanceof IGTTool igtTool) {
-            // Remove old tool stats
-            newTag.remove("GT.Tool");
+        ItemStack output = this.result.copy();
 
-            // Copy stats from the upgraded tool
-            var newStack = ToolHelper.get(igtTool.getToolType(), igtTool.getMaterial());
-            var newStats = newStack.getTag() != null ? newStack.getTag().get("GT.Tool") : null;
-            if (newStats != null) {
-                newTag.put("GT.Tool", newStats);
-                sharedTag.set(newTag);
-            }
+        if (!(output.getItem() instanceof IGTTool igtTool)) return;
+
+        CompoundTag originalTag = container.getItem(1).getTag();
+        CompoundTag newTag = originalTag != null ? originalTag.copy() : null;
+        if (newTag == null) return;
+
+        // Remove old tool stats
+        newTag.remove("GT.Tool");
+
+        // Copy stats from the upgraded tool
+        ItemStack newStack = ToolHelper.get(igtTool.getToolType(), igtTool.getMaterial());
+        Tag newStats = newStack.getTag() != null ? newStack.getTag().get("GT.Tool") : null;
+        if (newStats != null) {
+            newTag.put("GT.Tool", newStats);
+            sharedTag.set(newTag);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/SmithingTransformRecipeMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/SmithingTransformRecipeMixin.java
@@ -1,0 +1,50 @@
+package com.gregtechceu.gtceu.core.mixins;
+
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.SmithingTransformRecipe;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SmithingTransformRecipe.class)
+public class SmithingTransformRecipeMixin {
+    @Unique
+    private static CompoundTag gtceu$newTag;
+
+    @Shadow
+    @Final
+    ItemStack result;
+
+
+    @Inject(method = "assemble", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;setTag(Lnet/minecraft/nbt/CompoundTag;)V"))
+    private void gtceu$gtToolSmithingTransform1(Container container, RegistryAccess registryAccess, CallbackInfoReturnable<ItemStack> cir) {
+        gtceu$newTag = container.getItem(1).getTag().copy();
+        var output = this.result.copy();
+            if (output.getItem() instanceof IGTTool igtTool) {
+                // Remove old tool stats
+                gtceu$newTag.remove("GT.Tool");
+
+                // Copy stats from the upgraded tool
+                var newStack = ToolHelper.get(igtTool.getToolType(), igtTool.getMaterial());
+                var newStats = newStack.getTag() != null ? newStack.getTag().get("GT.Tool") : null;
+                if (newStats != null) {
+                    gtceu$newTag.put("GT.Tool", newStats);
+                }
+            }
+    }
+
+    @Redirect(method = "assemble", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;setTag(Lnet/minecraft/nbt/CompoundTag;)V"))
+    private void gtceu$gtToolSmithingTransform2(ItemStack itemStack, CompoundTag tag) {
+        itemStack.setTag(gtceu$newTag);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/SmithingTransformRecipeMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/SmithingTransformRecipeMixin.java
@@ -2,15 +2,18 @@ package com.gregtechceu.gtceu.core.mixins;
 
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
+
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.SmithingTransformRecipe;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -18,33 +21,38 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(SmithingTransformRecipe.class)
 public class SmithingTransformRecipeMixin {
-    @Unique
-    private static CompoundTag gtceu$newTag;
 
     @Shadow
     @Final
     ItemStack result;
 
-
-    @Inject(method = "assemble", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;setTag(Lnet/minecraft/nbt/CompoundTag;)V"))
-    private void gtceu$gtToolSmithingTransform1(Container container, RegistryAccess registryAccess, CallbackInfoReturnable<ItemStack> cir) {
-        gtceu$newTag = container.getItem(1).getTag().copy();
+    @Inject(method = "assemble",
+            at = @At(value = "INVOKE",
+                     target = "Lnet/minecraft/world/item/ItemStack;setTag(Lnet/minecraft/nbt/CompoundTag;)V"))
+    private void gtceu$gtToolSmithingTransform1(Container container, RegistryAccess registryAccess,
+                                                CallbackInfoReturnable<ItemStack> cir,
+                                                @Share("newTag") LocalRef<CompoundTag> sharedTag) {
+        var newTag = container.getItem(1).getTag().copy();
         var output = this.result.copy();
-            if (output.getItem() instanceof IGTTool igtTool) {
-                // Remove old tool stats
-                gtceu$newTag.remove("GT.Tool");
+        if (output.getItem() instanceof IGTTool igtTool) {
+            // Remove old tool stats
+            newTag.remove("GT.Tool");
 
-                // Copy stats from the upgraded tool
-                var newStack = ToolHelper.get(igtTool.getToolType(), igtTool.getMaterial());
-                var newStats = newStack.getTag() != null ? newStack.getTag().get("GT.Tool") : null;
-                if (newStats != null) {
-                    gtceu$newTag.put("GT.Tool", newStats);
-                }
+            // Copy stats from the upgraded tool
+            var newStack = ToolHelper.get(igtTool.getToolType(), igtTool.getMaterial());
+            var newStats = newStack.getTag() != null ? newStack.getTag().get("GT.Tool") : null;
+            if (newStats != null) {
+                newTag.put("GT.Tool", newStats);
+                sharedTag.set(newTag);
             }
+        }
     }
 
-    @Redirect(method = "assemble", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;setTag(Lnet/minecraft/nbt/CompoundTag;)V"))
-    private void gtceu$gtToolSmithingTransform2(ItemStack itemStack, CompoundTag tag) {
-        itemStack.setTag(gtceu$newTag);
+    @Redirect(method = "assemble",
+              at = @At(value = "INVOKE",
+                       target = "Lnet/minecraft/world/item/ItemStack;setTag(Lnet/minecraft/nbt/CompoundTag;)V"))
+    private void gtceu$gtToolSmithingTransform2(ItemStack itemStack, CompoundTag tag,
+                                                @Share("newTag") LocalRef<CompoundTag> sharedTag) {
+        itemStack.setTag(sharedTag.get());
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -592,7 +592,8 @@ public class VanillaRecipeHelper {
                                                   @NotNull Item result, @NotNull ItemLike baseInput,
                                                   @NotNull ItemLike template, @NotNull ItemLike addition,
                                                   @NotNull RecipeCategory category) {
-        SmithingTransformRecipeBuilder.smithing(Ingredient.of(template), Ingredient.of(baseInput), Ingredient.of(addition), category, result)
+        SmithingTransformRecipeBuilder
+                .smithing(Ingredient.of(template), Ingredient.of(baseInput), Ingredient.of(addition), category, result)
                 .unlocks(String.format("has_%s", baseInput), has(baseInput))
                 .save(provider, regName);
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -610,6 +610,8 @@ public class VanillaRecipeHelper {
         ItemStack upgradeToolStack = ToolHelper.get(tool, upgradeMaterial);
         ItemStack baseToolStack = ToolHelper.get(tool, baseMaterial);
 
+        if (upgradeToolStack.isEmpty() || baseToolStack.isEmpty()) return;
+
         VanillaRecipeHelper.addSmithingTransformRecipe(provider,
                 String.format("%s_%s_smithing_transform_from_%s", upgradeMaterial.getName(), tool.name,
                         baseMaterial.getName()),

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -16,6 +16,7 @@ import com.gregtechceu.gtceu.data.recipe.builder.*;
 
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.data.recipes.RecipeCategory;
+import net.minecraft.data.recipes.SmithingTransformRecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
@@ -591,8 +592,7 @@ public class VanillaRecipeHelper {
                                                   @NotNull Item result, @NotNull ItemLike baseInput,
                                                   @NotNull ItemLike template, @NotNull ItemLike addition,
                                                   @NotNull RecipeCategory category) {
-        net.minecraft.data.recipes.SmithingTransformRecipeBuilder
-                .smithing(Ingredient.of(template), Ingredient.of(baseInput), Ingredient.of(addition), category, result)
+        SmithingTransformRecipeBuilder.smithing(Ingredient.of(template), Ingredient.of(baseInput), Ingredient.of(addition), category, result)
                 .unlocks(String.format("has_%s", baseInput), has(baseInput))
                 .save(provider, regName);
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -10,10 +10,12 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.ItemMaterialInfo;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.data.recipe.builder.*;
 
 import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.data.recipes.RecipeCategory;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
@@ -22,11 +24,15 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
 
 import com.tterrag.registrate.util.entry.ItemProviderEntry;
-import it.unimi.dsi.fastutil.chars.*;
+import it.unimi.dsi.fastutil.chars.Char2IntOpenHashMap;
+import it.unimi.dsi.fastutil.chars.CharArraySet;
+import it.unimi.dsi.fastutil.chars.CharSet;
 import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
+
+import static com.tterrag.registrate.providers.RegistrateRecipeProvider.has;
 
 public class VanillaRecipeHelper {
 
@@ -579,6 +585,36 @@ public class VanillaRecipeHelper {
             }
         }
         builder.save(provider);
+    }
+
+    public static void addSmithingTransformRecipe(Consumer<FinishedRecipe> provider, @NotNull ResourceLocation regName,
+                                                  @NotNull Item result, @NotNull ItemLike baseInput,
+                                                  @NotNull ItemLike template, @NotNull ItemLike addition,
+                                                  @NotNull RecipeCategory category) {
+        net.minecraft.data.recipes.SmithingTransformRecipeBuilder
+                .smithing(Ingredient.of(template), Ingredient.of(baseInput), Ingredient.of(addition), category, result)
+                .unlocks(String.format("has_%s", baseInput), has(baseInput))
+                .save(provider, regName);
+    }
+
+    public static void addSmithingTransformRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName,
+                                                  @NotNull Item result, @NotNull ItemLike baseInput,
+                                                  @NotNull ItemLike template, @NotNull ItemLike addition) {
+        addSmithingTransformRecipe(provider, GTCEu.id(regName), result, baseInput, template, addition,
+                RecipeCategory.MISC);
+    }
+
+    public static void addToolUpgradingRecipe(@NotNull Consumer<FinishedRecipe> provider, @NotNull GTToolType tool,
+                                              @NotNull Material upgradeMaterial, @NotNull Material baseMaterial,
+                                              @NotNull ItemLike template, @NotNull ItemLike addition) {
+        ItemStack upgradeToolStack = ToolHelper.get(tool, upgradeMaterial);
+        ItemStack baseToolStack = ToolHelper.get(tool, baseMaterial);
+
+        VanillaRecipeHelper.addSmithingTransformRecipe(provider,
+                String.format("%s_%s_smithing_transform_from_%s", upgradeMaterial.getName(), tool.name,
+                        baseMaterial.getName()),
+                upgradeToolStack.getItem(), baseToolStack.getItem(),
+                template, addition);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
@@ -195,6 +195,8 @@ public final class ToolRecipeHandler {
             GTCEu.LOGGER.warn("Did not find rod for " + material.getName() +
                     ", skipping wirecutter, butchery knife, screwdriver, crowbar recipes");
         }
+
+        GTToolType.getTypes().forEach((s, gtToolType) -> addNetheriteToolRecipe(provider, gtToolType));
     }
 
     private static void processElectricTool(@NotNull Consumer<FinishedRecipe> provider, @NotNull ToolProperty property,
@@ -345,6 +347,16 @@ public final class ToolRecipeHandler {
             VanillaRecipeHelper.addShapedRecipe(provider, String.format("%s_%s", tool.name, material.getName()),
                     toolStack, recipe);
         }
+    }
+
+    public static void addNetheriteToolRecipe(@NotNull Consumer<FinishedRecipe> provider, @NotNull GTToolType tool) {
+        ItemStack netheriteTool = ToolHelper.get(tool, GTMaterials.Netherite);
+        ItemStack diamondTool = ToolHelper.get(tool, GTMaterials.Diamond);
+
+        if (netheriteTool.isEmpty() || diamondTool.isEmpty()) return;
+
+        VanillaRecipeHelper.addToolUpgradingRecipe(provider, tool, GTMaterials.Netherite, GTMaterials.Diamond,
+                Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE, ChemicalHelper.get(ingot, GTMaterials.Netherite).getItem());
     }
 
     public static void addArmorRecipe(Consumer<FinishedRecipe> provider, @NotNull Material material,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
@@ -350,11 +350,6 @@ public final class ToolRecipeHandler {
     }
 
     public static void addNetheriteToolRecipe(@NotNull Consumer<FinishedRecipe> provider, @NotNull GTToolType tool) {
-        ItemStack netheriteTool = ToolHelper.get(tool, GTMaterials.Netherite);
-        ItemStack diamondTool = ToolHelper.get(tool, GTMaterials.Diamond);
-
-        if (netheriteTool.isEmpty() || diamondTool.isEmpty()) return;
-
         VanillaRecipeHelper.addToolUpgradingRecipe(provider, tool, GTMaterials.Netherite, GTMaterials.Diamond,
                 Items.NETHERITE_UPGRADE_SMITHING_TEMPLATE, ChemicalHelper.get(ingot, GTMaterials.Netherite).getItem());
     }

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -57,6 +57,7 @@
         "ServerGamePacketListenerImplAccessor",
         "ShapedRecipeAccessor",
         "SidedRedstoneConnectivityMixin",
+        "SmithingTransformRecipeMixin",
         "TagLoaderMixin",
         "TagManagerMixin",
         "TagValueAccessor",


### PR DESCRIPTION
## What
Adds diamond tool + netherite template + netherite ingot as a smithing recipe for all GTToolTypes

## Implementation Details
Since vanilla's smithing transform recipe copies all NBT from input to output item, smithed GT tools would keep their old stats, since we apply them using NBT.

I've implemented a mixin to check if the crafted item is an IGTTool. If so, it removes the `GT.Tool` tag and copies it over from a new tool stack. This should keep compat with any other mods doing funky stuff with `SmithingTransformRecipe`

Also added helpers for smithing transform recipes to VanillaRecipeHelper

## Outcome
Netherite tools are now obtainable :hapybapycat:

## Additional Information
<img width="1306" height="985" alt="image" src="https://github.com/user-attachments/assets/8c8baaa4-6a13-455f-8b4a-6d549f271a0a" />
<img width="1306" height="985" alt="image" src="https://github.com/user-attachments/assets/661a55e9-590b-44d1-81b9-afac037ede91" />
<img width="1306" height="985" alt="image" src="https://github.com/user-attachments/assets/5283bc9d-4e66-4374-a2a6-b8002506d635" />

## Potential Compatibility Issues
Hopefully none!