### PR TITLE
Add #dragon_immune tag to endstone-based ores

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/MixinHelpers.java
@@ -177,6 +177,11 @@ public class MixinHelpers {
                     }
                 }
 
+                if (entry.tagPrefix() == TagPrefix.oreEndstone) {
+                    // Make endstone-based ores dragon-immune
+                    tagMap.computeIfAbsent(BlockTags.DRAGON_IMMUNE.location(), $ -> new ArrayList<>()).addAll(entries);
+                }
+
                 if (entry.tagPrefix() == TagPrefix.frameGt) {
                     tagMap.computeIfAbsent(CustomTags.SLOW_WALKABLE_BLOCKS.location(), path -> new ArrayList<>())
                             .addAll(entries);


### PR DESCRIPTION
## What

Add `#dragon_immune` tag to endstone-based ores

## Implementation Details

Add the tag to blocks with `TagPrefix.oreEndstone` dynamically.

## Outcome

Close #4676

## How Was This Tested

Tested in the end, and the dragon just can't destroy End Chromite Ores.
