### PR TITLE
Fix CME with parts and partpositions when calling getParts in addedToController

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
@@ -187,13 +187,13 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
             }
         }
         this.parts.sort(getPartSorter());
+        updatePartPositions();
         for (var part : parts) {
             if (part instanceof IParallelHatch pHatch) {
                 parallelHatch = pHatch;
             }
             part.addedToController(this);
         }
-        updatePartPositions();
     }
 
     @Override


### PR DESCRIPTION
## What
Previously, if you called getParts() in addedToController() it would CME, since the following code would clear the part list:
```java
 @Override
    public List<IMultiPart> getParts() {
        // for the client side, when the chunk unloaded
        if (parts.size() != this.partPositions.length) {
            parts.clear();
            for (var pos : this.partPositions) {
                if (getMachine(getLevel(), pos) instanceof IMultiPart part) {
                    parts.add(part);
                }
            }
        }
        return this.parts;
    }
```

because of the way it was done before:
1. collect the parts array
2. run addedToController() for each part
3. update partlocations

if during step 2 you called getParts(), it would not match parts.size() with (the empty) partLocations.size() and then clear this.parts. However, we're still iterating this.parts, so CME and crashes

Now we swap 2 and 3:

1. collect the parts array
2. update partlocations
3. run addedToController() for each part

and calling getParts() in that function is fine again.

## How Was This Tested
ran /test runall, all tests passed and no visual anomalies were seen out of the ordinary

