### PR TITLE
Fix kubejs namespaces

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/block/ActiveBlockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/block/ActiveBlockBuilder.java
@@ -39,7 +39,7 @@ public class ActiveBlockBuilder extends BlockBuilder {
     public transient String activeTexture;
 
     public ActiveBlockBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         property(GTBlockStateProperties.ACTIVE);
         renderType(BlockRenderType.CUTOUT_MIPPED);
         activeTexture = ACTIVE.apply(baseTexture);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/block/CoilBlockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/block/CoilBlockBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.block;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.block.SimpleCoilType;
 import com.gregtechceu.gtceu.api.block.property.GTBlockStateProperties;
@@ -29,7 +30,7 @@ public class CoilBlockBuilder extends ActiveBlockBuilder {
     public transient String texture = "minecraft:missingno";
 
     public CoilBlockBuilder(ResourceLocation i) {
-        super(i);
+        super(GTCEu.id(i.getPath()));
         property(GTBlockStateProperties.ACTIVE);
         renderType(BlockRenderType.CUTOUT_MIPPED);
         noValidSpawns(true);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
@@ -39,7 +39,7 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> imple
     private MachineDefinition lpObject = null, hpObject = null;
 
     public KJSSteamMachineBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.dummyBuilder = true;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -55,7 +55,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<@Nullable MachineDefini
     public transient BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI;
 
     public KJSTieredMachineBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.addDefaultTooltips = false;
         this.addDefaultModel = false;
         this.dummyBuilder = true;
@@ -64,7 +64,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<@Nullable MachineDefini
     public KJSTieredMachineBuilder(ResourceLocation id, TieredCreationFunction machine,
                                    BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI,
                                    boolean isGenerator) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.machine = machine;
         this.editableUI = editableUI;
         this.isGenerator = isGenerator;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
@@ -38,12 +39,12 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<@Nullable Multiblock
     public transient DefinitionFunction definition = (tier, def) -> def.tier(tier);
 
     public KJSTieredMultiblockBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.dummyBuilder = true;
     }
 
     public KJSTieredMultiblockBuilder(ResourceLocation id, TieredCreationFunction machine) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.machine = machine;
         this.dummyBuilder = true;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMachineBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 
 import net.minecraft.resources.ResourceLocation;
@@ -22,7 +23,7 @@ public class KJSWrappingMachineBuilder extends BuilderBase<MachineDefinition> im
     private final KJSTieredMachineBuilder tieredBuilder;
 
     public KJSWrappingMachineBuilder(ResourceLocation id, KJSTieredMachineBuilder tieredBuilder) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.tieredBuilder = tieredBuilder;
         this.dummyBuilder = true;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 
 import net.minecraft.resources.ResourceLocation;
@@ -21,7 +22,7 @@ public class KJSWrappingMultiblockBuilder extends BuilderBase<MultiblockMachineD
     private final KJSTieredMultiblockBuilder tieredBuilder;
 
     public KJSWrappingMultiblockBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.tieredBuilder = new KJSTieredMultiblockBuilder(id);
         this.dummyBuilder = true;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/MultiblockMachineBuilderWrapper.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/MultiblockMachineBuilderWrapper.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.machine;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.MetaMachineBlock;
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
@@ -59,7 +60,7 @@ public class MultiblockMachineBuilderWrapper extends BuilderBase<MultiblockMachi
     private final MultiblockMachineBuilder internal;
 
     public MultiblockMachineBuilderWrapper(ResourceLocation id, MultiblockMachineBuilder internal) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.internal = internal;
         this.dummyBuilder = true;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/ElementBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/ElementBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.material;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.material.Element;
 import com.gregtechceu.gtceu.data.material.GTElements;
 
@@ -25,7 +26,7 @@ public class ElementBuilder extends BuilderBase<Element> {
     public transient boolean isIsotope;
 
     public ElementBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         name = id.getPath();
         translatableName = Component.translatable(id.toLanguageKey("element"));
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/MaterialBuilderWrapper.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/MaterialBuilderWrapper.java
@@ -11,7 +11,6 @@ import com.gregtechceu.gtceu.api.material.material.info.MaterialIconSet;
 import com.gregtechceu.gtceu.api.material.material.properties.*;
 import com.gregtechceu.gtceu.api.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.tag.TagPrefix;
-import com.gregtechceu.gtceu.integration.kjs.helpers.GTResourceLocation;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MaterialStackWrapper;
 
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/MaterialBuilderWrapper.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/material/MaterialBuilderWrapper.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.material;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.fluid.FluidBuilder;
 import com.gregtechceu.gtceu.api.fluid.FluidState;
 import com.gregtechceu.gtceu.api.fluid.store.FluidStorageKey;
@@ -10,6 +11,7 @@ import com.gregtechceu.gtceu.api.material.material.info.MaterialIconSet;
 import com.gregtechceu.gtceu.api.material.material.properties.*;
 import com.gregtechceu.gtceu.api.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.tag.TagPrefix;
+import com.gregtechceu.gtceu.integration.kjs.helpers.GTResourceLocation;
 import com.gregtechceu.gtceu.integration.kjs.helpers.MaterialStackWrapper;
 
 import net.minecraft.resources.ResourceLocation;
@@ -28,8 +30,8 @@ public class MaterialBuilderWrapper extends BuilderBase<Material> {
     private final Material.Builder internal;
 
     public MaterialBuilderWrapper(ResourceLocation id) {
-        super(id);
-        this.internal = new Material.Builder(id);
+        super(GTCEu.id(id.getPath()));
+        this.internal = new Material.Builder(this.id);
         this.dummyBuilder = true;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/prefix/OreTagPrefixBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/prefix/OreTagPrefixBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.prefix;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.OreBlock;
 import com.gregtechceu.gtceu.api.material.material.Material;
 import com.gregtechceu.gtceu.api.material.material.info.MaterialIconType;
@@ -37,7 +38,7 @@ public class OreTagPrefixBuilder extends TagPrefixBuilder {
     public transient boolean shouldDropAsItem = false;
 
     public OreTagPrefixBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/prefix/TagPrefixBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/prefix/TagPrefixBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.prefix;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.material.material.Material;
 import com.gregtechceu.gtceu.api.material.material.info.MaterialIconType;
 import com.gregtechceu.gtceu.api.material.material.stack.MaterialStack;
@@ -32,7 +33,7 @@ public class TagPrefixBuilder extends BuilderBase<TagPrefix> {
     private final List<MaterialStack> secondaryMaterials = new ArrayList<>();
 
     public TagPrefixBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         this.base = create(id.getPath());
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/recipetype/GTRecipeCategoryBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/recipetype/GTRecipeCategoryBuilder.java
@@ -38,7 +38,7 @@ public class GTRecipeCategoryBuilder extends BuilderBase<GTRecipeCategory> {
     private transient String langValue;
 
     public GTRecipeCategoryBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
         name = id.getPath();
         recipeType = GTRecipeTypes.DUMMY_RECIPES;
         icon = null;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/recipetype/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/recipetype/GTRecipeTypeBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.recipetype;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.gui.SteamTexture;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
@@ -58,7 +59,7 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
     protected transient BiConsumer<GTRecipe, WidgetGroup> uiBuilder;
 
     public GTRecipeTypeBuilder(ResourceLocation i) {
-        super(i);
+        super(GTCEu.id(i.getPath()));
         name = i.getPath();
         category = "custom";
         maxInputs = new Object2IntOpenHashMap<>();

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/BedrockFluidBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/BedrockFluidBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.worldgen;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.worldgen.BiomeWeightModifier;
 import com.gregtechceu.gtceu.api.worldgen.bedrockfluid.BedrockFluidDefinition;
 
@@ -36,7 +37,7 @@ public class BedrockFluidBuilder extends BuilderBase<BedrockFluidDefinition> {
     private final transient Set<ResourceKey<Level>> dimensions = new HashSet<>();
 
     public BedrockFluidBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
     }
 
     public static BedrockFluidBuilder from(BedrockFluidDefinition definition, ResourceLocation id) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/BedrockOreBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/BedrockOreBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.worldgen;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.material.material.Material;
 import com.gregtechceu.gtceu.api.worldgen.BiomeWeightModifier;
 import com.gregtechceu.gtceu.api.worldgen.bedrockore.BedrockOreDefinition;
@@ -40,7 +41,7 @@ public class BedrockOreBuilder extends BuilderBase<BedrockOreDefinition> {
     private final List<BiomeWeightModifier> biomes = new LinkedList<>();
 
     public BedrockOreBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
     }
 
     public static BedrockOreBuilder from(BedrockOreDefinition definition, ResourceLocation id) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilder.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.kjs.builders.worldgen;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.worldgen.*;
 import com.gregtechceu.gtceu.api.worldgen.generator.IndicatorGenerator;
 import com.gregtechceu.gtceu.api.worldgen.generator.VeinGenerator;
@@ -60,7 +61,7 @@ public class OreVeinDefinitionBuilder extends BuilderBase<OreVeinDefinition> {
     private List<IndicatorGenerator> indicatorGenerators;
 
     public OreVeinDefinitionBuilder(ResourceLocation id) {
-        super(id);
+        super(GTCEu.id(id.getPath()));
     }
 
     @Tolerate


### PR DESCRIPTION
## What

Updates the builders to forcibly use GTCEu namespaces

## Implementation Details

All builders now use `super(GTCEu.id(id.getPath()))` as opposed to `super(id)`

## Outcome

Fixes random issues caused by using KubeJS namespaces