### PR TITLE
Turn groupColor field value into optional field codec

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -236,7 +236,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             CompoundTag.CODEC.optionalFieldOf("data", new CompoundTag()).forGetter(val -> val.data),
                             ExtraCodecs.NON_NEGATIVE_INT.fieldOf("duration").forGetter(val -> val.duration),
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
-                            Codec.INT.fieldOf("groupColor").forGetter(val -> val.groupColor))
+                            Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor))
                     .apply(instance, GTRecipe::new));
         }
         // spotless:on


### PR DESCRIPTION
## What
In #4273, the codec for GTRecipe was changed to include a recipeColor field. This field should have been made optional with a default value of -1, for compatability reasons.

## How Was This Tested
```
{"type":"gtceu:alloy_smelter","duration":100,"category":"gtceu:alloy_smelter","tickInputs":{"eu":[{"content":4}]},"inputs":{"item":[{"content":{"type":"gtceu:sized","count":5,"ingredient":{"item":"minecraft:acacia_planks"}}},{"content":{"type":"gtceu:circuit","configuration":15},"chance":0}]},"outputs":{"item":[{"content":{"type":"gtceu:sized","count":1,"ingredient":{"item":"minecraft:acacia_boat"}}}]}}
```
<img width="384" height="277" alt="image" src="https://github.com/user-attachments/assets/74491815-ed7a-4f5c-9b14-6790d6a8f91b" />


## Additional Information
It is worth noting that support like this for internal structures is an exception, not a rule.

