### PR TITLE
add a mixin to make test method names be displayed in snake_case

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/GTMixinPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/GTMixinPlugin.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.core.mixins;
 
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.fml.loading.FMLLoader;
 import net.minecraftforge.fml.loading.LoadingModList;
 
 import org.objectweb.asm.tree.ClassNode;
@@ -25,6 +26,8 @@ public class GTMixinPlugin implements IMixinConfigPlugin {
     private static final String MIXIN_PACKAGE = "com.gregtechceu.gtceu.core.mixins.";
     private static final Map<String, String> MOD_COMPAT_MIXINS = new HashMap<>();
 
+    private static final String DEV_PACKAGE = MIXIN_PACKAGE + "dev.";
+
     static {
         MOD_COMPAT_MIXINS.put("roughlyenoughitems", MIXIN_PACKAGE + "rei");
         addModCompatMixin("emi");
@@ -37,6 +40,9 @@ public class GTMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.startsWith(DEV_PACKAGE)) {
+            return !FMLLoader.isProduction();
+        }
         for (var compatMod : MOD_COMPAT_MIXINS.entrySet()) {
             if (mixinClassName.startsWith(compatMod.getValue())) {
                 return isModLoaded(compatMod.getKey());

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/dev/test/GameTestRegistryMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/dev/test/GameTestRegistryMixin.java
@@ -1,0 +1,19 @@
+package com.gregtechceu.gtceu.core.mixins.dev.test;
+
+import com.gregtechceu.gtceu.utils.FormattingUtil;
+
+import net.minecraft.gametest.framework.GameTestRegistry;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(GameTestRegistry.class)
+public class GameTestRegistryMixin {
+
+    @ModifyExpressionValue(method = "turnMethodIntoTestFunction",
+                           at = @At(value = "INVOKE", target = "Ljava/lang/reflect/Method;getName()Ljava/lang/String;"))
+    private static String gtceu$makeTestMethodNameSnakeCase(String original) {
+        return FormattingUtil.toLowerCaseUnderscore(original);
+    }
+}

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -61,6 +61,7 @@
         "TagManagerMixin",
         "TagValueAccessor",
         "client.ItemEntityMixin",
+        "dev.test.GameTestRegistryMixin",
         "emi.EmiRecipeFillerMixin",
         "emi.FillRecipePacketMixin",
         "emi.FluidEmiStackMixin",


### PR DESCRIPTION
...even if the actual method name is in camelCase

## What
The test methods being displayed as `blocked_by_ldlib_weirdness_probably_testadvancedactivitydetectorcover` and the like bothered me so I wrote this simple mixin to fix that :3
