### PR TITLE
EMI synthetic recipe warning fix

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/circuit/GTProgrammedCircuitCategory.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/circuit/GTProgrammedCircuitCategory.java
@@ -53,7 +53,7 @@ public class GTProgrammedCircuitCategory extends EmiRecipeCategory {
 
         @Override
         public @Nullable ResourceLocation getId() {
-            return GTCEu.id("programmed_circuit");
+            return GTCEu.id("/programmed_circuit");
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/multipage/MultiblockInfoEmiRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/multipage/MultiblockInfoEmiRecipe.java
@@ -44,7 +44,7 @@ public class MultiblockInfoEmiRecipe extends ModularEmiRecipe<WidgetGroup> {
 
     @Override
     public @Nullable ResourceLocation getId() {
-        return definition.getId();
+        return definition.getId().withPrefix("/");
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/emi/oreprocessing/GTEmiOreProcessing.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/emi/oreprocessing/GTEmiOreProcessing.java
@@ -26,7 +26,7 @@ public class GTEmiOreProcessing extends ModularEmiRecipe<GTOreByProductWidget> {
 
     @Override
     public @Nullable ResourceLocation getId() {
-        return material.getResourceLocation();
+        return material.getResourceLocation().withPrefix("/");
     }
 
     @Override


### PR DESCRIPTION
## What
For custom EMI categories, the EMI recipes don't correspond to a real underlying recipe. In this case, EMI requires the path part of the recipe to start with a `/` to know it's not a mistake.

Right now GT registers several different synthetic recipes, some of them correctly like the Ore Vein index.

A few of them are missing the `/` prefix: Multiblocks, Ore Processing, and Programmed Circuits. This causes several hundred EMI errors, drowning out legitimate issues.
<img width="1478" height="245" alt="image" src="https://github.com/user-attachments/assets/41963636-f73c-4aca-a70a-d38678cf04f6" />

This PR adds the missing slashes.

This only affects the EMI recipe IDs for these synthetic pages, but not any actual gameplay, items, or recipes.\
`getId()` here is specifically an EMI function, `dev.emi.emi.api.recipe.EmiRecipe::getId` so it doesn't affect anything else.