### PR TITLE
Fix LWJGL and FastUtil sources

### DIFF
--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -1,6 +1,14 @@
 repositories {
     mavenLocal()
     mavenCentral()
+    // force gradle to download FastUtil & LWJGL from the central maven so we can get source artifacts
+    exclusiveContent { // Force
+        forRepository { mavenCentral() }
+        filter {
+            includeGroup("it.unimi.dsi")
+            includeGroup("org.lwjgl")
+        }
+    }
 
     maven { // JEI
         name = "Jared's Maven"


### PR DESCRIPTION
## What
Make LWJGL and FastUtil be downloaded from the central maven repository so we get source artifacts for them