### PR TITLE
Fix Ender Link Cover memory card copy/paste and required-item handling

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/AbstractEnderLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/AbstractEnderLinkCover.java
@@ -31,6 +31,7 @@ import com.lowdragmc.lowdraglib.gui.widget.*;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
@@ -239,6 +240,24 @@ public abstract class AbstractEnderLinkCover<T extends VirtualEntry> extends Cov
 
     protected int getColor() {
         return VirtualEntry.parseColor(this.colorStr);
+    }
+
+    @Override
+    public CompoundTag copyConfig(CompoundTag tag) {
+        tag.putString("colorStr", colorStr);
+        tag.putInt("permission", getPermission().ordinal());
+        tag.putInt("io", getIo().ordinal());
+        tag.putInt("manualIO", getManualIOMode().ordinal());
+        return super.copyConfig(tag);
+    }
+
+    @Override
+    public void pasteConfig(ServerPlayer player, CompoundTag tag) {
+        setChannelName(tag.getString("colorStr"));
+        setPermission(Permissions.values()[tag.getInt("permission")]);
+        setIo(IO.values()[tag.getInt("io")]);
+        setManualIOMode(ManualIOMode.values()[tag.getInt("manualIO")]);
+        super.pasteConfig(player, tag);
     }
 
     protected enum Permissions implements EnumSelectorWidget.SelectableEnum {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderFluidLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderFluidLinkCover.java
@@ -138,8 +138,7 @@ public class EnderFluidLinkCover extends AbstractEnderLinkCover<VirtualTank> {
 
     //////////////////////////////////////
     // ************ GUI ************ //
-
-    /// ///////////////////////////////////
+    //////////////////////////////////////
 
     @Override
     protected Widget addVirtualEntryWidget(VirtualEntry entry, int x, int y, int width, int height, boolean canClick) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderFluidLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderFluidLinkCover.java
@@ -19,6 +19,9 @@ import com.gregtechceu.gtceu.utils.GTTransferUtils;
 import com.lowdragmc.lowdraglib.gui.widget.*;
 
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 
@@ -27,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 
 @ParametersAreNonnullByDefault
 public class EnderFluidLinkCover extends AbstractEnderLinkCover<VirtualTank> {
@@ -108,6 +112,27 @@ public class EnderFluidLinkCover extends AbstractEnderLinkCover<VirtualTank> {
 
         }
         return 0;
+    }
+
+    @Override
+    public CompoundTag copyConfig(CompoundTag tag) {
+        tag.put("filter", filterHandler.getFilterItem().serializeNBT());
+        return super.copyConfig(tag);
+    }
+
+    @Override
+    public void pasteConfig(ServerPlayer player, CompoundTag tag) {
+        filterHandler.setFilterItem(ItemStack.of(tag.getCompound("filter")));
+        super.pasteConfig(player, tag);
+    }
+
+    @Override
+    public @NotNull List<ItemStack> getAdditionalDrops() {
+        var list = super.getAdditionalDrops();
+        if (!filterHandler.getFilterItem().isEmpty()) {
+            list.add(filterHandler.getFilterItem());
+        }
+        return list;
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderFluidLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderFluidLinkCover.java
@@ -29,8 +29,9 @@ import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class EnderFluidLinkCover extends AbstractEnderLinkCover<VirtualTank> {
@@ -137,7 +138,8 @@ public class EnderFluidLinkCover extends AbstractEnderLinkCover<VirtualTank> {
 
     //////////////////////////////////////
     // ************ GUI ************ //
-    //////////////////////////////////////
+
+    /// ///////////////////////////////////
 
     @Override
     protected Widget addVirtualEntryWidget(VirtualEntry entry, int x, int y, int width, int height, boolean canClick) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderItemLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderItemLinkCover.java
@@ -19,11 +19,16 @@ import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
 
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class EnderItemLinkCover extends AbstractEnderLinkCover<VirtualItemStorage> {
 
@@ -98,6 +103,27 @@ public class EnderItemLinkCover extends AbstractEnderLinkCover<VirtualItemStorag
 
     public @Nullable IItemHandler getOwnItemHandler() {
         return coverHolder.getItemHandlerCap(attachedSide, false);
+    }
+
+    @Override
+    public CompoundTag copyConfig(CompoundTag tag) {
+        tag.put("filter", filterHandler.getFilterItem().serializeNBT());
+        return super.copyConfig(tag);
+    }
+
+    @Override
+    public void pasteConfig(ServerPlayer player, CompoundTag tag) {
+        filterHandler.setFilterItem(ItemStack.of(tag.getCompound("filter")));
+        super.pasteConfig(player, tag);
+    }
+
+    @Override
+    public @NotNull List<ItemStack> getAdditionalDrops() {
+        var list = super.getAdditionalDrops();
+        if (!filterHandler.getFilterItem().isEmpty()) {
+            list.add(filterHandler.getFilterItem());
+        }
+        return list;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/MachineConfigCopyBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/MachineConfigCopyBehaviour.java
@@ -108,7 +108,7 @@ public class MachineConfigCopyBehaviour implements IInteractionItem, IAddInforma
             if (tag == null) return InteractionResult.FAIL;
 
             List<ItemStack> items = new ArrayList<>();
-            tag.getList("itemsToPaste", CompoundTag.TAG_COMPOUND).forEach(t -> {
+            tag.getList(ITEMS_TO_PASTE, CompoundTag.TAG_COMPOUND).forEach(t -> {
                 if (t instanceof CompoundTag c) items.add(ItemStack.of(c));
             });
 
@@ -304,9 +304,9 @@ public class MachineConfigCopyBehaviour implements IInteractionItem, IAddInforma
         if (tag.contains(CIRCUIT)) tooltip.add(Component.translatable("behaviour.setting.tooltip.circuit_config")
                 .append(Component.literal(Integer.toString(tag.getInt(CIRCUIT))).withStyle(ChatFormatting.YELLOW)));
 
-        if (tag.contains("itemsToPaste")) {
+        if (tag.contains(ITEMS_TO_PASTE)) {
             List<ItemStack> items = new ArrayList<>();
-            tag.getList("itemsToPaste", CompoundTag.TAG_COMPOUND).forEach(t -> {
+            tag.getList(ITEMS_TO_PASTE, CompoundTag.TAG_COMPOUND).forEach(t -> {
                 if (t instanceof CompoundTag c) items.add(ItemStack.of(c));
             });
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTTransferUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTTransferUtils.java
@@ -315,7 +315,7 @@ public class GTTransferUtils {
         for (var stack : items) {
             var found = ContainerHelper.clearOrCountMatchingItems(inventory, (s) -> s.is(stack.getItem()),
                     stack.getCount(), simulate);
-            if (found != stack.getCount()) return false;
+            if (found < stack.getCount()) return false;
         }
 
         if (!simulate) player.inventoryMenu.broadcastChanges();


### PR DESCRIPTION
## What
Fixed the copy/paste process for Ender Link Cover settings using the Machine Memory Card.
In addition, corrected the required item determination and consumption process during pasting to ensure that requested items are handled correctly even in non-Creative mode.

## Implementation Details
- Implemented `getAdditionalDrops` for Ender Link Cover to return internal filters as additional drops.
  - To correctly include internal filters in the required item calculation during pasting.
- Fixed required item consumption in non-Creative mode to work as expected.
  - Changed some incorrect NBT key references from literal values (`"itemsToPaste"`) to constants (`ITEMS_TO_PASTE`).
  - Corrected the possession check to properly handle cases where the possessed quantity exceeds the required quantity.

## Outcome
- Machine Memory Card can now copy/paste Ender Link Cover settings.
- Fixes: #4680

## How Was This Tested
Confirmed that it works as implemented in both v7.5.2 and v8.

Additionally, in v8, there was an issue where opening the Ender Link Cover's settings UI would cause a crash, so the direct cause of the crash was temporarily commented out for testing.
This comment-out was for verification purposes and is not included in this PR.

## Additional Information
For reference, the direct cause of the aforementioned v8 crash is as follows:

- `com.gregtechceu.gtceu.common.cover.ender.AbstractEnderLinkCover.VirtualEntryWidget#initWidgets` returns `null` from `cover.getEntry()` during execution.

