### PR TITLE
Fix item count in chancedInput and chancedOutput

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -745,7 +745,7 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(Ingredient stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedOutput(SizedIngredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -782,7 +782,7 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipeBuilder chancedOutput(ItemStack stack, int chance, int tierChanceBoost) {
-        return chancedOutput(Ingredient.of(stack), chance, tierChanceBoost);
+        return chancedOutput(SizedIngredient.create(stack), chance, tierChanceBoost);
     }
 
     public GTRecipeBuilder chancedOutput(FluidStack stack, int chance, int tierChanceBoost) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -717,7 +717,7 @@ public class GTRecipeBuilder {
         return notConsumable(IntCircuitIngredient.of(configuration));
     }
 
-    public GTRecipeBuilder chancedInput(SizedIngredient stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedInput(Ingredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -745,7 +745,7 @@ public class GTRecipeBuilder {
         return this;
     }
 
-    public GTRecipeBuilder chancedOutput(SizedIngredient stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedOutput(Ingredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -717,7 +717,7 @@ public class GTRecipeBuilder {
         return notConsumable(IntCircuitIngredient.of(configuration));
     }
 
-    public GTRecipeBuilder chancedInput(Ingredient stack, int chance, int tierChanceBoost) {
+    public GTRecipeBuilder chancedInput(SizedIngredient stack, int chance, int tierChanceBoost) {
         if (checkChanceAndPrintError(chance)) {
             return this;
         }
@@ -774,7 +774,7 @@ public class GTRecipeBuilder {
     }
 
     public GTRecipeBuilder chancedInput(ItemStack stack, int chance, int tierChanceBoost) {
-        return chancedInput(Ingredient.of(stack), chance, tierChanceBoost);
+        return chancedInput(SizedIngredient.create(stack), chance, tierChanceBoost);
     }
 
     public GTRecipeBuilder chancedInput(FluidStack stack, int chance, int tierChanceBoost) {


### PR DESCRIPTION
## What

In #4202, the type of the first parameter of `chancedInput` and `chancedOutput` is changed from `ItemStack` to `Ingredient`. But `Ingredient` is a vanilla class which doesn't have count. So all chanced input and output with count is truncated to 1. And the ore processing has byproduct multiplier and some modpack author also use this api to write new recipes which have chanced output with count, so this bug should be fixed.

<img width="529" height="609" alt="98d8676fb6cbcba0840ec0bea2089f56" src="https://github.com/user-attachments/assets/0b21f2bb-c73c-48ed-b32d-737eeeaf6e8a" />

<img width="533" height="421" alt="c4837421592fc27c9810f87d0b9ca273" src="https://github.com/user-attachments/assets/c08b1a65-cb0c-4823-a3e6-84bd90f856f7" />


## Implementation Details

Use `SizedIngredient` instead of `Ingredient` as the parameters.

## Outcome

<img width="505" height="409" alt="7680ad9b57925f52d89ef6c7dddbe23f" src="https://github.com/user-attachments/assets/ecb2b839-cbb5-49a0-a3c2-ff2f20f97854" />
