### PR TITLE
Fix FluidIngredient::toJson

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
@@ -85,12 +85,13 @@ public class FluidIngredient implements Predicate<FluidStack> {
         }
         if (this.values.length == 1) {
             jsonObject.add("value", this.values[0].serialize());
+        } else {
+            JsonArray jsonArray = new JsonArray();
+            for (FluidIngredient.Value value : this.values) {
+                jsonArray.add(value.serialize());
+            }
+            jsonObject.add("value", jsonArray);
         }
-        JsonArray jsonArray = new JsonArray();
-        for (FluidIngredient.Value value : this.values) {
-            jsonArray.add(value.serialize());
-        }
-        jsonObject.add("value", jsonArray);
         return jsonObject;
     }
 


### PR DESCRIPTION
## What
FluidIngredient::toJson had code to output either a single value, or an array of values, depending on what's in FluidIngredient.values. However, a missing `else` means it would always output an array.

## Implementation Details
Put the array code inside an `else`

## Outcome
Output json is a single value or an array as expected

## How Was This Tested
Game compiles and runs

## Additional Information
The fromJson already correctly handles the two cases

## Potential Compatibility Issues
If any external code uses FluidIngredient::toJson and always expects an array, this change would break their code.
An alternative to this PR would be to explicitly always return an array.