### PR TITLE
 Correct Data Stick interaction handling

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/DataItemBehavior.java
@@ -153,6 +153,7 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
                 if (ResearchManager.readResearchId(itemStack) == null) {
                     return interactable.onDataStickShiftUse(context.getPlayer(), itemStack);
                 }
+                return InteractionResult.sidedSuccess(context.getLevel().isClientSide);
             } else {
                 return interactable.onDataStickUse(context.getPlayer(), itemStack);
             }
@@ -167,13 +168,12 @@ public class DataItemBehavior implements IInteractionItem, IAddInformation, IDat
                     if (ResearchManager.readResearchId(itemStack) == null) {
                         return interactable.onDataStickShiftUse(context.getPlayer(), itemStack);
                     }
+                    return InteractionResult.sidedSuccess(context.getLevel().isClientSide);
                 } else {
                     return interactable.onDataStickUse(context.getPlayer(), itemStack);
                 }
-            } else {
-                return InteractionResult.PASS;
             }
         }
-        return InteractionResult.sidedSuccess(context.getLevel().isClientSide);
+        return InteractionResult.PASS;
     }
 }


### PR DESCRIPTION
## What
The Data Stick blocks right-click interactions with other blocks like the ME Conversion Monitor