### PR TITLE
Fix CHANGELOG.md generation

### DIFF
--- a/.github/json/config-title-only-1.21.json
+++ b/.github/json/config-title-only-1.21.json
@@ -1,0 +1,45 @@
+{
+  "categories": [
+    {
+      "title": "### Added",
+      "labels": ["type: feature"]
+    },
+    {
+      "title": "### Fixed",
+      "labels": ["type: bugfix"]
+    },
+    {
+      "title": "### Changed",
+      "labels": ["type: refactor", "type: translation"]
+    }
+  ],
+  "sort": "ASC",
+  "template": "## Version [v#{{VERSION}}](#{{RELEASE_DIFF}})",
+  "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "custom_placeholders": [
+    {
+      "name": "VERSION",
+      "source": "TO_TAG",
+      "transformer": {
+        "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+        "target": "$1"
+      }
+    }
+  ],
+  "empty_template": "",
+  "ignore_labels": ["ignore changelog"],
+  "tag_resolver": {
+    "method": "semver",
+    "filter": {
+      "pattern": "^(?!v?[0-9\\.]+(-1\\.21)$).+$",
+      "flags": "gu"
+    },
+    "transformer": {
+      "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+      "target": "$1"
+    }
+  },
+  "max_pull_requests": 1000,
+  "max_back_track_time_days": 365,
+  "base_branches": ["1.21"]
+}

--- a/.github/json/config-title-only.json
+++ b/.github/json/config-title-only.json
@@ -1,0 +1,45 @@
+{
+  "categories": [
+    {
+      "title": "### Added",
+      "labels": ["type: feature"]
+    },
+    {
+      "title": "### Fixed",
+      "labels": ["type: bugfix"]
+    },
+    {
+      "title": "### Changed",
+      "labels": ["type: refactor", "type: translation"]
+    }
+  ],
+  "sort": "ASC",
+  "template": "## Version [v#{{VERSION}}](#{{RELEASE_DIFF}})",
+  "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in [##{{NUMBER}}](#{{URL}})",
+  "custom_placeholders": [
+    {
+      "name": "VERSION",
+      "source": "TO_TAG",
+      "transformer": {
+        "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+        "target": "$1"
+      }
+    }
+  ],
+  "empty_template": "",
+  "ignore_labels": ["ignore changelog"],
+  "tag_resolver": {
+    "method": "semver",
+    "filter": {
+      "pattern": "^(?!v?[0-9\\.]+(-1\\.20\\.1)?$).+$",
+      "flags": "gu"
+    },
+    "transformer": {
+      "pattern": "v?([0-9\\.]+)(-[0-9\\.]+)?",
+      "target": "$1"
+    }
+  },
+  "max_pull_requests": 1000,
+  "max_back_track_time_days": 365,
+  "base_branches": ["1.20.1"]
+}

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -26,7 +26,7 @@ jobs:
           CONFIG: ${{ contains(github.ref_name, '1.21') && '-1.21' || '' }}
         uses: mikepenz/release-changelog-builder-action@v5
         with:
-          configuration: './.github/json/config${{ env.CONFIG }}.json'
+          configuration: './.github/json/config-title-only${{ env.CONFIG }}.json'
           ignorePreReleases: true
           fetchViaCommits: true
           failOnError: true
@@ -42,7 +42,7 @@ jobs:
       branch: '1.20.1'
       tag-name: ${{ github.ref_name }}
       release-body: ${{ github.event.release.body }}
-      changelog-body: ${{ needs.meta.outputs.CHANGELOG }}
+      changelog-title: ${{ needs.meta.outputs.CHANGELOG }}
 
   publish-21:
     name: 1.21.1
@@ -55,4 +55,4 @@ jobs:
       branch: '1.21'
       tag-name: ${{ github.ref_name }}
       release-body: ${{ github.event.release.body }}
-      changelog-body: ${{ needs.meta.outputs.CHANGELOG }}
+      changelog-title: ${{ needs.meta.outputs.CHANGELOG }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,9 +145,9 @@ jobs:
           RELEASE_BODY: ${{ inputs.release-body }}
           CHANGELOG_TITLE: ${{ inputs.changelog-title }}
         run: |
-          RELEASE_BODY=$( echo -e "$RELEASE_BODY" | head -n -1 - | tail -n +1 - )
+          BODY=$( echo -e "$RELEASE_BODY" | head -n -1 - | tail -n +1 - )
           
-          { head -n 2 CHANGELOG.md; echo -e "$CHANGELOG_TITLE"; echo -e "$RELEASE_BODY"; tail -n +3 CHANGELOG.md; } > temp.md && mv temp.md CHANGELOG.md
+          { head -n 2 CHANGELOG.md; echo -e "$CHANGELOG_TITLE"; echo -e "$BODY"; tail -n +3 CHANGELOG.md; } > temp.md && mv temp.md CHANGELOG.md
           git commit -am "Updated CHANGELOG"
       - name: Push and PR
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,8 +78,8 @@ jobs:
           files: ./*.jar
           fail_on_unmatched_files: true
 
-  publish-modrinth:
-    name: Publish to Modrinth
+  publish:
+    name: Publish to CF & Modrinth
     needs: build
     if: ${{ !inputs.simulate }}
     runs-on: ubuntu-latest
@@ -98,41 +98,12 @@ jobs:
           VERSION_TYPE: ${{ inputs.branch == '1.21' && 'beta' || 'beta' }}
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
-          modrinth-id: 7tG215v7
-          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
-          files: |
-            ./gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar
-            ./!(gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)
-          name: 'GregTech CEu ${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
-          version: 'mc${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}'
-          version-type: ${{ env.VERSION_TYPE }}
-          changelog: ${{ inputs.release-body }}
-          loaders: ${{ env.LOADER }}
-          java: ${{ env.JAVA }}
-          fail-mode: fail
-
-  publish-cf:
-    name: Publish to CF
-    needs: build
-    if: ${{ !inputs.simulate }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts-${{ inputs.branch }}
-      - name: Publish Mod
-        env:
-          MC_VERSION: ${{ inputs.branch == '1.21' && '1.21.1' || '1.20.1' }}
-          LOADER: ${{ inputs.branch == '1.21' && 'neoforge' || 'forge' }}
-          JAVA: ${{ inputs.branch == '1.21' && '21' || '17' }}
-          VERSION_TYPE: ${{ inputs.branch == '1.21' && 'alpha' || 'beta' }}
-        uses: Kir-Antipov/mc-publish@v3.3.0
-        with:
           curseforge-id: 890405
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          modrinth-id: 7tG215v7
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
           files: |
             ./gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar
             ./!(gtceu-${{ env.MC_VERSION }}-${{ needs.build.outputs.ver }}.jar)
@@ -142,7 +113,7 @@ jobs:
           changelog: ${{ inputs.release-body }}
           loaders: ${{ env.LOADER }}
           java: ${{ env.JAVA }}
-          fail-mode: fail
+          fail-mode: skip
 
   # After successful release, PR version bump and changelog
   bump-version-and-changelog:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,11 +15,11 @@ on:
         required: true
         type: string
       release-body:
-        description: 'Body for published release notes'
+        description: 'Body for published release notes, also inserted into CHANGELOG.md'
         required: false
         type: string
-      changelog-body:
-        description: 'Body of change notes to insert into CHANGELOG.md'
+      changelog-title:
+        description: 'Title of change notes to insert into CHANGELOG.md'
         required: false
         type: string
 
@@ -166,9 +166,17 @@ jobs:
           sed -i "s/= ${{ needs.build.outputs.ver }}/= ${BUMPED}/" gradle.properties
           git commit -am "Bump version to ${BUMPED}"
       - name: Prepend to CHANGELOG
-        if: inputs.changelog-body
+        if: ${{ inputs.release-body && inputs.changelog-title }}
+        # Insert these into environment variables because using GitHub's input replacement with multi-line inputs will more often than not break the script, as they're inserted 'as-is'.
+        # e.g. if the input contains ` (backtick) characters, bash tries to use those backticks' contents as actual function input.
+        # Environment variables don't have that issue.
+        env:
+          RELEASE_BODY: ${{ inputs.release-body }}
+          CHANGELOG_TITLE: ${{ inputs.changelog-title }}
         run: |
-          { head -n 2 CHANGELOG.md; echo -e "${{ inputs.changelog-body }}"; tail -n +3 CHANGELOG.md; } > temp.md && mv temp.md CHANGELOG.md
+          RELEASE_BODY=$( echo -e "$RELEASE_BODY" | head -n -1 - | tail -n +1 - )
+          
+          { head -n 2 CHANGELOG.md; echo -e "$CHANGELOG_TITLE"; echo -e "$RELEASE_BODY"; tail -n +3 CHANGELOG.md; } > temp.md && mv temp.md CHANGELOG.md
           git commit -am "Updated CHANGELOG"
       - name: Push and PR
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,7 +145,7 @@ jobs:
           RELEASE_BODY: ${{ inputs.release-body }}
           CHANGELOG_TITLE: ${{ inputs.changelog-title }}
         run: |
-          BODY=$( echo -e "$RELEASE_BODY" | head -n -1 - | tail -n +1 - )
+          BODY=$( echo -e "$RELEASE_BODY" | head -n -1 - | tail -n +2 - )
           
           { head -n 2 CHANGELOG.md; echo -e "$CHANGELOG_TITLE"; echo -e "$BODY"; tail -n +3 CHANGELOG.md; } > temp.md && mv temp.md CHANGELOG.md
           git commit -am "Updated CHANGELOG"


### PR DESCRIPTION
## What
Fix CHANGELOG.md using autogenerated changelogs instead of the cleaned up ones CurseForge, Modrinth, and GitHub releases use

## Implementation Details
Made it use the changelogs from the GitHub release and only generate the header part

## Outcome
better changelogs in CHANGELOG.md that are also consistent with changelogs everywhere else

## How Was This Tested
on my fork

## Additional Information
I merged the `publish-modrinth` and `publish-cf` jobs in release.yml and made them use `fail-mode: skip` instead of `fail-mode: fail` so the other still runs even if one fails.
Tell me if this should be reverted.