### PR TITLE
Fix invalid comparison in dimension condition

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DimensionCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DimensionCondition.java
@@ -82,7 +82,7 @@ public class DimensionCondition extends RecipeCondition<DimensionCondition> {
     @Override
     public boolean testCondition(@NotNull GTRecipe recipe, @NotNull RecipeLogic recipeLogic) {
         Level level = recipeLogic.machine.self().getLevel();
-        return level != null && dimension.equals(level.dimension().location());
+        return level != null && dimension.location().equals(level.dimension().location());
     }
 
     @Override


### PR DESCRIPTION
## What
this.dimension is a ResourceKey
level.dimension().location() is a ResourceLocation

## Implementation Details
Simply add .location()


## How Was This Tested
Recipe:
<img width="1233" height="1078" alt="image" src="https://github.com/user-attachments/assets/407d2fcc-1528-4cd3-8eea-318e81e090c6" />


Before:
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/0661a819-e69b-486b-b260-d98b1704d6a7" />

After:
https://github.com/user-attachments/assets/518771a2-b8f2-48b4-9b7c-04575d3616be
