### PR TITLE
Clear categoryMap on reload to reload EMI correctly

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -333,6 +333,12 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
         return db;
     }
 
+    @ApiStatus.Internal
+    public void beginStagingRecipes() {
+        categoryMap.clear();
+        additionHandler.beginStaging();
+    }
+
     public interface ICustomRecipeLogic {
 
         /**

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/RecipeManagerMixin.java
@@ -40,7 +40,7 @@ public abstract class RecipeManagerMixin {
             if (!(recipeType instanceof GTRecipeType gtRecipeType)) {
                 continue;
             }
-            gtRecipeType.getAdditionHandler().beginStaging();
+            gtRecipeType.beginStagingRecipes();
             gtRecipeType.getProxyRecipes().forEach((type, list) -> {
                 var recipesByID = recipes.get(type);
                 if (recipesByID == null) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -515,7 +515,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
             if (!(recipeType instanceof GTRecipeType gtRecipeType)) {
                 continue;
             }
-            gtRecipeType.getAdditionHandler().beginStaging();
+            gtRecipeType.beginStagingRecipes();
             gtRecipeType.getProxyRecipes().forEach((type, list) -> {
                 RecipeManagerHandler.addProxyRecipesToLookup(recipesByName, gtRecipeType, type, list);
             });


### PR DESCRIPTION
## What
Adds a categoryMap.clear() in the /reload flow to clear the categoryMap, which is necessary for EMI to refresh properly. EMI reads its data from categoryMap
Fixes #4682

## Implementation Details
I need a context in which categoryMap is accessible, so I added a beginStagingRecipes method to GTRecipeType which then calls additionHandler.beginStaging in the body, instead of calling the additionHandler directly from the KubeJSPlugin or the mixin.

## Outcome
/reload correctly populates EMI now

## How Was This Tested
Fresh instance with GT 7.5.2, EMI, and KubeJS, single kubejs script with a simple recipe.

## Additional Information
Bug was introduced in #3981 by the deletion of GTRecipeLookup, which still called this.recipeType.getCategoryMap().clear();
The new RecipeDB system never deleted categoryMap.