### PR TITLE
PipeBlock neighbor change logic fix

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -271,6 +271,7 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
                     pipeTile.setConnection(facing, false, false);
                 updateActiveNodeStatus(level, pos, pipeTile);
             }
+            pipeTile.getCoverContainer().onNeighborChanged(block, fromPos, isMoving);
         }
     }
 


### PR DESCRIPTION
## Description
This would fix the issue with machine controller covers not updating shutters/pumps installed on a pipe on receiving a redstone signal, which was mentioned in #2752 and ThePansmith/Monifactory#1424 (which is where I discovered the bug).

## Implementation Details
`PipeBlock`s did not properly propagate vanilla `neighborChanged` events to covers, unlike `MetaMachineBlock`s. This change would make pipe blocks call their attached covers' update functions as well.

## Outcome
Fixes: #2752

## Testing
Tested in single player on the development build.

## Potential Compatibility Issues
When placed on a pipe, the machine controller cover's `controllerMode` doesn't seem to save on world exit, similar to #3615. This problem appears before applying the patch and seems unrelated.