### PR TITLE
Fix wireless_transmitter_cover_test not working on systems where the decimal separator isn't a dot

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
@@ -711,10 +711,11 @@ public class GTPlaceholders {
                         1000000000L, "B",
                         1000000000000L, "T");
                 long max = 1;
-                for (Long i : suffixes.keySet()) {
+                for (long i : suffixes.keySet()) {
                     if (n >= i && max < i) max = i;
                 }
-                return MultiLineComponent.literal("%.2f%s".formatted(((double) n) / max, suffixes.get(max)));
+                return MultiLineComponent.literal(String.format(Locale.ROOT, "%.2f%s",
+                        ((double) n) / max, suffixes.get(max)));
             }
         });
         PlaceholderHandler.addPlaceholder(new Placeholder("click") {


### PR DESCRIPTION
## What
Fix wireless_transmitter_cover_test not working on systems where the decimal separator isn't a dot.
Like german or finnish locale, where it's a comma.

## Implementation Details
Made it use `String.format(Locale.ROOT, ...` instead of `"constant".formatted(...)`.

## Outcome
Tests succeed on my PC again

## How Was This Tested
Ran tests, worked, didn't work before