### PR TITLE
Fix IllegalStateException when opening a machine GUI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/mui/GTMuiWidgets.java
@@ -265,13 +265,10 @@ public class GTMuiWidgets {
         IntSyncValue circuitSyncValue = createCircuitSlotSyncValue(
                 i -> machine.getCircuitInventory().setStackInSlot(0, i),
                 () -> machine.getCircuitInventory().getStackInSlot(0));
-        ModularPanel circuitPanel = createCircuitSlotPanel(
-                circuitSyncValue,
-                syncManager)
-                .relative(parentPanel)
-                .leftRelOffset(0.0f, -180);
         IPanelHandler circuitPanelHandler = syncManager.syncedPanel("circuit_panel", true,
-                (sm, sh) -> circuitPanel);
+                (sm, sh) -> createCircuitSlotPanel(circuitSyncValue, sm)
+                        .relative(parentPanel)
+                        .leftRel(0.0f, -4, 1f));
 
         return new ButtonWidget<>()
                 .size(18)


### PR DESCRIPTION
## What
This happened because the circuit dialog was created outside the panel creation funcion with a .relative() setter which immediatly attached the panel to the main panel. But since the circuit panel is not open, it fails on resize.

Also replaced the fixed offset in the x pos with a relative value.