### PR TITLE
Fix crash when right clicking in central monitor

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CentralMonitorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CentralMonitorMachine.java
@@ -604,7 +604,7 @@ public class CentralMonitorMachine extends WorkableElectricMultiblockMachine
                     }
                     textures.setTextures(rect, texture);
                     if (component.getDataItems() != null) {
-                        IItemHandler dataItems = component.getDataItems();
+                        ItemHandler dataItems = component.getDataItems();
                         MonitorGroup selectedGroup = null;
                         for (MonitorGroup group : monitorGroups) {
                             for (IMonitorComponent c : selectedComponents) {


### PR DESCRIPTION
## What
A Monifactory instance crashed when I right-clicked an icon in the Central Monitor. The crash cited this line under rightClickCallback, so I fixed the obvious typo

## Implementation Details
Not sure if this fixes the crash, but typos are typos

## Outcome
Fixed typo in line 607