### PR TITLE
Allow non-1.20.1 or 1.21 branch releases

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get Config
         uses: actions/checkout@v4
         with:
-          ref: '1.20.1'
+          ref: ${{ github.ref_name }}
           sparse-checkout: '.github/json'
       - name: Generate changelog
         id: changelog
@@ -39,8 +39,8 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       simulate: ${{ startsWith(github.event.release.name, 'simulate') || github.repository_owner != 'GregTechCEu' }}
-      branch: '1.20.1'
       tag-name: ${{ github.ref_name }}
+      version: '1.20.1'
       release-body: ${{ github.event.release.body }}
       changelog-body: ${{ needs.meta.outputs.CHANGELOG }}
 
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       simulate: ${{ startsWith(github.event.release.name, 'simulate') || github.repository_owner != 'GregTechCEu' }}
-      branch: '1.21'
       tag-name: ${{ github.ref_name }}
+      version: '1.21'
       release-body: ${{ github.event.release.body }}
       changelog-body: ${{ needs.meta.outputs.CHANGELOG }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
           MC_VERSION: ${{ inputs.version == '1.21' && '1.21.1' || '1.20.1' }}
           LOADER: ${{ inputs.version == '1.21' && 'neoforge' || 'forge' }}
           JAVA: ${{ inputs.version == '1.21' && '21' || '17' }}
-          VERSION_TYPE: ${{ inputs.version == '1.21' && 'beta' || 'beta' }}
+          VERSION_TYPE: ${{ inputs.version == '1.21' && 'alpha' || 'beta' }}
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
           modrinth-id: 7tG215v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,12 @@ on:
       simulate:
         required: false
         type: boolean
-      branch:
-        description: 'Branch to checkout; 1.20.1 or 1.21'
+      tag-name:
+        description: 'Tag to build from and upload to'
         required: true
         type: string
-      tag-name:
-        description: 'Tag to upload to'
+      version:
+        description: 'Version identifier; 1.20.1 or 1.21'
         required: true
         type: string
       release-body:
@@ -36,11 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.tag-name }}
       - name: Setup Build
         uses: ./.github/actions/build_setup
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.tag-name }}
       - name: Get Version
         id: ver
         run: echo "version=$(./gradlew -q printVersion)" >> $GITHUB_OUTPUT
@@ -49,7 +49,7 @@ jobs:
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.branch }}
+          name: build-artifacts-${{ inputs.tag-name }}
           path: build/libs/*
           if-no-files-found: error
           retention-days: 3
@@ -70,7 +70,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.branch }}
+          name: build-artifacts-${{ inputs.tag-name }}
       - name: Upload artifacts to release
         uses: softprops/action-gh-release@v2
         with:
@@ -89,13 +89,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.branch }}
+          name: build-artifacts-${{ inputs.tag-name }}
       - name: Publish Mod
         env:
-          MC_VERSION: ${{ inputs.branch == '1.21' && '1.21.1' || '1.20.1' }}
-          LOADER: ${{ inputs.branch == '1.21' && 'neoforge' || 'forge' }}
-          JAVA: ${{ inputs.branch == '1.21' && '21' || '17' }}
-          VERSION_TYPE: ${{ inputs.branch == '1.21' && 'beta' || 'beta' }}
+          MC_VERSION: ${{ inputs.version == '1.21' && '1.21.1' || '1.20.1' }}
+          LOADER: ${{ inputs.version == '1.21' && 'neoforge' || 'forge' }}
+          JAVA: ${{ inputs.version == '1.21' && '21' || '17' }}
+          VERSION_TYPE: ${{ inputs.version == '1.21' && 'beta' || 'beta' }}
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
           modrinth-id: 7tG215v7
@@ -122,13 +122,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-artifacts-${{ inputs.branch }}
+          name: build-artifacts-${{ inputs.tag-name }}
       - name: Publish Mod
         env:
-          MC_VERSION: ${{ inputs.branch == '1.21' && '1.21.1' || '1.20.1' }}
-          LOADER: ${{ inputs.branch == '1.21' && 'neoforge' || 'forge' }}
-          JAVA: ${{ inputs.branch == '1.21' && '21' || '17' }}
-          VERSION_TYPE: ${{ inputs.branch == '1.21' && 'alpha' || 'beta' }}
+          MC_VERSION: ${{ inputs.version == '1.21' && '1.21.1' || '1.20.1' }}
+          LOADER: ${{ inputs.version == '1.21' && 'neoforge' || 'forge' }}
+          JAVA: ${{ inputs.version == '1.21' && '21' || '17' }}
+          VERSION_TYPE: ${{ inputs.version == '1.21' && 'alpha' || 'beta' }}
         uses: Kir-Antipov/mc-publish@v3.3.0
         with:
           curseforge-id: 890405
@@ -156,12 +156,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.version }}
       - name: Bump Version
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git switch -C gh/release-${{ inputs.branch }}
+          git switch -C gh/release-${{ inputs.version }}
           BUMPED=$(echo ${{ needs.build.outputs.ver }} | awk -F. '/[0-9]+\./{$NF++;print}' OFS=.)
           sed -i "s/= ${{ needs.build.outputs.ver }}/= ${BUMPED}/" gradle.properties
           git commit -am "Bump version to ${BUMPED}"
@@ -174,5 +174,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git push --force --set-upstream origin gh/release-${{ inputs.branch }}
-          gh pr create -B ${{ inputs.branch }} -H gh/release-${{ inputs.branch }} --title "RELEASE for ${{ inputs.branch }} [no-snapshot]" --body "Created by GH Workflow" --label "ignore changelog"
+          git push --force --set-upstream origin gh/release-${{ inputs.version }}
+          gh pr create -B ${{ inputs.version }} -H gh/release-${{ inputs.version }} --title "RELEASE for ${{ inputs.version }} [no-snapshot]" --body "Created by GH Workflow" --label "ignore changelog"


### PR DESCRIPTION
## What
Allow non-1.20.1 or 1.21 releases

## Implementation Details
Pass the tag name to the publish action and do most stuff based on that instead of version number
It does still make the version bump / changelog PR to/from the 1.20.1 or 1.21 branch bcs idt it can do that off of tags since they're not branches

## How Was This Tested
Not, needs to be tested still somehow? Also needs like 4x review before we mess up another release lol