### PR TITLE
Fix blackstone and tuff ores not dropping dusts

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -5599,6 +5599,7 @@
   "material.gtceu.tritanium": "ɯnıuɐʇıɹ⟘",
   "material.gtceu.tritium": "ɯnıʇıɹ⟘",
   "material.gtceu.trona": "ɐuoɹ⟘",
+  "material.gtceu.tuff": "ɟɟn⟘",
   "material.gtceu.tungstate": "ǝʇɐʇsbun⟘",
   "material.gtceu.tungsten": "uǝʇsbun⟘",
   "material.gtceu.tungsten_carbide": "ǝpıqɹɐƆ uǝʇsbun⟘",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -5599,6 +5599,7 @@
   "material.gtceu.tritanium": "Tritanium",
   "material.gtceu.tritium": "Tritium",
   "material.gtceu.trona": "Trona",
+  "material.gtceu.tuff": "Tuff",
   "material.gtceu.tungstate": "Tungstate",
   "material.gtceu.tungsten": "Tungsten",
   "material.gtceu.tungsten_carbide": "Tungsten Carbide",

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -142,11 +142,10 @@ public class TagPrefix {
                             .sound(SoundType.DEEPSLATE),
                     new ResourceLocation("block/deepslate"), false, false, true);
 
-    // TODO figure out a composition for tuff
     public static final TagPrefix oreTuff = oreTagPrefix("tuff", BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Tuff %s Ore")
             .registerOre(
-                    Blocks.TUFF::defaultBlockState, null, BlockBehaviour.Properties.of()
+                    Blocks.TUFF::defaultBlockState, () -> GTMaterials.Tuff, BlockBehaviour.Properties.of()
                             .mapColor(MapColor.TERRACOTTA_GRAY).requiresCorrectToolForDrops().strength(3.0F, 3.0F)
                             .sound(SoundType.TUFF),
                     new ResourceLocation("block/tuff"));
@@ -187,10 +186,9 @@ public class TagPrefix {
                             .requiresCorrectToolForDrops().strength(3.0F, 3.0F).sound(SoundType.NETHER_ORE),
                     new ResourceLocation("block/netherrack"), true, false, true);
 
-    // TODO figure out a composition for blackstone
     public static final TagPrefix oreBlackstone = oreTagPrefix("blackstone", BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Blackstone %s Ore")
-            .registerOre(Blocks.BLACKSTONE::defaultBlockState, null,
+            .registerOre(Blocks.BLACKSTONE::defaultBlockState, () -> GTMaterials.Blackstone,
                     BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_BLACK)
                             .instrument(NoteBlockInstrument.BASEDRUM).requiresCorrectToolForDrops()
                             .strength(3.0F, 3.0F),

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
@@ -959,6 +959,7 @@ public class GTMaterials {
     public static Material Redstone;
     public static Material Dichloroethane;
     public static Material Diethylenetriamine;
+    public static Material Tuff;
 
     /**
      * Third Degree Materials

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/HigherDegreeMaterials.java
@@ -197,7 +197,7 @@ public class HigherDegreeMaterials {
 
         Blackstone = new Material.Builder(GTCEu.id("blackstone"))
                 .dust()
-                .color(0x090a0a).iconSet(ROUGH)
+                .color(0x3c3947).secondaryColor(0x160f10).iconSet(ROUGH)
                 .flags(NO_SMASHING)
                 .components(DarkAsh, 2, Basalt, 1, Stone, 5)
                 .buildAndRegister();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -534,7 +534,7 @@ public class SecondDegreeMaterials {
 
         Tuff = new Material.Builder(GTCEu.id("tuff"))
                 .dust()
-                .color(0x4d5046).secondaryColor(0x5d5d52).iconSet(ROUGH)
+                .color(0x75756a).secondaryColor(0x8a8a80).iconSet(ROUGH)
                 .flags(NO_SMASHING)
                 .components(Ash, 2, PotassiumFeldspar, 1)
                 .buildAndRegister();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/SecondDegreeMaterials.java
@@ -531,5 +531,12 @@ public class SecondDegreeMaterials {
                 .components(Carbon, 4, Hydrogen, 13, Nitrogen, 3)
                 .hazard(HazardProperty.HazardTrigger.ANY, GTMedicalConditions.CHEMICAL_BURNS)
                 .buildAndRegister();
+
+        Tuff = new Material.Builder(GTCEu.id("tuff"))
+                .dust()
+                .color(0x4d5046).secondaryColor(0x5d5d52).iconSet(ROUGH)
+                .flags(NO_SMASHING)
+                .components(Ash, 2, PotassiumFeldspar, 1)
+                .buildAndRegister();
     }
 }


### PR DESCRIPTION
## What
Blackstone and tuff ore prefixes did not have a material specified. Tuff did not have a material at all. This PR fixes those

Also makes blackstone look a little nicer

## Implementation Details
Tuff has been given the composition of `2x Ash, 1x PotassiumFeldspar`. Feel free to suggest a better composition for this

## Outcome
Dusts drop for these ores of these stones now, as well as other features dependent on having a material. Fixes #4375  

## Potential Compatibility Issues
None