### PR TITLE
fix: check `consumesAction()` result instead of hardcoded SUCCESS in `onItemUseFirst`

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/IGTTool.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/IGTTool.java
@@ -616,8 +616,9 @@ public interface IGTTool extends HeldItemUIFactory.IHeldItemUIHolder, ItemLike, 
 
     default InteractionResult definition$onItemUseFirst(ItemStack stack, UseOnContext context) {
         for (IToolBehavior behavior : getToolStats().getBehaviors()) {
-            if (behavior.onItemUseFirst(stack, context) == InteractionResult.SUCCESS) {
-                return InteractionResult.SUCCESS;
+            InteractionResult result = behavior.onItemUseFirst(stack, context);
+            if (result.consumesAction()) {
+                return result;
             }
         }
 


### PR DESCRIPTION
Previously, `definition$onItemUseFirst` only returned SUCCESS when any behavior returned SUCCESS, ignoring other consume actions. This caused vanilla blocks like furnace to incorrectly open their GUI after being rotated.

## What
Fix incorrect GUI opening for vanilla blocks (furnace, dispenser, dropper, etc.) after being rotated with a wrench.  
The root cause is that `definition$onItemUseFirst` in `IGTTool` only returns `SUCCESS` when any behavior returns `SUCCESS`, while other `consumesAction()` results (e.g., `CONSUME`, `CONSUME_PARTIAL`) are ignored. This leads to the original `use` method of the block being triggered afterwards, opening its GUI unexpectedly.

## Implementation Details
In `IGTTool.definition$onItemUseFirst`, change the behavior handling loop from:
```java
if (behavior.onItemUseFirst(stack, context) == InteractionResult.SUCCESS) {
    return InteractionResult.SUCCESS;
}
```
to
```java
InteractionResult result = behavior.onItemUseFirst(stack, context);
if (result.consumesAction()) {
    return result;
}
```