### PR TITLE
fluid regulators now check that the correct amount of fluid was moved

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
@@ -103,7 +103,7 @@ public class FluidRegulatorCover extends PumpCover {
                 continue;
 
             int insertableAmount = destination.fill(drained.copy(), FluidAction.SIMULATE);
-            if (insertableAmount <= 0)
+            if (insertableAmount != supplyAmount)
                 continue;
 
             drained.setAmount(insertableAmount);


### PR DESCRIPTION
## What
Fixes https://github.com/GregTechCEu/GregTech-Modern/issues/4692

## Implementation Details
This new check also does the same as the old check (that `insertableAmount > 0`), because `supplyAmount > 0` is checked earlier in the method

## How Was This Tested
Tested the same way as to cause the bug
Also tested with multiple fluid types being moved (by using fluid buffers instead of drums with the same setup to cause the bug), the behavior is that each fluid type is treated independently, which is intended.
