### PR TITLE
Use Generic Builder pattern for MachineBuilder

### DIFF
--- a/docs/content/Modpacks/Changes/v7.4.1.md
+++ b/docs/content/Modpacks/Changes/v7.4.1.md
@@ -1,0 +1,8 @@
+---
+title: "Version 7.4.1"
+---
+
+
+# Updating from `7.4.0` to `7.4.1`
+## MachineBuilder Generics
+We have added a second Generic argument to our (Multiblock)MachineBuilder. This effectively means that anywhere where you used to store a partially finished `MachineBuilder<?>`, you now need to store a `MachineBuilder<?, ?>`. The same holds for `MultiblockMachineBuilder<?,?>`.

--- a/docs/content/Modpacks/Changes/v7.5.0.md
+++ b/docs/content/Modpacks/Changes/v7.5.0.md
@@ -1,8 +1,8 @@
 ---
-title: "Version 7.4.1"
+title: "Version 7.5.0"
 ---
 
 
-# Updating from `7.4.0` to `7.4.1`
+# Updating from `7.4.1` to `7.5.0`
 ## MachineBuilder Generics
 We have added a second Generic argument to our (Multiblock)MachineBuilder. This effectively means that anywhere where you used to store a partially finished `MachineBuilder<?>`, you now need to store a `MachineBuilder<?, ?>`. The same holds for `MultiblockMachineBuilder<?,?>`.

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -126,34 +126,34 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
         return fluid(this, material, name, langKey, stillTexture, flowingTexture);
     }
 
-    public <DEFINITION extends MachineDefinition> MachineBuilder<DEFINITION> machine(String name,
-                                                                                     Function<ResourceLocation, DEFINITION> definitionFactory,
-                                                                                     Function<IMachineBlockEntity, MetaMachine> metaMachine,
-                                                                                     BiFunction<BlockBehaviour.Properties, DEFINITION, IMachineBlock> blockFactory,
-                                                                                     BiFunction<IMachineBlock, Item.Properties, MetaMachineItem> itemFactory,
-                                                                                     TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory) {
+    public <DEFINITION extends MachineDefinition> MachineBuilder<DEFINITION, ?> machine(String name,
+                                                                                        Function<ResourceLocation, DEFINITION> definitionFactory,
+                                                                                        Function<IMachineBlockEntity, MetaMachine> metaMachine,
+                                                                                        BiFunction<BlockBehaviour.Properties, DEFINITION, IMachineBlock> blockFactory,
+                                                                                        BiFunction<IMachineBlock, Item.Properties, MetaMachineItem> itemFactory,
+                                                                                        TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory) {
         return new MachineBuilder<>(this, name, definitionFactory, metaMachine,
                 blockFactory, itemFactory, blockEntityFactory);
     }
 
-    public MachineBuilder<MachineDefinition> machine(String name,
-                                                     Function<IMachineBlockEntity, MetaMachine> metaMachine) {
+    public MachineBuilder<MachineDefinition, ?> machine(String name,
+                                                        Function<IMachineBlockEntity, MetaMachine> metaMachine) {
         return new MachineBuilder<>(this, name, MachineDefinition::new, metaMachine,
                 MetaMachineBlock::new, MetaMachineItem::new, MetaMachineBlockEntity::new);
     }
 
-    public MultiblockMachineBuilder multiblock(String name,
-                                               Function<IMachineBlockEntity, ? extends MultiblockControllerMachine> metaMachine,
-                                               BiFunction<BlockBehaviour.Properties, MultiblockMachineDefinition, IMachineBlock> blockFactory,
-                                               BiFunction<IMachineBlock, Item.Properties, MetaMachineItem> itemFactory,
-                                               TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory) {
-        return new MultiblockMachineBuilder(this, name, metaMachine,
+    public MultiblockMachineBuilder<MultiblockMachineDefinition, ?> multiblock(String name,
+                                                                               Function<IMachineBlockEntity, ? extends MultiblockControllerMachine> metaMachine,
+                                                                               BiFunction<BlockBehaviour.Properties, MultiblockMachineDefinition, IMachineBlock> blockFactory,
+                                                                               BiFunction<IMachineBlock, Item.Properties, MetaMachineItem> itemFactory,
+                                                                               TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory) {
+        return new MultiblockMachineBuilder<>(this, name, metaMachine,
                 blockFactory, itemFactory, blockEntityFactory);
     }
 
-    public MultiblockMachineBuilder multiblock(String name,
-                                               Function<IMachineBlockEntity, ? extends MultiblockControllerMachine> metaMachine) {
-        return new MultiblockMachineBuilder(this, name, metaMachine,
+    public MultiblockMachineBuilder<MultiblockMachineDefinition, ?> multiblock(String name,
+                                                                               Function<IMachineBlockEntity, ? extends MultiblockControllerMachine> metaMachine) {
+        return new MultiblockMachineBuilder<>(this, name, metaMachine,
                 MetaMachineBlock::new, MetaMachineItem::new, MetaMachineBlockEntity::new);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -63,7 +63,6 @@ import dev.latvian.mods.rhino.util.RemapPrefixForJS;
 import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.experimental.Tolerate;
 import org.apache.commons.lang3.ArrayUtils;
@@ -84,7 +83,8 @@ import static com.gregtechceu.gtceu.integration.kjs.GregTechKubeJSPlugin.RUNTIME
 @MethodsReturnNonnullByDefault
 @RemapPrefixForJS("kjs$")
 @Accessors(chain = true, fluent = true)
-public class MachineBuilder<DEFINITION extends MachineDefinition> extends BuilderBase<DEFINITION> {
+public class MachineBuilder<DEFINITION extends MachineDefinition, TYPE extends MachineBuilder<DEFINITION, TYPE>>
+                           extends BuilderBase<DEFINITION> {
 
     protected final GTRegistrate registrate;
     protected final String name;
@@ -93,95 +93,65 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     protected final TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory;
 
     protected final Function<ResourceLocation, DEFINITION> definition;
-    @Setter
     protected Function<IMachineBlockEntity, MetaMachine> machine;
     @Nullable
     @Getter
-    @Setter
     private MachineBuilder.ModelInitializer model = null;
     @Nullable
     @Getter
-    @Setter
     private NonNullBiConsumer<DataGenContext<Block, ? extends Block>, GTBlockstateProvider> blockModel = null;
     @Getter
     protected final Map<Property<?>, @Nullable Comparable<?>> modelProperties = new IdentityHashMap<>();
-    @Setter
     private VoxelShape shape = Shapes.block();
-    @Setter
     private RotationState rotationState = RotationState.NON_Y_AXIS;
     /**
      * Whether this machine can be rotated or face upwards.
      */
-    @Setter
     private boolean allowExtendedFacing = false;
-    @Setter
     private boolean hasBER = ConfigHolder.INSTANCE.client.machinesHaveBERsByDefault;
-    @Setter
     private boolean renderMultiblockWorldPreview = true;
-    @Setter
     private boolean renderMultiblockXEIPreview = true;
-    @Setter
     private NonNullUnaryOperator<BlockBehaviour.Properties> blockProp = p -> p;
-    @Setter
     private NonNullUnaryOperator<Item.Properties> itemProp = p -> p;
     @Nullable
-    @Setter
     private Consumer<BlockBuilder<? extends Block, ?>> blockBuilder;
     @Nullable
-    @Setter
     private Consumer<ItemBuilder<? extends MetaMachineItem, ?>> itemBuilder;
-    @Setter
     private NonNullConsumer<BlockEntityType<BlockEntity>> onBlockEntityRegister = NonNullConsumer.noop();
     @Getter // getter for KJS
     private @NotNull GTRecipeType @NotNull [] recipeTypes = new GTRecipeType[0];
-    @Getter
-    @Setter // getter for KJS
+    @Getter // getter for KJS
     private int tier;
-    @Setter
     private Reference2IntMap<RecipeCapability<?>> recipeOutputLimits = new Reference2IntOpenHashMap<>();
-    @Setter
     private int paintingColor = ConfigHolder.INSTANCE.client.getDefaultPaintingColor();
-    @Setter
     private BiFunction<ItemStack, Integer, Integer> itemColor = ((itemStack, tintIndex) -> tintIndex == 2 ?
             GTValues.VC[tier] : tintIndex == 1 ? paintingColor : -1);
     private PartAbility[] abilities = new PartAbility[0];
     private final List<Component> tooltips = new ArrayList<>();
     @Nullable
-    @Setter
     private BiConsumer<ItemStack, List<Component>> tooltipBuilder;
     private RecipeModifier recipeModifier = new RecipeModifierList(GTRecipeModifiers.OC_NON_PERFECT);
-    @Setter
     private boolean alwaysTryModifyRecipe;
     @NotNull
     @Getter
-    @Setter
     private BiPredicate<IRecipeLogicMachine, GTRecipe> beforeWorking = (machine, recipe) -> true;
     @NotNull
     @Getter
-    @Setter
     private Predicate<IRecipeLogicMachine> onWorking = (machine) -> true;
     @NotNull
     @Getter
-    @Setter
     private Consumer<IRecipeLogicMachine> onWaiting = (machine) -> {};
     @NotNull
     @Getter
-    @Setter
     private Consumer<IRecipeLogicMachine> afterWorking = (machine) -> {};
     @Getter
-    @Setter
     private boolean regressWhenWaiting = true;
-
-    @Setter
     private boolean allowCoverOnFront = false;
-    @Setter
     private Supplier<BlockState> appearance;
     @Getter // getter for KJS
-    @Setter
     @Nullable
     private EditableMachineUI editableUI;
     @Getter // getter for KJS
-    @Setter
     @Nullable
     private String langValue = null;
 
@@ -201,21 +171,166 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         this.definition = definition;
     }
 
-    public MachineBuilder<DEFINITION> recipeType(GTRecipeType type) {
+    @SuppressWarnings("unchecked")
+    public TYPE getThis() {
+        return (TYPE) this;
+    }
+
+    public TYPE machine(Function<IMachineBlockEntity, MetaMachine> machine) {
+        this.machine = machine;
+        return getThis();
+    }
+
+    public TYPE blockModel(NonNullBiConsumer<DataGenContext<Block, ? extends Block>, GTBlockstateProvider> blockModel) {
+        this.blockModel = blockModel;
+        return getThis();
+    }
+
+    public TYPE shape(VoxelShape shape) {
+        this.shape = shape;
+        return getThis();
+    }
+
+    public TYPE rotationState(RotationState rotationState) {
+        this.rotationState = rotationState;
+        return getThis();
+    }
+
+    public TYPE allowExtendedFacing(boolean allowExtendedFacing) {
+        this.allowExtendedFacing = allowExtendedFacing;
+        return getThis();
+    }
+
+    public TYPE hasBER(boolean hasBER) {
+        this.hasBER = hasBER;
+        return getThis();
+    }
+
+    public TYPE renderMultiblockWorldPreview(boolean renderMultiblockWorldPreview) {
+        this.renderMultiblockWorldPreview = renderMultiblockWorldPreview;
+        return getThis();
+    }
+
+    public TYPE renderMultiblockXEIPreview(boolean renderMultiblockXEIPreview) {
+        this.renderMultiblockXEIPreview = renderMultiblockXEIPreview;
+        return getThis();
+    }
+
+    public TYPE blockProp(NonNullUnaryOperator<BlockBehaviour.Properties> blockProp) {
+        this.blockProp = blockProp;
+        return getThis();
+    }
+
+    public TYPE itemProp(NonNullUnaryOperator<Item.Properties> itemProp) {
+        this.itemProp = itemProp;
+        return getThis();
+    }
+
+    public TYPE blockBuilder(Consumer<BlockBuilder<? extends Block, ?>> blockBuilder) {
+        this.blockBuilder = blockBuilder;
+        return getThis();
+    }
+
+    public TYPE itemBuilder(Consumer<ItemBuilder<? extends MetaMachineItem, ?>> itemBuilder) {
+        this.itemBuilder = itemBuilder;
+        return getThis();
+    }
+
+    public TYPE onBlockEntityRegister(NonNullConsumer<BlockEntityType<BlockEntity>> onBlockEntityRegister) {
+        this.onBlockEntityRegister = onBlockEntityRegister;
+        return getThis();
+    }
+
+    public TYPE tier(int tier) {
+        this.tier = tier;
+        return getThis();
+    }
+
+    public TYPE recipeOutputLimits(Reference2IntMap<RecipeCapability<?>> recipeOutputLimits) {
+        this.recipeOutputLimits = recipeOutputLimits;
+        return getThis();
+    }
+
+    public TYPE paintingColor(int paintingColor) {
+        this.paintingColor = paintingColor;
+        return getThis();
+    }
+
+    public TYPE itemColor(BiFunction<ItemStack, Integer, Integer> itemColor) {
+        this.itemColor = itemColor;
+        return getThis();
+    }
+
+    public TYPE tooltipBuilder(BiConsumer<ItemStack, List<Component>> tooltipBuilder) {
+        this.tooltipBuilder = tooltipBuilder;
+        return getThis();
+    }
+
+    public TYPE alwaysTryModifyRecipe(boolean alwaysTryModifyRecipe) {
+        this.alwaysTryModifyRecipe = alwaysTryModifyRecipe;
+        return getThis();
+    }
+
+    public TYPE beforeWorking(BiPredicate<IRecipeLogicMachine, GTRecipe> beforeWorking) {
+        this.beforeWorking = beforeWorking;
+        return getThis();
+    }
+
+    public TYPE onWorking(Predicate<IRecipeLogicMachine> onWorking) {
+        this.onWorking = onWorking;
+        return getThis();
+    }
+
+    public TYPE onWaiting(Consumer<IRecipeLogicMachine> onWaiting) {
+        this.onWaiting = onWaiting;
+        return getThis();
+    }
+
+    public TYPE afterWorking(Consumer<IRecipeLogicMachine> afterWorking) {
+        this.afterWorking = afterWorking;
+        return getThis();
+    }
+
+    public TYPE regressWhenWaiting(boolean regressWhenWaiting) {
+        this.regressWhenWaiting = regressWhenWaiting;
+        return getThis();
+    }
+
+    public TYPE allowCoverOnFront(boolean allowCoverOnFront) {
+        this.allowCoverOnFront = allowCoverOnFront;
+        return getThis();
+    }
+
+    public TYPE appearance(Supplier<BlockState> appearance) {
+        this.appearance = appearance;
+        return getThis();
+    }
+
+    public TYPE editableUI(EditableMachineUI editableUI) {
+        this.editableUI = editableUI;
+        return getThis();
+    }
+
+    public TYPE langValue(String langValue) {
+        this.langValue = langValue;
+        return getThis();
+    }
+
+    public TYPE recipeType(GTRecipeType type) {
         // noinspection ConstantValue
         if (type == null) {
             GTCEu.LOGGER.error(
                     "Tried to set null recipe type on machine {}. Did you create the recipe type before this machine?",
                     this.id);
-            return this;
+            return getThis();
         }
         this.recipeTypes = ArrayUtils.add(this.recipeTypes, type);
         initRecipeMachineModelProperties(type);
-        return this;
+        return getThis();
     }
 
     @Tolerate
-    public MachineBuilder<DEFINITION> recipeTypes(GTRecipeType... types) {
+    public TYPE recipeTypes(GTRecipeType... types) {
         List<GTRecipeType> typeList = new ArrayList<>();
         Collections.addAll(typeList, this.recipeTypes);
 
@@ -231,7 +346,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
             }
         }
         this.recipeTypes = typeList.toArray(GTRecipeType[]::new);
-        return this;
+        return getThis();
     }
 
     protected void initRecipeMachineModelProperties(GTRecipeType type) {
@@ -243,34 +358,39 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         }
     }
 
-    public MachineBuilder<DEFINITION> simpleModel(ResourceLocation modelName) {
+    public TYPE model(MachineBuilder.ModelInitializer model) {
+        this.model = model;
+        return getThis();
+    }
+
+    public TYPE simpleModel(ResourceLocation modelName) {
         return model(createBasicMachineModel(modelName));
     }
 
-    public MachineBuilder<DEFINITION> defaultModel() {
+    public TYPE defaultModel() {
         return simpleModel(new ResourceLocation(registrate.getModid(), "block/machine/template/" + name));
     }
 
-    public MachineBuilder<DEFINITION> tieredHullModel(ResourceLocation model) {
+    public TYPE tieredHullModel(ResourceLocation model) {
         return model(createTieredHullMachineModel(model));
     }
 
-    public MachineBuilder<DEFINITION> overlayTieredHullModel(String name) {
+    public TYPE overlayTieredHullModel(String name) {
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
         return overlayTieredHullModel(new ResourceLocation(registrate.getModid(), "block/machine/part/" + name));
     }
 
-    public MachineBuilder<DEFINITION> overlayTieredHullModel(ResourceLocation overlayModel) {
+    public TYPE overlayTieredHullModel(ResourceLocation overlayModel) {
         return model(createOverlayTieredHullMachineModel(overlayModel));
     }
 
-    public MachineBuilder<DEFINITION> colorOverlayTieredHullModel(String overlay) {
+    public TYPE colorOverlayTieredHullModel(String overlay) {
         return colorOverlayTieredHullModel(overlay, null, null);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlayTieredHullModel(String overlay,
-                                                                  @Nullable String pipeOverlay,
-                                                                  @Nullable String emissiveOverlay) {
+    public TYPE colorOverlayTieredHullModel(String overlay,
+                                            @Nullable String pipeOverlay,
+                                            @Nullable String emissiveOverlay) {
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
         ResourceLocation overlayTex = new ResourceLocation(registrate.getModid(), "block/overlay/machine/" + overlay);
         ResourceLocation pipeOverlayTex = pipeOverlay == null ? null :
@@ -280,35 +400,35 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         return colorOverlayTieredHullModel(overlayTex, pipeOverlayTex, emissiveOverlayTex);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlayTieredHullModel(ResourceLocation overlay) {
+    public TYPE colorOverlayTieredHullModel(ResourceLocation overlay) {
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
         return colorOverlayTieredHullModel(overlay, null, null);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlayTieredHullModel(ResourceLocation overlay,
-                                                                  @Nullable ResourceLocation pipeOverlay,
-                                                                  @Nullable ResourceLocation emissiveOverlay) {
+    public TYPE colorOverlayTieredHullModel(ResourceLocation overlay,
+                                            @Nullable ResourceLocation pipeOverlay,
+                                            @Nullable ResourceLocation emissiveOverlay) {
         modelProperty(GTMachineModelProperties.IS_PAINTED, false);
         return model(createColorOverlayTieredHullMachineModel(overlay, pipeOverlay, emissiveOverlay));
     }
 
-    public MachineBuilder<DEFINITION> overlaySteamHullModel(String name) {
+    public TYPE overlaySteamHullModel(String name) {
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
         return overlaySteamHullModel(new ResourceLocation(registrate.getModid(), "block/machine/part/" + name));
     }
 
-    public MachineBuilder<DEFINITION> overlaySteamHullModel(ResourceLocation overlayModel) {
+    public TYPE overlaySteamHullModel(ResourceLocation overlayModel) {
         modelProperty(GTMachineModelProperties.IS_STEEL_MACHINE, ConfigHolder.INSTANCE.machines.steelSteamMultiblocks);
         return model(createOverlaySteamHullMachineModel(overlayModel));
     }
 
-    public MachineBuilder<DEFINITION> colorOverlaySteamHullModel(String overlay) {
+    public TYPE colorOverlaySteamHullModel(String overlay) {
         return colorOverlaySteamHullModel(overlay, (String) null, null);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlaySteamHullModel(String overlay,
-                                                                 @Nullable String pipeOverlay,
-                                                                 @Nullable String emissiveOverlay) {
+    public TYPE colorOverlaySteamHullModel(String overlay,
+                                           @Nullable String pipeOverlay,
+                                           @Nullable String emissiveOverlay) {
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
         ResourceLocation overlayTex = new ResourceLocation(registrate.getModid(), "block/overlay/machine/" + overlay);
         ResourceLocation pipeOverlayTex = pipeOverlay == null ? null :
@@ -318,9 +438,9 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         return colorOverlaySteamHullModel(overlayTex, pipeOverlayTex, emissiveOverlayTex);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlaySteamHullModel(String overlay,
-                                                                 @Nullable ResourceLocation pipeOverlay,
-                                                                 @Nullable String emissiveOverlay) {
+    public TYPE colorOverlaySteamHullModel(String overlay,
+                                           @Nullable ResourceLocation pipeOverlay,
+                                           @Nullable String emissiveOverlay) {
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
         ResourceLocation overlayTex = new ResourceLocation(registrate.getModid(), "block/overlay/machine/" + overlay);
         ResourceLocation pipeOverlayTex = pipeOverlay == null ? null :
@@ -330,169 +450,169 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         return colorOverlaySteamHullModel(overlayTex, pipeOverlayTex, emissiveOverlayTex);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlaySteamHullModel(ResourceLocation overlay) {
+    public TYPE colorOverlaySteamHullModel(ResourceLocation overlay) {
         return colorOverlaySteamHullModel(overlay, null, null);
     }
 
-    public MachineBuilder<DEFINITION> colorOverlaySteamHullModel(ResourceLocation overlay,
-                                                                 @Nullable ResourceLocation pipeOverlay,
-                                                                 @Nullable ResourceLocation emissiveOverlay) {
+    public TYPE colorOverlaySteamHullModel(ResourceLocation overlay,
+                                           @Nullable ResourceLocation pipeOverlay,
+                                           @Nullable ResourceLocation emissiveOverlay) {
         modelProperty(GTMachineModelProperties.IS_PAINTED, false);
         return model(createColorOverlaySteamHullMachineModel(overlay, pipeOverlay, emissiveOverlay));
     }
 
-    public MachineBuilder<DEFINITION> workableTieredHullModel(ResourceLocation workableModel) {
+    public TYPE workableTieredHullModel(ResourceLocation workableModel) {
         modelProperty(GTMachineModelProperties.RECIPE_LOGIC_STATUS, RecipeLogic.Status.IDLE);
         return model(createWorkableTieredHullMachineModel(workableModel));
     }
 
-    public MachineBuilder<DEFINITION> simpleGeneratorModel(ResourceLocation workableModel) {
+    public TYPE simpleGeneratorModel(ResourceLocation workableModel) {
         modelProperty(GTMachineModelProperties.RECIPE_LOGIC_STATUS, RecipeLogic.Status.IDLE);
         return model(createSimpleGeneratorModel(workableModel));
     }
 
-    public MachineBuilder<DEFINITION> workableSteamHullModel(boolean isHighPressure, ResourceLocation workableModel) {
+    public TYPE workableSteamHullModel(boolean isHighPressure, ResourceLocation workableModel) {
         modelProperty(GTMachineModelProperties.RECIPE_LOGIC_STATUS, RecipeLogic.Status.IDLE);
         return model(createWorkableSteamHullMachineModel(isHighPressure, workableModel));
     }
 
-    public MachineBuilder<DEFINITION> workableCasingModel(ResourceLocation baseCasing, ResourceLocation workableModel) {
+    public TYPE workableCasingModel(ResourceLocation baseCasing, ResourceLocation workableModel) {
         modelProperty(GTMachineModelProperties.RECIPE_LOGIC_STATUS, RecipeLogic.Status.IDLE);
         return model(createWorkableCasingMachineModel(baseCasing, workableModel));
     }
 
-    public MachineBuilder<DEFINITION> sidedOverlayCasingModel(ResourceLocation baseCasing,
-                                                              ResourceLocation workableModel) {
+    public TYPE sidedOverlayCasingModel(ResourceLocation baseCasing,
+                                        ResourceLocation workableModel) {
         return model(createSidedOverlayCasingMachineModel(baseCasing, workableModel));
     }
 
-    public MachineBuilder<DEFINITION> sidedWorkableCasingModel(ResourceLocation baseCasing,
-                                                               ResourceLocation workableModel) {
+    public TYPE sidedWorkableCasingModel(ResourceLocation baseCasing,
+                                         ResourceLocation workableModel) {
         modelProperty(GTMachineModelProperties.RECIPE_LOGIC_STATUS, RecipeLogic.Status.IDLE);
         return model(createSidedWorkableCasingMachineModel(baseCasing, workableModel));
     }
 
-    public MachineBuilder<DEFINITION> appearanceBlock(Supplier<? extends Block> block) {
+    public TYPE appearanceBlock(Supplier<? extends Block> block) {
         appearance = () -> block.get().defaultBlockState();
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> tooltips(@Nullable Component... components) {
+    public TYPE tooltips(@Nullable Component... components) {
         return tooltips(Arrays.asList(components));
     }
 
-    public MachineBuilder<DEFINITION> tooltips(List<? extends @Nullable Component> components) {
+    public TYPE tooltips(List<? extends @Nullable Component> components) {
         tooltips.addAll(components.stream().filter(Objects::nonNull).toList());
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> conditionalTooltip(Component component, BooleanSupplier condition) {
+    public TYPE conditionalTooltip(Component component, BooleanSupplier condition) {
         return conditionalTooltip(component, condition.getAsBoolean());
     }
 
-    public MachineBuilder<DEFINITION> conditionalTooltip(Component component, boolean condition) {
+    public TYPE conditionalTooltip(Component component, boolean condition) {
         if (condition)
             tooltips.add(component);
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> abilities(PartAbility... abilities) {
+    public TYPE abilities(PartAbility... abilities) {
         this.abilities = abilities;
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> modelProperty(Property<?> property) {
+    public TYPE modelProperty(Property<?> property) {
         return modelProperty(property, null);
     }
 
-    public <T extends Comparable<T>> MachineBuilder<DEFINITION> modelProperty(Property<T> property,
-                                                                              @Nullable T defaultValue) {
+    public <T extends Comparable<T>> TYPE modelProperty(Property<T> property,
+                                                        @Nullable T defaultValue) {
         this.modelProperties.put(property, defaultValue);
-        return this;
+        return getThis();
     }
 
     // KJS helpers for model property defaults
     // These don't need to be copied to the multiblock builder because KJS doesn't care about the return type downgrade
 
-    public MachineBuilder<DEFINITION> kjs$modelPropertyBool(Property<Boolean> property, boolean defaultValue) {
+    public TYPE kjs$modelPropertyBool(Property<Boolean> property, boolean defaultValue) {
         return modelProperty(property, defaultValue);
     }
 
-    public MachineBuilder<DEFINITION> kjs$modelPropertyInt(Property<Integer> property, int defaultValue) {
+    public TYPE kjs$modelPropertyInt(Property<Integer> property, int defaultValue) {
         return modelProperty(property, defaultValue);
     }
 
-    public <T extends Enum<T> & Comparable<T>> MachineBuilder<DEFINITION> kjs$modelPropertyEnum(Property<T> property,
-                                                                                                T defaultValue) {
+    public <T extends Enum<T> & Comparable<T>> TYPE kjs$modelPropertyEnum(Property<T> property,
+                                                                          T defaultValue) {
         return modelProperty(property, defaultValue);
     }
 
     @Tolerate
-    public MachineBuilder<DEFINITION> modelProperties(Property<?>... properties) {
+    public TYPE modelProperties(Property<?>... properties) {
         return this.modelProperties(List.of(properties));
     }
 
     @Tolerate
-    public MachineBuilder<DEFINITION> modelProperties(Collection<Property<?>> properties) {
+    public TYPE modelProperties(Collection<Property<?>> properties) {
         for (Property<?> prop : properties) {
             this.modelProperties.put(prop, null);
         }
-        return this;
+        return getThis();
     }
 
     @Tolerate
-    public MachineBuilder<DEFINITION> modelProperties(Map<Property<?>, ? extends Comparable<?>> properties) {
+    public TYPE modelProperties(Map<Property<?>, ? extends Comparable<?>> properties) {
         this.modelProperties.putAll(properties);
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> removeModelProperty(Property<?> property) {
+    public TYPE removeModelProperty(Property<?> property) {
         this.modelProperties.remove(property);
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> clearModelProperties() {
+    public TYPE clearModelProperties() {
         this.modelProperties.clear();
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> recipeModifier(RecipeModifier recipeModifier) {
+    public TYPE recipeModifier(RecipeModifier recipeModifier) {
         this.recipeModifier = recipeModifier instanceof RecipeModifierList list ? list :
                 new RecipeModifierList(recipeModifier);
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> recipeModifier(RecipeModifier recipeModifier, boolean alwaysTryModifyRecipe) {
+    public TYPE recipeModifier(RecipeModifier recipeModifier, boolean alwaysTryModifyRecipe) {
         this.alwaysTryModifyRecipe = alwaysTryModifyRecipe;
         return this.recipeModifier(recipeModifier);
     }
 
-    public MachineBuilder<DEFINITION> recipeModifiers(RecipeModifier... recipeModifiers) {
+    public TYPE recipeModifiers(RecipeModifier... recipeModifiers) {
         this.recipeModifier = new RecipeModifierList(recipeModifiers);
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> recipeModifiers(boolean alwaysTryModifyRecipe,
-                                                      RecipeModifier... recipeModifiers) {
+    public TYPE recipeModifiers(boolean alwaysTryModifyRecipe,
+                                RecipeModifier... recipeModifiers) {
         return this.recipeModifier(new RecipeModifierList(recipeModifiers), alwaysTryModifyRecipe);
     }
 
-    public MachineBuilder<DEFINITION> noRecipeModifier() {
+    public TYPE noRecipeModifier() {
         this.recipeModifier = new RecipeModifierList(RecipeModifier.NO_MODIFIER);
         this.alwaysTryModifyRecipe = false;
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> addOutputLimit(RecipeCapability<?> capability, int limit) {
+    public TYPE addOutputLimit(RecipeCapability<?> capability, int limit) {
         this.recipeOutputLimits.put(capability, limit);
-        return this;
+        return getThis();
     }
 
-    public MachineBuilder<DEFINITION> multiblockPreviewRenderer(boolean multiBlockWorldPreview,
-                                                                boolean multiBlockXEIPreview) {
+    public TYPE multiblockPreviewRenderer(boolean multiBlockWorldPreview,
+                                          boolean multiBlockXEIPreview) {
         this.renderMultiblockWorldPreview = multiBlockWorldPreview;
         this.renderMultiblockXEIPreview = multiBlockXEIPreview;
-        return this;
+        return getThis();
     }
 
     protected DEFINITION createDefinition() {
@@ -539,7 +659,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         if (model == null && blockModel == null) {
             simpleModel(new ResourceLocation(registrate.getModid(), "block/machine/template/" + name));
         }
-        var blockBuilder = BlockBuilderWrapper.makeBlockBuilder(this, definition);
+        var blockBuilder = BlockBuilderWrapper.makeBlockBuilder(getThis(), definition);
         if (this.langValue != null) {
             blockBuilder.lang(langValue);
             definition.setLangValue(langValue);
@@ -549,7 +669,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
         }
         var block = blockBuilder.register();
 
-        var itemBuilder = ItemBuilderWrapper.makeItemBuilder(this, block);
+        var itemBuilder = ItemBuilderWrapper.makeItemBuilder(getThis(), block);
         if (this.itemBuilder != null) {
             this.itemBuilder.accept(itemBuilder);
         }
@@ -646,7 +766,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     // spotless:off
     protected static class BlockBuilderWrapper {
 
-        public static <DEFINITION extends MachineDefinition> BlockBuilder<Block, ? extends AbstractRegistrate<?>> makeBlockBuilder(MachineBuilder<DEFINITION> builder,
+        public static <DEFINITION extends MachineDefinition> BlockBuilder<Block, ? extends AbstractRegistrate<?>> makeBlockBuilder(MachineBuilder<DEFINITION, ?> builder,
                                                                                                                                    DEFINITION definition) {
             return builder.registrate.block(properties -> makeBlock(builder, definition, properties))
                     .color(() -> () -> IMachineBlock::colorTinted)
@@ -658,7 +778,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
                     .onRegister(b -> Arrays.stream(builder.abilities).forEach(a -> a.register(builder.tier, b)));
         }
 
-        private static <DEFINITION extends MachineDefinition> Block makeBlock(MachineBuilder<DEFINITION> builder, DEFINITION definition,
+        private static <DEFINITION extends MachineDefinition> Block makeBlock(MachineBuilder<DEFINITION, ?> builder, DEFINITION definition,
                                                                               BlockBehaviour.Properties properties) {
             MachineDefinition.setBuilt(definition);
             var b = builder.blockFactory.apply(properties, definition);
@@ -669,7 +789,7 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
 
     protected static class ItemBuilderWrapper {
 
-        public static <DEFINITION extends MachineDefinition> ItemBuilder<MetaMachineItem, ? extends AbstractRegistrate<?>> makeItemBuilder(MachineBuilder<DEFINITION> builder,
+        public static <DEFINITION extends MachineDefinition> ItemBuilder<MetaMachineItem, ? extends AbstractRegistrate<?>> makeItemBuilder(MachineBuilder<DEFINITION, ?> builder,
                                                                                                                                            BlockEntry<Block> block) {
             return builder.registrate
                     .item(properties -> builder.itemFactory.apply((IMachineBlock) block.get(), properties))
@@ -688,7 +808,8 @@ public class MachineBuilder<DEFINITION extends MachineDefinition> extends Builde
     protected static final class KJSCallWrapper {
 
         public static <D extends MachineDefinition> void generateAssetJsons(@Nullable AssetJsonGenerator generator,
-                                                                            MachineBuilder<D> builder, D definition) {
+                                                                            MachineBuilder<D, ?> builder,
+                                                                            D definition) {
             if (builder.model() == null && builder.blockModel() == null) return;
 
             final ResourceLocation id = definition.getId();

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MultiblockMachineBuilder.java
@@ -1,57 +1,33 @@
 package com.gregtechceu.gtceu.api.registry.registrate;
 
 import com.gregtechceu.gtceu.api.block.IMachineBlock;
-import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
-import com.gregtechceu.gtceu.api.data.RotationState;
-import com.gregtechceu.gtceu.api.gui.editor.EditableMachineUI;
 import com.gregtechceu.gtceu.api.item.MetaMachineItem;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
-import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
-import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
 import com.gregtechceu.gtceu.api.pattern.BlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
-import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
-import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
-import com.gregtechceu.gtceu.api.registry.registrate.provider.GTBlockstateProvider;
 import com.gregtechceu.gtceu.utils.memoization.GTMemoizer;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.Property;
-import net.minecraft.world.phys.shapes.VoxelShape;
 
-import com.tterrag.registrate.builders.BlockBuilder;
-import com.tterrag.registrate.builders.ItemBuilder;
-import com.tterrag.registrate.providers.DataGenContext;
-import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
-import com.tterrag.registrate.util.nullness.NonNullConsumer;
-import com.tterrag.registrate.util.nullness.NonNullUnaryOperator;
 import dev.latvian.mods.rhino.util.HideFromJS;
-import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.experimental.Tolerate;
 import org.apache.commons.lang3.function.TriFunction;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.*;
@@ -61,33 +37,29 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 @Accessors(chain = true, fluent = true)
-public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDefinition> {
+public class MultiblockMachineBuilder<DEFINITION extends MultiblockMachineDefinition,
+        TYPE extends MultiblockMachineBuilder<DEFINITION, TYPE>> extends MachineBuilder<DEFINITION, TYPE> {
 
-    @Setter
     private boolean generator;
-    @Setter
     private Function<MultiblockMachineDefinition, BlockPattern> pattern;
     private final List<Function<MultiblockMachineDefinition, List<MultiblockShapeInfo>>> shapeInfos = new ArrayList<>();
     /**
      * Set this to false only if your multiblock is set up such that it could have a wall-shared controller.
      */
-    @Setter
     private boolean allowFlip = true;
     private final List<Supplier<ItemStack[]>> recoveryItems = new ArrayList<>();
-    @Setter
     private Function<MultiblockControllerMachine, Comparator<IMultiPart>> partSorter = (c) -> (a, b) -> 0;
-    @Setter
     private TriFunction<IMultiController, IMultiPart, Direction, BlockState> partAppearance;
     @Getter
-    @Setter
     private BiConsumer<IMultiController, List<Component>> additionalDisplay = (m, l) -> {};
 
     public MultiblockMachineBuilder(GTRegistrate registrate, String name,
                                     Function<IMachineBlockEntity, ? extends MultiblockControllerMachine> metaMachine,
-                                    BiFunction<BlockBehaviour.Properties, MultiblockMachineDefinition, IMachineBlock> blockFactory,
+                                    BiFunction<BlockBehaviour.Properties, DEFINITION, IMachineBlock> blockFactory,
                                     BiFunction<IMachineBlock, Item.Properties, MetaMachineItem> itemFactory,
                                     TriFunction<BlockEntityType<?>, BlockPos, BlockState, IMachineBlockEntity> blockEntityFactory) {
-        super(registrate, name, MultiblockMachineDefinition::new, metaMachine::apply, blockFactory,
+        super(registrate, name, (loc -> (DEFINITION) new MultiblockMachineDefinition(loc)), metaMachine::apply,
+                blockFactory,
                 itemFactory, blockEntityFactory);
         allowExtendedFacing(true);
         allowCoverOnFront(true);
@@ -95,396 +67,66 @@ public class MultiblockMachineBuilder extends MachineBuilder<MultiblockMachineDe
         modelProperty(GTMachineModelProperties.IS_FORMED, false);
     }
 
-    public MultiblockMachineBuilder shapeInfo(Function<MultiblockMachineDefinition, MultiblockShapeInfo> shape) {
+    public TYPE generator(boolean generator) {
+        this.generator = generator;
+        return getThis();
+    }
+
+    public TYPE pattern(Function<MultiblockMachineDefinition, BlockPattern> pattern) {
+        this.pattern = pattern;
+        return getThis();
+    }
+
+    public TYPE allowFlip(boolean allowFlip) {
+        this.allowFlip = allowFlip;
+        return getThis();
+    }
+
+    public TYPE partSorter(Function<MultiblockControllerMachine, Comparator<IMultiPart>> partSorter) {
+        this.partSorter = partSorter;
+        return getThis();
+    }
+
+    public TYPE partAppearance(TriFunction<IMultiController, IMultiPart, Direction, BlockState> partAppearance) {
+        this.partAppearance = partAppearance;
+        return getThis();
+    }
+
+    public TYPE additionalDisplay(BiConsumer<IMultiController, List<Component>> additionalDisplay) {
+        this.additionalDisplay = additionalDisplay;
+        return getThis();
+    }
+
+    public TYPE shapeInfo(Function<MultiblockMachineDefinition, MultiblockShapeInfo> shape) {
         this.shapeInfos.add(d -> List.of(shape.apply(d)));
-        return this;
+        return getThis();
     }
 
-    public MultiblockMachineBuilder shapeInfos(Function<MultiblockMachineDefinition, List<MultiblockShapeInfo>> shapes) {
+    public TYPE shapeInfos(Function<MultiblockMachineDefinition, List<MultiblockShapeInfo>> shapes) {
         this.shapeInfos.add(shapes);
-        return this;
+        return getThis();
     }
 
-    public MultiblockMachineBuilder recoveryItems(Supplier<ItemLike[]> items) {
+    public TYPE recoveryItems(Supplier<ItemLike[]> items) {
         this.recoveryItems.add(() -> Arrays.stream(items.get()).map(ItemLike::asItem).map(Item::getDefaultInstance)
                 .toArray(ItemStack[]::new));
-        return this;
+        return getThis();
     }
 
-    public MultiblockMachineBuilder recoveryStacks(Supplier<ItemStack[]> stacks) {
+    public TYPE recoveryStacks(Supplier<ItemStack[]> stacks) {
         this.recoveryItems.add(stacks);
-        return this;
-    }
-
-    @Override
-    public MultiblockMachineBuilder machine(Function<IMachineBlockEntity, MetaMachine> metaMachine) {
-        return (MultiblockMachineBuilder) super.machine(metaMachine);
-    }
-
-    @Override
-    public MultiblockMachineBuilder model(@Nullable MachineBuilder.ModelInitializer model) {
-        return (MultiblockMachineBuilder) super.model(model);
-    }
-
-    @Override
-    public MultiblockMachineBuilder blockModel(@Nullable NonNullBiConsumer<DataGenContext<Block, ? extends Block>, GTBlockstateProvider> blockModel) {
-        return (MultiblockMachineBuilder) super.blockModel(blockModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder shape(VoxelShape shape) {
-        return (MultiblockMachineBuilder) super.shape(shape);
-    }
-
-    @Override
-    public MultiblockMachineBuilder multiblockPreviewRenderer(boolean multiBlockWorldPreview,
-                                                              boolean multiBlockXEIPreview) {
-        return (MultiblockMachineBuilder) super.multiblockPreviewRenderer(multiBlockWorldPreview, multiBlockXEIPreview);
-    }
-
-    @Override
-    public MultiblockMachineBuilder rotationState(RotationState rotationState) {
-        return (MultiblockMachineBuilder) super.rotationState(rotationState);
-    }
-
-    @Override
-    public MultiblockMachineBuilder hasBER(boolean hasBER) {
-        return (MultiblockMachineBuilder) super.hasBER(hasBER);
-    }
-
-    @Override
-    public MultiblockMachineBuilder blockProp(NonNullUnaryOperator<BlockBehaviour.Properties> blockProp) {
-        return (MultiblockMachineBuilder) super.blockProp(blockProp);
-    }
-
-    @Override
-    public MultiblockMachineBuilder itemProp(NonNullUnaryOperator<Item.Properties> itemProp) {
-        return (MultiblockMachineBuilder) super.itemProp(itemProp);
-    }
-
-    @Override
-    public MultiblockMachineBuilder blockBuilder(Consumer<BlockBuilder<? extends Block, ?>> blockBuilder) {
-        return (MultiblockMachineBuilder) super.blockBuilder(blockBuilder);
-    }
-
-    @Override
-    public MultiblockMachineBuilder itemBuilder(Consumer<ItemBuilder<? extends MetaMachineItem, ?>> itemBuilder) {
-        return (MultiblockMachineBuilder) super.itemBuilder(itemBuilder);
-    }
-
-    @Override
-    public MultiblockMachineBuilder recipeTypes(GTRecipeType... recipeTypes) {
-        return (MultiblockMachineBuilder) super.recipeTypes(recipeTypes);
-    }
-
-    @Override
-    public MultiblockMachineBuilder recipeType(GTRecipeType recipeTypes) {
-        return (MultiblockMachineBuilder) super.recipeType(recipeTypes);
-    }
-
-    @Override
-    public MultiblockMachineBuilder tier(int tier) {
-        return (MultiblockMachineBuilder) super.tier(tier);
-    }
-
-    public MultiblockMachineBuilder recipeOutputLimits(Reference2IntMap<RecipeCapability<?>> map) {
-        return (MultiblockMachineBuilder) super.recipeOutputLimits(map);
-    }
-
-    @Override
-    public MultiblockMachineBuilder addOutputLimit(RecipeCapability<?> capability, int limit) {
-        return (MultiblockMachineBuilder) super.addOutputLimit(capability, limit);
-    }
-
-    @Override
-    public MultiblockMachineBuilder itemColor(BiFunction<ItemStack, Integer, Integer> itemColor) {
-        return (MultiblockMachineBuilder) super.itemColor(itemColor);
-    }
-
-    @Override
-    public MultiblockMachineBuilder simpleModel(ResourceLocation model) {
-        return (MultiblockMachineBuilder) super.simpleModel(model);
-    }
-
-    @Override
-    public MultiblockMachineBuilder defaultModel() {
-        return (MultiblockMachineBuilder) super.defaultModel();
-    }
-
-    @Override
-    public MultiblockMachineBuilder tieredHullModel(ResourceLocation model) {
-        return (MultiblockMachineBuilder) super.tieredHullModel(model);
-    }
-
-    @Override
-    public MultiblockMachineBuilder overlayTieredHullModel(String name) {
-        return (MultiblockMachineBuilder) super.overlayTieredHullModel(name);
-    }
-
-    @Override
-    public MultiblockMachineBuilder overlayTieredHullModel(ResourceLocation overlayModel) {
-        return (MultiblockMachineBuilder) super.overlayTieredHullModel(overlayModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlayTieredHullModel(String overlay) {
-        return (MultiblockMachineBuilder) super.colorOverlayTieredHullModel(overlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlayTieredHullModel(String overlay,
-                                                                @Nullable String pipeOverlay,
-                                                                @Nullable String emissiveOverlay) {
-        return (MultiblockMachineBuilder) super.colorOverlayTieredHullModel(overlay, pipeOverlay, emissiveOverlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlayTieredHullModel(ResourceLocation overlay) {
-        return (MultiblockMachineBuilder) super.colorOverlayTieredHullModel(overlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlayTieredHullModel(ResourceLocation overlay,
-                                                                @Nullable ResourceLocation pipeOverlay,
-                                                                @Nullable ResourceLocation emissiveOverlay) {
-        return (MultiblockMachineBuilder) super.colorOverlayTieredHullModel(overlay, pipeOverlay, emissiveOverlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder workableTieredHullModel(ResourceLocation workableModel) {
-        return (MultiblockMachineBuilder) super.workableTieredHullModel(workableModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder simpleGeneratorModel(ResourceLocation workableModel) {
-        return (MultiblockMachineBuilder) super.simpleGeneratorModel(workableModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder workableCasingModel(ResourceLocation baseCasing, ResourceLocation overlayModel) {
-        return (MultiblockMachineBuilder) super.workableCasingModel(baseCasing, overlayModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder sidedOverlayCasingModel(ResourceLocation baseCasing,
-                                                            ResourceLocation workableModel) {
-        return (MultiblockMachineBuilder) super.sidedOverlayCasingModel(baseCasing, workableModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder sidedWorkableCasingModel(ResourceLocation baseCasing,
-                                                             ResourceLocation workableModel) {
-        return (MultiblockMachineBuilder) super.sidedWorkableCasingModel(baseCasing, workableModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder tooltipBuilder(@Nullable BiConsumer<ItemStack, List<Component>> tooltipBuilder) {
-        return (MultiblockMachineBuilder) super.tooltipBuilder(tooltipBuilder);
-    }
-
-    @Override
-    public MultiblockMachineBuilder appearance(Supplier<BlockState> state) {
-        return (MultiblockMachineBuilder) super.appearance(state);
-    }
-
-    @Override
-    public MultiblockMachineBuilder appearanceBlock(Supplier<? extends Block> block) {
-        return (MultiblockMachineBuilder) super.appearanceBlock(block);
-    }
-
-    @Override
-    public MultiblockMachineBuilder langValue(@Nullable String langValue) {
-        return (MultiblockMachineBuilder) super.langValue(langValue);
-    }
-
-    @Override
-    public MultiblockMachineBuilder overlaySteamHullModel(String name) {
-        return (MultiblockMachineBuilder) super.overlaySteamHullModel(name);
-    }
-
-    @Override
-    public MultiblockMachineBuilder overlaySteamHullModel(ResourceLocation overlayModel) {
-        return (MultiblockMachineBuilder) super.overlaySteamHullModel(overlayModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlaySteamHullModel(String overlay) {
-        return (MultiblockMachineBuilder) super.colorOverlaySteamHullModel(overlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlaySteamHullModel(String overlay,
-                                                               @Nullable ResourceLocation pipeOverlay,
-                                                               @Nullable String emissiveOverlay) {
-        return (MultiblockMachineBuilder) super.colorOverlaySteamHullModel(overlay, pipeOverlay, emissiveOverlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlaySteamHullModel(ResourceLocation overlay,
-                                                               @Nullable ResourceLocation pipeOverlay,
-                                                               @Nullable ResourceLocation emissiveOverlay) {
-        return (MultiblockMachineBuilder) super.colorOverlaySteamHullModel(overlay, pipeOverlay, emissiveOverlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder colorOverlaySteamHullModel(ResourceLocation overlay) {
-        return (MultiblockMachineBuilder) super.colorOverlaySteamHullModel(overlay);
-    }
-
-    @Override
-    public MultiblockMachineBuilder workableSteamHullModel(boolean isHighPressure, ResourceLocation workableModel) {
-        return (MultiblockMachineBuilder) super.workableSteamHullModel(isHighPressure, workableModel);
-    }
-
-    @Override
-    public MultiblockMachineBuilder tooltips(@Nullable Component... components) {
-        return (MultiblockMachineBuilder) super.tooltips(components);
-    }
-
-    @Override
-    public MultiblockMachineBuilder tooltips(List<? extends @Nullable Component> components) {
-        return (MultiblockMachineBuilder) super.tooltips(components);
-    }
-
-    @Override
-    public MultiblockMachineBuilder conditionalTooltip(Component component, BooleanSupplier condition) {
-        return (MultiblockMachineBuilder) super.conditionalTooltip(component, condition);
-    }
-
-    @Override
-    public MultiblockMachineBuilder conditionalTooltip(Component component, boolean condition) {
-        return (MultiblockMachineBuilder) super.conditionalTooltip(component, condition);
+        return getThis();
     }
 
     @Tolerate
-    public MultiblockMachineBuilder partSorter(Comparator<IMultiPart> sorter) {
+    public TYPE partSorter(Comparator<IMultiPart> sorter) {
         this.partSorter = $ -> sorter;
-        return this;
-    }
-
-    @Override
-    public MultiblockMachineBuilder abilities(PartAbility... abilities) {
-        return (MultiblockMachineBuilder) super.abilities(abilities);
-    }
-
-    @Override
-    public MultiblockMachineBuilder modelProperty(Property<?> property) {
-        return (MultiblockMachineBuilder) super.modelProperty(property);
-    }
-
-    @Override
-    public <T extends Comparable<T>> MultiblockMachineBuilder modelProperty(Property<T> property,
-                                                                            @Nullable T defaultValue) {
-        return (MultiblockMachineBuilder) super.modelProperty(property, defaultValue);
-    }
-
-    @Override
-    public MultiblockMachineBuilder modelProperties(Property<?>... properties) {
-        return (MultiblockMachineBuilder) super.modelProperties(properties);
-    }
-
-    @Override
-    public MultiblockMachineBuilder modelProperties(Collection<Property<?>> properties) {
-        return (MultiblockMachineBuilder) super.modelProperties(properties);
-    }
-
-    @Override
-    public MultiblockMachineBuilder modelProperties(Map<Property<?>, ? extends Comparable<?>> properties) {
-        return (MultiblockMachineBuilder) super.modelProperties(properties);
-    }
-
-    @Override
-    public MultiblockMachineBuilder removeModelProperty(Property<?> property) {
-        return (MultiblockMachineBuilder) super.removeModelProperty(property);
-    }
-
-    @Override
-    public MultiblockMachineBuilder clearModelProperties() {
-        return (MultiblockMachineBuilder) super.clearModelProperties();
-    }
-
-    @Override
-    public MultiblockMachineBuilder paintingColor(int paintingColor) {
-        return (MultiblockMachineBuilder) super.paintingColor(paintingColor);
-    }
-
-    @Override
-    public MultiblockMachineBuilder recipeModifier(RecipeModifier recipeModifier) {
-        return (MultiblockMachineBuilder) super.recipeModifier(recipeModifier);
-    }
-
-    @Override
-    public MultiblockMachineBuilder recipeModifier(RecipeModifier recipeModifier, boolean alwaysTryModifyRecipe) {
-        return (MultiblockMachineBuilder) super.recipeModifier(recipeModifier, alwaysTryModifyRecipe);
-    }
-
-    @Override
-    public MultiblockMachineBuilder recipeModifiers(RecipeModifier... recipeModifiers) {
-        return (MultiblockMachineBuilder) super.recipeModifiers(recipeModifiers);
-    }
-
-    @Override
-    public MultiblockMachineBuilder recipeModifiers(boolean alwaysTryModifyRecipe, RecipeModifier... recipeModifiers) {
-        return (MultiblockMachineBuilder) super.recipeModifiers(alwaysTryModifyRecipe, recipeModifiers);
-    }
-
-    public MultiblockMachineBuilder noRecipeModifier() {
-        return (MultiblockMachineBuilder) super.noRecipeModifier();
-    }
-
-    @Override
-    public MultiblockMachineBuilder alwaysTryModifyRecipe(boolean alwaysTryModifyRecipe) {
-        return (MultiblockMachineBuilder) super.alwaysTryModifyRecipe(alwaysTryModifyRecipe);
-    }
-
-    @Override
-    public MultiblockMachineBuilder beforeWorking(BiPredicate<IRecipeLogicMachine, GTRecipe> beforeWorking) {
-        return (MultiblockMachineBuilder) super.beforeWorking(beforeWorking);
-    }
-
-    @Override
-    public MultiblockMachineBuilder onWorking(Predicate<IRecipeLogicMachine> onWorking) {
-        return (MultiblockMachineBuilder) super.onWorking(onWorking);
-    }
-
-    @Override
-    public MultiblockMachineBuilder onWaiting(Consumer<IRecipeLogicMachine> onWaiting) {
-        return (MultiblockMachineBuilder) super.onWaiting(onWaiting);
-    }
-
-    @Override
-    public MultiblockMachineBuilder afterWorking(Consumer<IRecipeLogicMachine> afterWorking) {
-        return (MultiblockMachineBuilder) super.afterWorking(afterWorking);
-    }
-
-    @Override
-    public MultiblockMachineBuilder regressWhenWaiting(boolean regressWhenWaiting) {
-        return (MultiblockMachineBuilder) super.regressWhenWaiting(regressWhenWaiting);
-    }
-
-    @Override
-    public MultiblockMachineBuilder editableUI(@Nullable EditableMachineUI editableUI) {
-        return (MultiblockMachineBuilder) super.editableUI(editableUI);
-    }
-
-    @Override
-    public MultiblockMachineBuilder onBlockEntityRegister(NonNullConsumer<BlockEntityType<BlockEntity>> onBlockEntityRegister) {
-        return (MultiblockMachineBuilder) super.onBlockEntityRegister(onBlockEntityRegister);
-    }
-
-    @Override
-    public MultiblockMachineBuilder allowExtendedFacing(boolean allowExtendedFacing) {
-        return (MultiblockMachineBuilder) super.allowExtendedFacing(allowExtendedFacing);
-    }
-
-    @Override
-    public MultiblockMachineBuilder allowCoverOnFront(boolean allowCoverOnFront) {
-        return (MultiblockMachineBuilder) super.allowCoverOnFront(allowCoverOnFront);
+        return getThis();
     }
 
     @Override
     @HideFromJS
-    public MultiblockMachineDefinition register() {
+    public DEFINITION register() {
         var definition = super.register();
         definition.setGenerator(generator);
         if (pattern == null) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
@@ -191,7 +191,7 @@ public class GTMachineUtils {
 
     public static MachineDefinition[] registerTieredMachines(String name,
                                                              BiFunction<IMachineBlockEntity, Integer, MetaMachine> factory,
-                                                             BiFunction<Integer, MachineBuilder<MachineDefinition>, MachineDefinition> builder,
+                                                             BiFunction<Integer, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder,
                                                              int... tiers) {
         return registerTieredMachines(REGISTRATE, name, factory, builder, tiers);
     }
@@ -199,7 +199,7 @@ public class GTMachineUtils {
     public static MachineDefinition[] registerTieredMachines(GTRegistrate registrate,
                                                              String name,
                                                              BiFunction<IMachineBlockEntity, Integer, MetaMachine> factory,
-                                                             BiFunction<Integer, MachineBuilder<MachineDefinition>, MachineDefinition> builder,
+                                                             BiFunction<Integer, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder,
                                                              int... tiers) {
         MachineDefinition[] definitions = new MachineDefinition[GTValues.TIER_COUNT];
         for (int tier : tiers) {
@@ -214,13 +214,13 @@ public class GTMachineUtils {
 
     public static Pair<MachineDefinition, MachineDefinition> registerSteamMachines(String name,
                                                                                    BiFunction<IMachineBlockEntity, Boolean, MetaMachine> factory,
-                                                                                   BiFunction<Boolean, MachineBuilder<MachineDefinition>, MachineDefinition> builder) {
+                                                                                   BiFunction<Boolean, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder) {
         return registerSteamMachines(REGISTRATE, name, factory, builder);
     }
 
     public static Pair<MachineDefinition, MachineDefinition> registerSteamMachines(GTRegistrate registrate, String name,
                                                                                    BiFunction<IMachineBlockEntity, Boolean, MetaMachine> factory,
-                                                                                   BiFunction<Boolean, MachineBuilder<MachineDefinition>, MachineDefinition> builder) {
+                                                                                   BiFunction<Boolean, MachineBuilder<MachineDefinition, ?>, MachineDefinition> builder) {
         MachineDefinition lowTier = builder.apply(false,
                 registrate.machine("lp_%s".formatted(name), holder -> factory.apply(holder, false))
                         .langValue("Low Pressure " + FormattingUtil.toEnglishName(name))
@@ -633,14 +633,14 @@ public class GTMachineUtils {
     }
 
     public static MachineDefinition registerTankValve(String name, String displayName, boolean isMetal,
-                                                      BiConsumer<MachineBuilder<?>, ResourceLocation> rendererSetup) {
+                                                      BiConsumer<MachineBuilder<?, ?>, ResourceLocation> rendererSetup) {
         return registerTankValve(REGISTRATE, name, displayName, isMetal, rendererSetup);
     }
 
     public static MachineDefinition registerTankValve(GTRegistrate registrate, String name, String displayName,
                                                       boolean isMetal,
-                                                      BiConsumer<MachineBuilder<?>, ResourceLocation> rendererSetup) {
-        MachineBuilder<MachineDefinition> builder = registrate
+                                                      BiConsumer<MachineBuilder<?, ?>, ResourceLocation> rendererSetup) {
+        MachineBuilder<MachineDefinition, ?> builder = registrate
                 .machine(name, holder -> new TankValvePartMachine(holder, isMetal))
                 .langValue(displayName)
                 .tooltips(Component.translatable("gtceu.machine.tank_valve.tooltip"),
@@ -652,14 +652,14 @@ public class GTMachineUtils {
 
     public static MultiblockMachineDefinition[] registerTieredMultis(String name,
                                                                      BiFunction<IMachineBlockEntity, Integer, MultiblockControllerMachine> factory,
-                                                                     BiFunction<Integer, MultiblockMachineBuilder, MultiblockMachineDefinition> builder,
+                                                                     BiFunction<Integer, MultiblockMachineBuilder<?, ?>, MultiblockMachineDefinition> builder,
                                                                      int... tiers) {
         return registerTieredMultis(REGISTRATE, name, factory, builder, tiers);
     }
 
     public static MultiblockMachineDefinition[] registerTieredMultis(GTRegistrate registrate, String name,
                                                                      BiFunction<IMachineBlockEntity, Integer, MultiblockControllerMachine> factory,
-                                                                     BiFunction<Integer, MultiblockMachineBuilder, MultiblockMachineDefinition> builder,
+                                                                     BiFunction<Integer, MultiblockMachineBuilder<?, ?>, MultiblockMachineDefinition> builder,
                                                                      int... tiers) {
         MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[GTValues.TIER_COUNT];
         for (int tier : tiers) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTResearchMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTResearchMachines.java
@@ -438,9 +438,9 @@ public class GTResearchMachines {
             .register();
 
     @NotNull
-    private static MachineBuilder<MachineDefinition> registerDataHatch(String name, String displayName, int tier,
-                                                                       Function<IMachineBlockEntity, MetaMachine> constructor,
-                                                                       String model, PartAbility... abilities) {
+    private static MachineBuilder<MachineDefinition, ?> registerDataHatch(String name, String displayName, int tier,
+                                                                          Function<IMachineBlockEntity, MetaMachine> constructor,
+                                                                          String model, PartAbility... abilities) {
         return REGISTRATE.machine(name, constructor)
                 .langValue(displayName)
                 .tier(tier)
@@ -449,9 +449,9 @@ public class GTResearchMachines {
                 .overlayTieredHullModel(model);
     }
 
-    private static MachineBuilder<MachineDefinition> registerHPCAPart(String name, String displayName,
-                                                                      Function<IMachineBlockEntity, MetaMachine> constructor,
-                                                                      String texture, boolean isAdvanced) {
+    private static MachineBuilder<MachineDefinition, ?> registerHPCAPart(String name, String displayName,
+                                                                         Function<IMachineBlockEntity, MetaMachine> constructor,
+                                                                         String texture, boolean isAdvanced) {
         return REGISTRATE.machine(name, constructor)
                 .langValue(displayName)
                 .rotationState(RotationState.ALL)

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -57,6 +57,7 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.nbtpredicate.NBTPredicates;
 import com.gregtechceu.gtceu.api.recipe.lookup.RecipeManagerHandler;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
 import com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder;
 import com.gregtechceu.gtceu.client.renderer.machine.DynamicRenderHelper;
 import com.gregtechceu.gtceu.common.cosmetics.GTCapes;
@@ -176,11 +177,13 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
                         new KJSTieredMachineBuilder(id, SimpleGeneratorMachine::new,
                                 SimpleGeneratorMachine.EDITABLE_UI_CREATOR, true)),
                 false);
-        GTRegistryInfo.MACHINE.addType("multiblock", MultiblockMachineBuilder.class,
+        GTRegistryInfo.MACHINE.addType("multiblock",
+                (Class<? extends BuilderBase<? extends MachineDefinition>>) (Class<?>) MultiblockMachineBuilder.class,
                 KJSWrappingMultiblockBuilder::createKJSMulti, false);
         GTRegistryInfo.MACHINE.addType("tiered_multiblock", KJSWrappingMultiblockBuilder.class,
                 (id) -> new KJSWrappingMultiblockBuilder(id, new KJSTieredMultiblockBuilder(id)), false);
-        GTRegistryInfo.MACHINE.addType("primitive", MultiblockMachineBuilder.class,
+        GTRegistryInfo.MACHINE.addType("primitive",
+                (Class<? extends BuilderBase<? extends MachineDefinition>>) (Class<?>) MultiblockMachineBuilder.class,
                 (id) -> KJSWrappingMultiblockBuilder.createKJSMulti(id, PrimitiveFancyUIWorkableMachine::new),
                 false);
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
@@ -30,7 +30,7 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
     @Setter
     public volatile SteamDefinitionFunction definition = (isHP, def) -> def.tier(isHP ? 1 : 0);
 
-    private volatile MachineBuilder<?> lowPressureBuilder = null, highPressureBuilder = null;
+    private volatile MachineBuilder<?, ?> lowPressureBuilder = null, highPressureBuilder = null;
     private volatile MachineDefinition hpValue = null;
 
     public KJSSteamMachineBuilder(ResourceLocation id) {
@@ -104,6 +104,6 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
     @FunctionalInterface
     public interface SteamDefinitionFunction {
 
-        void apply(boolean isHighPressure, MachineBuilder<?> builder);
+        void apply(boolean isHighPressure, MachineBuilder<?, ?> builder);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -31,7 +31,7 @@ import static com.gregtechceu.gtceu.utils.FormattingUtil.toEnglishName;
 @Accessors(fluent = true, chain = true)
 public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
 
-    private final MachineBuilder<?>[] builders = new MachineBuilder[TIER_COUNT];
+    private final MachineBuilder<?, ?>[] builders = new MachineBuilder[TIER_COUNT];
 
     @Setter
     public volatile int[] tiers = GTMachineUtils.ELECTRIC_TIERS;
@@ -69,7 +69,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     public void generateAssetJsons(@Nullable AssetJsonGenerator generator) {
         super.generateAssetJsons(generator);
         for (int tier : this.tiers) {
-            MachineBuilder<?> builder = this.builders[tier];
+            MachineBuilder<?, ?> builder = this.builders[tier];
             if (builder != null) {
                 builder.generateAssetJsons(generator);
             }
@@ -80,7 +80,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     public void generateLang(@NotNull LangEventJS lang) {
         super.generateLang(lang);
         for (int tier : this.tiers) {
-            MachineBuilder<?> builder = this.builders[tier];
+            MachineBuilder<?, ?> builder = this.builders[tier];
             if (builder != null) {
                 builder.generateLang(lang);
             }
@@ -98,7 +98,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
         MachineDefinition[] definitions = new MachineDefinition[TIER_COUNT];
         for (final int tier : tiers) {
             String tierName = VN[tier].toLowerCase(Locale.ROOT);
-            MachineBuilder<?> builder = GTRegistration.REGISTRATE.machine(
+            MachineBuilder<?, ?> builder = GTRegistration.REGISTRATE.machine(
                     String.format("%s_%s", tierName, this.id.getPath()),
                     holder -> machine.create(holder, tier, tankScalingFunction));
 
@@ -142,6 +142,6 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     @FunctionalInterface
     public interface DefinitionFunction {
 
-        void apply(int tier, MachineBuilder<?> builder);
+        void apply(int tier, MachineBuilder<?, ?> builder);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -99,6 +99,6 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
     @FunctionalInterface
     public interface DefinitionFunction {
 
-        void apply(int tier, MachineBuilder<?> builder);
+        void apply(int tier, MachineBuilder<?, ?> builder);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
@@ -75,17 +75,17 @@ public class KJSWrappingMultiblockBuilder extends BuilderBase<MultiblockMachineD
                 " With id " + tieredBuilder.id);
     }
 
-    public static MultiblockMachineBuilder createKJSMulti(ResourceLocation id) {
-        return new MultiblockMachineBuilder(GTRegistration.REGISTRATE, id.getPath(),
+    public static MultiblockMachineBuilder<?, ?> createKJSMulti(ResourceLocation id) {
+        return new MultiblockMachineBuilder<>(GTRegistration.REGISTRATE, id.getPath(),
                 WorkableElectricMultiblockMachine::new,
                 MetaMachineBlock::new,
                 MetaMachineItem::new,
                 MetaMachineBlockEntity::new);
     }
 
-    public static MultiblockMachineBuilder createKJSMulti(ResourceLocation id,
-                                                          KJSTieredMachineBuilder.CreationFunction<? extends MultiblockControllerMachine> machine) {
-        return new MultiblockMachineBuilder(GTRegistration.REGISTRATE, id.getPath(),
+    public static MultiblockMachineBuilder<?, ?> createKJSMulti(ResourceLocation id,
+                                                                KJSTieredMachineBuilder.CreationFunction<? extends MultiblockControllerMachine> machine) {
+        return new MultiblockMachineBuilder<>(GTRegistration.REGISTRATE, id.getPath(),
                 machine::create,
                 MetaMachineBlock::new,
                 MetaMachineItem::new,


### PR DESCRIPTION
## What
Add second generic to MachineBuilder and reduce code duplication 

## Implementation Details
go from `MachineBuilder<DEFINITION extends MachineDefinition> extends BuilderBase<DEFINITION>` to `MachineBuilder<DEFINITION extends MachineDefinition, TYPE extends MachineBuilder<DEFINITION, TYPE>> extends BuilderBase<DEFINITION>`

## Outcome
No longer need to add a `public MultiblockMachineBuilder foo(Bar bar){ (MultiblockMachineBuilder) super.foo(bar) };` for every. single. MachineBuilder. method.

## Additional Information
Unfortunately Lombok doesn't support returning getThis() and TYPE, so I had to un-lombok both classes for setters.

Genericslop.

## Potential Compatibility Issues
People who store partially finished builders need to move from `MachineBuilder<?>` to `MachineBuilder<?,?>`
