### PR TITLE
Fix dust disassembly recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/StrictShapedRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/StrictShapedRecipe.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.recipe;
 
 import com.gregtechceu.gtceu.core.mixins.ShapedRecipeAccessor;
 
+import lombok.Getter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.FriendlyByteBuf;
@@ -28,13 +29,18 @@ public class StrictShapedRecipe extends ShapedRecipe {
 
     public static final RecipeSerializer<StrictShapedRecipe> SERIALIZER = new Serializer();
 
+    @Getter
+    private final boolean matchSize;
+
     public StrictShapedRecipe(ResourceLocation id, String group, CraftingBookCategory category, int width, int height,
-                              NonNullList<Ingredient> recipeItems, ItemStack result) {
+                              NonNullList<Ingredient> recipeItems, ItemStack result, boolean matchSize) {
         super(id, group, category, width, height, recipeItems, result);
+        this.matchSize = matchSize;
     }
 
     @Override
     public boolean matches(CraftingContainer inv, Level level) {
+        if (matchSize && (inv.getWidth() != this.getWidth() || inv.getHeight() != this.getHeight())) return false;
         for (int i = 0; i <= inv.getWidth() - this.getWidth(); ++i) {
             for (int j = 0; j <= inv.getHeight() - this.getHeight(); ++j) {
                 if (this.matches(inv, i, j)) {
@@ -82,7 +88,8 @@ public class StrictShapedRecipe extends ShapedRecipe {
             int j = strings.length;
             NonNullList<Ingredient> nonNullList = ShapedRecipeAccessor.callDissolvePattern(strings, map, i, j);
             ItemStack itemStack = StrictShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(json, "result"));
-            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack);
+            boolean matchSize = json.get("matchSize").getAsBoolean();
+            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack, matchSize);
         }
 
         @Override
@@ -94,7 +101,8 @@ public class StrictShapedRecipe extends ShapedRecipe {
             NonNullList<Ingredient> nonNullList = NonNullList.withSize(i * j, Ingredient.EMPTY);
             nonNullList.replaceAll(ignored -> Ingredient.fromNetwork(buffer));
             ItemStack itemStack = buffer.readItem();
-            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack);
+            boolean matchSize = buffer.readBoolean();
+            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack, matchSize);
         }
 
         @Override
@@ -107,6 +115,7 @@ public class StrictShapedRecipe extends ShapedRecipe {
                 ingredient.toNetwork(buffer);
             }
             buffer.writeItem(((ShapedRecipeAccessor) recipe).getResult());
+            buffer.writeBoolean(recipe.matchSize);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/StrictShapedRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/StrictShapedRecipe.java
@@ -2,7 +2,6 @@ package com.gregtechceu.gtceu.api.recipe;
 
 import com.gregtechceu.gtceu.core.mixins.ShapedRecipeAccessor;
 
-import lombok.Getter;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.FriendlyByteBuf;
@@ -17,6 +16,7 @@ import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.level.Level;
 
 import com.google.gson.JsonObject;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -89,7 +89,8 @@ public class StrictShapedRecipe extends ShapedRecipe {
             NonNullList<Ingredient> nonNullList = ShapedRecipeAccessor.callDissolvePattern(strings, map, i, j);
             ItemStack itemStack = StrictShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(json, "result"));
             boolean matchSize = json.get("matchSize").getAsBoolean();
-            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack, matchSize);
+            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack,
+                    matchSize);
         }
 
         @Override
@@ -102,7 +103,8 @@ public class StrictShapedRecipe extends ShapedRecipe {
             nonNullList.replaceAll(ignored -> Ingredient.fromNetwork(buffer));
             ItemStack itemStack = buffer.readItem();
             boolean matchSize = buffer.readBoolean();
-            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack, matchSize);
+            return new StrictShapedRecipe(recipeId, string, craftingBookCategory, i, j, nonNullList, itemStack,
+                    matchSize);
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -268,7 +268,7 @@ public class VanillaRecipeHelper {
      * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName,
-                                             @NotNull ItemStack result, @NotNull Object... recipe) {
+                                                 @NotNull ItemStack result, @NotNull Object... recipe) {
         addStrictSizeShapedRecipe(provider, GTCEu.id(regName), result, recipe);
     }
 
@@ -276,8 +276,8 @@ public class VanillaRecipeHelper {
      * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
-                                             @NotNull String regName,
-                                             @NotNull ItemStack result, @NotNull Object... recipe) {
+                                                 @NotNull String regName,
+                                                 @NotNull ItemStack result, @NotNull Object... recipe) {
         addStrictSizeShapedRecipe(provider, setMaterialInfoData, GTCEu.id(regName), result, recipe);
     }
 
@@ -285,7 +285,7 @@ public class VanillaRecipeHelper {
      * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull ResourceLocation regName,
-                                             @NotNull ItemStack result, @NotNull Object... recipe) {
+                                                 @NotNull ItemStack result, @NotNull Object... recipe) {
         addStrictSizeShapedRecipe(provider, false, regName, result, recipe);
     }
 
@@ -309,12 +309,13 @@ public class VanillaRecipeHelper {
      * <li>{@code 'w'} - {@code craftingToolWrench}</li>
      * <li>{@code 'x'} - {@code craftingToolWireCutter}</li>
      * </ul>
-     *  @param setMaterialInfoData whether to add material decomposition information to the recipe output
+     * 
+     * @param setMaterialInfoData whether to add material decomposition information to the recipe output
      *
      * @param matchSize
-     * @param regName   the registry name for the recipe
-     * @param result    the output for the recipe
-     * @param recipe    the contents of the recipe
+     * @param regName             the registry name for the recipe
+     * @param result              the output for the recipe
+     * @param recipe              the contents of the recipe
      */
     public static void addShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData, boolean isStrict,
                                        boolean matchSize, @NotNull ResourceLocation regName, @NotNull ItemStack result,
@@ -410,8 +411,8 @@ public class VanillaRecipeHelper {
      * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
-                                             @NotNull ResourceLocation regName, @NotNull ItemStack result,
-                                             @NotNull Object... recipe) {
+                                                 @NotNull ResourceLocation regName, @NotNull ItemStack result,
+                                                 @NotNull Object... recipe) {
         addShapedRecipe(provider, setMaterialInfoData, true, true, regName, result, recipe);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -224,7 +224,7 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName,
                                        @NotNull ItemStack result, @NotNull Object... recipe) {
@@ -232,7 +232,7 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull ResourceLocation regName,
                                        @NotNull ItemStack result, @NotNull Object... recipe) {
@@ -240,7 +240,7 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName,
                                              @NotNull ItemStack result, @NotNull Object... recipe) {
@@ -248,7 +248,7 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
                                              @NotNull String regName,
@@ -257,11 +257,36 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull ResourceLocation regName,
                                              @NotNull ItemStack result, @NotNull Object... recipe) {
         addStrictShapedRecipe(provider, false, regName, result, recipe);
+    }
+
+    /**
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     */
+    public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName,
+                                             @NotNull ItemStack result, @NotNull Object... recipe) {
+        addStrictSizeShapedRecipe(provider, GTCEu.id(regName), result, recipe);
+    }
+
+    /**
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     */
+    public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
+                                             @NotNull String regName,
+                                             @NotNull ItemStack result, @NotNull Object... recipe) {
+        addStrictSizeShapedRecipe(provider, setMaterialInfoData, GTCEu.id(regName), result, recipe);
+    }
+
+    /**
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     */
+    public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, @NotNull ResourceLocation regName,
+                                             @NotNull ItemStack result, @NotNull Object... recipe) {
+        addStrictSizeShapedRecipe(provider, false, regName, result, recipe);
     }
 
     /**
@@ -284,17 +309,19 @@ public class VanillaRecipeHelper {
      * <li>{@code 'w'} - {@code craftingToolWrench}</li>
      * <li>{@code 'x'} - {@code craftingToolWireCutter}</li>
      * </ul>
+     *  @param setMaterialInfoData whether to add material decomposition information to the recipe output
      *
-     * @param setMaterialInfoData whether to add material decomposition information to the recipe output
-     * @param regName             the registry name for the recipe
-     * @param result              the output for the recipe
-     * @param recipe              the contents of the recipe
+     * @param matchSize
+     * @param regName   the registry name for the recipe
+     * @param result    the output for the recipe
+     * @param recipe    the contents of the recipe
      */
     public static void addShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData, boolean isStrict,
-                                       @NotNull ResourceLocation regName, @NotNull ItemStack result,
+                                       boolean matchSize, @NotNull ResourceLocation regName, @NotNull ItemStack result,
                                        @NotNull Object... recipe) {
         var builder = new ShapedRecipeBuilder(regName).output(result);
         builder.isStrict(isStrict);
+        builder.matchSize(matchSize);
         final CharSet tools = ToolHelper.getToolSymbols();
         CharSet foundTools = new CharArraySet(9);
         for (int i = 0; i < recipe.length; i++) {
@@ -354,7 +381,7 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
                                        @NotNull String regName, @NotNull ItemStack result, @NotNull Object... recipe) {
@@ -362,21 +389,30 @@ public class VanillaRecipeHelper {
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
                                        @NotNull ResourceLocation regName, @NotNull ItemStack result,
                                        @NotNull Object... recipe) {
-        addShapedRecipe(provider, setMaterialInfoData, false, regName, result, recipe);
+        addShapedRecipe(provider, setMaterialInfoData, false, false, regName, result, recipe);
     }
 
     /**
-     * @see #addShapedRecipe(Consumer, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
      */
     public static void addStrictShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
                                              @NotNull ResourceLocation regName, @NotNull ItemStack result,
                                              @NotNull Object... recipe) {
-        addShapedRecipe(provider, setMaterialInfoData, true, regName, result, recipe);
+        addShapedRecipe(provider, setMaterialInfoData, true, false, regName, result, recipe);
+    }
+
+    /**
+     * @see #addShapedRecipe(Consumer, boolean, boolean, boolean, ResourceLocation, ItemStack, Object...)
+     */
+    public static void addStrictSizeShapedRecipe(Consumer<FinishedRecipe> provider, boolean setMaterialInfoData,
+                                             @NotNull ResourceLocation regName, @NotNull ItemStack result,
+                                             @NotNull Object... recipe) {
+        addShapedRecipe(provider, setMaterialInfoData, true, true, regName, result, recipe);
     }
 
     public static void addShapelessRecipe(Consumer<FinishedRecipe> provider, @NotNull String regName,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/ShapedRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/ShapedRecipeBuilder.java
@@ -30,6 +30,7 @@ public class ShapedRecipeBuilder extends Builder<Ingredient, ShapedRecipeBuilder
     protected ResourceLocation id;
     protected String group;
     protected boolean isStrict;
+    protected boolean matchSize;
 
     public ShapedRecipeBuilder(@Nullable ResourceLocation id) {
         this.id = id;
@@ -97,6 +98,12 @@ public class ShapedRecipeBuilder extends Builder<Ingredient, ShapedRecipeBuilder
         return this;
     }
 
+    public ShapedRecipeBuilder matchSize(boolean matchSize) {
+        if (matchSize) this.isStrict = true;
+        this.matchSize = matchSize;
+        return this;
+    }
+
     @Override
     public ShapedRecipeBuilder shallowCopy() {
         var builder = super.shallowCopy();
@@ -124,6 +131,8 @@ public class ShapedRecipeBuilder extends Builder<Ingredient, ShapedRecipeBuilder
             symbolMap.forEach((k, v) -> key.add(k.toString(), v.toJson()));
             json.add("key", key);
         }
+
+        json.addProperty("matchSize", matchSize);
 
         if (output.isEmpty()) {
             GTCEu.LOGGER.error("shaped recipe {} output is empty", id);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
@@ -254,9 +254,12 @@ public final class MaterialRecipeHandler {
         ItemStack smallDustStack = ChemicalHelper.get(dustSmall, material);
         ItemStack dustStack = ChemicalHelper.get(dust, material);
 
-        VanillaRecipeHelper.addStrictShapedRecipe(provider,
+        VanillaRecipeHelper.addStrictSizeShapedRecipe(provider,
                 String.format("small_dust_disassembling_%s", material.getName()),
                 smallDustStack.copyWithCount(4), " X", "  ", 'X', new MaterialEntry(dust, material));
+        VanillaRecipeHelper.addStrictSizeShapedRecipe(provider,
+                String.format("small_dust_disassembling_3x3_%s", material.getName()),
+                smallDustStack.copyWithCount(4), " X ", "   ", "   ", 'X', new MaterialEntry(dust, material));
         VanillaRecipeHelper.addShapedRecipe(provider, String.format("small_dust_assembling_%s", material.getName()),
                 dustStack, "XX", "XX", 'X', new MaterialEntry(dustSmall, material));
 
@@ -282,9 +285,12 @@ public final class MaterialRecipeHandler {
         ItemStack tinyDustStack = ChemicalHelper.get(dustTiny, material);
         ItemStack dustStack = ChemicalHelper.get(dust, material);
 
-        VanillaRecipeHelper.addStrictShapedRecipe(provider,
+        VanillaRecipeHelper.addStrictSizeShapedRecipe(provider,
                 String.format("tiny_dust_disassembling_%s", material.getName()),
                 tinyDustStack.copyWithCount(9), "X ", "  ", 'X', new MaterialEntry(dust, material));
+        VanillaRecipeHelper.addStrictSizeShapedRecipe(provider,
+                String.format("tiny_dust_disassembling_3x3_%s", material.getName()),
+                tinyDustStack.copyWithCount(9), "X  ", "   ", "   ", 'X', new MaterialEntry(dust, material));
         VanillaRecipeHelper.addShapedRecipe(provider, String.format("tiny_dust_assembling_%s", material.getName()),
                 dustStack, "XXX", "XXX", "XXX", 'X', new MaterialEntry(dustTiny, material));
 


### PR DESCRIPTION
## What
Make dusts consistently disassemble into tiny dusts if put into the top left slot, and into small dusts if put into the top middle slot.

## Implementation Details
Adds a `matchSize` parameter to `StrictShapedRecipe` that allows you to restrict recipes to a crafting grid of a certain size (here it's used for 2x2)

A side effect of this PR is that recipes for dust disassembly will show up twice in XEI.

## Outcome
Resolves #4435