### PR TITLE
Fix bug in NBTPredicateIngredient serializer

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/NBTPredicateIngredient.java
@@ -96,7 +96,7 @@ public class NBTPredicateIngredient extends AbstractIngredient {
 
         public void write(FriendlyByteBuf buffer, NBTPredicateIngredient ingredient) {
             buffer.writeItem(ingredient.stack);
-            buffer.writeUtf(ingredient.toJson().toString());
+            buffer.writeUtf(ingredient.predicate.toJson().toString());
         }
     }
 }


### PR DESCRIPTION
The writer wrote the entire ingredient to json, the parser expects only the predicate. This would lead to NPEs when a player would try to join a server using NBTPredicateIngredients.
