### PR TITLE
Add recipe for Copper Ingot disassembling

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -141,7 +141,7 @@ public class RecipeAddition {
         if (!ConfigHolder.INSTANCE.recipes.disableManualCompression) {
             VanillaRecipeHelper.addShapelessRecipe(provider, "nether_quartz_block_to_nether_quartz",
                     new ItemStack(Items.QUARTZ, 4), Blocks.QUARTZ_BLOCK);
-            VanillaRecipeHelper.addShapelessRecipe(provider, "nugget_disassembling_copper",
+            VanillaRecipeHelper.addShapelessRecipe(provider, "copper_ingot_to_copper_nuggets",
                     ChemicalHelper.get(nugget, Copper, 9), new ItemStack(Items.COPPER_INGOT));
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/configurable/RecipeAddition.java
@@ -141,6 +141,8 @@ public class RecipeAddition {
         if (!ConfigHolder.INSTANCE.recipes.disableManualCompression) {
             VanillaRecipeHelper.addShapelessRecipe(provider, "nether_quartz_block_to_nether_quartz",
                     new ItemStack(Items.QUARTZ, 4), Blocks.QUARTZ_BLOCK);
+            VanillaRecipeHelper.addShapelessRecipe(provider, "nugget_disassembling_copper",
+                    ChemicalHelper.get(nugget, Copper, 9), new ItemStack(Items.COPPER_INGOT));
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -629,11 +629,5 @@ public class MiscRecipeLoader {
                 new MaterialEntry(gem, Lazurite));
         VanillaRecipeHelper.addShapelessRecipe(provider, "sodalite_to_dye", new ItemStack(Items.BLUE_DYE),
                 new MaterialEntry(gem, Sodalite));
-
-        // Copper Ingot disassembling
-        if (!ConfigHolder.INSTANCE.recipes.disableManualCompression) {
-            VanillaRecipeHelper.addShapelessRecipe(provider, "nugget_disassembling_copper",
-                    ChemicalHelper.get(nugget, Copper, 9), new ItemStack(Items.COPPER_INGOT));
-        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -629,5 +629,11 @@ public class MiscRecipeLoader {
                 new MaterialEntry(gem, Lazurite));
         VanillaRecipeHelper.addShapelessRecipe(provider, "sodalite_to_dye", new ItemStack(Items.BLUE_DYE),
                 new MaterialEntry(gem, Sodalite));
+
+        // Copper Ingot disassembling
+        if (!ConfigHolder.INSTANCE.recipes.disableManualCompression) {
+            VanillaRecipeHelper.addShapelessRecipe(provider, "nugget_disassembling_copper",
+                    ChemicalHelper.get(nugget, Copper, 9), new ItemStack(Items.COPPER_INGOT));
+        }
     }
 }


### PR DESCRIPTION
## What
Fix #4397 

## Implementation Details
Copper is not handled correctly by the automatic creation of ingot -> nugget recipes, due to the ingot being vanilla while the nugget is added by GregTech. This PR adds this recipe manually.

## Outcome
If the `disableManualCompression` config is set fo false, a recipe is added that turns 1 Copper Ingot into 9 Copper Nuggets