### PR TITLE
Improve FluidIngredient::getStacks dedup performance

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
@@ -168,7 +168,7 @@ public class FluidIngredient implements Predicate<FluidStack> {
     public FluidStack[] getStacks() {
         if (changed || this.stacks == null) {
             List<FluidStack> fluidStacks = new ObjectArrayList<>(1);
-            List<Fluid> found = new ObjectArrayList<>(1);
+            Set<Fluid> found = new HashSet<>();
             for (Value value : this.values) {
                 for (Fluid fluid : value.getFluids()) {
                     if (found.contains(fluid)) continue;


### PR DESCRIPTION
## What
ObjectArrayList is O(n²) for .contains. Since Fluids have a meaningful identity, it's better to use a HashSet.
This only matters if there are FluidIngredients that use a (tag with) a large number of fluids.

## Implementation Details
Change to HashSet

## Outcome
O(n) dedup

## How Was This Tested
Game compiles and runs

## Potential Compatibility Issues
\-