### PR TITLE
Add testing mention to github template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,9 @@ _Any implementations in this PR that should be carefully looked over, or that co
 _A short description of what this PR added/fixed/changed/removed._
 _For correct linking of issues please use any of the Closes/Fixes/Resolves keywords. Example: When a PR is fixing a bug use "Fixes: #number-of-bug"_
 
+## How Was This Tested
+_This section is for screenshots, code snippets or descriptions of how the PR was tested in code or in game to ensure correctness._
+
 ## Additional Information
 _This section is for screenshots to demonstrate any GUI or rendering changes, or any other additional information that reviewers should be aware of._
 


### PR DESCRIPTION
## What
Adds a section to our github PR template that encourages the dev to elaborate on how they tested their PR, to increase accountability and get more insight on how ready PRs are for deployment

## Outcome
A single line + section added to our PR template, see files

## Potential Compatibility Issues
Might not be compatible with devs who don't want to be held accountable for the (lack of) testing in their PRs :3