### PR TITLE
Revert "Revert "update configuration (#3579)" (#3611)"

### DIFF
--- a/gradle/forge.versions.toml
+++ b/gradle/forge.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 ldlib = "1.0.40.b"
 registrate = "MC1.20-1.3.11"
-configuration = "2.2.0"
+configuration = "3.1.0-forge"
 mixinExtras = "0.5.0-rc.3"
 
 jei = "15.20.0.115"
@@ -52,11 +52,10 @@ ftbteams-cm = "5267190"
 ftbquests-cm = "6167056"
 ftbchunks-cm = "5956390"
 
-
 [libraries]
 ldlib               = { module = "com.lowdragmc.ldlib:ldlib-forge-1.20.1", version.ref = "ldlib" }
 registrate          = { module = "com.tterrag.registrate:Registrate", version.ref = "registrate" }
-configuration       = { module = "dev.toma.configuration:configuration-forge-1.20.1", version.ref = "configuration" }
+configuration       = { module = "dev.toma.configuration:configuration-1.20.1", version.ref = "configuration" }
 mixinExtras-common  = { module = "io.github.llamalad7:mixinextras-common", version.ref = "mixinExtras" }
 mixinExtras-forge   = { module = "io.github.llamalad7:mixinextras-forge", version.ref = "mixinExtras" }
 

--- a/gradle/scripts/repositories.gradle
+++ b/gradle/scripts/repositories.gradle
@@ -27,6 +27,7 @@ repositories {
         url = "https://maven.firstdark.dev/snapshots"
     }
 
+
     exclusiveContent { // Create, Ponder, Flywheel
         forRepository { maven { url = "https://maven.createmod.net" } }
         filter {
@@ -34,6 +35,13 @@ repositories {
             includeGroup("com.simibubi.create")
             includeGroup("dev.engine-room.flywheel")
         }
+    }
+    exclusiveContent { // Configuration
+        forRepositories(
+                maven { url = "https://repo.repsy.io/mvn/toma/public/" },
+                maven { url = "https://api.repsy.io/mvn/toma/public" },
+        )
+        filter { includeGroup("dev.toma.configuration")}
     }
     exclusiveContent { // KubeJS and Rhino
         forRepository { maven { url = "https://maven.latvian.dev/releases" } }

--- a/gradle/scripts/resources.gradle
+++ b/gradle/scripts/resources.gradle
@@ -39,7 +39,7 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
             minecraft_version   : libs.versions.minecraft.get(),
             loader_version      : forgeVers,
             forge_version       : forgeVers, // only specify major version of forge
-            configuration_version: forge.versions.configuration.get(),
+            configuration_version: forge.versions.configuration.get().split("-")[0],
             kjs_version         : forge.versions.kubejs.get().split("\\.")[0], // only specify major version of kjs
             ldlib_version       : forge.versions.ldlib.get(),
             jei_version         : forge.versions.jei.get(),

--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1956,6 +1956,7 @@
   "config.jade.plugin_gtceu.steam_boiler_info": "oɟuI ɹǝןıoᗺ ɯɐǝʇS ]nƎƆ⟘⅁[",
   "config.jade.plugin_gtceu.transformer": "oɟuI ɹǝɯɹoɟsuɐɹ⟘ ]nƎƆ⟘⅁[",
   "config.jade.plugin_gtceu.workable_provider": "ǝןqɐʞɹoM ]nƎƆ⟘⅁[",
+  "config.screen.gtceu": "uoıʇɐɹnbıɟuoƆ nƎƆɥɔǝ⟘bǝɹ⅁",
   "cover.advanced_detector.latch.disabled.0": "snonuıʇuoƆ :ɹoıʌɐɥǝᗺ",
   "cover.advanced_detector.latch.disabled.1": "",
   "cover.advanced_detector.latch.disabled.2": "˙ɹǝʌoƆ sıɥʇ ɟo ɹoıʌɐɥǝq ǝuoʇspǝɹ ǝɥʇ ǝbuɐɥƆ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1956,6 +1956,7 @@
   "config.jade.plugin_gtceu.steam_boiler_info": "[GTCEu] Steam Boiler Info",
   "config.jade.plugin_gtceu.transformer": "[GTCEu] Transformer Info",
   "config.jade.plugin_gtceu.workable_provider": "[GTCEu] Workable",
+  "config.screen.gtceu": "GregTechCEu Configuration",
   "cover.advanced_detector.latch.disabled.0": "Behavior: Continuous",
   "cover.advanced_detector.latch.disabled.1": "",
   "cover.advanced_detector.latch.disabled.2": "Change the redstone behavior of this Cover.",

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -8,7 +8,9 @@ import net.minecraft.commands.Commands;
 import dev.toma.configuration.Configuration;
 import dev.toma.configuration.config.Config;
 import dev.toma.configuration.config.Configurable;
+import dev.toma.configuration.config.UpdateRestrictions;
 import dev.toma.configuration.config.format.ConfigFormats;
+import org.jetbrains.annotations.ApiStatus;
 
 @Config(id = GTCEu.MOD_ID)
 public class ConfigHolder {
@@ -16,10 +18,14 @@ public class ConfigHolder {
     public static ConfigHolder INSTANCE;
     private static final Object LOCK = new Object();
 
+    @ApiStatus.Internal
+    public static dev.toma.configuration.config.ConfigHolder<ConfigHolder> INTERNAL_INSTANCE;
+
     public static void init() {
         synchronized (LOCK) {
-            if (INSTANCE == null) {
-                INSTANCE = Configuration.registerConfig(ConfigHolder.class, ConfigFormats.yaml()).getConfigInstance();
+            if (INSTANCE == null || INTERNAL_INSTANCE == null) {
+                INTERNAL_INSTANCE = Configuration.registerConfig(ConfigHolder.class, ConfigFormats.YAML);
+                INSTANCE = INTERNAL_INSTANCE.getConfigInstance();
             }
         }
     }
@@ -49,85 +55,107 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Whether to generate Flawed and Chipped Gems for materials and recipes involving them.",
                 "Useful for mods like TerraFirmaCraft.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean generateLowQualityGems = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to remove Block/Ingot compression and decompression in the Crafting Table.",
                 "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean disableManualCompression = true; // default true
         @Configurable
         @Configurable.Comment({
                 "Change the recipe of Rods in the Lathe to 1 Rod and 2 Small Piles of Dust, instead of 2 Rods.",
                 "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean harderRods = true; // default true
         @Configurable
         @Configurable.Comment({
                 "Whether to make crafting recipes for Bricks, Firebricks, Nether Bricks, and Coke Bricks harder.",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean harderBrickRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to nerf Wood crafting to 2 Planks from 1 Log, and 2 Sticks from 2 Planks.",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean nerfWoodCrafting = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to make Wood related recipes harder.", "Excludes sticks and planks.",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardWoodRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Recipes for Buckets, Cauldrons, Hoppers, and Iron Bars" +
                 " require Iron Plates, Rods, and more.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardIronRecipes = true; // default true
         @Configurable
         @Configurable.Comment({ "Whether to make Redstone related recipes harder.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardRedstoneRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to make Vanilla Tools and Armor recipes harder.",
                 "Excludes Flint and Steel, and Buckets.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardToolArmorRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to make miscellaneous recipes harder.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardMiscRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to make Glass related recipes harder. Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardGlassRecipes = true; // default true
         @Configurable
         @Configurable.Comment({ "Whether to nerf the Paper crafting recipe.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean nerfPaperCrafting = true; // default true
         @Configurable
         @Configurable.Comment({ "Recipes for items like Iron Doors, Trapdoors, Anvil" +
                 " require Iron Plates, Rods, and more.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardAdvancedIronRecipes = true; // default true
         @Configurable
         @Configurable.Comment({ "Whether to make coloring blocks like Concrete or Glass harder.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardDyeRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to remove charcoal smelting recipes from the vanilla furnace.",
                 "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean harderCharcoalRecipe = true; // default true
         @Configurable
         @Configurable.Comment({ "Whether to make the Flint and Steel recipe require steel parts.", "Default: true." })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean flintAndSteelRequireSteel = true; // default true
         @Configurable
         @Configurable.Comment({ "Whether to remove Vanilla Block Recipes from the Crafting Table.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean removeVanillaBlockRecipes = false; // default false
         @Configurable
         @Configurable.Comment({ "Whether to remove Vanilla TNT Recipe from the Crafting Table.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean removeVanillaTNTRecipe = true; // default true
         @Configurable
         @Configurable.Comment({ "How many Multiblock Casings to make per craft. Either 1, 2, or 3.", "Default: 2" })
         @Configurable.Range(min = 1, max = 3)
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public int casingsPerCraft = 2;
         @Configurable
         @Configurable.Comment({
                 "Whether to nerf the output amounts of the first circuit in a set to 1 (from 2) and SoC to 2 (from 4).",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean harderCircuitRecipes = false;
         @Configurable
         @Configurable.Comment({ "Whether to nerf machine controller recipes.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean hardMultiRecipes = false; // default false
         @Configurable
         @Configurable.Comment({
                 "Whether tools should have enchants or not. Like the flint sword getting fire aspect.",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean enchantedTools = false;
 
         @Configurable
@@ -209,6 +237,7 @@ public class ConfigHolder {
 
             @Configurable
             @Configurable.Comment({ "Enable GTEU to FE (and vice versa) Converters.", "Default: false" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
             public boolean enableFEConverters = false;
 
             @Configurable
@@ -235,6 +264,7 @@ public class ConfigHolder {
             @Configurable
             @Configurable.Comment({ "The energy consumption of ME Hatch/Bus.", "Default: 4.0AE/t" })
             @Configurable.DecimalRange(min = 0.0, max = Integer.MAX_VALUE)
+            @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
             public double meHatchEnergyUsage = 4.0;
         }
 
@@ -242,18 +272,19 @@ public class ConfigHolder {
 
             @Configurable
             @Configurable.Comment({
-                    "Toggle specific map mod integration on/off (need to restart for this to take effect)" })
+                    "Toggle specific map mod integration on/off" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
             public Toggle toggle = new Toggle();
 
             @Configurable
             @Configurable.Comment({ "The radius, in blocks, that picking up a surface rock will search for veins in.",
                     "-1 to disable.", "Default: 24" })
-            @Configurable.Range(min = -1)
+            @Configurable.Range(min = 1)
             public int surfaceRockProspectRange = 24;
             @Configurable
             @Configurable.Comment({ "The radius, in blocks, that clicking an ore block will search for veins in.",
                     "-1 to disable", "Default: 24" })
-            @Configurable.Range(min = -1)
+            @Configurable.Range(min = 1)
             public int oreBlockProspectRange = 24;
 
             @Configurable
@@ -370,10 +401,12 @@ public class ConfigHolder {
         @Configurable.Comment({
                 "Whether to increase number of rolls for dungeon chests. Increases dungeon loot drastically.",
                 "Default: true", "WARNING: Currently unimplemented." })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean increaseDungeonLoot = true;
         @Configurable
         @Configurable.Comment({ "Allow GregTech to add additional GregTech Items as loot in various structures.",
                 "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean addLoot = true;
 
         @Configurable
@@ -398,9 +431,11 @@ public class ConfigHolder {
             @Configurable
             @Configurable.Comment({ "Prevents regular vanilla ores from being generated outside GregTech ore veins",
                     "Default: true" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
             public boolean removeVanillaOreGen = true;
             @Configurable
             @Configurable.Comment({ "Prevents vanilla's large ore veins from being generated", "Default: true" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
             public boolean removeVanillaLargeOreVeins = true;
             @Configurable
             @Configurable.Comment({ "Distance between bedrock ore veins in chunks, if enabled.", "Default: 16" })
@@ -416,15 +451,17 @@ public class ConfigHolder {
                     "Sets the maximum number of chunks that may be cached for ore vein generation.",
                     "Higher values may improve world generation performance, but at the cost of more RAM usage.",
                     "If you substantially increase the ore vein grid size, random vein offset, or have very large (custom) veins, you may need to increase this value as well.",
-                    "Default: 512 (requires restarting the server / re-opening the world)"
+                    "Default: 512"
             })
+            @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
             public int oreGenerationChunkCacheSize = 512;
             @Configurable
             @Configurable.Comment({
                     "Sets the maximum number of chunks for which ore indicators may be cached.",
                     "If you register any custom veins with very large indicator ranges (or modify existing ones that way), you may need to increase this value.",
-                    "Default: 2048 (requires restarting the server / re-opening the world)"
+                    "Default: 2048"
             })
+            @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
             public int oreIndicatorChunkCacheSize = 2048;
         }
     }
@@ -435,28 +472,34 @@ public class ConfigHolder {
         @Configurable.Comment({
                 "Whether to require a Wrench, Wirecutter, or other GregTech tools to break machines, casings, wires, and more.",
                 "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean requireGTToolsForBlocks = true;
         @Configurable
         @Configurable.Comment({
                 "Whether machines explode in rainy weather or when placed next to certain terrain, such as fire or lava",
                 "Default: false" })
+        @Configurable.Synchronized
         public boolean shouldWeatherOrTerrainExplosion = false;
         @Configurable
         @Configurable.Comment({ "Energy use multiplier for electric items.", "Default: 100" })
+        @Configurable.Synchronized
         public int energyUsageMultiplier = 100;
 
         @Configurable
         @Configurable.Comment({ "Energy use multiplier for prospectors.", "Default: 100" })
+        @Configurable.Synchronized
         public int prospectorEnergyUseMultiplier = 100;
         @Configurable
         @Configurable.Comment({ "Whether machines or boilers damage the terrain when they explode.",
                 "Note machines and boilers always explode when overloaded with power or met with special conditions, regardless of this config.",
                 "Default: true" })
+        @Configurable.Synchronized
         public boolean doesExplosionDamagesTerrain = true;
         @Configurable
         @Configurable.Comment({
                 "Enables Safe Active Transformers, removing their ability to explode if unformed while transmitting/receiving power.",
                 "Default: false" })
+        @Configurable.Synchronized
         public boolean harmlessActiveTransformers = false;
         @Configurable
         @Configurable.Comment({ "Whether to play machine sounds while machines are active.", "Default: true" })
@@ -466,9 +509,11 @@ public class ConfigHolder {
         public int batchDuration = 100;
         @Configurable
         @Configurable.Comment({ "Whether Steam Multiblocks should use Steel instead of Bronze.", "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean steelSteamMultiblocks = false;
         @Configurable
         @Configurable.Comment({ "Whether to enable the cleanroom, required for various recipes.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean enableCleanroom = true;
         @Configurable
         @Configurable.Comment({ "Whether multiblocks should ignore all cleanroom requirements.",
@@ -485,9 +530,11 @@ public class ConfigHolder {
         public String replaceMinedBlocksWith = "minecraft:cobblestone";
         @Configurable
         @Configurable.Comment({ "Whether to enable Assembly Line research for recipes.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean enableResearch = true;
         @Configurable
         @Configurable.Comment({ "Whether to enable the Maintenance Hatch, required for Multiblocks.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean enableMaintenance = true;
         @Configurable
         @Configurable.Comment({
@@ -500,6 +547,7 @@ public class ConfigHolder {
         @Configurable.Comment({
                 "Whether to enable World Accelerators, which accelerate ticks for surrounding Tile Entities, Crops, etc.",
                 "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean enableWorldAccelerators = true;
 
         @Configurable
@@ -507,6 +555,7 @@ public class ConfigHolder {
                 "GregTech TileEntities are always blocked.",
                 "Entries must be in a fully qualified format. For example: appeng.tile.networking.TileController",
                 "Default: none" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public String[] worldAcceleratorBlacklist = new String[0];
 
         @Configurable
@@ -514,13 +563,16 @@ public class ConfigHolder {
                 "Whether to use GT6-style pipe and cable connections, meaning they will not auto-connect " +
                         "unless placed directly onto another pipe or cable.",
                 "Default: true" })
+        @Configurable.Synchronized
         public boolean gt6StylePipesCables = true;
         @Configurable
         @Configurable.Comment({ "Whether the machine's circuit slot need to be inserted a real circuit." })
+        @Configurable.Synchronized
         public boolean ghostCircuit = true;
         @Configurable
         @Configurable.Comment({ "Whether to add a \"Bedrock Ore Miner\" (also enables bedrock ore generation)",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean doBedrockOres = false;
         @Configurable
         @Configurable.Comment({ "What Kind of material should the bedrock ore miner output?", "Default: \"raw\"" })
@@ -533,24 +585,30 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Makes nearly every GCYM Multiblock require blocks which set their maximum voltages.",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         // todo: implement or purge
         public boolean enableTieredCasings = false;
         @Configurable
         @Configurable.Comment({ "Minimum distance between Long Distance Item Pipe Endpoints", "Default: 50" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int ldItemPipeMinDistance = 50;
         @Configurable
         @Configurable.Comment({ "Minimum distance betweeb Long Distance Fluid Pipe Endpoints", "Default: 50" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int ldFluidPipeMinDistance = 50;
 
         @Configurable
         @Configurable.Comment({ "Whether ONLY owners can open a machine gui", "Default: false" })
+        @Configurable.Synchronized
         public boolean onlyOwnerGUI = false;
         @Configurable
         @Configurable.Comment({ "Whether ONLY owners can break a machine", "Default: false" })
+        @Configurable.Synchronized
         public boolean onlyOwnerBreak = false;
         @Configurable
         @Configurable.Comment({ "Minimum op level to bypass the ownership checks", "Default: 2" })
         @Configurable.Range(min = Commands.LEVEL_ALL, max = Commands.LEVEL_OWNERS)
+        @Configurable.Synchronized
         public int ownerOPBypass = Commands.LEVEL_GAMEMASTERS;
 
         /**
@@ -563,6 +621,7 @@ public class ConfigHolder {
                 "This is intended for modpack developers only, and is not playable without custom tweaks or addons.",
                 "Other mods can override this to true, regardless of the config file.",
                 "Default: false" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public boolean highTierContent = false;
 
         @Configurable
@@ -579,13 +638,16 @@ public class ConfigHolder {
                 "Default maximum parallel of steam multiblocks",
                 "Default: 8"
         })
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int steamMultiParallelAmount = 8;
 
         @Configurable
         @Configurable.Comment("Small Steam Boiler Options")
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public SmallBoilers smallBoilers = new SmallBoilers();
         @Configurable
         @Configurable.Comment("Large Steam Boiler Options")
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public LargeBoilers largeBoilers = new LargeBoilers();
 
         public static class SmallBoilers {
@@ -671,30 +733,37 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment("NightVision Goggles Voltage Tier. Default: 1 (LV)")
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierNightVision = 1;
         @Configurable
         @Configurable.Comment("NanoSuit Voltage Tier. Default: 3 (HV)")
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierNanoSuit = 3;
         @Configurable
         @Configurable.Comment({ "Advanced NanoSuit Chestplate Voltage Tier.", "Default: 3 (HV)" })
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierAdvNanoSuit = 3;
         @Configurable
         @Configurable.Comment({ "QuarkTech Suit Voltage Tier.", "Default: 5 (IV)" })
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierQuarkTech = 5;
         @Configurable
         @Configurable.Comment({ "Advanced QuarkTech Suit Chestplate Voltage Tier.", "Default: 6 (LuV)" })
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierAdvQuarkTech = 6;
         @Configurable
         @Configurable.Comment({ "Electric Impeller Jetpack Voltage Tier.", "Default: 2 (MV)" })
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierImpeller = 2;
         @Configurable
         @Configurable.Comment({ "Advanced Electric Jetpack Voltage Tier.", "Default: 3 (HV)" })
         @Configurable.Range(min = 0, max = 14)
+        @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
         public int voltageTierAdvImpeller = 3;
 
         public static class NanoSaber {
@@ -702,10 +771,12 @@ public class ConfigHolder {
             @Configurable
             @Configurable.DecimalRange(min = 0, max = 100)
             @Configurable.Comment({ "The additional damage added when the NanoSaber is powered.", "Default: 20.0" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
             public double nanoSaberDamageBoost = 20;
             @Configurable
             @Configurable.DecimalRange(min = 0, max = 100)
             @Configurable.Comment({ "The base damage of the NanoSaber.", "Default: 5.0" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
             public double nanoSaberBaseDamage = 5;
             @Configurable
             @Configurable.Comment({ "Should Zombies spawn with charged, active NanoSabers on hard difficulty?",
@@ -714,6 +785,7 @@ public class ConfigHolder {
             @Configurable
             @Configurable.Range(min = 1, max = 512)
             @Configurable.Comment({ "The EU/t consumption of the NanoSaber.", "Default: 64" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
             public int energyConsumption = 64;
         }
     }
@@ -722,14 +794,17 @@ public class ConfigHolder {
 
         @Configurable
         @Configurable.Comment({ "Enable hazardous materials", "Default: true" })
+        @Configurable.Synchronized
         public boolean hazardsEnabled = true;
         @Configurable
         @Configurable.Comment({ "Whether hazards are applied to all valid items, or just GT's.",
                 "true = all, false = GT only.", "Default: true" })
+        @Configurable.Synchronized
         public boolean universalHazards = true;
         @Configurable
         @Configurable.Comment({ "Whether environmental hazards like pollution or radiation are active",
                 "Default: false" })
+        @Configurable.Synchronized
         public boolean environmentalHazards = false;
         @Configurable
         @Configurable.Comment({ "How much environmental hazards decay per chunk, per tick.",
@@ -778,6 +853,7 @@ public class ConfigHolder {
         @Configurable
         @Configurable.Comment({ "Use VBO cache for multiblock preview.",
                 "Disable if you have issues with rendering multiblocks.", "Default: true" })
+        @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
         public boolean useVBO = true;
         @Configurable
         @Configurable.Comment({ "Duration of the multiblock in-world preview (s)", "Default: 10" })
@@ -790,7 +866,7 @@ public class ConfigHolder {
         @Configurable
         public ArmorHud armorHud = new ArmorHud();
         @Configurable
-        public RendererConfigs renderer = new RendererConfigs();
+        public Renderers renderer = new Renderers();
         @Configurable
         public TankItemFluidPreview tankItemFluidPreview = new TankItemFluidPreview();
 
@@ -814,6 +890,33 @@ public class ConfigHolder {
             @Configurable.Comment({ "Vertical offset of HUD.", "Default: 0" })
             @Configurable.Range(min = 0, max = 100)
             public int hudOffsetY = 0;
+        }
+
+        public static class Renderers {
+
+            @Configurable
+            @Configurable.Comment({ "Render fluids in multiblocks that support them?", "Default: true" })
+            public boolean renderFluids = true;
+
+            @Configurable
+            @Configurable.Comment({ "Render growing plants in multiblocks that support them?", "Default: true" })
+            public boolean renderGrowingPlants = true;
+
+            @Configurable
+            @Configurable.Comment({ "Whether or not to color material/ore block highlights in the material color",
+                    "Default: true" })
+            public boolean coloredMaterialBlockOutline = true;
+
+            @Configurable
+            @Configurable.Comment({ "Whether or not to color tiered machine highlights in the tier color",
+                    "Default: true" })
+            public boolean coloredTieredMachineOutline = true;
+
+            @Configurable
+            @Configurable.Comment({
+                    "Whether or not to color wire/cable highlights based on voltage tier or material color",
+                    "Default: true" })
+            public boolean coloredWireOutline = true;
         }
 
         public static class TankItemFluidPreview {
@@ -850,31 +953,5 @@ public class ConfigHolder {
         @Configurable.Comment({ "Executes ./gradlew :processResources when F3+T is pressed",
                 "Only works in a development environment", "Default: false" })
         public boolean autoRebuildResources = false;
-    }
-
-    public static class RendererConfigs {
-
-        @Configurable
-        @Configurable.Comment({ "Render fluids in multiblocks that support them?", "Default: true" })
-        public boolean renderFluids = true;
-
-        @Configurable
-        @Configurable.Comment({ "Render growing plants in multiblocks that support them?", "Default: true" })
-        public boolean renderGrowingPlants = true;
-
-        @Configurable
-        @Configurable.Comment({ "Whether or not to color material/ore block highlights in the material color",
-                "Default: true" })
-        public boolean coloredMaterialBlockOutline = true;
-
-        @Configurable
-        @Configurable.Comment({ "Whether or not to color tiered machine highlights in the tier color",
-                "Default: true" })
-        public boolean coloredTieredMachineOutline = true;
-
-        @Configurable
-        @Configurable.Comment({ "Whether or not to color wire/cable highlights based on voltage tier or material color",
-                "Default: true" })
-        public boolean coloredWireOutline = true;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/ConfigurationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/ConfigurationLang.java
@@ -1,33 +1,33 @@
 package com.gregtechceu.gtceu.data.lang;
 
-import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import com.tterrag.registrate.providers.RegistrateLangProvider;
-import dev.toma.configuration.Configuration;
-import dev.toma.configuration.config.format.ConfigFormats;
-import dev.toma.configuration.config.value.ConfigValue;
-import dev.toma.configuration.config.value.ObjectValue;
+import dev.toma.configuration.config.value.IConfigValue;
+import dev.toma.configuration.config.value.IHierarchical;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 public class ConfigurationLang {
 
-    public static void init(RegistrateLangProvider provider) {
-        dfs(provider, new HashSet<>(),
-                Configuration.registerConfig(ConfigHolder.class, ConfigFormats.yaml()).getValueMap());
+    public static void init(final RegistrateLangProvider provider) {
+        final Set<String> added = new HashSet<>();
+        ConfigHolder.INTERNAL_INSTANCE.values()
+                .forEach((value) -> addTranslation(provider, added, value));
     }
 
-    private static void dfs(RegistrateLangProvider provider, Set<String> added, Map<String, ConfigValue<?>> map) {
-        for (var entry : map.entrySet()) {
-            var id = entry.getValue().getId();
-            if (added.add(id)) {
-                provider.add(String.format("config.%s.option.%s", GTCEu.MOD_ID, id), id);
-            }
-            if (entry.getValue() instanceof ObjectValue objectValue) {
-                dfs(provider, added, objectValue.get());
+    private static void addTranslation(RegistrateLangProvider provider, Set<String> added, IConfigValue<?> value) {
+        var id = value.getId();
+        if (added.add(id)) {
+            provider.add("config.gtceu.option." + id, id);
+        }
+        if (value instanceof IHierarchical hierarchical) {
+            for (String childKey : value.getChildrenKeys()) {
+                IConfigValue<?> child = hierarchical.getChildById(childKey);
+                if (child != null) {
+                    addTranslation(provider, added, child);
+                }
             }
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/ConfigurationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/ConfigurationLang.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.data.lang;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import com.tterrag.registrate.providers.RegistrateLangProvider;
@@ -12,6 +13,8 @@ import java.util.Set;
 public class ConfigurationLang {
 
     public static void init(final RegistrateLangProvider provider) {
+        provider.add("config.screen.gtceu", GTCEu.NAME + " Configuration");
+
         final Set<String> added = new HashSet<>();
         ConfigHolder.INTERNAL_INSTANCE.values()
                 .forEach((value) -> addTranslation(provider, added, value));

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/IGridConnectedMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/IGridConnectedMachine.java
@@ -14,8 +14,6 @@ import appeng.me.helpers.IGridConnectedBlockEntity;
  */
 public interface IGridConnectedMachine extends IMachineFeature, IGridConnectedBlockEntity {
 
-    int ME_UPDATE_INTERVAL = ConfigHolder.INSTANCE.compat.ae2.updateIntervals;
-
     /**
      * @return return {@code true} if current machine connected to a valid ME network, {@code false} otherwise.
      */
@@ -27,7 +25,7 @@ public interface IGridConnectedMachine extends IMachineFeature, IGridConnectedBl
      * @return {@code true} if current machine should interact with ME network, {@code false} otherwise.
      */
     default boolean shouldSyncME() {
-        return self().getOffsetTimer() % ME_UPDATE_INTERVAL == 0;
+        return self().getOffsetTimer() % ConfigHolder.INSTANCE.compat.ae2.updateIntervals == 0;
     }
 
     default AECableType getCableConnectionType(Direction dir) {


### PR DESCRIPTION
## What
Un-undo the config lib update.
TL;DR: Update our config library to a version that backports some tooling from 1.21.

## Implementation Details
This reverts commit [dcc1d93](https://github.com/GregTechCEu/GregTech-Modern/commit/dcc1d9361b7dfd1dc067bfe8cd9307f9a6597993)
See #3579

## Outcome
It actually tells you if you need to restart/reopen world/etc. now

## How Was This Tested
Ran the game in a clean Prism instance, it runs as expected. Also tested with (most) optional dependencies installed, still works fine.

Production environment: <img width="854" height="480" alt="javaw_hpl2uJkg71" src="https://github.com/user-attachments/assets/d44082d5-2192-4568-959a-bb0973d484fc" />
Development environment: <img width="854" height="480" alt="java_0uX9PgHl9L" src="https://github.com/user-attachments/assets/7d8d330e-dc3c-4642-853d-6ea1b6177f26" />

## Additional Information
This is a revert of a revert :3