### PR TITLE
FOV and Block Speed Toggle Config (1.21-v8.0.0)

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1749,6 +1749,8 @@
     "config.gtceu.option.batchDuration": "uoıʇɐɹnᗡɥɔʇɐq",
     "config.gtceu.option.bedrockOreDistance": "ǝɔuɐʇsıᗡǝɹOʞɔoɹpǝq",
     "config.gtceu.option.bedrockOreDropTagPrefix": "xıɟǝɹԀbɐ⟘doɹᗡǝɹOʞɔoɹpǝq",
+    "config.gtceu.option.blockFovChange": "ǝbuɐɥƆʌoℲʞɔoןq",
+    "config.gtceu.option.blockSpeedChange": "ǝbuɐɥƆpǝǝdSʞɔoןq",
     "config.gtceu.option.borderColor": "ɹoןoƆɹǝpɹoq",
     "config.gtceu.option.bronzeBoilerHeatSpeed": "pǝǝdSʇɐǝHɹǝןıoᗺǝzuoɹq",
     "config.gtceu.option.bronzeBoilerMaxTemperature": "ǝɹnʇɐɹǝdɯǝ⟘xɐWɹǝןıoᗺǝzuoɹq",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1749,6 +1749,8 @@
     "config.gtceu.option.batchDuration": "batchDuration",
     "config.gtceu.option.bedrockOreDistance": "bedrockOreDistance",
     "config.gtceu.option.bedrockOreDropTagPrefix": "bedrockOreDropTagPrefix",
+    "config.gtceu.option.blockFovChange": "blockFovChange",
+    "config.gtceu.option.blockSpeedChange": "blockSpeedChange",
     "config.gtceu.option.borderColor": "borderColor",
     "config.gtceu.option.bronzeBoilerHeatSpeed": "bronzeBoilerHeatSpeed",
     "config.gtceu.option.bronzeBoilerMaxTemperature": "bronzeBoilerMaxTemperature",

--- a/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/forge/ForgeClientEventListener.java
@@ -14,6 +14,7 @@ import com.gregtechceu.gtceu.client.renderer.BlockHighlightRenderer;
 import com.gregtechceu.gtceu.client.renderer.MultiblockInWorldPreviewRenderer;
 import com.gregtechceu.gtceu.client.renderer.cover.FacadeCoverRenderer;
 import com.gregtechceu.gtceu.client.util.TooltipHelper;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.client.AbstractClientPlayerAccessor;
 import com.gregtechceu.gtceu.core.mixins.client.PlayerSkinAccessor;
 import com.gregtechceu.gtceu.data.command.GTClientCommands;
@@ -117,18 +118,22 @@ public class ForgeClientEventListener {
         Map<AttributeModifier.Operation, List<AttributeModifier>> mods = attrib.getModifiers().stream()
                 .collect(Collectors.groupingBy(t -> t.operation()));
 
-        for (AttributeModifier mod : mods.get(AttributeModifier.Operation.ADD_VALUE)) {
-            base += mod.amount();
+        if (mods.get(AttributeModifier.Operation.ADD_VALUE) != null) {
+            for (AttributeModifier mod : mods.get(AttributeModifier.Operation.ADD_VALUE)) {
+                base += mod.amount();
+            }
         }
 
         double applied = base;
         for (AttributeModifier mod : mods.get(AttributeModifier.Operation.ADD_MULTIPLIED_BASE)) {
-            if (mod.id() == BlockAttributes.BLOCK_SPEED_BOOST) continue;
+            if (mod.id() == BlockAttributes.BLOCK_SPEED_BOOST || !ConfigHolder.INSTANCE.client.blockFovChange) continue;
             applied += base * mod.amount();
         }
 
-        for (AttributeModifier mod : mods.get(AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)) {
-            applied *= 1 + mod.amount();
+        if (mods.get(AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL) != null) {
+            for (AttributeModifier mod : mods.get(AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)) {
+                applied *= 1 + mod.amount();
+            }
         }
 
         return attrib.getAttribute().value().sanitizeValue(applied);

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -745,6 +745,9 @@ public class ConfigHolder {
         @Configurable.Comment({ "How much environmental hazards decay per chunk, per tick.",
                 "Default: 0.001" })
         public float environmentalHazardDecayRate = 0.001f;
+        @Configurable
+        @Configurable.Comment({ "Whether or not speed-modifying blocks should change player's speed." })
+        public boolean blockSpeedChange = true;
     }
 
     public static class ClientConfigs {
@@ -796,6 +799,9 @@ public class ConfigHolder {
         public RendererConfigs renderer = new RendererConfigs();
         @Configurable
         public TankItemFluidPreview tankItemFluidPreview = new TankItemFluidPreview();
+        @Configurable
+        @Configurable.Comment({ "Whether or not speed-modifying blocks should change player's FOV." })
+        public boolean blockFovChange = true;
 
         public int getDefaultPaintingColor() {
             // OR with full alpha to differentiate from a machine that's painted white (map color 0xffffff)

--- a/src/main/java/com/gregtechceu/gtceu/forge/CommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/forge/CommonEventListener.java
@@ -420,6 +420,8 @@ public class CommonEventListener {
     public static void playerTickEvent(PlayerTickEvent.Pre event) {
         Player player = event.getEntity();
         if (!player.level().isClientSide) {
+            if (!ConfigHolder.INSTANCE.gameplay.blockSpeedChange) return;
+
             var speedAttrib = player.getAttribute(Attributes.MOVEMENT_SPEED);
             if (speedAttrib == null) return;
             var speedMod = speedAttrib.getModifier(BlockAttributes.BLOCK_SPEED_BOOST);


### PR DESCRIPTION
### What
Adds 2 configs:
1. Allows players to disable FOV changes from blocks that modify player speed.
2. Allows players to disable speed change from blocks that modify player speed.

### Implementation Details
- Added one client and one gameplay config in `ConfigHolder.java`
- Added an early return in `playerTickEvent(TickEvent.PlayerTickEvent event)`
- Added a config check in `getValueWithoutWalkingBoost(AttributeInstance attrib)` that sets fov to normal as it forces BLOCK_SPEED_BOOST to be included in the calculations.

### How Was This Tested
- Tested in runClient, sorry for the long video: https://cdn.kitsuryuki.net/Videos/gtceu_config_video_1_21.mp4

### Additional Information
- I had to modify `getValueWithoutWalkingBoost(AttributeInstance attrib)` to add two null checks as it kept crashing on me due to for loops complaining about null objects.
- I am not that great at naming things so, if there are any issues, do tell me.
- 1.20 PR: #4843 