### PR TITLE
Simplify machine models

### DIFF
--- a/src/generated/resources/assets/gtceu/models/block/machine/active_transformer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/active_transformer.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/hpca/high_power_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/advanced_data_access_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/advanced_data_access_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/data_access_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/data_access_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/alloy_blast_smelter.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/alloy_blast_smelter.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/blast_alloy_smelter/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/assembly_line.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/assembly_line.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/assembly_line/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/assembly_line/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/assembly_line/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/assembly_line/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/assembly_line/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/assembly_line/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/assembly_line/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/assembly_line/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/auto_maintenance_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/auto_maintenance_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/auto_maintenance_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/auto_maintenance_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/basic_data_access_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/basic_data_access_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/data_access_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/data_access_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/bronze_large_boiler.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/bronze_large_boiler.json
@@ -26,7 +26,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,7 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -46,7 +46,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -56,47 +56,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_bronze_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/bronze_multiblock_tank.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/bronze_multiblock_tank.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -15,7 +15,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -24,7 +24,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -33,43 +33,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front_active"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front_active"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/central_monitor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/central_monitor.json
@@ -11,7 +11,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_frost_proof"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -20,7 +20,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -29,7 +29,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -39,45 +39,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/central_monitor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/central_monitor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/central_monitor/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/central_monitor/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/central_monitor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/central_monitor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/charcoal_pile_igniter.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/charcoal_pile_igniter.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_top": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top_active",
-          "overlay_top_emissive": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_top": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top",
-          "overlay_top_emissive": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_top": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top",
-          "overlay_top_emissive": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_top": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top_active",
-          "overlay_top_emissive": "gtceu:block/multiblock/charcoal_pile_igniter/overlay_top_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/cleaning_maintenance_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/cleaning_maintenance_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/cleaning_maintenance_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/cleaning_maintenance_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/cleanroom.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/cleanroom.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/cleanroom/plascrete"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/cleanroom/plascrete",
-          "overlay_bottom": "gtceu:block/multiblock/cleanroom/overlay_bottom_active",
-          "overlay_top": "gtceu:block/multiblock/cleanroom/overlay_top_active"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/cleanroom/plascrete",
-          "overlay_bottom": "gtceu:block/multiblock/cleanroom/overlay_bottom",
-          "overlay_top": "gtceu:block/multiblock/cleanroom/overlay_top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/cleanroom/plascrete",
-          "overlay_bottom": "gtceu:block/multiblock/cleanroom/overlay_bottom",
-          "overlay_top": "gtceu:block/multiblock/cleanroom/overlay_top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/cleanroom/plascrete",
-          "overlay_bottom": "gtceu:block/multiblock/cleanroom/overlay_bottom_active",
-          "overlay_top": "gtceu:block/multiblock/cleanroom/overlay_top_active"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/coke_oven.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/coke_oven.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_coke_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_coke_bricks",
-          "overlay_front": "gtceu:block/multiblock/coke_oven/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/coke_oven/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_coke_bricks",
-          "overlay_front": "gtceu:block/multiblock/coke_oven/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/coke_oven/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_coke_bricks",
-          "overlay_front": "gtceu:block/multiblock/coke_oven/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/coke_oven/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_coke_bricks",
-          "overlay_front": "gtceu:block/multiblock/coke_oven/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/coke_oven/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/coke_oven_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/coke_oven_hatch.json
@@ -3,10 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:coke_oven_hatch",
   "variants": {
-    "is_formed=false": {
-      "model": "gtceu:block/machine/part/coke_oven_hatch"
-    },
-    "is_formed=true": {
+    "": {
       "model": "gtceu:block/machine/part/coke_oven_hatch"
     }
   }

--- a/src/generated/resources/assets/gtceu/models/block/machine/computation_receiver_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/computation_receiver_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/computation_data_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/computation_data_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/computation_transmitter_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/computation_transmitter_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/computation_data_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/computation_data_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/configurable_maintenance_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/configurable_maintenance_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,taped=false": {
+    "taped=false": {
       "model": {
         "parent": "gtceu:block/machine/part/configurable_maintenance_hatch",
         "textures": {
@@ -18,28 +18,7 @@
         }
       }
     },
-    "is_formed=false,taped=true": {
-      "model": {
-        "parent": "gtceu:block/machine/part/configurable_maintenance_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay_2": "gtceu:block/overlay/machine/overlay_maintenance_taped",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,taped=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/configurable_maintenance_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,taped=true": {
+    "taped=true": {
       "model": {
         "parent": "gtceu:block/machine/part/configurable_maintenance_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/cracker.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/cracker.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/cracking_unit/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/cracking_unit/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/cracking_unit/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/cracking_unit/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/cracking_unit/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/cracking_unit/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/cracking_unit/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/cracking_unit/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/creative_data_access_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/creative_data_access_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/data_access_hatch_creative",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/data_access_hatch_creative",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/data_access_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/data_access_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/data_access_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/data_access_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/data_bank.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/data_bank.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/hpca/high_power_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/hpca/high_power_casing",
-          "overlay_front": "gtceu:block/multiblock/data_bank/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/data_bank/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/data_receiver_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/data_receiver_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/optical_data_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/optical_data_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/data_transmitter_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/data_transmitter_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/optical_data_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/optical_data_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/distillation_tower.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/distillation_tower.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/distillation_tower/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/distillation_tower/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/distillation_tower/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/distillation_tower/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/distillation_tower/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/distillation_tower/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_clean_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/distillation_tower/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/distillation_tower/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/electric_blast_furnace.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/electric_blast_furnace.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_heatproof"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/electric_blast_furnace/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/electric_blast_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_bedrock_ore_miner.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_bedrock_ore_miner.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_fluid_drilling_rig.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_fluid_drilling_rig.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_large_miner.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_large_miner.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,49 +36,9 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
         "textures": {
           "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
           "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ev_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ev_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/extreme_combustion_engine.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/extreme_combustion_engine.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/extreme_combustion_engine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/gas_large_turbine.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/gas_large_turbine.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/mechanic/machine_casing_turbine_stainless_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_stainless_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_gas_turbine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/high_performance_computation_array.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/high_performance_computation_array.json
@@ -8,7 +8,7 @@
     "top": "gtceu:block/casings/hpca/computer_casing/top"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -20,7 +20,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -32,7 +32,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -44,55 +44,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/hpca/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/hpca/overlay_front_active_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/hpca/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/hpca/overlay_front_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/hpca/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/hpca/overlay_front_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/hpca/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/hpca/overlay_front_active_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hpca_active_cooler_component.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hpca_active_cooler_component.json
@@ -3,7 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:hpca_active_cooler_component",
   "variants": {
-    "active=false,hpca_part_damaged=false,is_formed=false": {
+    "active=false,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_active_cooler_component_base",
         "textures": {
@@ -12,16 +12,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_active_cooler_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/active_cooler",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=false,hpca_part_damaged=true,is_formed=false": {
+    "active=false,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_active_cooler_component_base",
         "textures": {
@@ -30,16 +21,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=true,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_active_cooler_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_advanced",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_advanced_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=false,is_formed=false": {
+    "active=true,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_active_cooler_component_base",
         "textures": {
@@ -48,25 +30,7 @@
         }
       }
     },
-    "active=true,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_active_cooler_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/active_cooler_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/active_cooler_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/hpca_active_cooler_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_advanced_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_advanced_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=true": {
+    "active=true,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_active_cooler_component_base",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hpca_advanced_computation_component.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hpca_advanced_computation_component.json
@@ -3,7 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:hpca_advanced_computation_component",
   "variants": {
-    "active=false,hpca_part_damaged=false,is_formed=false": {
+    "active=false,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_advanced_computation_component_base",
         "textures": {
@@ -12,16 +12,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_advanced_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/advanced_computation",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=false,hpca_part_damaged=true,is_formed=false": {
+    "active=false,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_advanced_computation_component_base",
         "textures": {
@@ -30,16 +21,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=true,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_advanced_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_advanced",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_advanced_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=false,is_formed=false": {
+    "active=true,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_advanced_computation_component_base",
         "textures": {
@@ -48,25 +30,7 @@
         }
       }
     },
-    "active=true,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_advanced_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/advanced_computation_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/advanced_computation_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/hpca_advanced_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_advanced_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_advanced_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=true": {
+    "active=true,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_advanced_computation_component_base",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hpca_bridge_component.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hpca_bridge_component.json
@@ -3,7 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:hpca_bridge_component",
   "variants": {
-    "active=false,hpca_part_damaged=false,is_formed=false": {
+    "active=false,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_bridge_component_base",
         "textures": {
@@ -12,16 +12,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_bridge_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/bridge",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=false,hpca_part_damaged=true,is_formed=false": {
+    "active=false,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_bridge_component_base",
         "textures": {
@@ -30,16 +21,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=true,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_bridge_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=false,is_formed=false": {
+    "active=true,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_bridge_component_base",
         "textures": {
@@ -48,25 +30,7 @@
         }
       }
     },
-    "active=true,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_bridge_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/bridge_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/bridge_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/hpca_bridge_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=true": {
+    "active=true,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_bridge_component_base",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hpca_computation_component.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hpca_computation_component.json
@@ -3,7 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:hpca_computation_component",
   "variants": {
-    "active=false,hpca_part_damaged=false,is_formed=false": {
+    "active=false,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_computation_component_base",
         "textures": {
@@ -12,16 +12,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/computation",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=false,hpca_part_damaged=true,is_formed=false": {
+    "active=false,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_computation_component_base",
         "textures": {
@@ -30,16 +21,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=true,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=false,is_formed=false": {
+    "active=true,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_computation_component_base",
         "textures": {
@@ -48,25 +30,7 @@
         }
       }
     },
-    "active=true,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/computation_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/computation_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/hpca_computation_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=true": {
+    "active=true,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_computation_component_base",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hpca_empty_component.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hpca_empty_component.json
@@ -3,7 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:hpca_empty_component",
   "variants": {
-    "active=false,hpca_part_damaged=false,is_formed=false": {
+    "active=false,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_empty_component_base",
         "textures": {
@@ -12,16 +12,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_empty_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/empty",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=false,hpca_part_damaged=true,is_formed=false": {
+    "active=false,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_empty_component_base",
         "textures": {
@@ -30,16 +21,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=true,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_empty_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=false,is_formed=false": {
+    "active=true,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_empty_component_base",
         "textures": {
@@ -48,25 +30,7 @@
         }
       }
     },
-    "active=true,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_empty_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/empty",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/hpca_empty_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=true": {
+    "active=true,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_empty_component_base",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hpca_heat_sink_component.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hpca_heat_sink_component.json
@@ -3,7 +3,7 @@
   "loader": "gtceu:machine",
   "machine": "gtceu:hpca_heat_sink_component",
   "variants": {
-    "active=false,hpca_part_damaged=false,is_formed=false": {
+    "active=false,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_heat_sink_component_base",
         "textures": {
@@ -12,16 +12,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_heat_sink_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/heat_sink",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=false,hpca_part_damaged=true,is_formed=false": {
+    "active=false,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_heat_sink_component_base",
         "textures": {
@@ -30,16 +21,7 @@
         }
       }
     },
-    "active=false,hpca_part_damaged=true,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_heat_sink_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=false,is_formed=false": {
+    "active=true,hpca_part_damaged=false": {
       "model": {
         "parent": "gtceu:block/hpca_heat_sink_component_base",
         "textures": {
@@ -48,25 +30,7 @@
         }
       }
     },
-    "active=true,hpca_part_damaged=false,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/hpca_heat_sink_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/heat_sink",
-          "overlay_emissive": "gtceu:block/void"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/hpca_heat_sink_component_base",
-        "textures": {
-          "overlay": "gtceu:block/overlay/machine/hpca/damaged_active",
-          "overlay_emissive": "gtceu:block/overlay/machine/hpca/damaged_active_emissive"
-        }
-      }
-    },
-    "active=true,hpca_part_damaged=true,is_formed=true": {
+    "active=true,hpca_part_damaged=true": {
       "model": {
         "parent": "gtceu:block/hpca_heat_sink_component_base",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_bedrock_ore_miner.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_bedrock_ore_miner.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_stable_titanium"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_fluid_drilling_rig.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_fluid_drilling_rig.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_stable_titanium"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/hv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/hv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/hv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/hv/side",
-          "top": "gtceu:block/casings/voltage/hv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/implosion_compressor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/implosion_compressor.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/implosion_compressor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/implosion_compressor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/implosion_compressor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/implosion_compressor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/implosion_compressor/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/implosion_compressor/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/implosion_compressor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/implosion_compressor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_large_miner.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_large_miner.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_stable_titanium"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,49 +36,9 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
         "textures": {
           "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
           "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_parallel_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_parallel_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/casings/voltage/iv",
         "textures": {
@@ -17,7 +17,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/casings/voltage/iv",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/casings/voltage/iv",
         "textures": {
@@ -35,43 +35,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/iv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk1/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk1/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/iv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk1/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk1/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/iv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk1/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk1/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/iv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk1/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk1/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/casings/voltage/iv",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/iv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/iv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/iv/bottom",
-          "side": "gtceu:block/casings/voltage/iv/side",
-          "top": "gtceu:block/casings/voltage/iv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_arc_smelter.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_arc_smelter.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_arc_smelter/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_assembler.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_assembler.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/large_scale_assembling_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_assembler/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_assembler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_autoclave.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_autoclave.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/watertight_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_autoclave/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_brewer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_brewer.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/corrosion_proof_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/corrosion_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/corrosion_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_brewer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/corrosion_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/corrosion_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_brewer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_centrifuge.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_centrifuge.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/vibration_safe_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_centrifuge/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_chemical_bath.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_chemical_bath.json
@@ -15,7 +15,7 @@
     "all": "gtceu:block/casings/gcym/watertight_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -25,7 +25,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -35,7 +35,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -45,47 +45,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_chemical_bath/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_chemical_reactor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_chemical_reactor.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_inert_ptfe"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_inert_ptfe",
-          "overlay_front": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_inert_ptfe",
-          "overlay_front": "gtceu:block/multiblock/large_chemical_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_inert_ptfe",
-          "overlay_front": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_inert_ptfe",
-          "overlay_front": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_chemical_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_circuit_assembler.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_circuit_assembler.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/large_scale_assembling_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/large_scale_assembling_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_circuit_assembler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_combustion_engine.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_combustion_engine.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_stable_titanium"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_combustion_engine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_cutter.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_cutter.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/shock_proof_cutting_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/shock_proof_cutting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/shock_proof_cutting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_cutter/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/shock_proof_cutting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/shock_proof_cutting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_cutter/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_distillery.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_distillery.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/watertight_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_distillery/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_distillery/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_electrolyzer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_electrolyzer.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/nonconducting_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_electromagnet.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_electromagnet.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/nonconducting_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/nonconducting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_electrolyzer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_engraving_laser.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_engraving_laser.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/laser_safe_engraving_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/laser_safe_engraving_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/laser_safe_engraving_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/laser_safe_engraving_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/laser_safe_engraving_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_engraving_laser/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_extractor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_extractor.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/watertight_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extractor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extractor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_extruder.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_extruder.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/stress_proof_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extruder/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_extruder/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_maceration_tower.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_maceration_tower.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/secure_maceration_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/secure_maceration_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/secure_maceration_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/secure_maceration_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/secure_maceration_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_maceration_tower/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_material_press.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_material_press.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/stress_proof_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_material_press/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_material_press/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_mixer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_mixer.json
@@ -15,7 +15,7 @@
     "all": "gtceu:block/casings/gcym/reaction_safe_mixing_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -25,7 +25,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -35,7 +35,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -45,47 +45,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/reaction_safe_mixing_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/reaction_safe_mixing_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_mixer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/reaction_safe_mixing_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/reaction_safe_mixing_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_mixer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_packer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_packer.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_packer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_packer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_packer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_packer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_packer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_packer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_packer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_packer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_sifting_funnel.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_sifting_funnel.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/vibration_safe_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/vibration_safe_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_sifting_funnel/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_solidifier.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_solidifier.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/watertight_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/watertight_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_solidifier/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/large_wiremill.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/large_wiremill.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/stress_proof_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/stress_proof_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/large_wiremill/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/long_distance_fluid_pipeline_endpoint.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/long_distance_fluid_pipeline_endpoint.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/long_distance_fluid_pipeline_endpoint",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/long_distance_fluid_pipeline_endpoint",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/long_distance_item_pipeline_endpoint.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/long_distance_item_pipeline_endpoint.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/long_distance_item_pipeline_endpoint",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/long_distance_item_pipeline_endpoint",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_fusion_reactor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_fusion_reactor.json
@@ -11,7 +11,7 @@
     "all": "gtceu:block/casings/fusion/fusion_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -21,7 +21,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -31,7 +31,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -41,47 +41,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_large_miner.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_large_miner.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,49 +36,9 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/large_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/large_miner_active",
         "textures": {
           "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
           "overlay_front": "gtceu:block/multiblock/large_miner/overlay_front_active",

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_parallel_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_parallel_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/casings/voltage/luv",
         "textures": {
@@ -17,7 +17,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/casings/voltage/luv",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/casings/voltage/luv",
         "textures": {
@@ -35,43 +35,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/luv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk2/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk2/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/luv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk2/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk2/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/luv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk2/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk2/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/luv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk2/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk2/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/casings/voltage/luv",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/luv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/luv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/lv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/lv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/maintenance_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/maintenance_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,taped=false": {
+    "taped=false": {
       "model": {
         "parent": "gtceu:block/machine/part/maintenance_hatch",
         "textures": {
@@ -18,28 +18,7 @@
         }
       }
     },
-    "is_formed=false,taped=true": {
-      "model": {
-        "parent": "gtceu:block/machine/part/maintenance_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "overlay_2": "gtceu:block/overlay/machine/overlay_maintenance_taped",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,taped=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/maintenance_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/lv/bottom",
-          "side": "gtceu:block/casings/voltage/lv/side",
-          "top": "gtceu:block/casings/voltage/lv/top"
-        }
-      }
-    },
-    "is_formed=true,taped=true": {
+    "taped=true": {
       "model": {
         "parent": "gtceu:block/machine/part/maintenance_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/max_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/max_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/max/bottom",
-          "side": "gtceu:block/casings/voltage/max/side",
-          "top": "gtceu:block/casings/voltage/max/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_bus",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_bus",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_hatch",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_hatch",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_output_bus",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_output_bus",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_output_hatch",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_output_hatch",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_pattern_buffer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_pattern_buffer.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_buffer_hatch",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_buffer_hatch",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_pattern_buffer_proxy.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_pattern_buffer_proxy.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_buffer_hatch_proxy",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_buffer_hatch_proxy",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_stocking_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_stocking_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_bus",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_bus",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/me_stocking_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/me_stocking_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine",
         "textures": {
@@ -19,29 +19,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_hatch",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/luv/bottom",
-          "overlay": "gtceu:block/overlay/appeng/me_input_hatch",
-          "side": "gtceu:block/casings/voltage/luv/side",
-          "top": "gtceu:block/casings/voltage/luv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mega_blast_furnace.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mega_blast_furnace.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/gcym/high_temperature_smelting_casing",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_blast_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mega_vacuum_freezer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mega_vacuum_freezer.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_frost_proof"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/gcym/mega_vacuum_freezer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/multi_smelter.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/multi_smelter.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_heatproof"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/multi_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/multi_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/multi_furnace/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/multi_furnace/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/multi_furnace/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/multi_furnace/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_heatproof",
-          "overlay_front": "gtceu:block/multiblock/multi_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/multi_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_bedrock_ore_miner.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_bedrock_ore_miner.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/bedrock_ore_miner/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_fluid_drilling_rig.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_fluid_drilling_rig.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fluid_drilling_rig/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/mv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/mv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/mv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/mv/side",
-          "top": "gtceu:block/casings/voltage/mv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/network_switch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/network_switch.json
@@ -8,7 +8,7 @@
     "top": "gtceu:block/casings/hpca/computer_casing/top"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -20,7 +20,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -32,7 +32,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -44,55 +44,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/network_switch/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/network_switch/overlay_front_active_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/network_switch/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/network_switch/overlay_front_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/network_switch/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/network_switch/overlay_front_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/network_switch/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/network_switch/overlay_front_active_emissive",
-          "side": "gtceu:block/casings/hpca/computer_casing/side",
-          "top": "gtceu:block/casings/hpca/computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/object_holder.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/object_holder.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {
@@ -24,7 +24,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {
@@ -33,41 +33,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/object_holder/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/object_holder/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/object_holder/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/object_holder/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/object_holder/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/object_holder/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/opv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/opv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/opv/bottom",
-          "side": "gtceu:block/casings/voltage/opv/side",
-          "top": "gtceu:block/casings/voltage/opv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/plasma_large_turbine.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/plasma_large_turbine.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/mechanic/machine_casing_turbine_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_plasma_turbine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/power_substation.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/power_substation.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_palladium_substation"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -15,7 +15,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -24,7 +24,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -34,45 +34,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_palladium_substation",
-          "overlay_front": "gtceu:block/multiblock/power_substation/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/power_substation/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_palladium_substation",
-          "overlay_front": "gtceu:block/multiblock/power_substation/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_palladium_substation",
-          "overlay_front": "gtceu:block/multiblock/power_substation/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_palladium_substation",
-          "overlay_front": "gtceu:block/multiblock/power_substation/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/power_substation/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/primitive_blast_furnace.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/primitive_blast_furnace.json
@@ -16,7 +16,7 @@
     "all": "gtceu:block/casings/solid/machine_primitive_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,7 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -46,47 +46,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_primitive_bricks",
-          "overlay_front": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_primitive_bricks",
-          "overlay_front": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_primitive_bricks",
-          "overlay_front": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_primitive_bricks",
-          "overlay_front": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/primitive_blast_furnace/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/primitive_pump.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/primitive_pump.json
@@ -8,7 +8,7 @@
     "top": "gtceu:block/casings/pump_deck/top"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -17,10 +17,9 @@
           "side": "gtceu:block/casings/pump_deck/side",
           "top": "gtceu:block/casings/pump_deck/top"
         }
-      },
-      "uvlock": true
+      }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -29,10 +28,9 @@
           "side": "gtceu:block/casings/pump_deck/side",
           "top": "gtceu:block/casings/pump_deck/top"
         }
-      },
-      "uvlock": true
+      }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -41,10 +39,9 @@
           "side": "gtceu:block/casings/pump_deck/side",
           "top": "gtceu:block/casings/pump_deck/top"
         }
-      },
-      "uvlock": true
+      }
     },
-    "is_formed=false,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -53,56 +50,7 @@
           "side": "gtceu:block/casings/pump_deck/side",
           "top": "gtceu:block/casings/pump_deck/top"
         }
-      },
-      "uvlock": true
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/pump_deck/bottom",
-          "overlay_front": "gtceu:block/multiblock/primitive_pump/overlay_front",
-          "side": "gtceu:block/casings/pump_deck/side",
-          "top": "gtceu:block/casings/pump_deck/top"
-        }
-      },
-      "uvlock": true
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/pump_deck/bottom",
-          "overlay_front": "gtceu:block/multiblock/primitive_pump/overlay_front",
-          "side": "gtceu:block/casings/pump_deck/side",
-          "top": "gtceu:block/casings/pump_deck/top"
-        }
-      },
-      "uvlock": true
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/pump_deck/bottom",
-          "overlay_front": "gtceu:block/multiblock/primitive_pump/overlay_front",
-          "side": "gtceu:block/casings/pump_deck/side",
-          "top": "gtceu:block/casings/pump_deck/top"
-        }
-      },
-      "uvlock": true
-    },
-    "is_formed=true,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/pump_deck/bottom",
-          "overlay_front": "gtceu:block/multiblock/primitive_pump/overlay_front",
-          "side": "gtceu:block/casings/pump_deck/side",
-          "top": "gtceu:block/casings/pump_deck/top"
-        }
-      },
-      "uvlock": true
+      }
     }
   }
 }

--- a/src/generated/resources/assets/gtceu/models/block/machine/pump_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/pump_hatch.json
@@ -8,10 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": "gtceu:block/machine/part/pump_hatch"
-    },
-    "is_formed=true": {
+    "": {
       "model": "gtceu:block/machine/part/pump_hatch"
     }
   }

--- a/src/generated/resources/assets/gtceu/models/block/machine/pyrolyse_oven.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/pyrolyse_oven.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/voltage/ulv/side"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/voltage/ulv/side",
-          "overlay_front": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/voltage/ulv/side",
-          "overlay_front": "gtceu:block/multiblock/pyrolyse_oven/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/voltage/ulv/side",
-          "overlay_front": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/voltage/ulv/side",
-          "overlay_front": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/pyrolyse_oven/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/research_station.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/research_station.json
@@ -8,7 +8,7 @@
     "top": "gtceu:block/casings/hpca/advanced_computer_casing/top"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -20,7 +20,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -32,7 +32,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -44,55 +44,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/advanced_computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/research_station/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/research_station/overlay_front_active_emissive",
-          "side": "gtceu:block/casings/hpca/advanced_computer_casing/side",
-          "top": "gtceu:block/casings/hpca/advanced_computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/advanced_computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/research_station/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/research_station/overlay_front_emissive",
-          "side": "gtceu:block/casings/hpca/advanced_computer_casing/side",
-          "top": "gtceu:block/casings/hpca/advanced_computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/advanced_computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/research_station/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/research_station/overlay_front_emissive",
-          "side": "gtceu:block/casings/hpca/advanced_computer_casing/side",
-          "top": "gtceu:block/casings/hpca/advanced_computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/hpca/advanced_computer_casing/bottom",
-          "overlay_front": "gtceu:block/multiblock/research_station/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/research_station/overlay_front_active_emissive",
-          "side": "gtceu:block/casings/hpca/advanced_computer_casing/side",
-          "top": "gtceu:block/casings/hpca/advanced_computer_casing/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/reservoir_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/reservoir_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/reservoir_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ev/bottom",
-          "side": "gtceu:block/casings/voltage/ev/side",
-          "top": "gtceu:block/casings/voltage/ev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/reservoir_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steam_grinder.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steam_grinder.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_grinder/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_grinder/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_grinder/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_grinder/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_grinder/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_grinder/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_grinder/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_grinder/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steam_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steam_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/steam/bronze/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/steam/bronze/side",
-          "top": "gtceu:block/casings/steam/bronze/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/steam/bronze/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/steam/bronze/side",
-          "top": "gtceu:block/casings/steam/bronze/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steam_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steam_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,steel=false": {
+    "steel=false": {
       "model": {
         "parent": "gtceu:block/machine/part/steam_hatch",
         "textures": {
@@ -18,27 +18,7 @@
         }
       }
     },
-    "is_formed=false,steel=true": {
-      "model": {
-        "parent": "gtceu:block/machine/part/steam_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/steam/steel/bottom",
-          "side": "gtceu:block/casings/steam/steel/side",
-          "top": "gtceu:block/casings/steam/steel/top"
-        }
-      }
-    },
-    "is_formed=true,steel=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/steam_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/steam/bronze/bottom",
-          "side": "gtceu:block/casings/steam/bronze/side",
-          "top": "gtceu:block/casings/steam/bronze/top"
-        }
-      }
-    },
-    "is_formed=true,steel=true": {
+    "steel=true": {
       "model": {
         "parent": "gtceu:block/machine/part/steam_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steam_large_turbine.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steam_large_turbine.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/mechanic/machine_casing_turbine_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/mechanic/machine_casing_turbine_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steam_turbine/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steam_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steam_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/steam/bronze/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/steam/bronze/side",
-          "top": "gtceu:block/casings/steam/bronze/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/steam/bronze/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/steam/bronze/side",
-          "top": "gtceu:block/casings/steam/bronze/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steam_oven.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steam_oven.json
@@ -26,7 +26,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,7 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -46,7 +46,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -56,47 +56,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_bronze_plated_bricks",
-          "overlay_front": "gtceu:block/multiblock/steam_oven/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/steam_oven/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steel_large_boiler.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steel_large_boiler.json
@@ -26,7 +26,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,7 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -46,7 +46,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -56,47 +56,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_steel_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/steel_multiblock_tank.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/steel_multiblock_tank.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_solid_steel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -15,7 +15,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -24,7 +24,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -33,43 +33,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front_active"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_solid_steel",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front_active"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/titanium_large_boiler.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/titanium_large_boiler.json
@@ -26,7 +26,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_stable_titanium"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,7 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -46,7 +46,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -56,47 +56,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_stable_titanium",
-          "overlay_front": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_titanium_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/tungstensteel_large_boiler.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/tungstensteel_large_boiler.json
@@ -26,7 +26,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,7 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -46,7 +46,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -56,47 +56,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_robust_tungstensteel",
-          "overlay_front": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/generator/large_tungstensteel_boiler/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uev_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uev_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uev/bottom",
-          "side": "gtceu:block/casings/voltage/uev/side",
-          "top": "gtceu:block/casings/voltage/uev/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uhv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uhv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uhv/bottom",
-          "side": "gtceu:block/casings/voltage/uhv/side",
-          "top": "gtceu:block/casings/voltage/uhv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uiv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uiv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uiv/bottom",
-          "side": "gtceu:block/casings/voltage/uiv/side",
-          "top": "gtceu:block/casings/voltage/uiv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/ulv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/ulv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/ulv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/ulv/side",
-          "top": "gtceu:block/casings/voltage/ulv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_fusion_reactor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_fusion_reactor.json
@@ -11,7 +11,7 @@
     "all": "gtceu:block/casings/fusion/fusion_casing_mk3"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -21,7 +21,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -31,7 +31,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -41,47 +41,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk3",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk3",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk3",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk3",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_parallel_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_parallel_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/casings/voltage/uv",
         "textures": {
@@ -17,7 +17,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/casings/voltage/uv",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/casings/voltage/uv",
         "textures": {
@@ -35,43 +35,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/uv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk4/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk4/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/uv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk4/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk4/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/uv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk4/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk4/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/uv",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk4/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk4/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/casings/voltage/uv",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uv/bottom",
-          "side": "gtceu:block/casings/voltage/uv/side",
-          "top": "gtceu:block/casings/voltage/uv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/uxv_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/uxv_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/uxv/bottom",
-          "side": "gtceu:block/casings/voltage/uxv/side",
-          "top": "gtceu:block/casings/voltage/uxv/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/vacuum_freezer.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/vacuum_freezer.json
@@ -6,7 +6,7 @@
     "all": "gtceu:block/casings/solid/machine_casing_frost_proof"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -16,7 +16,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -36,47 +36,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/vacuum_freezer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/vacuum_freezer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/vacuum_freezer/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/vacuum_freezer/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/vacuum_freezer/overlay_front_paused",
-          "overlay_front_emissive": "gtceu:block/multiblock/vacuum_freezer/overlay_front_paused_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/solid/machine_casing_frost_proof",
-          "overlay_front": "gtceu:block/multiblock/vacuum_freezer/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/vacuum_freezer/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/wooden_multiblock_tank.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/wooden_multiblock_tank.json
@@ -8,7 +8,7 @@
     "top": "gtceu:block/casings/wood_wall/top"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -19,7 +19,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -30,7 +30,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {
@@ -41,51 +41,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/wood_wall/bottom",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front_active",
-          "side": "gtceu:block/casings/wood_wall/side",
-          "top": "gtceu:block/casings/wood_wall/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/wood_wall/bottom",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front",
-          "side": "gtceu:block/casings/wood_wall/side",
-          "top": "gtceu:block/casings/wood_wall/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/wood_wall/bottom",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front",
-          "side": "gtceu:block/casings/wood_wall/side",
-          "top": "gtceu:block/casings/wood_wall/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/sided/sided",
-        "textures": {
-          "bottom": "gtceu:block/casings/wood_wall/bottom",
-          "overlay_front": "gtceu:block/multiblock/multiblock_tank/overlay_front_active",
-          "side": "gtceu:block/casings/wood_wall/side",
-          "top": "gtceu:block/casings/wood_wall/top"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/sided/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_1024a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_1024a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_1024a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_1024a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_256a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_256a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_256a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_256a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_4096a_laser_source_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_4096a_laser_source_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_source_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_source_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_4096a_laser_target_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_4096a_laser_target_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/laser_target_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/laser_target_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_diode.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_diode.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "amp_mode=16a,is_formed=false": {
+    "amp_mode=16a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -24,23 +24,7 @@
         }
       }
     },
-    "amp_mode=16a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_16a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_16a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_16a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_16a_tinted",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "amp_mode=1a,is_formed=false": {
+    "amp_mode=1a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -56,23 +40,7 @@
         }
       }
     },
-    "amp_mode=1a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_1a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_1a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_1a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_1a_tinted",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "amp_mode=2a,is_formed=false": {
+    "amp_mode=2a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -88,23 +56,7 @@
         }
       }
     },
-    "amp_mode=2a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_2a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_2a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_2a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_2a_tinted",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "amp_mode=4a,is_formed=false": {
+    "amp_mode=4a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {
@@ -120,39 +72,7 @@
         }
       }
     },
-    "amp_mode=4a,is_formed=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_4a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_4a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_4a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_4a_tinted",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/transformer_like_machine",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay_in_io": "gtceu:block/overlay/machine/overlay_energy_8a_in",
-          "overlay_in_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_in_emissive",
-          "overlay_in_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "overlay_out_io": "gtceu:block/overlay/machine/overlay_energy_8a_out",
-          "overlay_out_io_emissive": "gtceu:block/overlay/machine/overlay_energy_8a_out_emissive",
-          "overlay_out_tinted": "gtceu:block/overlay/machine/overlay_energy_8a_tinted",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "amp_mode=8a,is_formed=true": {
+    "amp_mode=8a": {
       "model": {
         "parent": "gtceu:block/machine/template/transformer_like_machine",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_dual_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_dual_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_dual_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_dual_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/dual_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/dual_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_input_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_input_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_input_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_input_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_input_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_output_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_output_hatch_16a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_output_hatch_16a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_16a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_output_hatch_4a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_energy_output_hatch_4a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_4a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_fluid_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_fluid_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/fluid_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_fusion_reactor.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_fusion_reactor.json
@@ -11,7 +11,7 @@
     "all": "gtceu:block/casings/fusion/fusion_casing_mk2"
   },
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -21,7 +21,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -31,7 +31,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {
@@ -41,47 +41,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk2",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk2",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk2",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/machine/template/cube_all/sided",
-        "textures": {
-          "all": "gtceu:block/casings/fusion/fusion_casing_mk2",
-          "overlay_front": "gtceu:block/multiblock/fusion_reactor/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/multiblock/fusion_reactor/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/machine/template/cube_all/sided",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_input_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_input",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_in_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_item_passthrough_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_item_passthrough_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/item_passthrough_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/item_passthrough_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_machine_hull.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_machine_hull.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/hull",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/hull",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_muffler_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_muffler_hatch.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/muffler_hatch",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/muffler_hatch",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_bus.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_bus.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_item_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -20,31 +20,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_hatch_4x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_hatch_4x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_4x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_hatch_9x.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_output_hatch_9x.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,is_painted=false": {
+    "is_painted=false": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
         "textures": {
@@ -21,33 +21,7 @@
         }
       }
     },
-    "is_formed=false,is_painted=true": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=false": {
-      "model": {
-        "parent": "gtceu:block/machine/template/part/hatch_machine_emissive",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "overlay": "gtceu:block/overlay/machine/overlay_fluid_hatch_output",
-          "overlay_emissive": "gtceu:block/overlay/machine/overlay_pipe_out_emissive",
-          "overlay_pipe": "gtceu:block/overlay/machine/overlay_pipe_9x",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true,is_painted=true": {
+    "is_painted=true": {
       "model": {
         "parent": "gtceu:block/machine/template/part/hatch_machine_emissive_color_ring",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_parallel_hatch.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_parallel_hatch.json
@@ -8,7 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false,recipe_logic_status=idle": {
+    "recipe_logic_status=idle": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {
@@ -17,7 +17,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=suspend": {
+    "recipe_logic_status=suspend": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {
@@ -26,7 +26,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=waiting": {
+    "recipe_logic_status=waiting": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {
@@ -35,43 +35,7 @@
         }
       }
     },
-    "is_formed=false,recipe_logic_status=working": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk3/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk3/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=idle": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk3/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk3/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=suspend": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk3/overlay_front",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk3/overlay_front_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=waiting": {
-      "model": {
-        "parent": "gtceu:block/casings/voltage/zpm",
-        "textures": {
-          "overlay_front": "gtceu:block/machines/parallel_hatch_mk3/overlay_front_active",
-          "overlay_front_emissive": "gtceu:block/machines/parallel_hatch_mk3/overlay_front_active_emissive"
-        }
-      }
-    },
-    "is_formed=true,recipe_logic_status=working": {
+    "recipe_logic_status=working": {
       "model": {
         "parent": "gtceu:block/casings/voltage/zpm",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_substation_input_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_substation_input_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_input_hatch_64a",
         "textures": {

--- a/src/generated/resources/assets/gtceu/models/block/machine/zpm_substation_output_hatch_64a.json
+++ b/src/generated/resources/assets/gtceu/models/block/machine/zpm_substation_output_hatch_64a.json
@@ -8,17 +8,7 @@
     "side"
   ],
   "variants": {
-    "is_formed=false": {
-      "model": {
-        "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
-        "textures": {
-          "bottom": "gtceu:block/casings/voltage/zpm/bottom",
-          "side": "gtceu:block/casings/voltage/zpm/side",
-          "top": "gtceu:block/casings/voltage/zpm/top"
-        }
-      }
-    },
-    "is_formed=true": {
+    "": {
       "model": {
         "parent": "gtceu:block/machine/part/energy_output_hatch_64a",
         "textures": {

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/MachineBuilder.java
@@ -717,9 +717,8 @@ public class MachineBuilder<DEFINITION extends MachineDefinition, TYPE extends M
     @FunctionalInterface
     public interface ModelInitializer {
 
-        void configureModel(@NotNull DataGenContext<Block, ? extends Block> context,
-                            @NotNull GTBlockstateProvider provider,
-                            @NotNull MachineModelBuilder<BlockModelBuilder> builder);
+        void configureModel(DataGenContext<Block, ? extends Block> context, GTBlockstateProvider provider,
+                            MachineModelBuilder<BlockModelBuilder> builder);
 
         default ModelInitializer andThen(ModelInitializer after) {
             Objects.requireNonNull(after);

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/provider/GTBlockstateProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/provider/GTBlockstateProvider.java
@@ -101,16 +101,16 @@ public class GTBlockstateProvider extends RegistrateBlockstateProvider {
         if (rotationState == RotationState.NONE) return null;
 
         PropertyDispatch dispatch;
-        if (allowExtendedFacing) {
-            dispatch = PropertyDispatch.properties(rotationState.property, GTBlockStateProperties.UPWARDS_FACING)
-                    .generate((front, up) -> {
-                        var orientation = ExtendedBlockModelRotation.get(front, up);
-                        return applyOrientation(Variant.variant(), orientation);
-                    });
-        } else {
+        if (!allowExtendedFacing) {
             dispatch = PropertyDispatch.property(rotationState.property)
                     .generate((front) -> {
                         var orientation = ExtendedBlockModelRotation.get(front, Direction.NORTH);
+                        return applyOrientation(Variant.variant(), orientation);
+                    });
+        } else {
+            dispatch = PropertyDispatch.properties(rotationState.property, GTBlockStateProperties.UPWARDS_FACING)
+                    .generate((front, up) -> {
+                        var orientation = ExtendedBlockModelRotation.get(front, up);
                         return applyOrientation(Variant.variant(), orientation);
                     });
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/provider/GTBlockstateProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/provider/GTBlockstateProvider.java
@@ -101,20 +101,18 @@ public class GTBlockstateProvider extends RegistrateBlockstateProvider {
         if (rotationState == RotationState.NONE) return null;
 
         PropertyDispatch dispatch;
-        if (!allowExtendedFacing) {
-            var disp = PropertyDispatch.property(rotationState.property);
-
-            dispatch = disp.generate((front) -> {
-                var orientation = ExtendedBlockModelRotation.get(front, Direction.NORTH);
-                return applyOrientation(Variant.variant(), orientation);
-            });
+        if (allowExtendedFacing) {
+            dispatch = PropertyDispatch.properties(rotationState.property, GTBlockStateProperties.UPWARDS_FACING)
+                    .generate((front, up) -> {
+                        var orientation = ExtendedBlockModelRotation.get(front, up);
+                        return applyOrientation(Variant.variant(), orientation);
+                    });
         } else {
-            var disp = PropertyDispatch.properties(rotationState.property, GTBlockStateProperties.UPWARDS_FACING);
-
-            dispatch = disp.generate((front, up) -> {
-                var orientation = ExtendedBlockModelRotation.get(front, up);
-                return applyOrientation(Variant.variant(), orientation);
-            });
+            dispatch = PropertyDispatch.property(rotationState.property)
+                    .generate((front) -> {
+                        var orientation = ExtendedBlockModelRotation.get(front, Direction.NORTH);
+                        return applyOrientation(Variant.variant(), orientation);
+                    });
         }
         return dispatch;
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -40,6 +40,7 @@ import com.gregtechceu.gtceu.utils.FormattingUtil;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.client.model.generators.ConfiguredModel;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.fml.ModLoader;
@@ -878,7 +879,18 @@ public class GTMachines {
             .rotationState(RotationState.ALL)
             .abilities(PartAbility.PUMP_FLUID_HATCH)
             .modelProperty(IS_FORMED, false)
-            .model(createBasicReplaceableTextureMachineModel(GTCEu.id("block/machine/part/pump_hatch")))
+            .model(createBasicReplaceableTextureMachineModel(GTCEu.id("block/machine/part/pump_hatch"))
+                    .andThen(builder -> {
+                        // UV lock the model so the plank texture doesn't rotate weirdly
+                        builder.replaceForAllStates((state, models) -> {
+                            for (int i = 0; i < models.length; i++) {
+                                models[i] = ConfiguredModel.builder()
+                                        .modelFile(models[i].model).uvLock(true)
+                                        .buildLast();
+                            }
+                            return models;
+                        });
+                    }))
             .register();
 
     public static final MachineDefinition MAINTENANCE_HATCH = REGISTRATE

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -585,6 +585,7 @@ public class GTMultiMachines {
             .model(createSidedWorkableCasingMachineModel(GTCEu.id("block/casings/pump_deck"),
                     GTCEu.id("block/multiblock/primitive_pump"))
                     .andThen(builder -> {
+                        // UV lock the model so the plank texture doesn't rotate weirdly
                         builder.replaceForAllStates((state, models) -> {
                             for (int i = 0; i < models.length; i++) {
                                 models[i] = ConfiguredModel.builder()

--- a/src/main/java/com/gregtechceu/gtceu/common/data/models/GTMachineModels.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/models/GTMachineModels.java
@@ -23,6 +23,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.data.models.blockstates.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraftforge.client.model.generators.*;
 
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +31,7 @@ import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
@@ -70,14 +72,14 @@ public class GTMachineModels {
     public static MachineBuilder.ModelInitializer createBasicMachineModel(ResourceLocation baseModel) {
         return (ctx, prov, builder) -> {
             var model = prov.models().getExistingFile(baseModel);
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
         };
     }
 
     public static MachineBuilder.ModelInitializer createBasicReplaceableTextureMachineModel(ResourceLocation baseModel) {
         return (ctx, prov, builder) -> {
             var model = prov.models().getExistingFile(baseModel);
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
             builder.addReplaceableTextures("bottom", "top", "side");
         };
     }
@@ -88,7 +90,7 @@ public class GTMachineModels {
                     .parent(prov.models().getExistingFile(parentModel));
             tieredHullTextures(model, builder.getOwner().getTier());
 
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
         };
     }
 
@@ -97,7 +99,7 @@ public class GTMachineModels {
             BlockModelBuilder model = prov.models().nested()
                     .parent(prov.models().getExistingFile(overlayModel));
             tieredHullTextures(model, builder.getOwner().getTier());
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -110,7 +112,7 @@ public class GTMachineModels {
                     .parent(prov.models().getExistingFile(overlayModel));
             model.texture("all", baseCasingTexture);
 
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
             builder.addReplaceableTextures("all");
         };
     }
@@ -119,11 +121,11 @@ public class GTMachineModels {
                                                                                            @Nullable ResourceLocation pipeOverlay,
                                                                                            @Nullable ResourceLocation emissiveOverlay) {
         return (ctx, prov, builder) -> {
-            builder.forAllStatesModels(state -> {
-                BlockModelBuilder model = colorOverlayHullModel(overlay, pipeOverlay, emissiveOverlay, state,
-                        prov.models());
+            builder.forAllStatesModelsExcept(state -> {
+                BlockModelBuilder model = colorOverlayHullModel(overlay, pipeOverlay, emissiveOverlay,
+                        state, prov.models());
                 return tieredHullTextures(model, builder.getOwner().getTier());
-            });
+            }, IS_FORMED);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -137,7 +139,7 @@ public class GTMachineModels {
                     .texture("overlay", overlayTexture)
                     .texture("overlay_emissive", emissiveOverlayTexture);
             tieredHullTextures(model, builder.getOwner().getTier());
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -147,25 +149,25 @@ public class GTMachineModels {
         return (ctx, prov, builder) -> {
             WorkableOverlays overlays = WorkableOverlays.get(overlayDir, prov.getExistingFileHelper());
 
-            builder.forAllStates(state -> {
+            builder.forAllStatesModelsExcept(state -> {
                 RecipeLogic.Status status = state.getValue(RECIPE_LOGIC_STATUS);
 
                 BlockModelBuilder model = prov.models().nested().parent(tieredHullModel(prov.models(), builder));
                 return addWorkableOverlays(overlays, status, model);
-            });
+            }, IS_FORMED);
         };
     }
 
     public static MachineBuilder.ModelInitializer createOverlaySteamHullMachineModel(ResourceLocation overlayModel) {
         return (ctx, prov, builder) -> {
-            builder.forAllStatesModels(state -> {
+            builder.forAllStatesModelsExcept(state -> {
                 boolean steel = state.getOptionalValue(IS_STEEL_MACHINE).orElse(false);
 
                 BlockModelBuilder model = prov.models().nested()
                         .parent(prov.models().getExistingFile(overlayModel));
                 steamCasingTextures(model, steel);
                 return model;
-            });
+            }, IS_FORMED);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -175,12 +177,12 @@ public class GTMachineModels {
                                                                                           @Nullable ResourceLocation pipeOverlay,
                                                                                           @Nullable ResourceLocation emissiveOverlay) {
         return (ctx, prov, builder) -> {
-            builder.forAllStatesModels(state -> {
-                BlockModelBuilder model = colorOverlayHullModel(overlay, pipeOverlay, emissiveOverlay, state,
-                        prov.models());
+            builder.forAllStatesModelsExcept(state -> {
+                BlockModelBuilder model = colorOverlayHullModel(overlay, pipeOverlay, emissiveOverlay,
+                        state, prov.models());
                 steamCasingTextures(model, state.getOptionalValue(IS_STEEL_MACHINE).orElse(false));
                 return model;
-            });
+            }, IS_FORMED);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -228,14 +230,14 @@ public class GTMachineModels {
         return (ctx, prov, builder) -> {
             WorkableOverlays overlays = WorkableOverlays.get(overlayDir, prov.getExistingFileHelper());
 
-            builder.forAllStates(state -> {
+            builder.forAllStatesModelsExcept(state -> {
                 RecipeLogic.Status status = state.getValue(RECIPE_LOGIC_STATUS);
 
                 BlockModelBuilder model = prov.models().nested()
                         .parent(prov.models().getExistingFile(CUBE_ALL_SIDED_OVERLAY_MODEL))
                         .texture("all", baseCasingTexture);
                 return addWorkableOverlays(overlays, status, model);
-            });
+            }, IS_FORMED);
             builder.addTextureOverride("all", baseCasingTexture);
         };
     }
@@ -247,7 +249,7 @@ public class GTMachineModels {
             BlockModelBuilder model = prov.models().nested()
                     .parent(prov.models().getExistingFile(overlayModel));
             casingTextures(model, baseCasingTexture);
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -258,14 +260,14 @@ public class GTMachineModels {
         return (ctx, prov, builder) -> {
             WorkableOverlays overlays = WorkableOverlays.get(overlayDir, prov.getExistingFileHelper());
 
-            builder.forAllStates(state -> {
+            builder.forAllStatesModelsExcept(state -> {
                 RecipeLogic.Status status = state.getValue(RECIPE_LOGIC_STATUS);
 
                 BlockModelBuilder model = prov.models().nested()
                         .parent(prov.models().getExistingFile(SIDED_SIDED_OVERLAY_MODEL));
                 casingTextures(model, baseCasingTexture);
                 return addWorkableOverlays(overlays, status, model);
-            });
+            }, IS_FORMED);
 
             var texturePath = baseCasingTexture;
             if (!texturePath.getPath().endsWith("/")) {
@@ -325,7 +327,7 @@ public class GTMachineModels {
                     .texture("overlay_out_io", BLANK_TEXTURE);
             tieredHullTextures(model, builder.getOwner().getTier());
 
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
         };
     }
 
@@ -362,17 +364,14 @@ public class GTMachineModels {
             });
         };
     }
-    // spotless:on
 
     public static final ResourceLocation TRANSFORMER_LIKE = GTCEu.id("block/machine/template/transformer_like_machine");
 
     public static final ResourceLocation CONVERTER_FE_IN = GTCEu.id("block/overlay/converter/converter_native_in");
     public static final ResourceLocation CONVERTER_FE_OUT = GTCEu.id("block/overlay/converter/converter_native_out");
 
-    public static final ResourceLocation CONVERTER_FE_IN_EMISSIVE = GTCEu
-            .id("block/overlay/converter/converter_native_in_emissive");
-    public static final ResourceLocation CONVERTER_FE_OUT_EMISSIVE = GTCEu
-            .id("block/overlay/converter/converter_native_out_emissive");
+    public static final ResourceLocation CONVERTER_FE_IN_EMISSIVE = GTCEu.id("block/overlay/converter/converter_native_in_emissive");
+    public static final ResourceLocation CONVERTER_FE_OUT_EMISSIVE = GTCEu.id("block/overlay/converter/converter_native_out_emissive");
 
     public static MachineBuilder.ModelInitializer createConverterModel(int amperage) {
         return (ctx, prov, builder) -> {
@@ -398,14 +397,14 @@ public class GTMachineModels {
             tieredHullTextures(feToEuModel, builder.getOwner().getTier());
 
             builder.partialState()
-                    .with(IS_FE_TO_EU, false)
-                    .setModel(euToFeModel)
+                        .with(IS_FE_TO_EU, false)
+                        .setModel(euToFeModel)
                     .partialState()
-                    .with(IS_FE_TO_EU, true)
-                    .setModel(feToEuModel)
-                    .end();
+                        .with(IS_FE_TO_EU, true)
+                        .setModel(feToEuModel);
         };
     }
+    // spotless:on
 
     public static MachineBuilder.ModelInitializer createCrateModel(boolean wooden) {
         return (ctx, prov, builder) -> {
@@ -425,7 +424,7 @@ public class GTMachineModels {
 
     public static MachineBuilder.ModelInitializer createDiodeModel() {
         return (ctx, prov, builder) -> {
-            builder.forAllStatesModels(renderState -> {
+            builder.forAllStatesModelsExcept(renderState -> {
                 DiodePartMachine.AmpMode mode = renderState.getValue(DIODE_AMP_MODE);
                 final EnergyIOOverlay energyIn = IN_OVERLAYS_FOR_AMP.get(mode.getAmpValue());
                 final EnergyIOOverlay energyOut = OUT_OVERLAYS_FOR_AMP.get(mode.getAmpValue());
@@ -440,7 +439,7 @@ public class GTMachineModels {
                         .texture("overlay_out_tinted", energyOut.getTintedPart());
                 tieredHullTextures(model, builder.getOwner().getTier());
                 return model;
-            });
+            }, IS_FORMED);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -448,7 +447,7 @@ public class GTMachineModels {
 
     public static MachineBuilder.ModelInitializer createTransformerModel(int baseAmp) {
         return (ctx, prov, builder) -> {
-            builder.forAllStatesModels(renderState -> {
+            builder.forAllStatesModelsExcept(renderState -> {
                 boolean transformUp = renderState.getValue(IS_TRANSFORM_UP);
                 EnergyIOOverlay frontFace = (transformUp ? OUT_OVERLAYS_FOR_AMP : IN_OVERLAYS_FOR_AMP)
                         .get(baseAmp);
@@ -464,7 +463,7 @@ public class GTMachineModels {
                         .texture("overlay_out_tinted", otherFace.getTintedPart());
                 tieredHullTextures(model, builder.getOwner().getTier());
                 return model;
-            });
+            }, IS_FORMED);
         };
     }
 
@@ -526,23 +525,9 @@ public class GTMachineModels {
             WorkableOverlays rtOverlays = WorkableOverlays.get(rtModeModelPath, prov.getExistingFileHelper());
             WorkableOverlays beOverlays = WorkableOverlays.get(beModeModelPath, prov.getExistingFileHelper());
 
-            builder.forAllStates(state -> {
-                boolean rtMode = state.getValue(IS_RANDOM_TICK_MODE);
-                WorkableOverlays overlays = rtMode ? rtOverlays : beOverlays;
-
-                boolean active = state.getValue(IS_ACTIVE);
-                boolean workingEnabled = state.getValue(IS_WORKING_ENABLED);
-                RecipeLogic.Status status = active ?
-                        workingEnabled ?
-                                RecipeLogic.Status.WORKING :
-                                RecipeLogic.Status.SUSPEND :
-                        RecipeLogic.Status.IDLE;
-
-                BlockModelBuilder model = prov.models().nested()
-                        .parent(prov.models().getExistingFile(SIDED_SIDED_OVERLAY_MODEL));
-                tieredHullTextures(model, builder.getOwner().getTier());
-
-                return addWorkableOverlays(overlays, status, model);
+            builder.forAllStatesModels(state -> {
+                WorkableOverlays overlays = state.getValue(IS_RANDOM_TICK_MODE) ? rtOverlays : beOverlays;
+                return createModelFromActiveWorkingState(prov, builder, overlays, state);
             });
         };
     }
@@ -552,7 +537,7 @@ public class GTMachineModels {
 
     public static MachineBuilder.ModelInitializer createMaintenanceModel(ResourceLocation overlayModel) {
         return (ctx, prov, builder) -> {
-            builder.forAllStatesModels(state -> {
+            builder.forAllStatesModelsExcept(state -> {
                 var baseModel = prov.models().nested()
                         .parent(prov.models().getExistingFile(overlayModel));
                 tieredHullTextures(baseModel, builder.getOwner().getTier());
@@ -561,7 +546,7 @@ public class GTMachineModels {
                     baseModel.texture("overlay_2", MAINTENANCE_TAPED_OVERLAY);
                 }
                 return baseModel;
-            });
+            }, IS_FORMED);
 
             builder.addReplaceableTextures("bottom", "top", "side");
         };
@@ -571,6 +556,7 @@ public class GTMachineModels {
     public static final ResourceLocation HPCA_PART_MODEL = GTCEu.id("block/machine/template/part/hpca_part_machine");
     public static final ResourceLocation COMPUTER_CASING_TEXTURE = GTCEu.id("block/casings/hpca/computer_casing/");
     public static final ResourceLocation ADVANCED_COMPUTER_CASING_TEXTURE = GTCEu.id("block/casings/hpca/advanced_computer_casing/");
+    // spotless:on
 
     public static MachineBuilder.ModelInitializer createHPCAPartModel(boolean advanced,
                                                                       ResourceLocation normalTexture,
@@ -586,14 +572,14 @@ public class GTMachineModels {
             casingTexture(baseModel, "back", textures);
             casingTexture(baseModel, "side", textures);
 
-            builder.forAllStatesModels(state -> {
+            builder.forAllStatesModelsExcept(state -> {
                 boolean damaged = state.getValue(IS_HPCA_PART_DAMAGED);
                 boolean active = state.getValue(IS_ACTIVE);
 
                 return prov.models().nested().parent(baseModel)
                         .texture("overlay", overlay.getTexture(active, damaged))
                         .texture("overlay_emissive", overlay.getEmissiveTexture(active, damaged));
-            });
+            }, IS_FORMED);
         };
     }
 
@@ -608,7 +594,7 @@ public class GTMachineModels {
                     .texture("overlay_emissive", OVERLAY_QTANK_EMISSIVE_TEXTURE);
             tieredHullTextures(model, builder.getOwner().getTier());
 
-            builder.forAllStatesModels(state -> model);
+            builder.partialState().setModel(model);
         };
     }
 
@@ -616,28 +602,31 @@ public class GTMachineModels {
         return (ctx, prov, builder) -> {
             WorkableOverlays overlays = WorkableOverlays.get(overlayDir, prov.getExistingFileHelper());
 
-            builder.forAllStates(state -> {
-                boolean active = state.getValue(IS_ACTIVE);
-                boolean workingEnabled = state.getValue(IS_WORKING_ENABLED);
-                RecipeLogic.Status status = active ?
-                                            workingEnabled ?
-                                            RecipeLogic.Status.WORKING :
-                                            RecipeLogic.Status.SUSPEND :
-                                            RecipeLogic.Status.IDLE;
-
-                BlockModelBuilder model = prov.models().nested()
-                        .parent(prov.models().getExistingFile(SIDED_SIDED_OVERLAY_MODEL));
-                tieredHullTextures(model, builder.getOwner().getTier());
-
-                return addWorkableOverlays(overlays, status, model);
-            });
+            builder.forAllStatesModels(state -> createModelFromActiveWorkingState(prov, builder, overlays, state));
         };
+    }
+
+    public static ModelFile createModelFromActiveWorkingState(@NotNull GTBlockstateProvider prov,
+                                                              @NotNull MachineModelBuilder<BlockModelBuilder> builder,
+                                                              WorkableOverlays overlays, MachineRenderState state) {
+        RecipeLogic.Status status = state.getValue(IS_ACTIVE) ?
+                state.getValue(IS_WORKING_ENABLED) ?
+                        RecipeLogic.Status.WORKING :
+                        RecipeLogic.Status.SUSPEND :
+                RecipeLogic.Status.IDLE;
+
+        BlockModelBuilder model = prov.models().nested()
+                .parent(prov.models().getExistingFile(SIDED_SIDED_OVERLAY_MODEL));
+        tieredHullTextures(model, builder.getOwner().getTier());
+
+        return addWorkableOverlays(overlays, status, model);
     }
 
     // endregion
 
     // region helper functions
 
+    // spotless:off
     public static NonNullBiConsumer<DataGenContext<Block, ? extends Block>, GTBlockstateProvider> createMachineModel(MachineBuilder.ModelInitializer modelInitializer) {
         return (ctx, prov) -> {
             Block block = ctx.getEntry();
@@ -651,8 +640,9 @@ public class GTMachineModels {
             MachineModelBuilder<BlockModelBuilder> builder = prov.models().getBuilder(modelLocation)
                     .customLoader(MachineModelBuilder.begin(definition));
             modelInitializer.configureModel(ctx, prov, builder);
+
             final BlockModelBuilder model = builder.end();
-            model.parent(prov.models().getExistingFile(prov.mcLoc("block/block")));
+            model.parent(new ModelFile.UncheckedModelFile("block/block"));
 
             var generator = prov.multiVariantGenerator(block,
                     Variant.variant().with(VariantProperties.MODEL, model.getLocation()));
@@ -664,7 +654,7 @@ public class GTMachineModels {
     }
     // spotless:on
 
-    public static ConfiguredModel[] addWorkableOverlays(WorkableOverlays overlays, RecipeLogic.Status status,
+    public static ModelFile addWorkableOverlays(WorkableOverlays overlays, RecipeLogic.Status status,
                                                         BlockModelBuilder model) {
         for (var entry : overlays.getTextures().entrySet()) {
             var face = entry.getKey();
@@ -680,7 +670,7 @@ public class GTMachineModels {
                 model.texture(OVERLAY_PREFIX + face.getName() + EMISSIVE_SUFFIX, overlayEmissive);
             }
         }
-        return ConfiguredModel.builder().modelFile(model).build();
+        return model;
     }
 
     public static BlockModelBuilder colorOverlayHullModel(ResourceLocation overlay,

--- a/src/main/java/com/gregtechceu/gtceu/common/data/models/GTMachineModels.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/models/GTMachineModels.java
@@ -23,7 +23,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.data.models.blockstates.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.properties.Property;
 import net.minecraftforge.client.model.generators.*;
 
 import com.google.common.collect.ImmutableMap;
@@ -584,7 +583,8 @@ public class GTMachineModels {
     }
 
     public static final ResourceLocation OVERLAY_SCREEN_TEXTURE = GTCEu.id("block/overlay/machine/overlay_screen");
-    public static final ResourceLocation OVERLAY_QTANK_EMISSIVE_TEXTURE = GTCEu.id("block/overlay/machine/overlay_qtank_emissive");
+    public static final ResourceLocation OVERLAY_QTANK_EMISSIVE_TEXTURE = GTCEu
+            .id("block/overlay/machine/overlay_qtank_emissive");
 
     public static MachineBuilder.ModelInitializer createFisherModel() {
         return (ctx, prov, builder) -> {
@@ -655,7 +655,7 @@ public class GTMachineModels {
     // spotless:on
 
     public static ModelFile addWorkableOverlays(WorkableOverlays overlays, RecipeLogic.Status status,
-                                                        BlockModelBuilder model) {
+                                                BlockModelBuilder model) {
         for (var entry : overlays.getTextures().entrySet()) {
             var face = entry.getKey();
             var textures = entry.getValue();

--- a/src/main/java/com/gregtechceu/gtceu/data/model/builder/MachineModelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/model/builder/MachineModelBuilder.java
@@ -2,10 +2,12 @@ package com.gregtechceu.gtceu.data.model.builder;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
+import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
 import com.gregtechceu.gtceu.api.registry.registrate.provider.GTBlockstateProvider;
 import com.gregtechceu.gtceu.client.model.machine.MachineModelLoader;
 import com.gregtechceu.gtceu.client.model.machine.MachineRenderState;
 import com.gregtechceu.gtceu.client.renderer.machine.DynamicRender;
+import com.gregtechceu.gtceu.common.data.models.GTMachineModels;
 import com.gregtechceu.gtceu.core.mixins.forge.ConfiguredModelBuilderAccessor;
 import com.gregtechceu.gtceu.core.mixins.forge.ConfiguredModelListAccessor;
 
@@ -302,7 +304,12 @@ public class MachineModelBuilder<T extends ModelBuilder<T>> extends CustomLoader
     }
 
     public MachineModelBuilder<T> forAllStatesModels(Function<MachineRenderState, ModelFile> mapper) {
-        return forAllStates(mapper.andThen(m -> ConfiguredModel.builder().modelFile(m).build()));
+        return forAllStatesModelsExcept(mapper);
+    }
+
+    public MachineModelBuilder<T> forAllStatesModelsExcept(Function<MachineRenderState, ModelFile> mapper,
+                                                           Property<?>... ignored) {
+        return forAllStatesExcept(mapper.andThen(m -> ConfiguredModel.builder().modelFile(m).build()), ignored);
     }
 
     public MachineModelBuilder<T> forAllStates(Function<MachineRenderState, ConfiguredModel[]> mapper) {
@@ -357,15 +364,14 @@ public class MachineModelBuilder<T extends ModelBuilder<T>> extends CustomLoader
         private final MachineDefinition owner;
         @Getter
         private final SortedMap<Property<?>, Comparable<?>> setStates;
-        @Nullable
         private final MachineModelBuilder<B> outerBuilder;
 
-        private PartialState(MachineDefinition owner, @Nullable MachineModelBuilder<B> outerBuilder) {
+        private PartialState(MachineDefinition owner, MachineModelBuilder<B> outerBuilder) {
             this(owner, ImmutableMap.of(), outerBuilder);
         }
 
         private PartialState(MachineDefinition owner, Map<Property<?>, Comparable<?>> setStates,
-                             @Nullable MachineModelBuilder<B> outerBuilder) {
+                             MachineModelBuilder<B> outerBuilder) {
             this.owner = owner;
             this.outerBuilder = outerBuilder;
             for (Map.Entry<Property<?>, Comparable<?>> entry : setStates.entrySet()) {
@@ -688,7 +694,7 @@ public class MachineModelBuilder<T extends ModelBuilder<T>> extends CustomLoader
                     .arrayListValues()
                     .build();
             public final List<ConditionGroup> nestedConditionGroups = new ArrayList<>();
-            private ConditionGroup parent = null;
+            private @Nullable ConditionGroup parent = null;
             public boolean useOr;
 
             /**

--- a/src/main/java/com/gregtechceu/gtceu/data/model/builder/MachineModelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/model/builder/MachineModelBuilder.java
@@ -2,12 +2,10 @@ package com.gregtechceu.gtceu.data.model.builder;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
-import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
 import com.gregtechceu.gtceu.api.registry.registrate.provider.GTBlockstateProvider;
 import com.gregtechceu.gtceu.client.model.machine.MachineModelLoader;
 import com.gregtechceu.gtceu.client.model.machine.MachineRenderState;
 import com.gregtechceu.gtceu.client.renderer.machine.DynamicRender;
-import com.gregtechceu.gtceu.common.data.models.GTMachineModels;
 import com.gregtechceu.gtceu.core.mixins.forge.ConfiguredModelBuilderAccessor;
 import com.gregtechceu.gtceu.core.mixins.forge.ConfiguredModelListAccessor;
 


### PR DESCRIPTION
## What
Simplify machines' model JSONs by not specifying properties that do not affect the actual model in any way.

## Implementation Details
Approximately **75** lines of code changed, most of which were to add a `, IS_FORMED` to most utility functions in `GTMachineModels`.
The model parser assumes undefined properties to mean "any value". That's used to cut down _10 500_ lines of JSON.

## Outcome
Probably half a megabyte of final JAR file size saved.

## How Was This Tested
The actual ingame models are the exact same before & after, as 
Looked the same, I forgot to take screenshots. 

## Additional Information
Datagen produced ~450 file changes. I recommend ignoring those in the GitHub review UI before it tries to load all of them and your browser gives up.