### PR TITLE
Replace mandatory air with any in blast chiler structure

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCYMMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCYMMachines.java
@@ -923,7 +923,7 @@ public class GCYMMachines {
             .pattern(definition -> FactoryBlockPattern.start()
                     .aisle("XXXXXXX#KKK", "XXXXXXX#KVK", "XXXXXXX#KVK", "XXXXXXX#KVK", "XXXXXXX#KKK", "XXXXXXX####", "XXXXXXX####")
                     .aisle("XXXXXXX#KVK", "XPPPPPPPPPV", "XPAPAPX#VPV", "XPPPPPPPPPV", "XPAPAPX#KVK", "XPPPPPX####", "XXXXXXX####")
-                    .aisle("XXXXXXX#KVK", "XPAPAPXAVPV", "XAAAAAX#VPV", "XPAAAPX#VPV", "XAAAAAX#KVK", "XPAPAPX####", "XXXXXXX####")
+                    .aisle("XXXXXXX#KVK", "XPAPAPX#VPV", "XAAAAAX#VPV", "XPAAAPX#VPV", "XAAAAAX#KVK", "XPAPAPX####", "XXXXXXX####")
                     .aisle("XXXXXXX#KVK", "XPAPAPPPPPV", "XAAAAAX#VPV", "XPAAAPPPPPV", "XAAAAAX#KVK", "XPAPAPX####", "XXXXXXX####")
                     .aisle("XXXXXXX#KKK", "XPPPPPX#KVK", "XPA#APX#KVK", "XPAAAPX#KVK", "XPAAAPX#KKK", "XPPPPPX####", "XXXXXXX####")
                     .aisle("#XXXXX#####", "#XXSXX#####", "#XGGGX#####", "#XGGGX#####", "#XGGGX#####", "#XXXXX#####", "###########")


### PR DESCRIPTION
## What
It used to be that specifically this spot of the blast chiller:
<img width="143" height="253" alt="image" src="https://github.com/user-attachments/assets/780e7c5e-84db-443f-a9e0-7460fbc3f05c" />

aka
```
X#X
###
XAX
```
was forced to be air `(A)`

this PR makes it so that it's
```
X#X
###
X#X
```
and you can put other blocks `(#)` in that one specific spot

## Outcome
closes #4501


Tested in game:
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/2e4c0fc3-fdc7-49d8-b7d2-793770fef637" />
