### PR TITLE
Add a configuration option to automatically run `gradlew processResources` when F3+T is pressed in a development environment

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -344,6 +344,10 @@ public class RecipeLogic extends MachineTrait implements IEnhancedManaged, IWork
             if (checkMatchedRecipeAvailable(match))
                 return;
 
+            if (!matchRecipe(match).isSuccess()) {
+                continue;
+            }
+
             // cache matching recipes.
             if (lastFailedMatches == null) {
                 lastFailedMatches = new ArrayList<>();

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -850,6 +850,10 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Dump all registered GT models/blockstates/etc?", "Default: false" })
         public boolean dumpAssets = false;
+        @Configurable
+        @Configurable.Comment({ "Executes ./gradlew :processResources when F3+T is pressed",
+                "Only works in a development environment", "Default: false" })
+        public boolean autoRebuildResources = false;
     }
 
     public static class RendererConfigs {

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/dev/client/KeyboardHandlerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/dev/client/KeyboardHandlerMixin.java
@@ -1,0 +1,25 @@
+package com.gregtechceu.gtceu.core.mixins.dev.client;
+
+import com.gregtechceu.gtceu.utils.dev.ResourceReloadDetector;
+
+import net.minecraft.client.KeyboardHandler;
+import net.minecraft.client.Minecraft;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.concurrent.CompletableFuture;
+
+@Mixin(KeyboardHandler.class)
+public abstract class KeyboardHandlerMixin {
+
+    @WrapOperation(method = "handleDebugKeys",
+                   at = @At(value = "INVOKE",
+                            target = "Lnet/minecraft/client/Minecraft;reloadResourcePacks()Ljava/util/concurrent/CompletableFuture;"))
+    private CompletableFuture<Void> gtceu$hookResourceReload(Minecraft instance,
+                                                             Operation<CompletableFuture<Void>> original) {
+        return ResourceReloadDetector.regenerateResourcesOnReload(() -> original.call(instance));
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1233,6 +1233,9 @@ public class LangHandler {
         provider.add("gtceu.key.enable_step_assist", "Enable StepAssist");
         provider.add("gtceu.debug.f3_h.enabled",
                 "GregTech has modified the debug info! For Developers: enable the misc:debug config option in the GregTech config file to see more");
+        provider.add("gtceu.debug.resource_rebuild.done", "Gradle resource rebuild done in %s");
+        provider.add("gtceu.debug.resource_rebuild.start",
+                "Invoking gradle resource rebuild (./gradlew :processResources)");
         provider.add("config.jade.plugin_gtceu.controllable_provider", "[GTCEu] Controllable");
         provider.add("config.jade.plugin_gtceu.workable_provider", "[GTCEu] Workable");
         provider.add("config.jade.plugin_gtceu.battery_info", "[GTCEu] Battery info");

--- a/src/main/java/com/gregtechceu/gtceu/utils/dev/ResourceReloadDetector.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/dev/ResourceReloadDetector.java
@@ -8,6 +8,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 
 import com.sun.jna.platform.win32.*;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -18,10 +19,12 @@ import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+@ApiStatus.Internal
 public class ResourceReloadDetector {
 
     private static final Path gradleDir = findGradleDir();
 
+    @ApiStatus.Internal
     public static CompletableFuture<Void> regenerateResourcesOnReload(Supplier<CompletableFuture<Void>> reloadFuture) {
         if (!ConfigHolder.INSTANCE.dev.autoRebuildResources || !GTCEu.isDev() || gradleDir == null) {
             return reloadFuture.get();

--- a/src/main/java/com/gregtechceu/gtceu/utils/dev/ResourceReloadDetector.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/dev/ResourceReloadDetector.java
@@ -1,0 +1,65 @@
+package com.gregtechceu.gtceu.utils.dev;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.config.ConfigHolder;
+
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+
+import com.sun.jna.platform.win32.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+public class ResourceReloadDetector {
+
+    private static final Path gradleDir = findGradleDir();
+
+    public static CompletableFuture<Void> regenerateResourcesOnReload(Supplier<CompletableFuture<Void>> reloadFuture) {
+        if (!ConfigHolder.INSTANCE.dev.autoRebuildResources || !GTCEu.isDev() || gradleDir == null) {
+            return reloadFuture.get();
+        }
+        ProcessBuilder builder = switch (Util.getPlatform()) {
+            case WINDOWS -> new ProcessBuilder("cmd.exe", "/c", "gradlew.bat", ":processResources");
+            default -> new ProcessBuilder("./gradlew", ":processResources");
+        };
+        builder.directory(gradleDir.toFile());
+        builder.inheritIO();
+        Process process;
+        try {
+            process = builder.start();
+        } catch (IOException exception) {
+            GTCEu.LOGGER.error("Cound not run ./gradlew :processResources", exception);
+            GTCEu.LOGGER.error("Message the GTCEu developers about this!");
+            return reloadFuture.get();
+        }
+        Minecraft.getInstance().player.sendSystemMessage(Component.translatable("gtceu.debug.resource_rebuild.start"));
+        Instant start = Instant.now();
+        // wait for the resource reload to finish, then send chat message, then let MC actually reload resources
+        return process.toHandle().onExit()
+                .thenRun(() -> Minecraft.getInstance().player
+                        .sendSystemMessage(Component.translatable("gtceu.debug.resource_rebuild.done",
+                                Duration.between(start, Instant.now()))))
+                .thenCompose($ -> reloadFuture.get());
+    }
+
+    private static @Nullable Path findGradleDir() {
+        Path path = Path.of(".").toAbsolutePath();
+        do {
+            if (Files.isRegularFile(path.resolve("settings.gradle")) ||
+                    Files.isRegularFile(path.resolve("settings.gradle.kts"))) {
+                return path;
+            }
+            path = path.getParent();
+        } while (path.getParent() != null);
+
+        return null;
+    }
+}

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -21,6 +21,7 @@
         "client.MultiPlayerGameModeMixin",
         "client.PlayerInfoAccessor",
         "client.VariantDeserializerMixin",
+        "dev.client.KeyboardHandlerMixin",
         "ftbchunks.FTBChunksClientMixin",
         "ftbchunks.LargeMapScreenMixin",
         "ftbchunks.RegionMapPanelMixin",


### PR DESCRIPTION
## What
Title

## Implementation Details
The mixin hook (conditionally) wraps the MC resource reload future with another one that runs `./gradlew :processResources` (on unix) or `cmd /c gradlew.bat :processResources` (on Windows) before letting MC do its thing.

## Outcome
Developers can now change textures/models/etc. without restarting the game every time.