### PR TITLE
[MUI2] Central Monitor fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/IMonitorModuleItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/IMonitorModuleItem.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.api.item.component;
 import com.gregtechceu.gtceu.api.mui.base.IPanelHandler;
 import com.gregtechceu.gtceu.api.mui.value.sync.PanelSyncManager;
 import com.gregtechceu.gtceu.api.placeholder.PlaceholderContext;
-import com.gregtechceu.gtceu.client.mui.screen.ModularPanel;
 import com.gregtechceu.gtceu.client.renderer.monitor.IMonitorRenderer;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.CentralMonitorMachine;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.monitor.MonitorGroup;
@@ -18,8 +17,8 @@ public interface IMonitorModuleItem extends IItemComponent {
 
     IMonitorRenderer getRenderer(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group);
 
-    ModularPanel createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
-                                    PanelSyncManager syncManager, IPanelHandler panelHandler);
+    IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
+                                    PanelSyncManager syncManager);
 
     default String getType() {
         return "unknown";

--- a/src/main/java/com/gregtechceu/gtceu/api/item/component/IMonitorModuleItem.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/component/IMonitorModuleItem.java
@@ -18,7 +18,7 @@ public interface IMonitorModuleItem extends IItemComponent {
     IMonitorRenderer getRenderer(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group);
 
     IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
-                                    PanelSyncManager syncManager);
+                                     PanelSyncManager syncManager);
 
     default String getType() {
         return "unknown";

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/widgets/textfield/CodeEditorWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/widgets/textfield/CodeEditorWidget.java
@@ -1,7 +1,8 @@
 package com.gregtechceu.gtceu.api.mui.widgets.textfield;
 
+import com.gregtechceu.gtceu.api.mui.base.value.ISyncOrValue;
 import com.gregtechceu.gtceu.api.mui.value.sync.GenericListSyncHandler;
-import com.gregtechceu.gtceu.api.mui.value.sync.PanelSyncManager;
+import com.gregtechceu.gtceu.api.mui.value.sync.StringSyncValue;
 import com.gregtechceu.gtceu.client.mui.screen.viewport.ModularGuiContext;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.utils.GTUtil;
@@ -47,11 +48,16 @@ public class CodeEditorWidget<W extends CodeEditorWidget<W, T>, T> extends TextE
 
     public CodeEditorWidget() {}
 
-    public CodeEditorWidget(@Nullable LanguageDefinition<T> language, PanelSyncManager panelSyncManager) {
+    public CodeEditorWidget(@Nullable LanguageDefinition<T> language) {
         this.language = language;
         GenericListSyncHandler<Component> formattedTextSync = new GenericListSyncHandler<>(
                 this::getTextAsComponents, this::formattedText, ByteBufAdapters.COMPONENT);
-        panelSyncManager.syncValue("formatted_code", formattedTextSync);
+        setSyncOrValue(formattedTextSync);
+    }
+
+    @Override
+    public boolean isValidSyncOrValue(@NotNull ISyncOrValue syncOrValue) {
+        return syncOrValue.isTypeOrEmpty(GenericListSyncHandler.class) || syncOrValue.isTypeOrEmpty(StringSyncValue.class);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/mui/widgets/textfield/CodeEditorWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/mui/widgets/textfield/CodeEditorWidget.java
@@ -57,7 +57,8 @@ public class CodeEditorWidget<W extends CodeEditorWidget<W, T>, T> extends TextE
 
     @Override
     public boolean isValidSyncOrValue(@NotNull ISyncOrValue syncOrValue) {
-        return syncOrValue.isTypeOrEmpty(GenericListSyncHandler.class) || syncOrValue.isTypeOrEmpty(StringSyncValue.class);
+        return syncOrValue.isTypeOrEmpty(GenericListSyncHandler.class) ||
+                syncOrValue.isTypeOrEmpty(StringSyncValue.class);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
@@ -281,12 +281,12 @@ public class PlaceholderHandler {
     }
 
     public static IPanelHandler createPlaceholderEditor(String name, PanelSyncManager syncManager,
-                                               PlaceholderContext ctx,
-                                               IStringValue<?> code,
-                                               @Nullable DoubleSyncValue scaleDouble,
-                                               @Nullable IIntValue<?> updateInterval,
-                                               @Nullable IBoolValue<?> pause,
-                                               @Nullable Runnable updateText) {
+                                                        PlaceholderContext ctx,
+                                                        IStringValue<?> code,
+                                                        @Nullable DoubleSyncValue scaleDouble,
+                                                        @Nullable IIntValue<?> updateInterval,
+                                                        @Nullable IBoolValue<?> pause,
+                                                        @Nullable Runnable updateText) {
         IPanelHandler helpPanel = syncManager.syncedPanel("placeholder_language_help",
                 true,
                 (syncManager1, panelHandler1) -> createHelpPanel());
@@ -315,7 +315,8 @@ public class PlaceholderHandler {
                                 .child(Flow.row()
                                         .height(20)
                                         .childIf(scaleDouble != null,
-                                                () -> new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.text_scale")))
+                                                () -> new TextWidget<>(
+                                                        IKey.lang("gtceu.gui.central_monitor.text_scale")))
                                         .childIf(scaleDouble != null, () -> new TextFieldWidget()
                                                 .setNumbersDouble(x -> Math.max(x, 0))
                                                 .setDefaultNumber(1.0)

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
@@ -10,10 +10,7 @@ import com.gregtechceu.gtceu.api.mui.base.value.IStringValue;
 import com.gregtechceu.gtceu.api.mui.drawable.BorderDrawable;
 import com.gregtechceu.gtceu.api.mui.utils.Alignment;
 import com.gregtechceu.gtceu.api.mui.value.StringValue;
-import com.gregtechceu.gtceu.api.mui.value.sync.DoubleSyncValue;
-import com.gregtechceu.gtceu.api.mui.value.sync.InteractionSyncHandler;
-import com.gregtechceu.gtceu.api.mui.value.sync.PanelSyncManager;
-import com.gregtechceu.gtceu.api.mui.value.sync.SyncHandlers;
+import com.gregtechceu.gtceu.api.mui.value.sync.*;
 import com.gregtechceu.gtceu.api.mui.widgets.ButtonWidget;
 import com.gregtechceu.gtceu.api.mui.widgets.SortableListWidget;
 import com.gregtechceu.gtceu.api.mui.widgets.TextWidget;
@@ -283,7 +280,7 @@ public class PlaceholderHandler {
         return out;
     }
 
-    public static Flow createPlaceholderEditor(PanelSyncManager syncManager,
+    public static IPanelHandler createPlaceholderEditor(String name, PanelSyncManager syncManager,
                                                PlaceholderContext ctx,
                                                IStringValue<?> code,
                                                @Nullable DoubleSyncValue scaleDouble,
@@ -292,99 +289,103 @@ public class PlaceholderHandler {
                                                @Nullable Runnable updateText) {
         IPanelHandler helpPanel = syncManager.syncedPanel("placeholder_language_help",
                 true,
-                (syncManager1, panelHandler1) -> createHelpPanel(syncManager1));
+                (syncManager1, panelHandler1) -> createHelpPanel());
         InteractionSyncHandler runCodeOnce = new InteractionSyncHandler();
         if (updateText != null) runCodeOnce.setOnMousePressed(mouseData -> updateText.run());
         syncManager.syncValue("run_code_sync_handler", runCodeOnce);
         // because the args are nullable, intellij complains about everything, even though childIf is used
         // noinspection DataFlowIssue
-        return Flow.row()
-                .childIf(ctx.itemStackHandler() != null, () -> Flow.column()
-                        .coverChildren()
-                        .paddingLeft(4)
-                        .children(
-                                ctx.itemStackHandler().getSlots(),
-                                i -> new ItemSlot()
-                                        .slot(ctx.itemStackHandler(), i)
-                                        .addTooltipLine(
-                                                IKey.lang("gtceu.gui.computer_monitor_cover.slot_tooltip", i))))
-                .child(Flow.column()
-                        .widthRel(.8f)
-                        .padding(5)
-                        .child(Flow.row()
-                                .height(20)
-                                .childIf(scaleDouble != null,
-                                        () -> new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.text_scale")))
-                                .childIf(scaleDouble != null, () -> new TextFieldWidget()
-                                        .setNumbersDouble(x -> Math.max(x, 0))
-                                        .setDefaultNumber(1.0)
-                                        .value(scaleDouble)
-                                        .marginLeft(4))
-                                .childIf(updateInterval != null,
-                                        () -> new TextWidget<>(
-                                                IKey.lang("gtceu.gui.computer_monitor_cover.update_interval")))
-                                .childIf(updateInterval != null, () -> new TextFieldWidget()
-                                        .setNumbers(1, 1000)
-                                        .setDefaultNumber(1)
-                                        .value(SyncHandlers.string(
-                                                () -> String.valueOf(updateInterval.getIntValue()),
-                                                s -> updateInterval.setIntValue(Integer.parseInt(s))))
-                                        .marginLeft(4))
-                                .childIf(pause != null, () -> new ToggleButton()
-                                        .value(pause)
-                                        .background(false, GTGuiTextures.PAUSE)
-                                        .background(true, GTGuiTextures.PLAY)
-                                        .addTooltip(false, IKey.lang("gtceu.gui.central_monitor.pause"))
-                                        .addTooltip(true, IKey.lang("gtceu.gui.central_monitor.resume"))
-                                        .margin(4))
-                                .childIf(updateText != null, () -> new ButtonWidget<>()
-                                        .background(GTGuiTextures.RIGHTLOAD)
-                                        .hoverBackground(GTGuiTextures.RIGHTLOAD, new BorderDrawable())
-                                        .addTooltipLine(IKey.lang("gtceu.gui.central_monitor.update_once"))
-                                        .syncHandler("run_code_sync_handler"))
-                                .child(new ButtonWidget<>()
-                                        .background(GTGuiTextures.HELP)
-                                        .hoverBackground(GTGuiTextures.HELP, new BorderDrawable())
-                                        .margin(4)
-                                        .onMousePressed((mouseX, mouseY, button) -> {
-                                            helpPanel.openPanel();
-                                            return true;
-                                        })))
-                        .child(new CodeEditorWidget<>(PlaceholderHandler.LANG_DEFINITION, syncManager)
-                                .value(code)
-                                .langContext(ctx)
-                                .widthRel(.95f)
-                                .heightRelOffset(() -> 1, -25)))
-                .child(new SortableListWidget<String>()
-                        .widthRel(.2f)
-                        .paddingBottom(5)
-                        .excludeAreaInRecipeViewer()
-                        .children(PlaceholderHandler.getAllPlaceholderNames()
-                                .stream()
-                                .sorted()
-                                .map(SortableListWidget.Item::new)
-                                .map(w -> w
-                                        .child(new TextWidget<>(w.getWidgetValue())
-                                                .sizeRel(1)
-                                                .alignment(Alignment.CENTER))
-                                        .tooltip(new RichTooltip()
-                                                .addDrawableLines(LangHandler
-                                                        .getSingleOrMultiLang(
-                                                                "gtceu.placeholder_info." + w.getWidgetValue())
-                                                        .stream()
-                                                        .map(IKey::lang)
-                                                        .map(key -> (IDrawable) key)
-                                                        .toList())))
-                                .toList()));
+        return syncManager.syncedPanel(name, true, (psm, handler) -> new ModularPanel(name)
+                .size(400, 250)
+                .resizeableOnDrag(true)
+                .excludeAreaInRecipeViewer()
+                .child(Flow.row()
+                        .childIf(ctx.itemStackHandler() != null, () -> Flow.column()
+                                .coverChildren()
+                                .paddingLeft(4)
+                                .children(
+                                        ctx.itemStackHandler().getSlots(),
+                                        i -> new ItemSlot()
+                                                .slot(ctx.itemStackHandler(), i)
+                                                .addTooltipLine(
+                                                        IKey.lang("gtceu.gui.computer_monitor_cover.slot_tooltip", i))))
+                        .child(Flow.column()
+                                .widthRel(.8f)
+                                .padding(5)
+                                .child(Flow.row()
+                                        .height(20)
+                                        .childIf(scaleDouble != null,
+                                                () -> new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.text_scale")))
+                                        .childIf(scaleDouble != null, () -> new TextFieldWidget()
+                                                .setNumbersDouble(x -> Math.max(x, 0))
+                                                .setDefaultNumber(1.0)
+                                                .value(scaleDouble)
+                                                .marginLeft(4))
+                                        .childIf(updateInterval != null,
+                                                () -> new TextWidget<>(
+                                                        IKey.lang("gtceu.gui.computer_monitor_cover.update_interval")))
+                                        .childIf(updateInterval != null, () -> new TextFieldWidget()
+                                                .setNumbers(1, 1000)
+                                                .setDefaultNumber(1)
+                                                .value(SyncHandlers.string(
+                                                        () -> String.valueOf(updateInterval.getIntValue()),
+                                                        s -> updateInterval.setIntValue(Integer.parseInt(s))))
+                                                .marginLeft(4))
+                                        .childIf(pause != null, () -> new ToggleButton()
+                                                .value(pause)
+                                                .background(false, GTGuiTextures.PAUSE)
+                                                .background(true, GTGuiTextures.PLAY)
+                                                .addTooltip(false, IKey.lang("gtceu.gui.central_monitor.pause"))
+                                                .addTooltip(true, IKey.lang("gtceu.gui.central_monitor.resume"))
+                                                .margin(4))
+                                        .childIf(updateText != null, () -> new ButtonWidget<>()
+                                                .background(GTGuiTextures.RIGHTLOAD)
+                                                .hoverBackground(GTGuiTextures.RIGHTLOAD, new BorderDrawable())
+                                                .addTooltipLine(IKey.lang("gtceu.gui.central_monitor.update_once"))
+                                                .syncHandler("run_code_sync_handler"))
+                                        .child(new ButtonWidget<>()
+                                                .background(GTGuiTextures.HELP)
+                                                .hoverBackground(GTGuiTextures.HELP, new BorderDrawable())
+                                                .margin(4)
+                                                .onMousePressed((mouseX, mouseY, button) -> {
+                                                    helpPanel.openPanel();
+                                                    return true;
+                                                })))
+                                .child(new CodeEditorWidget<>(PlaceholderHandler.LANG_DEFINITION)
+                                        .value(code)
+                                        .langContext(ctx)
+                                        .widthRel(.95f)
+                                        .heightRelOffset(1, -25)))
+                        .child(new SortableListWidget<String>()
+                                .widthRel(.2f)
+                                .paddingBottom(5)
+                                .excludeAreaInRecipeViewer()
+                                .children(PlaceholderHandler.getAllPlaceholderNames()
+                                        .stream()
+                                        .sorted()
+                                        .map(SortableListWidget.Item::new)
+                                        .map(w -> w
+                                                .child(new TextWidget<>(w.getWidgetValue())
+                                                        .sizeRel(1)
+                                                        .align(Alignment.CENTER))
+                                                .tooltip(new RichTooltip()
+                                                        .addDrawableLines(LangHandler
+                                                                .getSingleOrMultiLang(
+                                                                        "gtceu.placeholder_info." + w.getWidgetValue())
+                                                                .stream()
+                                                                .map(IKey::lang)
+                                                                .map(key -> (IDrawable) key)
+                                                                .toList())))
+                                        .toList()))));
     }
 
-    public static ModularPanel createHelpPanel(PanelSyncManager syncManager) {
+    public static ModularPanel createHelpPanel() {
         return new ModularPanel("placeholder_language_help")
                 .size(500, 250)
                 .child(Flow.column()
                         .padding(5)
                         .child(new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.text_module_help")))
-                        .child(new CodeEditorWidget<>(LANG_DEFINITION, syncManager)
+                        .child(new CodeEditorWidget<>(LANG_DEFINITION)
                                 .padding(5)
                                 .widthRel(.95f)
                                 .height(100)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
@@ -138,12 +138,10 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 String expression = args.stream().map(MultiLineComponent::toString).reduce("", (a, b) -> a + b);
-                ParseResult result = GTMath.parseExpression(expression, true);
+                ParseResult result = GTMath.parseExpression(expression, 0, true);
                 if (result.isFailure())
                     throw new PlaceholderException(result.getError().toString());
-                double res = (double) result.getResult().getValue();
-                if ((int) res == res) return MultiLineComponent.literal((int) res);
-                return MultiLineComponent.literal(result.getResult().toString());
+                return MultiLineComponent.literal(result.getResult().getNumberValue().toString());
             }
 
             @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/GuiModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/GuiModuleBehaviour.java
@@ -34,10 +34,11 @@ public class GuiModuleBehaviour implements IMonitorModuleItem {
     @Override
     public IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
                                             PanelSyncManager syncManager) {
-        return syncManager.syncedPanel("gui_module_" + group.getName(), true, (psm, handler) -> new ModularPanel("gui_module_info")
-                .coverChildren()
-                .child(new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.gui_module_info"))
-                        .height(50)
-                        .width(200)));
+        return syncManager.syncedPanel("gui_module_" + group.getName(), true,
+                (psm, handler) -> new ModularPanel("gui_module_info")
+                        .coverChildren()
+                        .child(new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.gui_module_info"))
+                                .height(50)
+                                .width(200)));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/GuiModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/GuiModuleBehaviour.java
@@ -32,12 +32,12 @@ public class GuiModuleBehaviour implements IMonitorModuleItem {
     }
 
     @Override
-    public ModularPanel createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
-                                           PanelSyncManager syncManager, IPanelHandler panelHandler) {
-        return new ModularPanel("gui_module_info")
+    public IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
+                                            PanelSyncManager syncManager) {
+        return syncManager.syncedPanel("gui_module_" + group.getName(), true, (psm, handler) -> new ModularPanel("gui_module_info")
                 .coverChildren()
                 .child(new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.gui_module_info"))
                         .height(50)
-                        .width(200));
+                        .width(200)));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/ImageModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/ImageModuleBehaviour.java
@@ -36,17 +36,18 @@ public class ImageModuleBehaviour implements IMonitorModuleItem, IAddInformation
     @Override
     public IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
                                             PanelSyncManager syncManager) {
-        return syncManager.syncedPanel("image_module_" + group.getName(), true, (psm, handler) -> new ModularPanel("image_module_editor")
-                .size(200, 50)
-                .child(Flow.column()
-                        .marginTop(5)
-                        .align(Alignment.CENTER)
-                        .widthRel(1)
-                        .child(new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.url")))
-                        .child(new TextFieldWidget()
-                                .value(SyncHandlers.string(() -> getUrl(stack), s -> setUrl(stack, s)))
+        return syncManager.syncedPanel("image_module_" + group.getName(), true,
+                (psm, handler) -> new ModularPanel("image_module_editor")
+                        .size(200, 50)
+                        .child(Flow.column()
+                                .marginTop(5)
                                 .align(Alignment.CENTER)
-                                .widthRel(.8f))));
+                                .widthRel(1)
+                                .child(new TextWidget<>(IKey.lang("gtceu.gui.central_monitor.url")))
+                                .child(new TextFieldWidget()
+                                        .value(SyncHandlers.string(() -> getUrl(stack), s -> setUrl(stack, s)))
+                                        .align(Alignment.CENTER)
+                                        .widthRel(.8f))));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/ImageModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/ImageModuleBehaviour.java
@@ -34,9 +34,9 @@ public class ImageModuleBehaviour implements IMonitorModuleItem, IAddInformation
     }
 
     @Override
-    public ModularPanel createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
-                                           PanelSyncManager syncManager, IPanelHandler panelHandler) {
-        return new ModularPanel("image_module_editor")
+    public IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
+                                            PanelSyncManager syncManager) {
+        return syncManager.syncedPanel("image_module_" + group.getName(), true, (psm, handler) -> new ModularPanel("image_module_editor")
                 .size(200, 50)
                 .child(Flow.column()
                         .marginTop(5)
@@ -46,7 +46,7 @@ public class ImageModuleBehaviour implements IMonitorModuleItem, IAddInformation
                         .child(new TextFieldWidget()
                                 .value(SyncHandlers.string(() -> getUrl(stack), s -> setUrl(stack, s)))
                                 .align(Alignment.CENTER)
-                                .widthRel(.8f)));
+                                .widthRel(.8f))));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/TextModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/TextModuleBehaviour.java
@@ -3,15 +3,10 @@ package com.gregtechceu.gtceu.common.item.modules;
 import com.gregtechceu.gtceu.api.item.component.IAddInformation;
 import com.gregtechceu.gtceu.api.item.component.IMonitorModuleItem;
 import com.gregtechceu.gtceu.api.mui.base.IPanelHandler;
-import com.gregtechceu.gtceu.api.mui.base.value.IBoolValue;
-import com.gregtechceu.gtceu.api.mui.base.value.IStringValue;
-import com.gregtechceu.gtceu.api.mui.value.sync.DoubleSyncValue;
-import com.gregtechceu.gtceu.api.mui.value.sync.PanelSyncManager;
-import com.gregtechceu.gtceu.api.mui.value.sync.SyncHandlers;
+import com.gregtechceu.gtceu.api.mui.value.sync.*;
 import com.gregtechceu.gtceu.api.placeholder.MultiLineComponent;
 import com.gregtechceu.gtceu.api.placeholder.PlaceholderContext;
 import com.gregtechceu.gtceu.api.placeholder.PlaceholderHandler;
-import com.gregtechceu.gtceu.client.mui.screen.ModularPanel;
 import com.gregtechceu.gtceu.client.renderer.monitor.IMonitorRenderer;
 import com.gregtechceu.gtceu.client.renderer.monitor.MonitorTextRenderer;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.CentralMonitorMachine;
@@ -69,24 +64,20 @@ public class TextModuleBehaviour implements IMonitorModuleItem, IAddInformation 
     }
 
     @Override
-    public ModularPanel createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
-                                           PanelSyncManager syncManager, IPanelHandler panelHandler) {
+    public IPanelHandler createModularPanel(ItemStack stack, CentralMonitorMachine machine, MonitorGroup group,
+                                            PanelSyncManager syncManager) {
         PlaceholderContext ctx = getContext(stack, machine, group);
-        IStringValue<?> code = SyncHandlers.string(
+        StringSyncValue code = SyncHandlers.string(
                 () -> getPlaceholderText(stack),
                 s -> setPlaceholderText(stack, s));
         DoubleSyncValue scale = SyncHandlers.doubleNumber(
                 () -> getScale(stack),
                 s -> setScale(stack, s));
-        IBoolValue<?> pause = SyncHandlers.bool(() -> isPaused(stack), p -> setPaused(stack, p));
+        BooleanSyncValue pause = SyncHandlers.bool(() -> isPaused(stack), p -> setPaused(stack, p));
         Runnable updateText = () -> updateText(stack, machine, group);
         assert ctx.itemStackHandler() != null;
-        return new ModularPanel("placeholder_editor")
-                .size(400, 250)
-                .resizeableOnDrag(true)
-                .excludeAreaInRecipeViewer()
-                .child(PlaceholderHandler.createPlaceholderEditor(syncManager, ctx, code, scale, null, pause,
-                        updateText));
+        return PlaceholderHandler.createPlaceholderEditor("text_module_" + group.getName(), syncManager, ctx, code, scale, null, pause,
+                updateText);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/TextModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/TextModuleBehaviour.java
@@ -76,7 +76,8 @@ public class TextModuleBehaviour implements IMonitorModuleItem, IAddInformation 
         BooleanSyncValue pause = SyncHandlers.bool(() -> isPaused(stack), p -> setPaused(stack, p));
         Runnable updateText = () -> updateText(stack, machine, group);
         assert ctx.itemStackHandler() != null;
-        return PlaceholderHandler.createPlaceholderEditor("text_module_" + group.getName(), syncManager, ctx, code, scale, null, pause,
+        return PlaceholderHandler.createPlaceholderEditor("text_module_" + group.getName(), syncManager, ctx, code,
+                scale, null, pause,
                 updateText);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
@@ -18,9 +18,7 @@ import com.gregtechceu.gtceu.api.mui.factory.PanelFactory;
 import com.gregtechceu.gtceu.api.mui.factory.PosGuiData;
 import com.gregtechceu.gtceu.api.mui.utils.Alignment;
 import com.gregtechceu.gtceu.api.mui.value.BoolValue;
-import com.gregtechceu.gtceu.api.mui.value.sync.GenericListSyncHandler;
-import com.gregtechceu.gtceu.api.mui.value.sync.PanelSyncManager;
-import com.gregtechceu.gtceu.api.mui.value.sync.SyncHandlers;
+import com.gregtechceu.gtceu.api.mui.value.sync.*;
 import com.gregtechceu.gtceu.api.mui.widgets.*;
 import com.gregtechceu.gtceu.api.mui.widgets.layout.Flow;
 import com.gregtechceu.gtceu.api.mui.widgets.layout.Grid;
@@ -59,8 +57,7 @@ public class CentralMonitorUIFactory implements PanelFactory {
         GenericListSyncHandler<MonitorGroup> groupSync = new GenericListSyncHandler<>(machine::getMonitorGroups,
                 machine::setMonitorGroups, MONITOR_GROUPS);
         syncManager.syncValue("monitor_groups_sync", groupSync);
-        List<MonitorGroup> groups = new ArrayList<>(groupSync.getValue());
-        SortableListWidget<MonitorGroup> listWidget = new SortableListWidget<>();
+        List<MonitorGroup> groups = new ArrayList<>(machine.getMonitorGroups());
         IPanelHandler helpPanel = syncManager.syncedPanel(
                 "help_panel", true,
                 (syncManager1, panelHandler1) -> createHelpPanel());
@@ -93,18 +90,15 @@ public class CentralMonitorUIFactory implements PanelFactory {
                                 return true;
                             })));
         };
-        IPanelHandler newGroupPanelHandler = syncManager.syncedPanel(
-                "editor_" + groups.size(), true,
-                (syncManager1, panelHandler1) -> {
-                    MonitorGroup group = new MonitorGroup(getNewGroupName(groupSync));
-                    groups.add(group);
-                    listWidget.child(processGroupItem.apply(new SortableListWidget.Item<>(group)));
-                    GTCEu.LOGGER.info("adding group: {} isClient = {}", groups, syncManager1.isClient());
-                    groupSync.setValue(groups, true, false);
-                    return this.createGroupEditorPanel(
-                            syncManager1, groupSync,
-                            machine, group, groups, helpPanel);
-                });
+        DynamicSyncHandler listHandler = new DynamicSyncHandler()
+                .widgetProvider((psm, buf) -> new SortableListWidget<MonitorGroup>()
+                        .children(groups.stream()
+                                .map(SortableListWidget.Item::new)
+                                .map(processGroupItem)
+                                .toList())
+                        .onChange(groupSync::setValue)
+                        .widthRel(1));
+        listHandler.notifyUpdate(buf -> {});
         return new Dialog<>("main")
                 .setDraggable(true)
                 .padding(5)
@@ -121,18 +115,19 @@ public class CentralMonitorUIFactory implements PanelFactory {
                                         .alignX(1)
                                         .background(GTGuiTextures.MC_BUTTON, GTGuiTextures.ADD)
                                         .hoverBackground(GTGuiTextures.MC_BUTTON_HOVERED, GTGuiTextures.ADD)
-                                        .onMousePressed((mouseX, mouseY, button) -> {
-                                            newGroupPanelHandler.openPanel();
-                                            return true;
-                                        }))
+                                        .syncHandler(new InteractionSyncHandler()
+                                                .setOnMousePressed(mouseData -> {
+                                                    MonitorGroup group = new MonitorGroup(getNewGroupName(groupSync));
+                                                    groups.add(group);
+                                                    GTCEu.LOGGER.info("adding group: {} isClient = {}", groups, syncManager.isClient());
+                                                    groupSync.setValue(groups, true, false);
+                                                    listHandler.notifyUpdate(buf -> {});
+                                                })))
                                 .widthRel(1).height(20))
-                        .child(listWidget.children(
-                                groups.stream()
-                                        .map(SortableListWidget.Item::new)
-                                        .map(processGroupItem)
-                                        .toList())
-                                .onChange(groupSync::setValue)
-                                .widthRel(1).heightRelOffset(() -> 1, -96))
+                        .child(new DynamicSyncedWidget<>()
+                                .syncHandler(listHandler)
+                                .widthRel(1)
+                                .heightRelOffset(() -> 1, -96))
                         .child(SlotGroupWidget.playerInventory(false)));
     }
 
@@ -214,7 +209,7 @@ public class CentralMonitorUIFactory implements PanelFactory {
         IPanelHandler moduleEditor = createModulePanelHandler(
                 syncManager,
                 group.getItemStackHandler().getStackInSlot(0),
-                group, machine, groups.indexOf(group));
+                group, machine);
         BoolValue moduleChanged = new BoolValue(false);
         return new ModularPanel("editor_" + groups.indexOf(group) + "_panel")
                 .width(Math.max(matrixWidth, 150))
@@ -354,7 +349,7 @@ public class CentralMonitorUIFactory implements PanelFactory {
     }
 
     private IPanelHandler createModulePanelHandler(PanelSyncManager syncManager, ItemStack stack, MonitorGroup group,
-                                                   CentralMonitorMachine machine, int index) {
+                                                   CentralMonitorMachine machine) {
         IMonitorModuleItem moduleItem = null;
         if (stack.getItem() instanceof IComponentItem componentItem) {
             for (IItemComponent component : componentItem.getComponents()) {
@@ -365,10 +360,7 @@ public class CentralMonitorUIFactory implements PanelFactory {
             }
         }
         IMonitorModuleItem finalModuleItem = moduleItem;
-        return moduleItem == null ? null : syncManager.syncedPanel(
-                "module_editor_" + index, true,
-                (syncManager1, panelHandler1) -> finalModuleItem.createModularPanel(stack, machine, group, syncManager1,
-                        panelHandler1));
+        return moduleItem == null ? null : finalModuleItem.createModularPanel(stack, machine, group, syncManager);
     }
 
     private String getNewGroupName(IValue<List<MonitorGroup>> groupSync) {

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
@@ -119,7 +119,8 @@ public class CentralMonitorUIFactory implements PanelFactory {
                                                 .setOnMousePressed(mouseData -> {
                                                     MonitorGroup group = new MonitorGroup(getNewGroupName(groupSync));
                                                     groups.add(group);
-                                                    GTCEu.LOGGER.info("adding group: {} isClient = {}", groups, syncManager.isClient());
+                                                    GTCEu.LOGGER.info("adding group: {} isClient = {}", groups,
+                                                            syncManager.isClient());
                                                     groupSync.setValue(groups, true, false);
                                                     listHandler.notifyUpdate(buf -> {});
                                                 })))


### PR DESCRIPTION
## What
Make the GUI work again, fix a couple of crashes when using `{calc}`

## Implementation Details
Now methods to create UI in modules return `IPanelHandlers` to allow subpanels.
We really should consider logging errors when handling MUI packets

## Additional Information
Apparently merging all the CM prs broke smth, because they worked fine separately.

## How Was This Tested
In-game