### PR TITLE
Add fluidbuilder binding

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTKubeJSPlugin.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.cosmetics.CapeRegistry;
+import com.gregtechceu.gtceu.api.fluid.FluidBuilder;
 import com.gregtechceu.gtceu.api.fluid.FluidState;
 import com.gregtechceu.gtceu.api.fluid.attribute.FluidAttributes;
 import com.gregtechceu.gtceu.api.fluid.store.FluidStorageKeys;
@@ -302,6 +303,7 @@ public class GTKubeJSPlugin implements KubeJSPlugin {
         event.add("MaterialEntry", MaterialEntry.class);
         event.add("GTMaterialFlags", MaterialFlags.class);
         event.add("GTFluidAttributes", FluidAttributes.class);
+        event.add("GTFluidBuilder", FluidBuilder.class);
         event.add("GTFluidStorageKeys", FluidStorageKeys.class);
         event.add("GTFluidState", FluidState.class);
         event.add("GTMaterialIconSet", MaterialIconSet.class);


### PR DESCRIPTION
## What
Re-adds the missing fluid builder

## Implementation Details
Materials with a builder NEED to be registered to the gtceu: namespace, or they will get a
                                                                                                    
        Exception message: java.lang.IllegalStateException: Some intrusive holders were not registered: [Reference{null=[unregistered]}] 
        
        ```
        StartupEvents.registry('gtceu:material', event => {
    event.create('gtceu:soul_stained_alumina')
        .color(0xdb3dff).secondaryColor(0xe683fc)
        .ingot()
    // THIS material is broken, in the context the fluidbuilder is now dead...
    event.create('gtceu:source_oils')
        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
        .color(0xe642f5)
})
```