### PR TITLE
Make netherite tools and items fire resistant

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialFlags.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialFlags.java
@@ -85,6 +85,11 @@ public class MaterialFlags {
      */
     public static final MaterialFlag PHOSPHORESCENT = new MaterialFlag.Builder("phosphorescent").build();
 
+    /**
+     * Add to material if it is fire resistant
+     */
+    public static final MaterialFlag FIRE_RESISTANT = new MaterialFlag.Builder("fire_resistant").build();
+
     //////////////////
     // DUST //
     //////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/GTToolItem.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.item.tool;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
 import com.gregtechceu.gtceu.api.item.IGTTool;
 import com.gregtechceu.gtceu.api.sound.SoundEntry;
 import com.gregtechceu.gtceu.client.renderer.item.ToolItemRenderer;
@@ -53,7 +54,8 @@ public class GTToolItem extends DiggerItem implements IGTTool {
 
     public GTToolItem(GTToolType toolType, MaterialToolTier tier, Material material, IGTToolDefinition definition,
                       Properties properties) {
-        super(0, 0, tier, toolType.harvestTags.isEmpty() ? null : toolType.harvestTags.get(0), properties);
+        super(0, 0, tier, toolType.harvestTags.isEmpty() ? null : toolType.harvestTags.get(0),
+                material.hasFlag(MaterialFlags.FIRE_RESISTANT) ? properties.fireResistant() : properties);
         this.toolType = toolType;
         this.material = material;
         this.electricTier = toolType.electricTier;

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialItems.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.common.data;
 
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
@@ -86,7 +87,9 @@ public class GTMaterialItems {
     private static void generateMaterialItem(TagPrefix tagPrefix, Material material, GTRegistrate registrate) {
         MATERIAL_ITEMS_BUILDER.put(tagPrefix, material, registrate
                 .item(tagPrefix.idPattern().formatted(material.getName()),
-                        properties -> tagPrefix.itemConstructor().create(properties, tagPrefix, material))
+                        properties -> tagPrefix.itemConstructor()
+                                .create(material.hasFlag(MaterialFlags.FIRE_RESISTANT) ? properties.fireResistant() :
+                                        properties, tagPrefix, material))
                 .setData(ProviderType.LANG, NonNullBiConsumer.noop())
                 .transform(GTItems.unificationItem(tagPrefix, material))
                 .properties(p -> p.stacksTo(tagPrefix.maxStackSize()))

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/UnknownCompositionMaterials.java
@@ -392,6 +392,7 @@ public class UnknownCompositionMaterials {
 
         Netherite = new Material.Builder(GTCEu.id("netherite"))
                 .ingot().color(0x4b4042).secondaryColor(0x474447)
+                .flags(FIRE_RESISTANT)
                 .toolStats(ToolProperty.Builder.of(10.0F, 4.0F, 2032, 4)
                         .enchantability(21).build())
                 .buildAndRegister();


### PR DESCRIPTION
## What
Adds a new MaterialFlag.FIRE_RESISTANT and applies it to Netherite

## Implementation Details
Currently, fire resistant only adds `fireResistant()` to the item properties for GTToolItem and TagPrefixItem if the material is fire resistant. Feel free to suggest any extra functionality for fire resistant relating to recipes or similar

## Outcome
Netherite items added by GT are now fire resistant