### PR TITLE
Fix child sync objects not being saved

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/ClassSyncData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/ClassSyncData.java
@@ -80,8 +80,9 @@ public final class ClassSyncData {
 
         for (Field field : clazz.getDeclaredFields()) {
 
-            boolean hasSaveField = field.isAnnotationPresent(SaveField.class);
-            boolean hasClientSync = field.isAnnotationPresent(SyncToClient.class);
+            boolean isSyncManaged = ISyncManaged.class.isAssignableFrom(field.getType());
+            boolean hasSaveField = field.isAnnotationPresent(SaveField.class) || isSyncManaged;
+            boolean hasClientSync = field.isAnnotationPresent(SyncToClient.class) || isSyncManaged;
             if (!hasSaveField && !hasClientSync) continue;
 
             if (Modifier.isStatic(field.getModifiers()))


### PR DESCRIPTION
## What
Fixes a bug where child sync objects would be unintentionally ignored if they did not have any sync annotations