### PR TITLE
Remove unchecked casts in TagPrefix

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/ChemicalHelper.java
@@ -193,7 +193,7 @@ public class ChemicalHelper {
                     MaterialEntry materialEntry1 = getMaterialEntry(itemTag);
                     // check that it's not the empty marker and that it's not a parent tag
                     if (!materialEntry1.isEmpty() &&
-                            Arrays.stream(materialEntry1.tagPrefix().getItemParentTags()).noneMatch(itemTag::equals)) {
+                            materialEntry1.tagPrefix().getItemParentTags().stream().noneMatch(itemTag::equals)) {
                         return materialEntry1;
                     }
                 }
@@ -210,7 +210,7 @@ public class ChemicalHelper {
             Set<TagKey<Item>> allItemTags = BuiltInRegistries.ITEM.getTagNames().collect(Collectors.toSet());
             for (TagPrefix prefix : TagPrefix.values()) {
                 for (Material material : GTCEuAPI.materialManager.getRegisteredMaterials()) {
-                    Arrays.stream(prefix.getItemTags(material))
+                    prefix.getItemTags(material).stream()
                             .filter(allItemTags::contains)
                             .forEach(tagKey -> {
                                 // remove the tag so that the next iteration is faster.
@@ -291,19 +291,19 @@ public class ChemicalHelper {
     @Nullable
     public static TagKey<Block> getBlockTag(TagPrefix orePrefix, @NotNull Material material) {
         var tags = orePrefix.getBlockTags(material);
-        if (tags.length > 0) {
-            return tags[0];
+        if (tags.isEmpty()) {
+            return null;
         }
-        return null;
+        return tags.get(0);
     }
 
     @Nullable
     public static TagKey<Item> getTag(TagPrefix orePrefix, @NotNull Material material) {
         var tags = orePrefix.getItemTags(material);
-        if (tags.length > 0) {
-            return tags[0];
+        if (tags.isEmpty()) {
+            return null;
         }
-        return null;
+        return tags.get(0);
     }
 
     public static List<Pair<ItemStack, ItemMaterialInfo>> getAllItemInfos() {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
@@ -163,7 +163,7 @@ public class ItemMaterialData {
         // Load new data
         TagsHandler.initExtraUnificationEntries();
         for (TagPrefix prefix : TagPrefix.values()) {
-            prefix.getIgnored().forEach((mat, items) -> registerMaterialEntries(Arrays.asList(items), prefix, mat));
+            prefix.getIgnored().forEach((mat, items) -> registerMaterialEntries(items, prefix, mat));
         }
         GTMaterialItems.toUnify
                 .forEach((materialEntry, supplier) -> registerMaterialEntry(supplier, materialEntry));

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialEntry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/stack/MaterialEntry.java
@@ -40,10 +40,10 @@ public record MaterialEntry(@NotNull TagPrefix tagPrefix, @NotNull Material mate
             return material.getResourceLocation().toString();
         }
         var tags = tagPrefix.getItemTags(material);
-        if (tags.length == 0) {
+        if (tags.isEmpty()) {
             return tagPrefix.name + "/" + material.getName();
         }
-        return tags[0].location().toString();
+        return tags.get(0).location().toString();
     }
 
     public static @Nullable MaterialEntry of(Object o) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -57,6 +57,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.*;
 import java.util.function.*;
@@ -1034,7 +1036,7 @@ public class TagPrefix {
     @Setter
     private BiConsumer<Material, List<Component>> tooltip;
 
-    private final Map<Material, Supplier<? extends ItemLike>[]> ignoredMaterials = new HashMap<>();
+    private final Map<Material, @Unmodifiable Collection<Supplier<? extends ItemLike>>> ignoredMaterials = new HashMap<>();
     private final Object2FloatMap<Material> materialAmounts = new Object2FloatOpenHashMap<>();
 
     @Getter
@@ -1173,43 +1175,51 @@ public class TagPrefix {
         return PREFIXES.getOrDefault(prefixName, replacement);
     }
 
-    @SuppressWarnings("unchecked")
-    public TagKey<Item>[] getItemParentTags() {
-        return tags.stream().filter(TagType::isParentTag).map(type -> type.getTag(this, GTMaterials.NULL))
-                .toArray(TagKey[]::new);
-    }
-
-    @SuppressWarnings("unchecked")
-    public TagKey<Item>[] getItemTags(@NotNull Material mat) {
-        return tags.stream().filter(type -> !type.isParentTag()).map(type -> type.getTag(this, mat))
+    public @UnmodifiableView List<TagKey<Item>> getItemParentTags() {
+        return tags.stream()
+                .filter(TagType::isParentTag)
+                .map(type -> type.getTag(this, GTMaterials.NULL))
                 .filter(Objects::nonNull)
-                .toArray(TagKey[]::new);
+                .toList();
     }
 
-    @SuppressWarnings("unchecked")
-    public TagKey<Item>[] getAllItemTags(@NotNull Material mat) {
-        return tags.stream().map(type -> type.getTag(this, mat)).filter(Objects::nonNull).toArray(TagKey[]::new);
+    public @UnmodifiableView List<TagKey<Item>> getItemTags(@NotNull Material mat) {
+        return tags.stream()
+                .filter(type -> !type.isParentTag())
+                .map(type -> type.getTag(this, mat))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
-    @SuppressWarnings("unchecked")
-    public TagKey<Block>[] getBlockTags(@NotNull Material mat) {
-        return tags.stream().filter(type -> !type.isParentTag()).map(type -> type.getTag(this, mat))
-                .map(itemTagKey -> TagKey.create(Registries.BLOCK, itemTagKey.location())).toArray(TagKey[]::new);
+    public @UnmodifiableView List<TagKey<Item>> getAllItemTags(@NotNull Material mat) {
+        return tags.stream()
+                .map(type -> type.getTag(this, mat))
+                .filter(Objects::nonNull)
+                .toList();
     }
 
-    @SuppressWarnings("unchecked")
-    public TagKey<Block>[] getAllBlockTags(@NotNull Material mat) {
+    public @UnmodifiableView List<TagKey<Block>> getBlockTags(@NotNull Material mat) {
+        return tags.stream()
+                .filter(type -> !type.isParentTag())
+                .map(type -> type.getTag(this, mat))
+                .filter(Objects::nonNull)
+                .map(itemTagKey -> TagKey.create(Registries.BLOCK, itemTagKey.location()))
+                .toList();
+    }
+
+    public @UnmodifiableView List<TagKey<Block>> getAllBlockTags(@NotNull Material mat) {
         return tags.stream().map(type -> type.getTag(this, mat))
-                .map(itemTagKey -> TagKey.create(Registries.BLOCK, itemTagKey.location())).toArray(TagKey[]::new);
+                .filter(Objects::nonNull)
+                .map(itemTagKey -> TagKey.create(Registries.BLOCK, itemTagKey.location()))
+                .toList();
     }
 
     public boolean hasItemTable() {
         return itemTable != null;
     }
 
-    @SuppressWarnings("unchecked")
-    public Supplier<ItemLike> getItemFromTable(Material material) {
-        return (Supplier<ItemLike>) itemTable.get().get(this, material);
+    public Supplier<? extends ItemLike> getItemFromTable(Material material) {
+        return itemTable.get().get(this, material);
     }
 
     public boolean doGenerateItem() {
@@ -1267,41 +1277,51 @@ public class TagPrefix {
 
     @SafeVarargs
     public final void setIgnored(Material material, Supplier<? extends ItemLike>... items) {
+        setIgnored(material, Arrays.asList(items));
+    }
+
+    public final void setIgnored(Material material, Collection<Supplier<? extends ItemLike>> items) {
         ignoredMaterials.put(material, items);
-        if (items.length > 0) {
-            ItemMaterialData.registerMaterialEntries(Arrays.asList(items), this, material);
+        if (!items.isEmpty()) {
+            ItemMaterialData.registerMaterialEntries(items, this, material);
         }
     }
 
-    @SuppressWarnings("unchecked")
     public void setIgnored(Material material, ItemLike... items) {
         // go through setIgnoredBlock to wrap if this is a block prefix
+        Collection<Supplier<? extends ItemLike>> collection = new ArrayList<>(items.length);
         if (this.doGenerateBlock()) {
-            this.setIgnoredBlock(material,
-                    Arrays.stream(items).filter(Block.class::isInstance).map(Block.class::cast).toArray(Block[]::new));
+            for (var item : items) {
+                if (item instanceof Block b) {
+                    collection.add(GTMemoizer.memoizeBlockSupplier(() -> b));
+                }
+            }
         } else {
-            this.setIgnored(material,
-                    Arrays.stream(items).map(item -> (Supplier<ItemLike>) () -> item).toArray(Supplier[]::new));
+            for (var item : items) {
+                collection.add(() -> item);
+            }
         }
+        setIgnored(material, collection);
     }
 
-    @SuppressWarnings("unchecked")
-    public void setIgnoredBlock(Material material, Block... items) {
-        this.setIgnored(material, Arrays.stream(items).map(block -> GTMemoizer.memoizeBlockSupplier(() -> block))
-                .toArray(Supplier[]::new));
+    public void setIgnoredBlock(Material material, Block... blocks) {
+        Collection<Supplier<? extends ItemLike>> collection = new ArrayList<>(blocks.length);
+        for (var block : blocks) {
+            collection.add(GTMemoizer.memoizeBlockSupplier(() -> block));
+        }
+        setIgnored(material, collection);
     }
 
-    @SuppressWarnings("unchecked")
     public void setIgnored(Material material) {
-        this.ignoredMaterials.put(material, new Supplier[0]);
+        this.ignoredMaterials.put(material, List.of());
     }
 
     public void removeIgnored(Material material) {
         ignoredMaterials.remove(material);
     }
 
-    public Map<Material, Supplier<? extends ItemLike>[]> getIgnored() {
-        return new HashMap<>(ignoredMaterials);
+    public @UnmodifiableView Map<Material, @Unmodifiable Collection<Supplier<? extends ItemLike>>> getIgnored() {
+        return Map.copyOf(ignoredMaterials);
     }
 
     public boolean isAmountModified(Material material) {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -58,7 +58,6 @@ import lombok.experimental.Accessors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
-import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.*;
 import java.util.function.*;
@@ -1175,7 +1174,7 @@ public class TagPrefix {
         return PREFIXES.getOrDefault(prefixName, replacement);
     }
 
-    public @UnmodifiableView List<TagKey<Item>> getItemParentTags() {
+    public @Unmodifiable List<TagKey<Item>> getItemParentTags() {
         return tags.stream()
                 .filter(TagType::isParentTag)
                 .map(type -> type.getTag(this, GTMaterials.NULL))
@@ -1183,7 +1182,7 @@ public class TagPrefix {
                 .toList();
     }
 
-    public @UnmodifiableView List<TagKey<Item>> getItemTags(@NotNull Material mat) {
+    public @Unmodifiable List<TagKey<Item>> getItemTags(@NotNull Material mat) {
         return tags.stream()
                 .filter(type -> !type.isParentTag())
                 .map(type -> type.getTag(this, mat))
@@ -1191,14 +1190,14 @@ public class TagPrefix {
                 .toList();
     }
 
-    public @UnmodifiableView List<TagKey<Item>> getAllItemTags(@NotNull Material mat) {
+    public @Unmodifiable List<TagKey<Item>> getAllItemTags(@NotNull Material mat) {
         return tags.stream()
                 .map(type -> type.getTag(this, mat))
                 .filter(Objects::nonNull)
                 .toList();
     }
 
-    public @UnmodifiableView List<TagKey<Block>> getBlockTags(@NotNull Material mat) {
+    public @Unmodifiable List<TagKey<Block>> getBlockTags(@NotNull Material mat) {
         return tags.stream()
                 .filter(type -> !type.isParentTag())
                 .map(type -> type.getTag(this, mat))
@@ -1207,7 +1206,7 @@ public class TagPrefix {
                 .toList();
     }
 
-    public @UnmodifiableView List<TagKey<Block>> getAllBlockTags(@NotNull Material mat) {
+    public @Unmodifiable List<TagKey<Block>> getAllBlockTags(@NotNull Material mat) {
         return tags.stream().map(type -> type.getTag(this, mat))
                 .filter(Objects::nonNull)
                 .map(itemTagKey -> TagKey.create(Registries.BLOCK, itemTagKey.location()))
@@ -1320,7 +1319,7 @@ public class TagPrefix {
         ignoredMaterials.remove(material);
     }
 
-    public @UnmodifiableView Map<Material, @Unmodifiable Collection<Supplier<? extends ItemLike>>> getIgnored() {
+    public @Unmodifiable Map<Material, @Unmodifiable Collection<Supplier<? extends ItemLike>>> getIgnored() {
         return Map.copyOf(ignoredMaterials);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/IntersectionMapIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/ingredient/item/IntersectionMapIngredient.java
@@ -48,8 +48,8 @@ public class IntersectionMapIngredient extends AbstractMapIngredient {
 
         if (!entry.isEmpty() && TagPrefix.ORES.containsKey(entry.tagPrefix())) {
             List<AbstractMapIngredient> children = new ArrayList<>();
-            children.add(new ItemTagMapIngredient(entry.tagPrefix().getItemTags(entry.material())[0]));
-            children.add(new ItemTagMapIngredient(entry.tagPrefix().getItemParentTags()[0]));
+            children.add(new ItemTagMapIngredient(entry.tagPrefix().getItemTags(entry.material()).get(0)));
+            children.add(new ItemTagMapIngredient(entry.tagPrefix().getItemParentTags().get(0)));
 
             return Collections.singletonList(new IntersectionMapIngredient(children));
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/VanillaRecipeHelper.java
@@ -327,8 +327,9 @@ public class VanillaRecipeHelper {
                 } else if (content instanceof TagKey<?> key) {
                     builder.define(sign, (TagKey<Item>) key);
                 } else if (content instanceof TagPrefix prefix) {
-                    if (prefix.getItemParentTags().length > 0) {
-                        builder.define(sign, prefix.getItemParentTags()[0]);
+                    var parentTags = prefix.getItemParentTags();
+                    if (!parentTags.isEmpty()) {
+                        builder.define(sign, parentTags.get(0));
                     }
                 } else if (content instanceof ItemLike itemLike) {
                     builder.define(sign, itemLike);
@@ -491,8 +492,9 @@ public class VanillaRecipeHelper {
                 } else if (content instanceof TagKey<?> key) {
                     builder.define(sign, (TagKey<Item>) key);
                 } else if (content instanceof TagPrefix prefix) {
-                    if (prefix.getItemParentTags().length > 0) {
-                        builder.define(sign, prefix.getItemParentTags()[0]);
+                    var parentTags = prefix.getItemParentTags();
+                    if (!parentTags.isEmpty()) {
+                        builder.define(sign, parentTags.get(0));
                     }
                 } else if (content instanceof ItemLike itemLike) {
                     builder.define(sign, itemLike);


### PR DESCRIPTION
## What
Removes uncheck casts in TagPrefix. As a side effect, removes things being arrays when they did not need to be.

Also adds a few `filter(Objects::nonNull)` calls to some of the streams which would otherwise crash.

## Implementation Details
Some of the streams interpreted `?` as a locally captured wildcard instead of a general wildcard, so they had to be turned into for loops.

## Outcome
Less suppressed warnings. More straightforward code which doesn't turn things into arrays only to turn the arrays into lists right after.

## How Was This Tested
Only checked compilation and tests passing.

## Potential Compatibility Issues
Changes some API to use `Collection<T>` instead of `T[]`, though I don't know how widely it is used.
