### PR TITLE
Fix the ore prospection radius config's minimum value

### DIFF
--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -131,3 +131,4 @@ A large number of machine feature interfaces have been removed, and have had the
     - Example usage: `SimpleCookingRecipeBuilder.campfireCooking("cooking_chicken").input(new ItemStack(Items.CHICKEN)).output(new ItemStacks(Items.COOKED_CHICKEN)).cookingTime(100).experience(100).save(provider);`
 - `GTFluidImpl` has been merged into `GTFluid`, use `GTFluid.Flowing` and `GTFluid.Source` instead of `GTFluidImpl.Flowing` and `GTFluidImpl.Source`.
 - Item behaviors have been moved to `common/item/behavior`, and some items have been moved from `api/item` to `common/item`.
+- Changed the minimum value of the `compat.minimap.surfaceRockProspectRange` and `compat.minimap.oreBlockProspectRange` configs from -1 to 0. The behavior is still disabled with 0. 

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -278,13 +278,13 @@ public class ConfigHolder {
 
             @Configurable
             @Configurable.Comment({ "The radius, in blocks, that picking up a surface rock will search for veins in.",
-                    "-1 to disable.", "Default: 24" })
-            @Configurable.Range(min = 1)
+                    "0 to disable.", "Default: 24" })
+            @Configurable.Range(min = 0)
             public int surfaceRockProspectRange = 24;
             @Configurable
             @Configurable.Comment({ "The radius, in blocks, that clicking an ore block will search for veins in.",
-                    "-1 to disable", "Default: 24" })
-            @Configurable.Range(min = 1)
+                    "0 to disable", "Default: 24" })
+            @Configurable.Range(min = 0)
             public int oreBlockProspectRange = 24;
 
             @Configurable

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/cache/server/ServerCache.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/cache/server/ServerCache.java
@@ -64,7 +64,7 @@ public class ServerCache extends WorldCache {
 
     public void prospectBySurfaceRockMaterial(ResourceKey<Level> dim, final Material material, BlockPos pos,
                                               ServerPlayer player, int radius) {
-        if (radius < 0) return;
+        if (radius <= 0) return;
         List<GeneratedVeinMetadata> nearbyVeins = getNearbyVeins(dim, pos, radius);
         List<GeneratedVeinMetadata> foundVeins = new ArrayList<>();
         for (GeneratedVeinMetadata nearbyVein : nearbyVeins) {
@@ -87,7 +87,7 @@ public class ServerCache extends WorldCache {
 
     public void prospectByOreMaterial(ResourceKey<Level> dim, Material material, BlockPos origin, ServerPlayer player,
                                       int radius) {
-        if (radius < 0) return;
+        if (radius <= 0) return;
         List<GeneratedVeinMetadata> nearbyVeins = getNearbyVeins(dim, origin, radius);
         List<GeneratedVeinMetadata> foundVeins = new ArrayList<>();
         for (GeneratedVeinMetadata nearbyVein : nearbyVeins) {
@@ -100,7 +100,7 @@ public class ServerCache extends WorldCache {
 
     public void prospectByDepositName(ResourceKey<Level> dim, String depositName, BlockPos origin, ServerPlayer player,
                                       int radius) {
-        if (radius < 0) return;
+        if (radius <= 0) return;
         List<GeneratedVeinMetadata> nearbyVeins = getNearbyVeins(dim, origin, radius);
         List<GeneratedVeinMetadata> foundVeins = new ArrayList<>();
         for (GeneratedVeinMetadata nearbyVein : nearbyVeins) {


### PR DESCRIPTION
## What
Title

## Implementation Details
Made it 0 instead of -1, as in practice a radius of 0 means nothing can be found anyway.

## Outcome
Prospection can be disabled again
