### PR TITLE
Remove double negative in DaytimeCondition

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DaytimeCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/recipe/condition/DaytimeCondition.java
@@ -43,7 +43,7 @@ public class DaytimeCondition extends RecipeCondition<DaytimeCondition> {
     @Override
     public boolean testCondition(@NotNull GTRecipe recipe, @NotNull RecipeLogic recipeLogic) {
         Level level = recipeLogic.machine.self().getLevel();
-        return level != null && !level.isNight();
+        return level != null && level.isDay();
     }
 
     @Override


### PR DESCRIPTION
## What
That's literally it.
`Level#isNight` is just `return !this.isDay();`, so doing `!level.isNight()` is the same as doing `level.isDay()`