### PR TITLE
Fix oreveins 

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -71,9 +71,6 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
     }
 
     public SurfaceIndicatorGenerator surfaceRock(Material material) {
-        if (material == null) {
-            throw new IllegalArgumentException("Surface rock material is null");
-        }
         validateSurfaceRockMaterial(material);
 
         this.block = Either.right(material);
@@ -112,14 +109,7 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
         return this;
     }
 
-    public void validateAfterBlocks() {
-        block.ifRight(SurfaceIndicatorGenerator::validateSurfaceRockMaterial);
-    }
-
     private static void validateSurfaceRockMaterial(Material material) {
-        if (GTMaterialBlocks.SURFACE_ROCK_BLOCKS == null) {
-            return;
-        }
         if (GTMaterialBlocks.SURFACE_ROCK_BLOCKS.get(material) == null)
             throw new IllegalArgumentException("No surface rock registered for material " + material.getName());
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -71,6 +71,9 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
     }
 
     public SurfaceIndicatorGenerator surfaceRock(Material material) {
+        if (material == null) {
+            throw new IllegalArgumentException("Surface rock material is null");
+        }
         validateSurfaceRockMaterial(material);
 
         this.block = Either.right(material);
@@ -109,7 +112,14 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
         return this;
     }
 
+    public void validateAfterBlocks() {
+        block.ifRight(SurfaceIndicatorGenerator::validateSurfaceRockMaterial);
+    }
+
     private static void validateSurfaceRockMaterial(Material material) {
+        if (GTMaterialBlocks.SURFACE_ROCK_BLOCKS == null) {
+            return;
+        }
         if (GTMaterialBlocks.SURFACE_ROCK_BLOCKS.get(material) == null)
             throw new IllegalArgumentException("No surface rock registered for material " + material.getName());
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/loader/PostRegistryListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/loader/PostRegistryListener.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.common.data.loader;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.worldgen.OreVeinDefinition;
 import com.gregtechceu.gtceu.api.worldgen.WorldGeneratorUtils;
-import com.gregtechceu.gtceu.api.worldgen.generator.indicators.SurfaceIndicatorGenerator;
 import com.gregtechceu.gtceu.data.worldgen.GTOreVeins;
 import com.gregtechceu.gtceu.integration.map.cache.server.ServerCache;
 
@@ -31,14 +30,7 @@ public class PostRegistryListener extends ContextAwareReloadListener implements 
         var biomeLookup = GTRegistries.builtinRegistry().lookupOrThrow(Registries.BIOME);
 
         var oreVeinRegistry = GTRegistries.builtinRegistry().registryOrThrow(GTRegistries.ORE_VEIN_REGISTRY);
-        oreVeinRegistry.holders().forEach(holder -> {
-            var definition = holder.value();
-            definition.biomeLookup(biomeLookup);
-            definition.indicatorGenerators().stream()
-                    .filter(SurfaceIndicatorGenerator.class::isInstance)
-                    .map(SurfaceIndicatorGenerator.class::cast)
-                    .forEach(SurfaceIndicatorGenerator::validateAfterBlocks);
-        });
+        oreVeinRegistry.holders().forEach(holder -> holder.value().biomeLookup(biomeLookup));
 
         buildVeinGenerators(oreVeinRegistry);
         GTOreVeins.updateLargestVeinSize(oreVeinRegistry);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/loader/PostRegistryListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/loader/PostRegistryListener.java
@@ -3,10 +3,12 @@ package com.gregtechceu.gtceu.common.data.loader;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.worldgen.OreVeinDefinition;
 import com.gregtechceu.gtceu.api.worldgen.WorldGeneratorUtils;
+import com.gregtechceu.gtceu.api.worldgen.generator.indicators.SurfaceIndicatorGenerator;
 import com.gregtechceu.gtceu.data.worldgen.GTOreVeins;
 import com.gregtechceu.gtceu.integration.map.cache.server.ServerCache;
 
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.server.packs.resources.PreparableReloadListener;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.util.profiling.ProfilerFiller;
@@ -25,11 +27,22 @@ public class PostRegistryListener extends ContextAwareReloadListener implements 
     private PostRegistryListener() {}
 
     protected void apply() {
-        var registry = GTRegistries.builtinRegistry().registryOrThrow(GTRegistries.ORE_VEIN_REGISTRY);
+        // Apply and validate stuff that requires registry access that isn't finished yet during the Registry event
+        var biomeLookup = GTRegistries.builtinRegistry().lookupOrThrow(Registries.BIOME);
 
-        buildVeinGenerators(registry);
-        GTOreVeins.updateLargestVeinSize(registry);
-        ServerCache.instance.oreVeinDefinitionsChanged(registry);
+        var oreVeinRegistry = GTRegistries.builtinRegistry().registryOrThrow(GTRegistries.ORE_VEIN_REGISTRY);
+        oreVeinRegistry.holders().forEach(holder -> {
+            var definition = holder.value();
+            definition.biomeLookup(biomeLookup);
+            definition.indicatorGenerators().stream()
+                    .filter(SurfaceIndicatorGenerator.class::isInstance)
+                    .map(SurfaceIndicatorGenerator.class::cast)
+                    .forEach(SurfaceIndicatorGenerator::validateAfterBlocks);
+        });
+
+        buildVeinGenerators(oreVeinRegistry);
+        GTOreVeins.updateLargestVeinSize(oreVeinRegistry);
+        ServerCache.instance.oreVeinDefinitionsChanged(oreVeinRegistry);
         WorldGeneratorUtils.invalidateOreVeinCache();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilder.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import com.mojang.datafixers.util.Pair;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
 import dev.latvian.mods.kubejs.util.RegistryAccessContainer;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.experimental.Tolerate;
@@ -42,7 +43,7 @@ public class OreVeinDefinitionBuilder extends BuilderBase<OreVeinDefinition> {
     private int weight;
     private IWorldGenLayer layer = WorldGenLayers.STONE;
     @Setter
-    private Set<ResourceKey<Level>> dimensionFilter;
+    private Set<ResourceKey<Level>> dimensionFilter = new HashSet<>();
     @Setter
     private HeightRangePlacement heightRange;
     @Setter
@@ -51,13 +52,13 @@ public class OreVeinDefinitionBuilder extends BuilderBase<OreVeinDefinition> {
     @Nullable
     private HolderSet<Biome> biomes;
     @Setter
-    private BiomeWeightModifier biomeWeightModifier;
+    private BiomeWeightModifier biomeWeightModifier = BiomeWeightModifier.EMPTY;
 
     @Setter
     @Nullable
     private VeinGenerator veinGenerator;
     @Setter
-    private List<IndicatorGenerator> indicatorGenerators;
+    private List<IndicatorGenerator> indicatorGenerators = new ObjectArrayList<>();
 
     public OreVeinDefinitionBuilder(ResourceLocation id) {
         super(id);
@@ -216,6 +217,6 @@ public class OreVeinDefinitionBuilder extends BuilderBase<OreVeinDefinition> {
         return new OreVeinDefinition(clusterSize, density, weight, layer,
                 Set.copyOf(dimensionFilter), heightRange, discardChanceOnAirExposure,
                 biomes, biomeWeightModifier, veinGenerator, indicatorGenerators,
-                RegistryAccessContainer.current.access().lookupOrThrow(Registries.BIOME));
+                RegistryAccessContainer.current.access().lookup(Registries.BIOME).orElse(null));
     }
 }


### PR DESCRIPTION
trying to fix oreveins so they work for KJS

Currently using
```js
ServerEvents.registry('gtceu:ore_vein', event => {
    event.create('kubejs:redstone')
        .layer(GTWorldGenLayers.STONE)
        .weight(60)
        .clusterSize(50)
        .density(0.55)
        .discardChanceOnAirExposure(1)
        .heightRangeUniform(16, 128)
        .layeredVeinGenerator(generator => {
            generator.withLayerPattern(pattern => {
                pattern.layer(l => l.weight(3).mat(GTMaterials.Redstone).size(2, 4))
                pattern.layer(l => l.weight(2).mat(GTMaterials.Barite).size(1, 3))
                pattern.layer(l => l.weight(3).mat(GTMaterials.Trona).size(1, 3))
            })
        })
        .surfaceIndicatorGenerator(indicator => {
            indicator.surfaceRock(GTMaterials.Redstone)
            indicator.density(0.2)
            indicator.radius(4)
        })
})
```
When running, it currently still gives a
`[Render thread/ERROR] [KubeJS Server/]: server_scripts:BrokenStuff.js#20: Failed to register object 'kubejs:redstone' of registry 'gtceu:ore_vein'! - java.lang.NullPointerException`

God why did we move away from having custom events. Everything isn't initialized yet in SeverEvents.registry() and a bunch of stuff that runs post-registry hasn't run yet either >:( 

Also why is KubeJS error logging so bad what od you mean "NullPointerException lol go figure it out" :(