### PR TITLE
Fix ore vein consistency by sorting the cache

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/WorldGeneratorUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/WorldGeneratorUtils.java
@@ -58,9 +58,11 @@ public class WorldGeneratorUtils {
         private final Map<Holder<Biome>, List<WeightedVein>> biomeVeins = new Object2ObjectOpenHashMap<>();
 
         public WorldOreVeinCache(ServerLevel level) {
-            this.worldVeins = GTRegistries.ORE_VEINS.values().stream()
-                    .filter(entry -> entry.dimensionFilter().stream()
+            this.worldVeins = GTRegistries.ORE_VEINS.entries().stream()
+                    .filter(entry -> entry.getValue().dimensionFilter().stream()
                             .anyMatch(dim -> WorldGeneratorUtils.isSameDimension(dim, level.dimension())))
+                    .sorted(Entry.comparingByKey())
+                    .map(Entry::getValue)
                     .collect(Collectors.toList());
         }
 


### PR DESCRIPTION
## What
Orevein gen changes on the same seed if you restart because of differences in vein cache order
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/4949bc58-8807-4314-9b49-780dcc11c86a" />

<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/f4f2f75e-f457-4af6-a466-96d629506cc6" />


## How Was This Tested
After
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/65411952-f28c-4c22-a11e-77b0e5225423" />
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/9d51d27d-7085-4b69-adea-c9bcd0ec0036" />
