### PR TITLE
Remove BlockEntity Check in MinerLogic

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -551,7 +551,6 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
                         BlockPos blockPos = new BlockPos(x, y, z);
                         BlockState state = level.getBlockState(blockPos);
                         if (state.getDestroySpeed(level, blockPos) >= 0 &&
-                                level.getBlockEntity(blockPos) == null &&
                                 state.is(Tags.Blocks.ORES)) {
                             blocks.addLast(blockPos);
                         }


### PR DESCRIPTION
## What
In MinerLogic's `getBlockstoMine()` there's a check to see if a block is valid to actually be mined. 2 out of 3 checks are fine, but there's one check to see if there isn't a BlockEntity at that position and that ones doesn't really feel like there's a justification for that one, especially in cases where someone DELIBERATELY tags a block that has a BlockEntity as an Ore... which is me, I'm that someone.

## Implementation Details
Simply removes the BlockEntity check while keeping the other 2 checks.

## Outcome
Now any block that is tagged with Ore and has a BlockEntity should be mineable.

## Additional Information
I made this PR because I was doing something that was conflicting with this BlockEntity check because it was the only reasonable way to actually do the thing I wanted to do.

## Potential Compatibility Issues
I can probably think of a really stupid edge case with containers but at the same time the other 2 remaining checks should stop that from happening unless that tag was deliberately put in place.