### PR TITLE
Fix accidental AE2 requirement

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/HullMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/HullMachine.java
@@ -38,7 +38,7 @@ public class HullMachine extends TieredPartMachine implements IMonitorComponent 
     public HullMachine(BlockEntityCreationInfo info, int tier) {
         super(info, tier);
         if (GTCEu.Mods.isAE2Loaded()) {
-            this.gridNodeHost = attachTrait(new GridNodeHostTrait(this));
+            this.gridNodeHost = GridNodeHostTransformer.attachToMachine(this);
         } else {
             this.gridNodeHost = null;
         }
@@ -81,6 +81,10 @@ public class HullMachine extends TieredPartMachine implements IMonitorComponent 
     //////////////////////////////////////
 
     private static class GridNodeHostTransformer implements ValueTransformer<Object> {
+
+        private static Object attachToMachine(HullMachine machine) {
+            return machine.attachTrait(new GridNodeHostTrait(machine));
+        }
 
         @Override
         public Tag serializeNBT(Object value, TransformerContext<Object> context) {


### PR DESCRIPTION
## What
Title

## Implementation Details
Moved the grid node host trait initialization to a static inner class so the JVM cast checker doesn't check it while loading `HullMachine`.

## Outcome
Mod no longer requires AE2 to launch

## How Was This Tested
Added the mod to a plain prism launcher instance and ran it

## Additional Information
Please add the "ignore changelog" label, this issue didn't ever get to a release