### PR TITLE
Give three alloy smelter glass recipes the right category

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CircuitRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CircuitRecipes.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.data.recipe.misc;
 import com.gregtechceu.gtceu.api.data.chemical.material.MarkerMaterials.Color;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
 import com.gregtechceu.gtceu.api.machine.multiblock.CleanroomType;
+import com.gregtechceu.gtceu.common.data.GTRecipeCategories;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
@@ -338,6 +339,7 @@ public class CircuitRecipes {
                 .inputItems(dust, Glass)
                 .notConsumable(SHAPE_MOLD_BALL)
                 .outputItems(GLASS_TUBE)
+                .category(GTRecipeCategories.INGOT_MOLDING)
                 .duration(160).EUt(16).save(provider);
 
         FLUID_SOLIDFICATION_RECIPES.recipeBuilder("solidify_glass_tube")

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/MiscRecipeLoader.java
@@ -401,6 +401,7 @@ public class MiscRecipeLoader {
                 .inputItems(dust, Glass, 2)
                 .notConsumable(SHAPE_MOLD_PLATE)
                 .outputItems(plate, Glass)
+                .category(GTRecipeCategories.INGOT_MOLDING)
                 .duration(40).EUt(6).save(provider);
 
         // Dyed Lens Recipes

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/VanillaStandardRecipes.java
@@ -225,6 +225,7 @@ public class VanillaStandardRecipes {
                 .inputItems(dust, Glass)
                 .notConsumable(SHAPE_MOLD_BOTTLE)
                 .outputItems(new ItemStack(Items.GLASS_BOTTLE))
+                .category(GTRecipeCategories.INGOT_MOLDING)
                 .addMaterialInfo(true)
                 .save(provider);
 
@@ -250,6 +251,7 @@ public class VanillaStandardRecipes {
                 .inputItems(dust, Glass)
                 .notConsumable(SHAPE_MOLD_BLOCK)
                 .outputItems(new ItemStack(Blocks.GLASS, 1))
+                .category(GTRecipeCategories.INGOT_MOLDING)
                 .save(provider);
 
         CUTTER_RECIPES.recipeBuilder("cut_glass_block_to_plate").duration(50).EUt(VA[ULV])


### PR DESCRIPTION
## What
Changed the category of three alloy smelter glass dust recipes. Before, half were in that tab and half were in the normal alloy smelter tab.

## Outcome
Now _all_ glass dust alloy smelter recipes should be under the "ingot molding" tab