### PR TITLE
Fix incorrect key mapping on macOS with vanilla ctrl detector

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ClickDataMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ClickDataMixin.java
@@ -1,0 +1,33 @@
+package com.gregtechceu.gtceu.core.mixins.ldlib;
+
+import com.lowdragmc.lowdraglib.gui.util.ClickData;
+
+import net.minecraft.client.gui.screens.Screen;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = ClickData.class, remap = false)
+public class ClickDataMixin {
+
+    @Mutable
+    @Shadow(remap = false)
+    @Final
+    public boolean isShiftClick;
+
+    @Mutable
+    @Shadow(remap = false)
+    @Final
+    public boolean isCtrlClick;
+
+    @Inject(method = "<init>()V", at = @At("RETURN"), remap = false)
+    private void gtceu$useVanillaModifierKeys(CallbackInfo ci) {
+        isShiftClick = Screen.hasShiftDown();
+        isCtrlClick = Screen.hasControlDown();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -12,7 +12,7 @@ import com.gregtechceu.gtceu.data.recipe.CustomTags;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
-import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -48,14 +48,12 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 
 import com.google.common.collect.ImmutableList;
-import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.lwjgl.glfw.GLFW;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -357,27 +355,21 @@ public class GTUtil {
 
     public static boolean isShiftDown() {
         if (GTCEu.isClientSide()) {
-            var id = Minecraft.getInstance().getWindow().getWindow();
-            return InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_SHIFT) ||
-                    InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_SHIFT);
+            return Screen.hasShiftDown();
         }
         return false;
     }
 
     public static boolean isCtrlDown() {
         if (GTCEu.isClientSide()) {
-            var id = Minecraft.getInstance().getWindow().getWindow();
-            return InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_CONTROL) ||
-                    InputConstants.isKeyDown(id, GLFW.GLFW_KEY_RIGHT_CONTROL);
+            return Screen.hasControlDown();
         }
         return false;
     }
 
     public static boolean isAltDown() {
         if (GTCEu.isClientSide()) {
-            var id = Minecraft.getInstance().getWindow().getWindow();
-            return InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_ALT) ||
-                    InputConstants.isKeyDown(id, GLFW.GLFW_KEY_RIGHT_ALT);
+            return Screen.hasAltDown();
         }
         return false;
     }

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -25,6 +25,7 @@
         "ftbchunks.FTBChunksClientMixin",
         "ftbchunks.LargeMapScreenMixin",
         "ftbchunks.RegionMapPanelMixin",
+        "ldlib.ClickDataMixin",
         "ldlib.ModularWrapperWidgetMixin",
         "rei.FluidEntryRendererMixin",
         "xaerominimap.HighlighterRegistryMixin",


### PR DESCRIPTION
## What

On macOS, `command` ⌘ is used as `Ctrl`, but the key code of `command` ⌘ is different. Instead, `control` ⌃ has the same key code as `Ctrl`.

So for those classes using `GTUtil`, users should press `control` ⌃ to represent `Ctrl`, which is weird.

This PR reuse vanilla MC's `hasControlDown` method to deal with "Ctrl" on different platforms, letting macOS users to press `command` ⌘ for `Ctrl`.

## Implementation Details

Vanilla MC's `hasControllDown` checks platform, if on macOS, then treat `GLFW_KEY_LEFT_SUPER` (which is `command` on macOS) as "Controll":

```java
// in net.minecraft.client.gui.screens.Screen
   public static boolean hasControlDown() {
      if (Minecraft.ON_OSX) {
         return InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 343) || InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 347);
      } else {
         return InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 341) || InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 345);
      }
   }
```

Since the vanilla MC has such an interface, I think there's no need for us to implement another one using the underlying GLFW interface.

So I replace the logic of `isShiftDown` `isCtrlDown` `isAltDown` with vanilla's `hasShiftDown` `hasControlDown` `hasAltDown` to make the code cleaner and more robust.

And unfortunately, ldlib also use GLFW's interface to check these keys in `ClickData` and no checks of platforms. So I write a new mixin to change the value of `isCtrlClick` to make sure the packet sent from client is correct.

## Outcome

On macOS, users will use `command` as `Ctrl`. And on other platforms, there is no changes.

## How Was This Tested

I have run `runClient` to ensure this works well on MacBook keyboard.