### PR TITLE
Improve getBlockState performance

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/LevelMixin.java
@@ -14,11 +14,9 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -38,19 +36,16 @@ public abstract class LevelMixin implements LevelAccessor {
     @Final
     private Thread thread;
 
-    @Unique
-    private @Nullable ChunkAccess gtceu$maybeGetChunkAsync(int chunkX, int chunkZ) {
-        if (this.isClientSide) return null;
-        if (Thread.currentThread() == this.thread) return null;
-        if (!MultiblockWorldSavedData.isThreadService() && !AsyncThreadData.isThreadService()) return null;
-        if (!this.getChunkSource().hasChunk(chunkX, chunkZ)) return null;
-
-        return this.getChunkSource().getChunkNow(chunkX, chunkZ);
-    }
-
     @Inject(method = "getBlockEntity", at = @At(value = "HEAD"), cancellable = true)
     private void gtceu$getBlockEntityOffThread(BlockPos pos, CallbackInfoReturnable<BlockEntity> cir) {
-        ChunkAccess chunk = gtceu$maybeGetChunkAsync(pos.getX() >> 4, pos.getZ() >> 4);
+        if (Thread.currentThread() == this.thread) return;
+        if (this.isClientSide) return;
+        if (!MultiblockWorldSavedData.isThreadService() && !AsyncThreadData.isThreadService()) return;
+
+        int chunkX = pos.getX() >> 4, chunkZ = pos.getZ() >> 4;
+        if (!this.getChunkSource().hasChunk(chunkX, chunkZ)) return;
+
+        ChunkAccess chunk = this.getChunkSource().getChunkNow(chunkX, chunkZ);
         if (chunk instanceof LevelChunk levelChunk) {
             cir.setReturnValue(levelChunk.getBlockEntities().get(pos));
         }
@@ -58,7 +53,14 @@ public abstract class LevelMixin implements LevelAccessor {
 
     @Inject(method = "getBlockState", at = @At(value = "HEAD"), cancellable = true)
     private void gtceu$getBlockStateOffThread(BlockPos pos, CallbackInfoReturnable<BlockState> cir) {
-        ChunkAccess chunk = gtceu$maybeGetChunkAsync(pos.getX() >> 4, pos.getZ() >> 4);
+        if (Thread.currentThread() == this.thread) return;
+        if (this.isClientSide) return;
+        if (!MultiblockWorldSavedData.isThreadService() && !AsyncThreadData.isThreadService()) return;
+
+        int chunkX = pos.getX() >> 4, chunkZ = pos.getZ() >> 4;
+        if (!this.getChunkSource().hasChunk(chunkX, chunkZ)) return;
+
+        ChunkAccess chunk = this.getChunkSource().getChunkNow(chunkX, chunkZ);
         if (chunk != null) {
             cir.setReturnValue(chunk.getBlockState(pos));
         }


### PR DESCRIPTION
## What
GT's LevelMixin makes every `getBlockState` call 6% slower.

The mixin exists to allow multiblock validation to happen off-thread. However, the cheap early exits are hidden behind some bitshifts and indirection.

Since `getBlockState` is a very hot path, fast exits should be frontloaded as much as possible, even at the cost of code duplication.

This PR moves the most important fast exit to the front.

## Implementation Details
I placed the thread check before the clientside check to prioritizing server speed over client speed, though the difference is minimal; both are fast checks.

## Outcome
getBlockState runs faster.

## How Was This Tested
Game compiles and runs, multiblocks still form.

## Additional Information
This is more of a quick fix than a proper solution. Even with this fix, the mixin still causes a CallbackInfoReturnable object to be generated for every `getBlockState` call, which is not that fast either.

Ultimately these mixin injections should not exist at all. The caller (multiblock validator) always already knows that it's the multiblock validator, that it should run async. The caller should not be calling `getBlockState`, it should be calling a dedicated `getBlockStateAsync` method. This would not pollute the vanilla `getBlockState` method with any mixin at all, so there would be zero slowdown.

## Potential Compatibility Issues
Nothing changed logic-wise.