### PR TITLE
1.20 Xaero's series fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,6 +58,7 @@ dependencies {
 
     // Maps
     modCompileOnly(forge.ftbchunks)
+    modCompileOnly(forge.xaeroslib)
     modCompileOnly(forge.xaerosminimap)
     modCompileOnly(forge.xaerosworldmap)
     modCompileOnly(forge.journeymap.api)

--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -38,8 +38,6 @@ modernfix = "DdUByV9S" # 5.24.1+mc1.20.1
 worldStripper = "4578579"
 javd = "4803995"
 trenzalore = "4848244"
-xaerosWorldMap = "5658224"
-xaerosMinimap = "5773012"
 journeyMap = "5789363"
 resourcefullib = "5659871"
 argonauts = "5263580"
@@ -91,9 +89,9 @@ jade                = { module = "maven.modrinth:jade", version.ref = "jade" }
 embeddium           = { module = "maven.modrinth:embeddium", version.ref = "embeddium" }
 oculus              = { module = "maven.modrinth:oculus", version.ref = "oculus" }
 modernfix           = { module = "maven.modrinth:modernfix", version.ref = "modernfix" }
-xaeroslib           = { module = "xaero.lib:xaerolib-neoforge-1.21.1", version.ref = "xaerosLib" }
-xaerosworldmap      = { module = "xaero.map:xaeroworldmap-neoforge-1.21.1", version.ref = "xaerosWorldMap" }
-xaerosminimap       = { module = "xaero.minimap:xaerominimap-neoforge-1.21.1", version.ref = "xaerosMinimap" }
+xaeroslib           = { module = "xaero.lib:xaerolib-forge-1.20.1", version.ref = "xaerosLib" }
+xaerosworldmap      = { module = "xaero.map:xaeroworldmap-forge-1.20.1", version.ref = "xaerosWorldMap" }
+xaerosminimap       = { module = "xaero.minimap:xaerominimap-forge-1.20.1", version.ref = "xaerosMinimap" }
 
 
 cc-tweaked-core-api   = { module = "cc.tweaked:cc-tweaked-1.20.1-core-api", version.ref = "ccTweaked" }
@@ -103,9 +101,6 @@ cc-tweaked-forge-impl = { module = "cc.tweaked:cc-tweaked-1.20.1-forge", version
 worldstripper       = { module = "curse.maven:worldStripper-250603", version.ref = "worldStripper" }
 javd                = { module = "curse.maven:javd-370890", version.ref = "javd" }
 trenzalore          = { module = "curse.maven:trenzalore-870210", version.ref = "trenzalore" }
-xaeroslib           = { module = "xaero.lib:xaerolib-neoforge-1.21.1", version.ref = "xaerosLib" }
-xaerosworldmap      = { module = "xaero.map:xaeroworldmap-neoforge-1.21.1", version.ref = "xaerosWorldMap" }
-xaerosminimap       = { module = "xaero.minimap:xaerominimap-neoforge-1.21.1", version.ref = "xaerosMinimap" }
 journeymap-forge    = { module = "curse.maven:journeymap-32274", version.ref = "journeyMap" }
 resourcefullib      = { module = "curse.maven:resourceful-lib-570073", version.ref = "resourcefullib" }
 argonauts           = { module = "curse.maven:argonauts-845833", version.ref = "argonauts" }

--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -24,6 +24,9 @@ ccTweaked = "1.114.3"
 create = "6.0.6-150"
 ponder = "1.0.80"
 flywheel = "1.0.4"
+xaerosLib = "1.1.0"
+xaerosWorldMap = "1.40.11"
+xaerosMinimap = "25.3.10"
 
 ## modrinth maven ##
 jade = "11.6.3"
@@ -88,6 +91,9 @@ jade                = { module = "maven.modrinth:jade", version.ref = "jade" }
 embeddium           = { module = "maven.modrinth:embeddium", version.ref = "embeddium" }
 oculus              = { module = "maven.modrinth:oculus", version.ref = "oculus" }
 modernfix           = { module = "maven.modrinth:modernfix", version.ref = "modernfix" }
+xaeroslib           = { module = "xaero.lib:xaerolib-neoforge-1.21.1", version.ref = "xaerosLib" }
+xaerosworldmap      = { module = "xaero.map:xaeroworldmap-neoforge-1.21.1", version.ref = "xaerosWorldMap" }
+xaerosminimap       = { module = "xaero.minimap:xaerominimap-neoforge-1.21.1", version.ref = "xaerosMinimap" }
 
 
 cc-tweaked-core-api   = { module = "cc.tweaked:cc-tweaked-1.20.1-core-api", version.ref = "ccTweaked" }

--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -97,8 +97,9 @@ cc-tweaked-forge-impl = { module = "cc.tweaked:cc-tweaked-1.20.1-forge", version
 worldstripper       = { module = "curse.maven:worldStripper-250603", version.ref = "worldStripper" }
 javd                = { module = "curse.maven:javd-370890", version.ref = "javd" }
 trenzalore          = { module = "curse.maven:trenzalore-870210", version.ref = "trenzalore" }
-xaerosworldmap      = { module = "curse.maven:xaeros-world-map-317780", version.ref = "xaerosWorldMap" }
-xaerosminimap       = { module = "curse.maven:xaeros-minimap-263420", version.ref = "xaerosMinimap" }
+xaeroslib           = { module = "xaero.lib:xaerolib-neoforge-1.21.1", version.ref = "xaerosLib" }
+xaerosworldmap      = { module = "xaero.map:xaeroworldmap-neoforge-1.21.1", version.ref = "xaerosWorldMap" }
+xaerosminimap       = { module = "xaero.minimap:xaerominimap-neoforge-1.21.1", version.ref = "xaerosMinimap" }
 journeymap-forge    = { module = "curse.maven:journeymap-32274", version.ref = "journeyMap" }
 resourcefullib      = { module = "curse.maven:resourceful-lib-570073", version.ref = "resourcefullib" }
 argonauts           = { module = "curse.maven:argonauts-845833", version.ref = "argonauts" }

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -80,4 +80,12 @@ repositories {
         forRepository { maven { url = "https://maven.squiddev.cc" } }
         filter { includeGroup("cc.tweaked") }
     }
+    exclusiveContent { // This one lib that KJS 1.21 uses for whatever reason?
+        forRepository { maven { url = "https://jitpack.io/" } }
+        filter { includeGroup("com.github.rtyley") }
+    }
+    exclusiveContent {
+        forRepository { maven { url = "https://chocolateminecraft.com/maven/" } }
+        filter { includeGroupByRegex("xaero\\..+") }
+    }
 }

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -84,8 +84,8 @@ repositories {
         forRepository { maven { url = "https://jitpack.io/" } }
         filter { includeGroup("com.github.rtyley") }
     }
-    exclusiveContent {
+    exclusiveContent { // Xaero's
         forRepository { maven { url = "https://chocolateminecraft.com/maven/" } }
-        filter { includeGroupByRegex("xaero\\..+") }
+        filter { includeGroupAndSubgroups("xaero") }
     }
 }

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -80,10 +80,6 @@ repositories {
         forRepository { maven { url = "https://maven.squiddev.cc" } }
         filter { includeGroup("cc.tweaked") }
     }
-    exclusiveContent { // This one lib that KJS 1.21 uses for whatever reason?
-        forRepository { maven { url = "https://jitpack.io/" } }
-        filter { includeGroup("com.github.rtyley") }
-    }
     exclusiveContent { // Xaero's
         forRepository { maven { url = "https://chocolateminecraft.com/maven/" } }
         filter { includeGroupAndSubgroups("xaero") }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/xaerominimap/MinimapFBORendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/xaerominimap/MinimapFBORendererMixin.java
@@ -11,14 +11,14 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import xaero.common.IXaeroMinimap;
+import xaero.common.HudMod;
 import xaero.common.minimap.MinimapProcessor;
 import xaero.common.minimap.render.MinimapFBORenderer;
 import xaero.common.minimap.render.MinimapRenderer;
 import xaero.hud.minimap.Minimap;
 import xaero.hud.minimap.compass.render.CompassRenderer;
 import xaero.hud.minimap.element.render.map.MinimapElementMapRendererHandler;
-import xaero.hud.minimap.waypoint.render.WaypointsGuiRenderer;
+import xaero.hud.minimap.waypoint.render.WaypointMapRenderer;
 
 // TODO move to xaeros api once that exists
 @Mixin(value = MinimapFBORenderer.class, remap = false)
@@ -30,9 +30,9 @@ public abstract class MinimapFBORendererMixin extends MinimapRenderer {
     @Unique
     private OreVeinElementRenderer gtceu$oreVeinElementRenderer;
 
-    public MinimapFBORendererMixin(IXaeroMinimap modMain, Minecraft mc, WaypointsGuiRenderer waypointsGuiRenderer,
+    public MinimapFBORendererMixin(HudMod modMain, Minecraft mc, WaypointMapRenderer waypointMapRenderer,
                                    Minimap minimap, CompassRenderer compassRenderer) {
-        super(modMain, mc, waypointsGuiRenderer, minimap, compassRenderer);
+        super(modMain, mc, waypointMapRenderer, minimap, compassRenderer);
     }
 
     @Inject(method = "loadFrameBuffer",

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/xaeroworldmap/GuiMapMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/xaeroworldmap/GuiMapMixin.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xaero.lib.client.gui.widget.Tooltip;
 import xaero.map.MapProcessor;
 import xaero.map.gui.*;
 
@@ -118,7 +119,7 @@ public abstract class GuiMapMixin extends ScreenBase implements IRightClickableE
                         ButtonState.toggleButton(button);
                         init(minecraft, width, height);
                     },
-                    () -> new CursorBox("gtceu.button." + button.name));
+                    () -> new Tooltip("gtceu.button." + button.name));
 
             addButton(mapButton);
             offset++;

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/fluid/FluidChunkHighlighter.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/fluid/FluidChunkHighlighter.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 
 import xaero.common.minimap.highlight.ChunkHighlighter;
-import xaero.common.minimap.info.render.compile.InfoDisplayCompiler;
 
 public class FluidChunkHighlighter extends ChunkHighlighter {
 
@@ -63,7 +62,8 @@ public class FluidChunkHighlighter extends ChunkHighlighter {
     }
 
     @Override
-    public void addChunkHighlightTooltips(InfoDisplayCompiler compiler, ResourceKey<Level> dimension, int chunkX,
+    public void addChunkHighlightTooltips(xaero.hud.minimap.info.render.compile.InfoDisplayCompiler compiler,
+                                          ResourceKey<Level> dimension, int chunkX,
                                           int chunkZ, int width) {}
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/fluid/FluidChunkHighlighter.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/fluid/FluidChunkHighlighter.java
@@ -12,6 +12,7 @@ import net.minecraft.world.level.Level;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 
 import xaero.common.minimap.highlight.ChunkHighlighter;
+import xaero.hud.minimap.info.render.compile.InfoDisplayCompiler;
 
 public class FluidChunkHighlighter extends ChunkHighlighter {
 
@@ -62,7 +63,7 @@ public class FluidChunkHighlighter extends ChunkHighlighter {
     }
 
     @Override
-    public void addChunkHighlightTooltips(xaero.hud.minimap.info.render.compile.InfoDisplayCompiler compiler,
+    public void addChunkHighlightTooltips(InfoDisplayCompiler compiler,
                                           ResourceKey<Level> dimension, int chunkX,
                                           int chunkZ, int width) {}
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/ore/OreVeinElementReader.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/ore/OreVeinElementReader.java
@@ -7,6 +7,7 @@ import net.minecraft.client.Minecraft;
 
 import xaero.hud.minimap.element.render.MinimapElementReader;
 import xaero.map.WorldMap;
+import xaero.map.common.config.option.WorldMapProfiledConfigOptions;
 
 public class OreVeinElementReader extends MinimapElementReader<OreVeinElement, OreVeinElementContext> {
 
@@ -42,12 +43,16 @@ public class OreVeinElementReader extends MinimapElementReader<OreVeinElement, O
 
     @Override
     public int getInteractionBoxTop(OreVeinElement element, OreVeinElementContext context, float partialTicks) {
-        return WorldMap.settings.waypointBackgrounds ? -41 : -12;
+        boolean flag = WorldMap.INSTANCE.getConfigs().getClientConfigManager()
+                .getEffective(WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS);
+        return flag ? -41 : -12;
     }
 
     @Override
     public int getInteractionBoxBottom(OreVeinElement element, OreVeinElementContext context, float partialTicks) {
-        return WorldMap.settings.waypointBackgrounds ? 0 : 12;
+        boolean flag = WorldMap.INSTANCE.getConfigs().getClientConfigManager()
+                .getEffective(WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS);
+        return flag ? 0 : 12;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/ore/OreVeinElementRenderProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/ore/OreVeinElementRenderProvider.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.Level;
 import xaero.hud.minimap.element.render.MinimapElementRenderLocation;
 import xaero.hud.minimap.element.render.MinimapElementRenderProvider;
 import xaero.map.WorldMap;
+import xaero.map.common.config.option.WorldMapProfiledConfigOptions;
 
 import java.util.Iterator;
 
@@ -20,7 +21,8 @@ public class OreVeinElementRenderProvider extends MinimapElementRenderProvider<O
 
     @Override
     public void begin(MinimapElementRenderLocation location, OreVeinElementContext context) {
-        if (WorldMap.settings.waypoints) {
+        if (WorldMap.INSTANCE.getConfigs().getClientConfigManager().getEffective(
+                WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS)) {
             ResourceKey<Level> currentDim = Minecraft.getInstance().level.dimension();
             this.iterator = XaerosRenderer.oreElements.row(currentDim).values().iterator();
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/gui/GuiTexturedButtonWithSize.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/gui/GuiTexturedButtonWithSize.java
@@ -4,7 +4,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import xaero.map.gui.CursorBox;
+import xaero.lib.client.gui.widget.Tooltip;
 import xaero.map.gui.GuiTexturedButton;
 
 import java.util.function.Supplier;
@@ -16,7 +16,7 @@ public class GuiTexturedButtonWithSize extends GuiTexturedButton {
 
     public GuiTexturedButtonWithSize(int x, int y, int w, int h, int textureX, int textureY, int textureW, int textureH,
                                      int spriteW, int spriteH, ResourceLocation texture, OnPress onPress,
-                                     Supplier<CursorBox> tooltip) {
+                                     Supplier<Tooltip> tooltip) {
         super(x, y, w, h, textureX, textureY, textureW, textureH, texture, onPress, tooltip);
         this.spriteW = spriteW;
         this.spriteH = spriteH;

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementReader.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementReader.java
@@ -8,9 +8,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
+import xaero.lib.client.gui.widget.Tooltip;
 import xaero.map.WorldMap;
+import xaero.map.common.config.option.WorldMapProfiledConfigOptions;
 import xaero.map.element.MapElementReader;
-import xaero.map.gui.CursorBox;
 import xaero.map.gui.IRightClickableElement;
 import xaero.map.gui.dropdown.rightclick.RightClickOption;
 
@@ -58,12 +59,16 @@ public class OreVeinElementReader extends
 
     @Override
     public int getInteractionBoxTop(OreVeinElement element, OreVeinElementContext context, float partialTicks) {
-        return WorldMap.settings.waypointBackgrounds ? -41 : -12;
+        boolean flag = WorldMap.INSTANCE.getConfigs().getClientConfigManager()
+                .getEffective(WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS);
+        return flag ? -41 : -12;
     }
 
     @Override
     public int getInteractionBoxBottom(OreVeinElement element, OreVeinElementContext context, float partialTicks) {
-        return WorldMap.settings.waypointBackgrounds ? 0 : 12;
+        boolean flag = WorldMap.INSTANCE.getConfigs().getClientConfigManager()
+                .getEffective(WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS);
+        return flag ? 0 : 12;
     }
 
     @Override
@@ -146,10 +151,10 @@ public class OreVeinElementReader extends
     }
 
     @Override
-    public CursorBox getTooltip(OreVeinElement element, OreVeinElementContext context, boolean overMenu) {
+    public Tooltip getTooltip(OreVeinElement element, OreVeinElementContext context, boolean overMenu) {
         List<Component> components = OreRenderLayer.getTooltip(element.getName(), element.getVein());
         // Xaeros requires spaces before/after newlines (see xaero.map.misc.TextSplitter)
         String joined = components.stream().map(Component::getString).collect(Collectors.joining(" \n "));
-        return new CursorBox(joined);
+        return new Tooltip(joined);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
@@ -7,6 +7,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
 
 import xaero.map.WorldMap;
+import xaero.map.common.config.option.WorldMapProfiledConfigOptions;
 import xaero.map.element.MapElementRenderProvider;
 
 import java.util.Iterator;
@@ -18,13 +19,15 @@ public class OreVeinElementRenderProvider extends MapElementRenderProvider<OreVe
     public OreVeinElementRenderProvider() {}
 
     public void begin(int location, OreVeinElementContext context) {
-        if (WorldMap.settings.waypoints) {
+        if (WorldMap.INSTANCE.getConfigs().getClientConfigManager().getEffective(
+                WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS)) {
             ResourceKey<Level> currentDim = Minecraft.getInstance().level.dimension();
             this.iterator = XaerosRenderer.oreElements.row(currentDim).values()
                     .stream()
                     .map(element -> new OreVeinElement(element.getVein(), element.getName()))
                     .iterator();
-            context.worldmapWaypointsScale = WorldMap.settings.worldmapWaypointsScale;
+            context.worldmapWaypointsScale = WorldMap.INSTANCE.getConfigs().getClientConfigManager()
+                    .getEffective(WorldMapProfiledConfigOptions.WAYPOINT_SCALE).floatValue();
         } else {
             this.iterator = null;
         }


### PR DESCRIPTION
## What

Fix crashing when working with the latest Xaeros' mods.

See Also #4642 

## Implementation Details

1. Replaced CurseMaven dependencies of Xaero's to their Maven repo.
2. `CursorBox` -> `Tooltip`.
3. Configuration migration

## Outcome

Fix #4670
Fix #4445

## How Was This Tested

Tested with Xaero's WorldMap and Minimap.

## Potential Compatibility Issues

Will break the compatibility with older Xaeros' mods.
