### PR TITLE
Fix autogenerating mortar recipes

### DIFF
--- a/docs/content/Modpacks/Changes/v7.5.0.md
+++ b/docs/content/Modpacks/Changes/v7.5.0.md
@@ -23,3 +23,6 @@ You also need to adjust the generics of `getType()` and `createTemplate()` to ma
 
 ## Machine & Cover Copy/Paste System
 A new system for copying machines using the Machine Memory Card has been added, see [this page](../Other-Topics/Cover-Machine-Copy-Paste-Support.md) if you want to add extra copy/paste behaviour to your own machines and covers.
+
+## Mortar Recipe Fix
+Previously, adding GTToolType.MORTAR to your tool did not automatically generate the recipe. This has been fixed. If you previously generated a recipe using this, you need to remove your manual recipe.

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.block.Blocks;
 
 import com.tterrag.registrate.util.entry.ItemEntry;
 import it.unimi.dsi.fastutil.ints.Int2ReferenceArrayMap;
@@ -71,6 +72,11 @@ public final class ToolRecipeHandler {
         MaterialEntry plate = new MaterialEntry(TagPrefix.plate, material);
         MaterialEntry ingot = new MaterialEntry(
                 material.hasProperty(PropertyKey.GEM) ? TagPrefix.gem : TagPrefix.ingot, material);
+
+        addToolRecipe(provider, material, GTToolType.MORTAR, false,
+                " I ", "SIS", "SSS",
+                'I', ingot,
+                'S', new ItemStack(Blocks.STONE));
 
         if (material.hasFlag(GENERATE_PLATE)) {
             addToolRecipe(provider, material, GTToolType.MINING_HAMMER, true,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/ToolRecipeHandler.java
@@ -64,19 +64,19 @@ public final class ToolRecipeHandler {
     }
 
     private static void processTool(@NotNull Consumer<FinishedRecipe> provider, @NotNull Material material) {
-        if (!material.shouldGenerateRecipesFor(plate)) {
-            return;
-        }
-
         ItemStack stick = new ItemStack(Items.STICK);
-        MaterialEntry plate = new MaterialEntry(TagPrefix.plate, material);
         MaterialEntry ingot = new MaterialEntry(
                 material.hasProperty(PropertyKey.GEM) ? TagPrefix.gem : TagPrefix.ingot, material);
-
         addToolRecipe(provider, material, GTToolType.MORTAR, false,
                 " I ", "SIS", "SSS",
                 'I', ingot,
                 'S', new ItemStack(Blocks.STONE));
+
+        if (!material.shouldGenerateRecipesFor(plate)) {
+            return;
+        }
+
+        MaterialEntry plate = new MaterialEntry(TagPrefix.plate, material);
 
         if (material.hasFlag(GENERATE_PLATE)) {
             addToolRecipe(provider, material, GTToolType.MINING_HAMMER, true,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CustomToolRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/CustomToolRecipes.java
@@ -130,7 +130,6 @@ public final class CustomToolRecipes {
 
     private static void registerCustomToolRecipes(@NotNull Consumer<FinishedRecipe> provider) {
         registerFlintToolRecipes(provider);
-        registerMortarRecipes(provider);
         registerSoftToolRecipes(provider);
         registerElectricRecipes(provider);
 
@@ -176,20 +175,6 @@ public final class CustomToolRecipes {
                 "I", "S",
                 'I', flint,
                 'S', stick);
-    }
-
-    private static void registerMortarRecipes(@NotNull Consumer<FinishedRecipe> provider) {
-        for (Material material : new Material[] {
-                GTMaterials.Bronze, GTMaterials.Iron, GTMaterials.Invar, GTMaterials.Steel,
-                GTMaterials.DamascusSteel, GTMaterials.CobaltBrass, GTMaterials.WroughtIron }) {
-
-            addToolRecipe(provider, material, GTToolType.MORTAR, false,
-                    " I ", "SIS", "SSS",
-                    'I',
-                    new MaterialEntry(material.hasProperty(PropertyKey.GEM) ? TagPrefix.gem : TagPrefix.ingot,
-                            material),
-                    'S', new ItemStack(Blocks.STONE));
-        }
     }
 
     private static void registerSoftToolRecipes(@NotNull Consumer<FinishedRecipe> provider) {


### PR DESCRIPTION
## What
Automatically generate mortar recipes instead of only doing so for select tools

## Outcome
```
event.create('seared_stone')
        .ingot()
        .components('2x clay', '2x quartz_sand', '2x flint')
        .iconSet(GTMaterialIconSet.ROUGH)
        .color(0x4E4946)
        .secondaryColor(0x242021)
        .flags(GTMaterialFlags.DECOMPOSITION_BY_ELECTROLYZING, GTMaterialFlags.MORTAR_GRINDABLE)
        .toolStats(new ToolProperty (1, 1, 128, 1,
            [
                GTToolType.MORTAR
            ]

        ))
```

<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/21d0efb7-ded1-4a81-b193-370911f1a29f" />

## Additional Information
Didn't change any of the existing mortars:
<img width="1982" height="1386" alt="image" src="https://github.com/user-attachments/assets/19fe45c7-4ec7-4014-b622-40b8b78746a2" />
<img width="995" height="480" alt="image" src="https://github.com/user-attachments/assets/17e15889-2121-4c8b-9e74-2c0c8c74dc0f" />

## Potential Compatibility Issues
Recipes might be generated that weren't previously generated, see docs

