### PR TITLE
Fix {fromAscii} placeholder

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/MultiLineComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/MultiLineComponent.java
@@ -29,6 +29,10 @@ public class MultiLineComponent extends ArrayList<MutableComponent> {
         return new MultiLineComponent(List.of(c.copy()));
     }
 
+    public static MultiLineComponent literal(char c) {
+        return MultiLineComponent.of(Component.literal(String.valueOf(c)));
+    }
+
     public static MultiLineComponent literal(String s) {
         return MultiLineComponent.of(Component.literal(s));
     }


### PR DESCRIPTION
## What
Fix `{fromAscii}` placeholder to actually output a char instead of a `long`

## Outcome
Fixes #4386