### PR TITLE
Add readable placeholder exception to show instead of a java exception

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3727,6 +3727,7 @@
   "gtceu.plasma_generator": "ɹoʇɐɹǝuǝ⅁ ɐɯsɐןԀ",
   "gtceu.polarizer": "ɹǝzıɹɐןoԀ",
   "gtceu.primitive_blast_furnace": "ǝɔɐuɹnℲ ʇsɐןᗺ ǝʌıʇıɯıɹԀ",
+  "gtceu.provider.computer_monitor_cover.error.no_target": "dnoɹb ɹoʇıuoɯ ǝɥʇ ɹoɟ pǝʇɔǝןǝs ʇǝbɹɐʇ oN",
   "gtceu.pyrolyse_oven": "uǝʌO ǝsʎןoɹʎԀ",
   "gtceu.recipe.byproduct_tier": "+ɹ§%s ɯoɹɟ sʇɔnpoɹdʎᗺ",
   "gtceu.recipe.category.arc_furnace_recycling": "buıddɐɹɔS ɔɹⱯ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3727,6 +3727,7 @@
   "gtceu.plasma_generator": "Plasma Generator",
   "gtceu.polarizer": "Polarizer",
   "gtceu.primitive_blast_furnace": "Primitive Blast Furnace",
+  "gtceu.provider.computer_monitor_cover.error.no_target": "No target selected for the monitor group",
   "gtceu.pyrolyse_oven": "Pyrolyse Oven",
   "gtceu.recipe.byproduct_tier": "Byproducts from %s§r+",
   "gtceu.recipe.category.arc_furnace_recycling": "Arc Scrapping",

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/exceptions/NoTargetException.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/exceptions/NoTargetException.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.placeholder.exceptions;
 import net.minecraft.network.chat.Component;
 
 public class NoTargetException extends PlaceholderException {
+
     public NoTargetException() {
         super(Component.translatable("gtceu.computer_monitor_cover.error.no_target").getString());
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/exceptions/NoTargetException.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/exceptions/NoTargetException.java
@@ -1,0 +1,9 @@
+package com.gregtechceu.gtceu.api.placeholder.exceptions;
+
+import net.minecraft.network.chat.Component;
+
+public class NoTargetException extends PlaceholderException {
+    public NoTargetException() {
+        super(Component.translatable("gtceu.computer_monitor_cover.error.no_target").getString());
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
@@ -101,6 +101,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 if (ctx.level().getBlockEntity(ctx.pos()) instanceof IEnergyInfoProvider energyInfoProvider) {
                     return MultiLineComponent.literal(energyInfoProvider.getEnergyInfo().stored().longValue());
                 }
@@ -135,6 +136,7 @@ public class GTPlaceholders {
             @Override
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
+                if (ctx.pos() == null) throw new NoTargetException();
                 IItemHandler itemHandler = GTCapabilityHelper.getItemHandler(ctx.level(), ctx.pos(), ctx.side());
                 if (args.isEmpty()) return MultiLineComponent.literal(countItems((ItemFilter) null, itemHandler));
                 if (args.size() == 1) return MultiLineComponent
@@ -159,6 +161,7 @@ public class GTPlaceholders {
             @Override
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
+                if (ctx.pos() == null) throw new NoTargetException();
                 IFluidHandler fluidHandler = GTCapabilityHelper.getFluidHandler(ctx.level(), ctx.pos(), ctx.side());
                 if (args.isEmpty()) return MultiLineComponent.literal(countFluids(null, fluidHandler));
                 if (args.size() == 1)
@@ -318,6 +321,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 IWorkable workable = GTCapabilityHelper.getWorkable(ctx.level(),
                         ctx.pos(), ctx.side());
                 if (workable == null) throw new NotSupportedException();
@@ -330,6 +334,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 IWorkable workable = GTCapabilityHelper.getWorkable(ctx.level(),
                         ctx.pos(), ctx.side());
                 if (workable == null) throw new NotSupportedException();
@@ -342,6 +347,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 IMaintenanceMachine maintenance = GTCapabilityHelper.getMaintenanceMachine(ctx.level(),
                         ctx.pos(), ctx.side());
                 if (maintenance == null) throw new NotSupportedException();
@@ -354,6 +360,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 IWorkable workable = GTCapabilityHelper.getWorkable(ctx.level(),
                         ctx.pos(), ctx.side());
                 if (workable == null) throw new NotSupportedException();
@@ -366,6 +373,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 if (ctx.level().getBlockEntity(ctx.pos()) instanceof CableBlockEntity cable) {
                     return MultiLineComponent.literal(cable.getAverageVoltage());
                 }
@@ -378,6 +386,7 @@ public class GTPlaceholders {
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
                 PlaceholderUtils.checkArgs(args, 0);
+                if (ctx.pos() == null) throw new NoTargetException();
                 if (ctx.level().getBlockEntity(ctx.pos()) instanceof CableBlockEntity cable) {
                     return MultiLineComponent.literal(cable.getAverageAmperage());
                 }
@@ -738,6 +747,7 @@ public class GTPlaceholders {
             @Override
             public MultiLineComponent apply(PlaceholderContext ctx,
                                             List<MultiLineComponent> args) throws PlaceholderException {
+                if (ctx.pos() == null) throw new NoTargetException();
                 if (!(MetaMachine.getMachine(ctx.level(), ctx.pos()) instanceof AdvancedMonitorPartMachine monitor))
                     throw new NotSupportedException();
                 monitor.resetClicked();
@@ -972,7 +982,8 @@ public class GTPlaceholders {
         PlaceholderHandler.addPlaceholder(new Placeholder("blockNbt") {
 
             @Override
-            public MultiLineComponent apply(PlaceholderContext ctx, List<MultiLineComponent> args) {
+            public MultiLineComponent apply(PlaceholderContext ctx, List<MultiLineComponent> args) throws PlaceholderException {
+                if (ctx.pos() == null) throw new NoTargetException();
                 BlockEntity blockEntity = ctx.level().getBlockEntity(ctx.pos());
                 if (blockEntity == null) return MultiLineComponent.empty();
                 Tag tag = blockEntity.saveWithFullMetadata();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
@@ -982,7 +982,8 @@ public class GTPlaceholders {
         PlaceholderHandler.addPlaceholder(new Placeholder("blockNbt") {
 
             @Override
-            public MultiLineComponent apply(PlaceholderContext ctx, List<MultiLineComponent> args) throws PlaceholderException {
+            public MultiLineComponent apply(PlaceholderContext ctx,
+                                            List<MultiLineComponent> args) throws PlaceholderException {
                 if (ctx.pos() == null) throw new NoTargetException();
                 BlockEntity blockEntity = ctx.level().getBlockEntity(ctx.pos());
                 if (blockEntity == null) return MultiLineComponent.empty();

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1766,6 +1766,7 @@ public class LangHandler {
         provider.add("gtceu.computer_monitor_cover.error.bf_invalid_num",
                 "Invalid number at index %d when processing symbol number %d");
         provider.add("gtceu.computer_monitor_cover.error.bf_invalid", "Invalid character at %d");
+        provider.add("gtceu.provider.computer_monitor_cover.error.no_target", "No target selected for the monitor group");
         multiLang(provider, "gtceu.gui.computer_monitor_cover.main_textbox_tooltip",
                 "Input string to display on line %d here.",
                 "It can have placeholders, for example: 'Energy: {energy}/{energyCapacity} EU'",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -1766,7 +1766,8 @@ public class LangHandler {
         provider.add("gtceu.computer_monitor_cover.error.bf_invalid_num",
                 "Invalid number at index %d when processing symbol number %d");
         provider.add("gtceu.computer_monitor_cover.error.bf_invalid", "Invalid character at %d");
-        provider.add("gtceu.provider.computer_monitor_cover.error.no_target", "No target selected for the monitor group");
+        provider.add("gtceu.provider.computer_monitor_cover.error.no_target",
+                "No target selected for the monitor group");
         multiLang(provider, "gtceu.gui.computer_monitor_cover.main_textbox_tooltip",
                 "Input string to display on line %d here.",
                 "It can have placeholders, for example: 'Energy: {energy}/{energyCapacity} EU'",

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/GTAEPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/GTAEPlaceholders.java
@@ -42,7 +42,7 @@ public class GTAEPlaceholders {
     private GTAEPlaceholders() {}
 
     private static IGrid getGrid(PlaceholderContext ctx) throws PlaceholderException {
-        if (ctx.pos() == null) throw new NotSupportedException();
+        if (ctx.pos() == null) throw new NoTargetException();
         IInWorldGridNodeHost nodeHost = GridHelper.getNodeHost(ctx.level(), ctx.pos());
         if (nodeHost != null) {
             IGridNode node = nodeHost.getGridNode(ctx.side());

--- a/src/main/java/com/gregtechceu/gtceu/integration/create/GTCreateIntegration.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/create/GTCreateIntegration.java
@@ -1,10 +1,7 @@
 package com.gregtechceu.gtceu.integration.create;
 
 import com.gregtechceu.gtceu.api.placeholder.*;
-import com.gregtechceu.gtceu.api.placeholder.exceptions.InvalidArgsException;
-import com.gregtechceu.gtceu.api.placeholder.exceptions.MissingItemException;
-import com.gregtechceu.gtceu.api.placeholder.exceptions.NotSupportedException;
-import com.gregtechceu.gtceu.api.placeholder.exceptions.PlaceholderException;
+import com.gregtechceu.gtceu.api.placeholder.exceptions.*;
 import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.utils.GTStringUtils;
 
@@ -60,7 +57,8 @@ public class GTCreateIntegration {
     }
 
     private static int getRedstoneLinkPower(PlaceholderContext ctx,
-                                            Couple<RedstoneLinkNetworkHandler.Frequency> freq) {
+                                            Couple<RedstoneLinkNetworkHandler.Frequency> freq) throws PlaceholderException {
+        if (ctx.pos() == null) throw new NoTargetException();
         IRedstoneLinkable linkable = new IRedstoneLinkable() {
 
             @Override


### PR DESCRIPTION
## What
Add `NoTargetException` to show when a placeholder that requires a target is executed without a target

## Outcome
Resolves #4769

## How Was This Tested
In-game