### PR TITLE
Fix crash when rejoining world in latest

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
@@ -50,6 +50,7 @@ public abstract class RecipeManagerMixin {
             });
             var recipesByID = recipes.get(gtRecipeType);
             if (recipesByID == null) {
+                gtRecipeType.getAdditionHandler().completeStaging();
                 continue;
             }
             RecipeManagerHandler.addRecipesToLookup(recipesByID, gtRecipeType);


### PR DESCRIPTION
We didn't complete the staging process if the recipes aer already in recipemanager's list