### PR TITLE
Fix ToolHeadReplaceRecipe.matches() for non-existent material+tier combos

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ToolHeadReplaceRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ToolHeadReplaceRecipe.java
@@ -75,7 +75,8 @@ public class ToolHeadReplaceRecipe extends CustomRecipe {
             if (!tool.isElectric()) return false;
             if (toolHead.isEmpty()) return false;
             GTToolType[] output = TOOL_HEAD_TO_TOOL_MAP.get(toolHead.tagPrefix());
-            return output != null && output[tool.getElectricTier()] != null;
+            return output != null && output[tool.getElectricTier()] != null &&
+                    GTMaterialItems.TOOL_ITEMS.get(toolHead.material(), output[tool.getElectricTier()]) != null;
         }
         return false;
     }


### PR DESCRIPTION
## What
Fixes #4807

See #4807 for details

## Outcome
Verifies `GTMaterialItems.TOOL_ITEMS.get(toolHead.material(), output[tool.getElectricTier()]) != null` before returning `true` from matches

## How Was This Tested
Game runs, doesn't NPE when putting a wirecutter head and a wirecutter in the crafting grid where the wirecutter head material doesn't work with the wirecutter's tier