### PR TITLE
Fix wrong argument check for 'redstone set #' placeholder

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
@@ -295,7 +295,7 @@ public class GTPlaceholders {
                         throw new InvalidArgsException();
                     return MultiLineComponent.literal(ctx.level()
                             .getSignal(ctx.pos().relative(direction), direction));
-                } else if (GTStringUtils.equals(args.get(1), "set")) {
+                } else if (GTStringUtils.equals(args.get(0), "set")) {
                     int power = PlaceholderUtils.toInt(args.get(1));
                     PlaceholderUtils.checkRange("redstone power", 0, 15, power);
                     if (ctx.cover() == null) throw new NotSupportedException();


### PR DESCRIPTION
Changes argument check to allow 'redstone set' to work

## What
'redstone set #' placeholder does not work; issue is due to checking second argument for 'set' when it should be used for power in line 298 (reference line 292 for correct implementation of 'redstone get')

## How Was This Tested
This was not tested, as I do not know how to actually rebuild java projects or anything; I am just aiming to correct what seems to be a simple typo that breaks important computer monitor functionality.