### PR TITLE
fix KJS builders using `volatile` instead of `transient` for hidden fields

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
@@ -24,14 +24,14 @@ import org.jetbrains.annotations.Nullable;
 public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
 
     @Setter
-    public volatile boolean hasLowPressure = true, hasHighPressure = true;
+    public transient boolean hasLowPressure = true, hasHighPressure = true;
     @Setter
-    public volatile SteamCreationFunction machine = SimpleSteamMachine::new;
+    public transient SteamCreationFunction machine = SimpleSteamMachine::new;
     @Setter
-    public volatile SteamDefinitionFunction definition = (isHP, def) -> def.tier(isHP ? 1 : 0);
+    public transient SteamDefinitionFunction definition = (isHP, def) -> def.tier(isHP ? 1 : 0);
 
-    private volatile MachineBuilder<?, ?> lowPressureBuilder = null, highPressureBuilder = null;
-    private volatile MachineDefinition hpValue = null;
+    private transient MachineBuilder<?, ?> lowPressureBuilder = null, highPressureBuilder = null;
+    private transient MachineDefinition hpValue = null;
 
     public KJSSteamMachineBuilder(ResourceLocation id) {
         super(id);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -34,21 +34,21 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
     private final MachineBuilder<?, ?>[] builders = new MachineBuilder[TIER_COUNT];
 
     @Setter
-    public volatile int[] tiers = GTMachineUtils.ELECTRIC_TIERS;
+    public transient int[] tiers = GTMachineUtils.ELECTRIC_TIERS;
     @Setter
-    public volatile TieredCreationFunction machine;
+    public transient TieredCreationFunction machine;
     @Setter
-    public volatile DefinitionFunction definition = (tier, def) -> def.tier(tier);
+    public transient DefinitionFunction definition = (tier, def) -> def.tier(tier);
     @Setter
-    public volatile Int2IntFunction tankScalingFunction = GTMachineUtils.defaultTankSizeFunction;
+    public transient Int2IntFunction tankScalingFunction = GTMachineUtils.defaultTankSizeFunction;
     @Setter
-    public volatile boolean addDefaultTooltips = true;
+    public transient boolean addDefaultTooltips = true;
     @Setter
-    public volatile boolean addDefaultModel = true;
+    public transient boolean addDefaultModel = true;
     @Setter
-    public volatile boolean isGenerator = false;
+    public transient boolean isGenerator = false;
 
-    public volatile BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI;
+    public transient BiFunction<ResourceLocation, GTRecipeType, EditableMachineUI> editableUI;
 
     public KJSTieredMachineBuilder(ResourceLocation id) {
         super(id);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -29,11 +29,11 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
     private final MultiblockMachineBuilder[] builders = new MultiblockMachineBuilder[TIER_COUNT];
 
     @Setter
-    public volatile int[] tiers = GTMachineUtils.ELECTRIC_TIERS;
+    public transient int[] tiers = GTMachineUtils.ELECTRIC_TIERS;
     @Setter
-    public volatile TieredCreationFunction machine;
+    public transient TieredCreationFunction machine;
     @Setter
-    public volatile DefinitionFunction definition = (tier, def) -> def.tier(tier);
+    public transient DefinitionFunction definition = (tier, def) -> def.tier(tier);
 
     public KJSTieredMultiblockBuilder(ResourceLocation id) {
         super(id);


### PR DESCRIPTION
## What
Old typo from #2574 that's sticked around since then

## Additional Information
my IntelliJ shelf has a lot of things in it, I guess.