### PR TITLE
Add gem slurry from purified ore recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GemSlurryRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GemSlurryRecipes.java
@@ -14,8 +14,14 @@ public class GemSlurryRecipes {
 
     public static void init(Consumer<FinishedRecipe> provider) {
         // Ruby
-        MIXER_RECIPES.recipeBuilder("ruby_slurry").duration(280).EUt(VA[EV])
+        MIXER_RECIPES.recipeBuilder("ruby_slurry_from_crushed_ruby").duration(280).EUt(VA[EV])
                 .inputItems(crushed, Ruby, 2)
+                .inputFluids(AquaRegia.getFluid(3000))
+                .outputFluids(RubySlurry.getFluid(3000))
+                .save(provider);
+
+        MIXER_RECIPES.recipeBuilder("ruby_slurry_from_washed_ruby").duration(280).EUt(VA[EV])
+                .inputItems(crushedPurified, Ruby, 2)
                 .inputFluids(AquaRegia.getFluid(3000))
                 .outputFluids(RubySlurry.getFluid(3000))
                 .save(provider);
@@ -31,8 +37,14 @@ public class GemSlurryRecipes {
                 .save(provider);
 
         // Sapphire
-        MIXER_RECIPES.recipeBuilder("sapphire_slurry").duration(280).EUt(VA[EV])
+        MIXER_RECIPES.recipeBuilder("sapphire_slurry_from_crushed_sapphire").duration(280).EUt(VA[EV])
                 .inputItems(crushed, Sapphire, 2)
+                .inputFluids(AquaRegia.getFluid(3000))
+                .outputFluids(SapphireSlurry.getFluid(3000))
+                .save(provider);
+
+        MIXER_RECIPES.recipeBuilder("sapphire_slurry_from_washed_sapphire").duration(280).EUt(VA[EV])
+                .inputItems(crushedPurified, Sapphire, 2)
                 .inputFluids(AquaRegia.getFluid(3000))
                 .outputFluids(SapphireSlurry.getFluid(3000))
                 .save(provider);
@@ -47,8 +59,14 @@ public class GemSlurryRecipes {
                 .save(provider);
 
         // Green Sapphire
-        MIXER_RECIPES.recipeBuilder("green_sapphire_slurry").duration(280).EUt(VA[EV])
+        MIXER_RECIPES.recipeBuilder("green_sapphire_slurry_from_crushed_green_sapphire").duration(280).EUt(VA[EV])
                 .inputItems(crushed, GreenSapphire, 2)
+                .inputFluids(AquaRegia.getFluid(3000))
+                .outputFluids(GreenSapphireSlurry.getFluid(3000))
+                .save(provider);
+
+        MIXER_RECIPES.recipeBuilder("green_sapphire_slurry_from_washed_green_sapphire").duration(280).EUt(VA[EV])
+                .inputItems(crushcrushedPurifieded, GreenSapphire, 2)
                 .inputFluids(AquaRegia.getFluid(3000))
                 .outputFluids(GreenSapphireSlurry.getFluid(3000))
                 .save(provider);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GemSlurryRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/GemSlurryRecipes.java
@@ -66,7 +66,7 @@ public class GemSlurryRecipes {
                 .save(provider);
 
         MIXER_RECIPES.recipeBuilder("green_sapphire_slurry_from_washed_green_sapphire").duration(280).EUt(VA[EV])
-                .inputItems(crushcrushedPurifieded, GreenSapphire, 2)
+                .inputItems(crushedPurified, GreenSapphire, 2)
                 .inputFluids(AquaRegia.getFluid(3000))
                 .outputFluids(GreenSapphireSlurry.getFluid(3000))
                 .save(provider);


### PR DESCRIPTION
## What
Allows gem slurries to be made from purified ore as well as crushed ore. When processing ruby via the gem slurry lines, you get less chromium on average compared to regular ore processing (original discussion on TFG, the gem slurry lines are unchanged in that pack: https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/2179). No idea if this would get added since its a balancing change and it depends on what the intent behind the gem slurries is.

## Implementation Details
Adds gem slurry from purified ore recipes. This is consistent with other ore processing lines that take in purified ores as input (e.g bauxite line/platline).

## Outcome
Addresses chromium deficit from ruby gem slurry compared to standard ore processing.

## Potential Compatibility Issues
Has balancing consequences since the ruby slurry is now chromium positive and sapphire/green sapphire slurry lines produce more aluminium
