### PR TITLE
Cyclohexanone oxime ru_ru name correction

### DIFF
--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -4211,7 +4211,7 @@
     "material.gtceu.curium": "Кюрий",
     "material.gtceu.cyan_dye": "Бирюзовый краситель",
     "material.gtceu.cyclohexane": "Циклогексан",
-    "material.gtceu.cyclohexanone_oxime": "Оксид циклогексанона",
+    "material.gtceu.cyclohexanone_oxime": "Циклогексаноноксим",
     "material.gtceu.damascus_steel": "Дамасская сталь",
     "material.gtceu.dark_ash": "Пепел",
     "material.gtceu.deepslate": "Глубинный сланец",


### PR DESCRIPTION
Cyclohexanone oxi**m**e translated Оксид циклогексанона which actually means Cyclohexanone oxi**d**e which actually is other substance