### PR TITLE
Adjust max width of text in multiblock UIs

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -144,7 +144,7 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
                 .addWidget(new LabelWidget(4, 5, self().getBlockState().getBlock().getDescriptionId()))
                 .addWidget(new ComponentPanelWidget(4, 17, this::addDisplayText)
                         .textSupplier(this.getLevel().isClientSide ? null : this::addDisplayText)
-                        .setMaxWidthLimit(200)
+                        .setMaxWidthLimit(182)
                         .clickHandler(this::handleDisplayClick)));
         group.setBackground(GuiTextures.BACKGROUND_INVERSE);
         return group;


### PR DESCRIPTION
## What
Fixes #4801 

## Implementation Details
Resizes the ComponentPanelWidget in the WorkableElectricMultiblockMachine class, which makes some text wrap around earlier if the last one or two characters would have been cut off.

## How Was This Tested
The multiblock issue in question now renders with all text visible:
<img width="914" height="608" alt="image" src="https://github.com/user-attachments/assets/53ed3271-c019-4cfb-8e4c-14f4d8fbc48b" />

## Potential Compatibility Issues
This could alter the rendering of some other multiblocks in specific scenarios. For example, the Multi Smelter active machine mode now also renders properly, where it didn't before.