### PR TITLE
Use Functions for Item Bus Inventories

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -602,7 +602,7 @@ public class GTMachines {
     // ********** Part **********//
     //////////////////////////////////////
     public static final MachineDefinition[] ITEM_IMPORT_BUS = registerTieredMachines("input_bus",
-            (holder, tier) -> new ItemBusPartMachine(holder, tier, IN),
+            (holder, tier) -> ItemBusPartMachine.create(holder, tier, IN),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " Input Bus")
                     .rotationState(RotationState.ALL)
@@ -611,13 +611,13 @@ public class GTMachines {
                     .colorOverlayTieredHullModel(OVERLAY_ITEM_HATCH_INPUT, "overlay_pipe", "overlay_pipe_in_emissive")
                     .tooltips(Component.translatable("gtceu.machine.item_bus.import.tooltip"),
                             Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
-                                    (1 + Math.min(9, tier)) * (1 + Math.min(9, tier))))
+                                    ItemBusPartMachine.getInventorySize(tier)))
                     .allowCoverOnFront(true)
                     .register(),
             ALL_TIERS);
 
     public static final MachineDefinition[] ITEM_EXPORT_BUS = registerTieredMachines("output_bus",
-            (holder, tier) -> new ItemBusPartMachine(holder, tier, OUT),
+            (holder, tier) -> ItemBusPartMachine.create(holder, tier, OUT),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " Output Bus")
                     .rotationState(RotationState.ALL)
@@ -626,7 +626,7 @@ public class GTMachines {
                     .colorOverlayTieredHullModel(OVERLAY_ITEM_HATCH_OUTPUT, "overlay_pipe", "overlay_pipe_out_emissive")
                     .tooltips(Component.translatable("gtceu.machine.item_bus.export.tooltip"),
                             Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
-                                    (1 + Math.min(9, tier)) * (1 + Math.min(9, tier))))
+                                    ItemBusPartMachine.getInventorySize(tier)))
                     .allowCoverOnFront(true)
                     .register(),
             ALL_TIERS);
@@ -830,7 +830,7 @@ public class GTMachines {
             ELECTRIC_TIERS);
 
     public static final MachineDefinition STEAM_IMPORT_BUS = REGISTRATE
-            .machine("steam_input_bus", holder -> new SteamItemBusPartMachine(holder, IN))
+            .machine("steam_input_bus", holder -> SteamItemBusPartMachine.create(holder, IN))
             .rotationState(RotationState.ALL)
             .abilities(PartAbility.STEAM_IMPORT_ITEMS)
             .modelProperty(IS_FORMED, false)
@@ -838,12 +838,13 @@ public class GTMachines {
             .langValue("Steam Input Bus")
             .tooltips(Component.translatable("gtceu.machine.item_bus.import.tooltip"),
                     Component.translatable("gtceu.machine.steam_bus.tooltip"),
-                    Component.translatable("gtceu.universal.tooltip.item_storage_capacity", 4))
+                    Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
+                            ItemBusPartMachine.getInventorySize(LV)))
             .allowCoverOnFront(true)
             .register();
 
     public static final MachineDefinition STEAM_EXPORT_BUS = REGISTRATE
-            .machine("steam_output_bus", holder -> new SteamItemBusPartMachine(holder, OUT))
+            .machine("steam_output_bus", holder -> SteamItemBusPartMachine.create(holder, OUT))
             .rotationState(RotationState.ALL)
             .abilities(PartAbility.STEAM_EXPORT_ITEMS)
             .modelProperty(IS_FORMED, false)
@@ -851,7 +852,8 @@ public class GTMachines {
             .langValue("Steam Output Bus")
             .tooltips(Component.translatable("gtceu.machine.item_bus.export.tooltip"),
                     Component.translatable("gtceu.machine.steam_bus.tooltip"),
-                    Component.translatable("gtceu.universal.tooltip.item_storage_capacity", 4))
+                    Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
+                            ItemBusPartMachine.getInventorySize(LV)))
             .allowCoverOnFront(true)
             .register();
 
@@ -932,7 +934,7 @@ public class GTMachines {
             .register();
 
     public static final MachineDefinition[] ITEM_PASSTHROUGH_HATCH = registerTieredMachines("item_passthrough_hatch",
-            (holder, tier) -> new ItemBusPartMachine(holder, tier, IO.BOTH),
+            (holder, tier) -> ItemBusPartMachine.create(holder, tier, IO.BOTH),
             (tier, builder) -> builder
                     .langValue("%s Item Passthrough Hatch".formatted(VNF[tier]))
                     .rotationState(RotationState.ALL)
@@ -941,7 +943,7 @@ public class GTMachines {
                     .overlayTieredHullModel("item_passthrough_hatch")
                     .tooltips(
                             Component.translatable("gtceu.universal.tooltip.item_storage_capacity",
-                                    (1 + Math.min(9, tier)) * (1 + Math.min(9, tier))),
+                                    ItemBusPartMachine.getInventorySize(tier)),
                             Component.translatable("gtceu.part_sharing.enabled"))
                     .register(),
             ELECTRIC_TIERS);
@@ -978,7 +980,7 @@ public class GTMachines {
 
     public static final MachineDefinition[] DUAL_IMPORT_HATCH = registerTieredMachines(
             "dual_input_hatch",
-            (holder, tier) -> new DualHatchPartMachine(holder, tier, IN),
+            (holder, tier) -> DualHatchPartMachine.create(holder, tier, IN),
             (tier, builder) -> builder
                     .langValue("%s Dual Input Hatch".formatted(VNF[tier]))
                     .rotationState(RotationState.ALL)
@@ -1001,7 +1003,7 @@ public class GTMachines {
 
     public static final MachineDefinition[] DUAL_EXPORT_HATCH = registerTieredMachines(
             "dual_output_hatch",
-            (holder, tier) -> new DualHatchPartMachine(holder, tier, OUT),
+            (holder, tier) -> DualHatchPartMachine.create(holder, tier, OUT),
             (tier, builder) -> builder
                     .langValue("%s Dual Output Hatch".formatted(VNF[tier]))
                     .rotationState(RotationState.ALL)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTAEMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTAEMachines.java
@@ -16,7 +16,7 @@ import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
 public class GTAEMachines {
 
     public final static MachineDefinition ITEM_IMPORT_BUS_ME = REGISTRATE
-            .machine("me_input_bus", MEInputBusPartMachine::new)
+            .machine("me_input_bus", MEInputBusPartMachine::create)
             .langValue("ME Input Bus")
             .tier(EV)
             .rotationState(RotationState.ALL)
@@ -30,7 +30,7 @@ public class GTAEMachines {
             .register();
 
     public final static MachineDefinition STOCKING_IMPORT_BUS_ME = REGISTRATE
-            .machine("me_stocking_input_bus", MEStockingBusPartMachine::new)
+            .machine("me_stocking_input_bus", MEStockingBusPartMachine::create)
             .langValue("ME Stocking Input Bus")
             .tier(LuV)
             .rotationState(RotationState.ALL)
@@ -46,7 +46,7 @@ public class GTAEMachines {
             .register();
 
     public final static MachineDefinition ITEM_EXPORT_BUS_ME = REGISTRATE
-            .machine("me_output_bus", MEOutputBusPartMachine::new)
+            .machine("me_output_bus", MEOutputBusPartMachine::create)
             .langValue("ME Output Bus")
             .tier(EV)
             .rotationState(RotationState.ALL)
@@ -103,7 +103,7 @@ public class GTAEMachines {
                     Component.translatable("gtceu.part_sharing.enabled"))
             .register();
     public static final MachineDefinition ME_PATTERN_BUFFER = REGISTRATE
-            .machine("me_pattern_buffer", MEPatternBufferPartMachine::new)
+            .machine("me_pattern_buffer", MEPatternBufferPartMachine::create)
             .tier(LuV)
             .rotationState(RotationState.ALL)
             .abilities(PartAbility.IMPORT_ITEMS, PartAbility.IMPORT_FLUIDS, PartAbility.EXPORT_FLUIDS,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DualHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DualHatchPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.machine.multiblock.part;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
@@ -7,6 +8,7 @@ import com.gregtechceu.gtceu.api.gui.widget.SlotWidget;
 import com.gregtechceu.gtceu.api.gui.widget.TankWidget;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
@@ -22,6 +24,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.fluids.FluidType;
 
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -40,10 +44,20 @@ public class DualHatchPartMachine extends ItemBusPartMachine {
     private boolean hasFluidHandler;
     private boolean hasItemHandler;
 
-    public DualHatchPartMachine(BlockEntityCreationInfo info, int tier, IO io) {
-        super(info, tier, io);
-        this.tank = new NotifiableFluidTank(this, (int) Math.sqrt(getInventorySize()),
-                getTankCapacity(INITIAL_TANK_CAPACITY, getTier()), io);
+    public static DualHatchPartMachine create(BlockEntityCreationInfo info, int tier, IO io) {
+        int inventorySize = getInventorySize(tier);
+        int tanks = (int) Math.sqrt(inventorySize);
+        int tankCapacity = getTankCapacity(INITIAL_TANK_CAPACITY, tier);
+        return new DualHatchPartMachine(info, tier, io,
+                m -> new NotifiableItemStackHandler(m, inventorySize, io),
+                m -> new NotifiableFluidTank(m, tanks, tankCapacity, io));
+    }
+
+    public DualHatchPartMachine(BlockEntityCreationInfo info, int tier, IO io,
+                                Function<ItemBusPartMachine, NotifiableItemStackHandler> inventory,
+                                Function<DualHatchPartMachine, NotifiableFluidTank> tank) {
+        super(info, tier, io, inventory);
+        this.tank = tank.apply(this);
     }
 
     ////////////////////////////////
@@ -51,12 +65,12 @@ public class DualHatchPartMachine extends ItemBusPartMachine {
     ////////////////////////////////
 
     public static int getTankCapacity(int initialCapacity, int tier) {
-        return initialCapacity * (1 << (tier - 6));
+        return initialCapacity * (1 << (tier - GTValues.LuV));
     }
 
-    @Override
-    public int getInventorySize() {
-        return (int) Math.pow((getTier() - 4), 2);
+    public static int getInventorySize(int tier) {
+        int sizeRoot = tier - GTValues.EV;
+        return sizeRoot * sizeRoot;
     }
 
     @Override
@@ -154,14 +168,15 @@ public class DualHatchPartMachine extends ItemBusPartMachine {
 
     @Override
     public Widget createUIWidget() {
-        int slots = getInventorySize();
-        int tanks = (int) Math.sqrt(slots);
+        int slots = getInventory().getSlots();
+        int gridSize = (int) Math.sqrt(slots);
+        int tanks = tank.getTanks();
         var group = new WidgetGroup(0, 0, 18 * (tanks + 1) + 16, 18 * tanks + 16);
         var container = new WidgetGroup(4, 4, 18 * (tanks + 1) + 8, 18 * tanks + 8);
 
         int index = 0;
-        for (int y = 0; y < tanks; y++) {
-            for (int x = 0; x < tanks; x++) {
+        for (int y = 0; y < gridSize; y++) {
+            for (int x = 0; x < gridSize; x++) {
                 container.addWidget(new SlotWidget(
                         getInventory().storage, index++, 4 + x * 18, 4 + y * 18, true, io.support(IO.IN))
                         .setBackgroundTexture(GuiTextures.SLOT)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.machine.multiblock.part;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.blockentity.IPaintable;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
@@ -44,6 +45,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Function;
+
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -63,7 +66,7 @@ public class ItemBusPartMachine extends TieredIOPartMachine
     @Getter
     @SaveField
     @SyncToClient
-    protected boolean circuitSlotEnabled;
+    protected boolean circuitSlotEnabled = true;
     @Getter
     @SaveField
     protected final NotifiableItemStackHandler circuitInventory;
@@ -72,10 +75,16 @@ public class ItemBusPartMachine extends TieredIOPartMachine
     @SyncToClient
     private boolean isDistinct = false;
 
-    public ItemBusPartMachine(BlockEntityCreationInfo info, int tier, IO io) {
+    public static ItemBusPartMachine create(BlockEntityCreationInfo info, int tier, IO io) {
+        int inventorySize = getInventorySize(tier);
+        return new ItemBusPartMachine(info, tier, io,
+                (m) -> new NotifiableItemStackHandler(m, inventorySize, io));
+    }
+
+    public ItemBusPartMachine(BlockEntityCreationInfo info, int tier, IO io,
+                              Function<ItemBusPartMachine, NotifiableItemStackHandler> inventory) {
         super(info, tier, io);
-        this.inventory = createInventory();
-        this.circuitSlotEnabled = true;
+        this.inventory = inventory.apply(this);
         this.circuitInventory = createCircuitItemHandler(io).shouldSearchContent(false);
     }
 
@@ -83,13 +92,9 @@ public class ItemBusPartMachine extends TieredIOPartMachine
     // ***** Initialization ******//
     //////////////////////////////////////
 
-    protected int getInventorySize() {
-        int sizeRoot = 1 + Math.min(9, getTier());
+    public static int getInventorySize(int tier) {
+        int sizeRoot = 1 + Math.min(GTValues.UHV, tier);
         return sizeRoot * sizeRoot;
-    }
-
-    protected NotifiableItemStackHandler createInventory() {
-        return new NotifiableItemStackHandler(this, getInventorySize(), io);
     }
 
     protected NotifiableItemStackHandler createCircuitItemHandler(IO io) {
@@ -289,9 +294,10 @@ public class ItemBusPartMachine extends TieredIOPartMachine
 
     @Override
     public Widget createUIWidget() {
-        int rowSize = (int) Math.sqrt(getInventorySize());
+        int slots = inventory.getSlots();
+        int rowSize = (int) Math.sqrt(slots);
         int colSize = rowSize;
-        if (getInventorySize() == 8) {
+        if (slots == 8) {
             rowSize = 4;
             colSize = 2;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/SteamItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/SteamItemBusPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.machine.multiblock.part;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
@@ -7,6 +8,7 @@ import com.gregtechceu.gtceu.api.gui.UITemplate;
 import com.gregtechceu.gtceu.api.gui.widget.SlotWidget;
 import com.gregtechceu.gtceu.api.gui.widget.ToggleButtonWidget;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
@@ -19,19 +21,30 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.function.Function;
+
 public class SteamItemBusPartMachine extends ItemBusPartMachine {
 
     private final String autoTooltipKey;
 
-    public SteamItemBusPartMachine(BlockEntityCreationInfo info, IO io) {
-        super(info, 1, io);
-        autoTooltipKey = io == IO.IN ? "gtceu.gui.item_auto_input.tooltip" : "gtceu.gui.item_auto_output.tooltip";
+    public static SteamItemBusPartMachine create(BlockEntityCreationInfo info, IO io) {
+        int tier = GTValues.LV;
+        int inventorySize = ItemBusPartMachine.getInventorySize(tier);
+        return new SteamItemBusPartMachine(info, tier, io,
+                m -> new NotifiableItemStackHandler(m, inventorySize, io));
+    }
+
+    public SteamItemBusPartMachine(BlockEntityCreationInfo info, int tier, IO io,
+                                   Function<ItemBusPartMachine, NotifiableItemStackHandler> inventory) {
+        super(info, tier, io, inventory);
+        this.autoTooltipKey = io == IO.IN ? "gtceu.gui.item_auto_input.tooltip" : "gtceu.gui.item_auto_output.tooltip";
     }
 
     @NotNull
     @Override
     public ModularUI createUI(@NotNull Player entityPlayer) {
-        int rowSize = (int) Math.sqrt(getInventorySize());
+        int slots = getInventory().getSlots();
+        int rowSize = (int) Math.sqrt(slots);
         int xOffset = rowSize == 10 ? 9 : 0;
         var modular = new ModularUI(176 + xOffset * 2,
                 18 + 18 * rowSize + 105, this, entityPlayer)

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEBusPartMachine.java
@@ -1,8 +1,8 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
-import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
@@ -17,6 +17,7 @@ import appeng.api.networking.security.IActionSource;
 import lombok.Getter;
 
 import java.util.EnumSet;
+import java.util.function.Function;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -34,10 +35,11 @@ public abstract class MEBusPartMachine extends ItemBusPartMachine implements IGr
 
     protected final IActionSource actionSource;
 
-    public MEBusPartMachine(BlockEntityCreationInfo info, IO io) {
-        super(info, GTValues.LuV, io);
+    protected MEBusPartMachine(BlockEntityCreationInfo info, int tier, IO io,
+                               Function<ItemBusPartMachine, NotifiableItemStackHandler> inventory) {
+        super(info, tier, io, inventory);
         this.nodeHolder = createNodeHolder();
-        this.actionSource = IActionSource.ofMachine(nodeHolder.getMainNode()::getNode);
+        this.actionSource = IActionSource.ofMachine(this.nodeHolder.getMainNode()::getNode);
     }
 
     public void setOnline(boolean online) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
@@ -1,12 +1,13 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.feature.IDataStickInteractable;
 import com.gregtechceu.gtceu.api.machine.feature.IHasCircuitSlot;
 import com.gregtechceu.gtceu.api.machine.feature.IMachineLife;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
+import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.integration.ae2.gui.widget.AEItemConfigWidget;
 import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEItemList;
 import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEItemSlot;
@@ -28,6 +29,8 @@ import appeng.api.config.Actionable;
 import appeng.api.stacks.GenericStack;
 import appeng.api.storage.MEStorage;
 
+import java.util.function.Function;
+
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
@@ -35,12 +38,17 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class MEInputBusPartMachine extends MEBusPartMachine
                                    implements IDataStickInteractable, IMachineLife, IHasCircuitSlot {
 
-    protected final static int CONFIG_SIZE = 16;
-
     protected ExportOnlyAEItemList aeItemHandler;
 
-    public MEInputBusPartMachine(BlockEntityCreationInfo info) {
-        super(info, IO.IN);
+    public static MEInputBusPartMachine create(BlockEntityCreationInfo info) {
+        return new MEInputBusPartMachine(info, GTValues.EV,
+                m -> new ExportOnlyAEItemList(m, 16));
+    }
+
+    public MEInputBusPartMachine(BlockEntityCreationInfo info, int tier,
+                                 Function<ItemBusPartMachine, ExportOnlyAEItemList> inventory) {
+        super(info, tier, IO.IN, inventory::apply);
+        this.aeItemHandler = inventory.apply(this);
     }
 
     /////////////////////////////////
@@ -50,12 +58,6 @@ public class MEInputBusPartMachine extends MEBusPartMachine
     @Override
     public void onMachineRemoved() {
         flushInventory();
-    }
-
-    @Override
-    protected NotifiableItemStackHandler createInventory() {
-        this.aeItemHandler = new ExportOnlyAEItemList(this, CONFIG_SIZE);
-        return this.aeItemHandler;
     }
 
     /////////////////////////////////
@@ -171,7 +173,8 @@ public class MEInputBusPartMachine extends MEBusPartMachine
         CompoundTag tag = new CompoundTag();
         CompoundTag configStacks = new CompoundTag();
         tag.put("ConfigStacks", configStacks);
-        for (int i = 0; i < CONFIG_SIZE; i++) {
+        int slots = getInventory().getSlots();
+        for (int i = 0; i < slots; i++) {
             var slot = this.aeItemHandler.getInventory()[i];
             GenericStack config = slot.getConfig();
             if (config == null) {
@@ -189,7 +192,8 @@ public class MEInputBusPartMachine extends MEBusPartMachine
     protected void readConfigFromTag(CompoundTag tag) {
         if (tag.contains("ConfigStacks")) {
             CompoundTag configStacks = tag.getCompound("ConfigStacks");
-            for (int i = 0; i < CONFIG_SIZE; i++) {
+            int slots = getInventory().getSlots();
+            for (int i = 0; i < slots; i++) {
                 String key = Integer.toString(i);
                 if (configStacks.contains(key)) {
                     CompoundTag configTag = configStacks.getCompound(key);

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputBusPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
@@ -8,6 +9,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IMachineLife;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
+import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.integration.ae2.gui.widget.list.AEListGridWidget;
 import com.gregtechceu.gtceu.integration.ae2.utils.KeyStorage;
 
@@ -25,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -36,22 +39,24 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class MEOutputBusPartMachine extends MEBusPartMachine implements IMachineLife, IInteractedMachine {
 
     @SaveField
-    private KeyStorage internalBuffer; // Do not use KeyCounter, use our simple implementation
+    private final KeyStorage internalBuffer = new KeyStorage(); // Do not use KeyCounter, use our simple implementation
 
-    public MEOutputBusPartMachine(BlockEntityCreationInfo info) {
-        super(info, IO.OUT);
+    public static MEOutputBusPartMachine create(BlockEntityCreationInfo info) {
+        return new MEOutputBusPartMachine(info, GTValues.EV, m -> {
+            var machine = (MEOutputBusPartMachine) m;
+            return machine.new InaccessibleInfiniteHandler(m);
+        });
+    }
+
+    public MEOutputBusPartMachine(BlockEntityCreationInfo info, int tier,
+                                  Function<ItemBusPartMachine, NotifiableItemStackHandler> inventory) {
+        super(info, tier, IO.OUT, inventory);
+        internalBuffer.setOnContentsChanged(getInventory()::onContentsChanged);
     }
 
     /////////////////////////////////
     // ***** Machine LifeCycle ****//
     /////////////////////////////////
-
-    @Override
-    protected NotifiableItemStackHandler createInventory() {
-        this.internalBuffer = new KeyStorage();
-        return new InaccessibleInfiniteHandler(this);
-    }
-
     @Override
     public void onMachineRemoved() {
         var grid = getMainNode().getGrid();
@@ -106,7 +111,6 @@ public class MEOutputBusPartMachine extends MEBusPartMachine implements IMachine
 
         public InaccessibleInfiniteHandler(MetaMachine holder) {
             super(holder, 1, IO.OUT, IO.NONE, ItemStackHandlerDelegate::new);
-            internalBuffer.setOnContentsChanged(this::onContentsChanged);
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
@@ -23,6 +24,7 @@ import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.data.machines.GTAEMachines;
 import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
+import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.integration.ae2.gui.widget.AETextInputButtonWidget;
 import com.gregtechceu.gtceu.integration.ae2.gui.widget.slot.AEPatternViewSlotWidget;
 import com.gregtechceu.gtceu.integration.ae2.machine.trait.InternalSlotRecipeHandler;
@@ -75,6 +77,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -141,9 +144,16 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
     @Nullable
     protected TickableSubscription updateSubs;
 
-    public MEPatternBufferPartMachine(BlockEntityCreationInfo info) {
-        super(info, IO.IN);
-        patternInventory.setOnContentsChanged(() -> getSyncDataHolder().markClientSyncFieldDirty("patternInventory"));
+    public static MEPatternBufferPartMachine create(BlockEntityCreationInfo info) {
+        return new MEPatternBufferPartMachine(info, GTValues.LuV,
+                m -> new NotifiableItemStackHandler(m, 0, IO.IN));
+    }
+
+    public MEPatternBufferPartMachine(BlockEntityCreationInfo info, int tier,
+                                      Function<ItemBusPartMachine, NotifiableItemStackHandler> inventory) {
+        super(info, tier, IO.IN, inventory);
+        this.patternInventory
+                .setOnContentsChanged(() -> getSyncDataHolder().markClientSyncFieldDirty("patternInventory"));
         this.patternInventory.setFilter(stack -> stack.getItem() instanceof ProcessingPatternItem);
         for (int i = 0; i < this.internalInventory.length; i++) {
             this.internalInventory[i] = new InternalSlot();

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.gui.fancy.ConfiguratorPanel;
 import com.gregtechceu.gtceu.api.gui.fancy.TabsWidget;
@@ -7,10 +8,10 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.AutoStockingFancyConfigurator;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
-import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.common.item.IntCircuitBehaviour;
+import com.gregtechceu.gtceu.common.machine.multiblock.part.ItemBusPartMachine;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock.IMEStockingPart;
 import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEItemList;
@@ -41,6 +42,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Comparator;
 import java.util.PriorityQueue;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -64,11 +66,18 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
     private int ticksPerCycle = 40;
 
     @Setter
-    private Predicate<GenericStack> autoPullTest;
+    private Predicate<GenericStack> autoPullTest = $ -> false;
 
-    public MEStockingBusPartMachine(BlockEntityCreationInfo info) {
-        super(info);
-        this.autoPullTest = $ -> false;
+    public static MEStockingBusPartMachine create(BlockEntityCreationInfo info) {
+        return new MEStockingBusPartMachine(info, GTValues.LuV, m -> {
+            var machine = (MEStockingBusPartMachine) m;
+            return machine.new ExportOnlyAEStockingItemList(m, 16);
+        });
+    }
+
+    public MEStockingBusPartMachine(BlockEntityCreationInfo info, int tier,
+                                    Function<ItemBusPartMachine, ExportOnlyAEItemList> inventory) {
+        super(info, tier, inventory);
     }
 
     /////////////////////////////////
@@ -85,12 +94,6 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
     public void removedFromController(IMultiController controller) {
         IMEStockingPart.super.removedFromController(controller);
         super.removedFromController(controller);
-    }
-
-    @Override
-    protected NotifiableItemStackHandler createInventory() {
-        this.aeItemHandler = new ExportOnlyAEStockingItemList(this, CONFIG_SIZE);
-        return this.aeItemHandler;
     }
 
     /////////////////////////////////
@@ -223,7 +226,7 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
             // Ensure that it is valid to configure with this stack
             if (autoPullTest != null && !autoPullTest.test(new GenericStack(itemKey, amount))) continue;
             if (amount >= minStackSize) {
-                if (topItems.size() < CONFIG_SIZE) {
+                if (topItems.size() < getInventory().getSlots()) {
                     topItems.offer(entry);
                 } else if (amount > topItems.peek().getLongValue()) {
                     topItems.poll();
@@ -233,9 +236,10 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
         }
 
         // Now, topItems is a PQ with CONFIG_SIZE highest amount items in the system.
+        int slots = getInventory().getSlots();
         int index;
         int itemAmount = topItems.size();
-        for (index = 0; index < CONFIG_SIZE; index++) {
+        for (index = 0; index < slots; index++) {
             if (topItems.isEmpty()) break;
             Object2LongMap.Entry<AEKey> entry = topItems.poll();
 


### PR DESCRIPTION
## What
Changes Item Buses to use a Function to supply their inventory instead of the super constructor calling a method. This prevents initialization order problems, where the `createInventory()` function would like to use instance variables defined in a subclass, but the superclass calls it before the subclass's variables are initialized.

This PR adds static factory methods to create all of the item bus classes to make registration easier, but leaves function-based constructors on all classes to keep future subclassing available as needed.

## Outcome
Allows for cleaner item bus initialization order, prevents non-obvious bugs due to the above scenario.

## How Was This Tested
I did a brief test to make sure all the buses worked as expected.
