### PR TITLE
Add check to not cache invalid recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -344,6 +344,10 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
             if (checkMatchedRecipeAvailable(match))
                 return;
 
+            if (!matchRecipe(match).isSuccess()) {
+                continue;
+            }
+
             // cache matching recipes.
             if (lastFailedMatches == null) {
                 lastFailedMatches = new ArrayList<>();


### PR DESCRIPTION
## What
Adds back a check to not invalidate recipes. This was caused by the r -> true change in #3986 


## Implementation Details

what happened before the r -> true change AKA scenario A:

1. iterate over all gtrecipes through the lookup
2. for every recipe, try to call matchRecipe(r) before returning it (expensive)
3. if it succeeds, return it, 
4. fully modify it, call matchRecipe(r) again (expensive)
5. if this post-modified check fails, store the recipe in lastFailedMatches and go back to 2 with the next recipe
6. if this post-modified check succeeds, return the recipe.

after the r->true change AKA scenario B:

1. iterate over all gtrecipes through the lookup
2. fully modify it, call matchRecipe(r) (expensive)
3. if this post-modified check fails, store the recipe in lastFailedMatches and go back to 2 with the next recipe
4. if this post-modified check succeeds, return the recipe.

The error here is that recipes that never passed the pre-modified matchRecipe(r) check go into the lastFailedMatches (because that check doesn't exist anymore), causing significant slowdowns and logic errors

after this PR aka scenario C:
1. iterate over all gtrecipes through the lookup
2. fully modify it, call matchRecipe(r) (expensive)
3. if this post-modified check succeeds, return the recipe.
4. if this post-modified check fails, do another check for matchRecipe(r) pre-modified
5. if this pre-modified check succeeds, store the recipe in lastFailedMatches 
6. go back to 2 with the next recipe

So in the happy path, it's faster than scenario A since we no longer call matchRecipe(r) on the pre-modified recipe. but in the unhappy path, we still call the check and don't store incorrect recipes in the cached miss list

Ty to luckyblock for reporting here: https://discord.com/channels/701354865217110096/1089296351906504835/1462466586022641933
