### PR TITLE
FOV and Block Speed Toggle Config (1.21)

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1765,6 +1765,8 @@
     "config.gtceu.option.batchDuration": "uoıʇɐɹnᗡɥɔʇɐq",
     "config.gtceu.option.bedrockOreDistance": "ǝɔuɐʇsıᗡǝɹOʞɔoɹpǝq",
     "config.gtceu.option.bedrockOreDropTagPrefix": "xıɟǝɹԀbɐ⟘doɹᗡǝɹOʞɔoɹpǝq",
+    "config.gtceu.option.blockFovChange": "ǝbuɐɥƆʌoℲʞɔoןq",
+    "config.gtceu.option.blockSpeedChange": "ǝbuɐɥƆpǝǝdSʞɔoןq",
     "config.gtceu.option.borderColor": "ɹoןoƆɹǝpɹoq",
     "config.gtceu.option.bronzeBoilerHeatSpeed": "pǝǝdSʇɐǝHɹǝןıoᗺǝzuoɹq",
     "config.gtceu.option.bronzeBoilerMaxTemperature": "ǝɹnʇɐɹǝdɯǝ⟘xɐWɹǝןıoᗺǝzuoɹq",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1765,6 +1765,8 @@
     "config.gtceu.option.batchDuration": "batchDuration",
     "config.gtceu.option.bedrockOreDistance": "bedrockOreDistance",
     "config.gtceu.option.bedrockOreDropTagPrefix": "bedrockOreDropTagPrefix",
+    "config.gtceu.option.blockFovChange": "blockFovChange",
+    "config.gtceu.option.blockSpeedChange": "blockSpeedChange",
     "config.gtceu.option.borderColor": "borderColor",
     "config.gtceu.option.bronzeBoilerHeatSpeed": "bronzeBoilerHeatSpeed",
     "config.gtceu.option.bronzeBoilerMaxTemperature": "bronzeBoilerMaxTemperature",

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientEventListener.java
@@ -18,7 +18,6 @@ import com.gregtechceu.gtceu.common.data.GTMobEffects;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.client.AbstractClientPlayerAccessor;
 import com.gregtechceu.gtceu.core.mixins.client.PlayerSkinAccessor;
-import com.gregtechceu.gtceu.data.recipe.CustomTags;
 import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
 
 import net.minecraft.ChatFormatting;
@@ -27,7 +26,6 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.resources.PlayerSkin;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.ai.attributes.AttributeInstance;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -35,7 +33,6 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.neoforged.api.distmarker.Dist;
@@ -130,7 +127,8 @@ public class ClientEventListener {
 
         double applied = base;
         for (AttributeModifier mod : modifiers.get(AttributeModifier.Operation.ADD_MULTIPLIED_BASE)) {
-            if (mod.id() == GTAttributeModifierIds.BLOCK_SPEED_BOOST || !ConfigHolder.INSTANCE.client.blockFovChange) continue;
+            if (mod.id() == GTAttributeModifierIds.BLOCK_SPEED_BOOST || !ConfigHolder.INSTANCE.client.blockFovChange)
+                continue;
             applied += base * mod.amount();
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientEventListener.java
@@ -15,6 +15,7 @@ import com.gregtechceu.gtceu.client.util.TooltipHelper;
 import com.gregtechceu.gtceu.common.commands.GTClientCommands;
 import com.gregtechceu.gtceu.common.data.GTAttributeModifierIds;
 import com.gregtechceu.gtceu.common.data.GTMobEffects;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.core.mixins.client.AbstractClientPlayerAccessor;
 import com.gregtechceu.gtceu.core.mixins.client.PlayerSkinAccessor;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
@@ -99,23 +100,21 @@ public class ClientEventListener {
         if (speedAttribute == null || !speedAttribute.hasModifier(GTAttributeModifierIds.BLOCK_SPEED_BOOST)) {
             return;
         }
+        boolean flying = player.getAbilities().flying;
+        float originalFov = flying ? 1.1F : 1.0F;
+        float walkSpeed = player.getAbilities().getWalkingSpeed();
 
-        float multiplier = 1.0f;
-        BlockState state = player.level().getBlockState(player.getOnPos());
-
-        // inverse of the math done with the speed attribute in AbstractClientPlayer
-        if (state.is(CustomTags.VERY_FAST_WALKABLE_BLOCKS)) {
-            // base speed is 0.1, boost is 0.1*0.6 -> boosted speed = 0.16
-            // the FOV modifier is `1 + (speed / base speed + 1) / 2`, so `1 + (0.16 / 0.1 + 1) / 2 = 1.3`
-            // thus, divide by 1.3 to get back to original FOV before the 'fast block boost' modifier
-            multiplier /= 1.3f;
-        } else if (state.is(CustomTags.FAST_WALKABLE_BLOCKS)) {
-            // same as above but the speed boost is 0.25
-            multiplier /= 1.125f;
+        originalFov *= ((float) speedAttribute.getBaseValue() / walkSpeed + 1.0F) / 2.0F;
+        if (walkSpeed == 0.0F || Float.isNaN(originalFov) ||
+                Float.isInfinite(originalFov)) {
+            return;
         }
 
-        multiplier = (float) Mth.lerp(Minecraft.getInstance().options.fovEffectScale().get(), 1.0, multiplier);
-        event.setNewFovModifier(event.getNewFovModifier() * multiplier);
+        float newFov = flying ? 1.1F : 1.0F;
+        newFov *= ((float) getValueWithoutWalkingBoost(speedAttribute) / walkSpeed + 1.0F) /
+                2.0F;
+
+        event.setNewFovModifier(newFov / originalFov);
     }
 
     private static double getValueWithoutWalkingBoost(AttributeInstance attribute) {
@@ -123,18 +122,22 @@ public class ClientEventListener {
         Map<AttributeModifier.Operation, List<AttributeModifier>> modifiers = attribute.getModifiers().stream()
                 .collect(Collectors.groupingBy(AttributeModifier::operation));
 
-        for (AttributeModifier mod : modifiers.get(AttributeModifier.Operation.ADD_VALUE)) {
-            base += mod.amount();
+        if (modifiers.get(AttributeModifier.Operation.ADD_VALUE) != null) {
+            for (AttributeModifier mod : modifiers.get(AttributeModifier.Operation.ADD_VALUE)) {
+                base += mod.amount();
+            }
         }
 
         double applied = base;
         for (AttributeModifier mod : modifiers.get(AttributeModifier.Operation.ADD_MULTIPLIED_BASE)) {
-            if (mod.id() == GTAttributeModifierIds.BLOCK_SPEED_BOOST) continue;
+            if (mod.id() == GTAttributeModifierIds.BLOCK_SPEED_BOOST || !ConfigHolder.INSTANCE.client.blockFovChange) continue;
             applied += base * mod.amount();
         }
 
-        for (AttributeModifier mod : modifiers.get(AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)) {
-            applied *= 1 + mod.amount();
+        if (modifiers.get(AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL) != null) {
+            for (AttributeModifier mod : modifiers.get(AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL)) {
+                applied *= 1 + mod.amount();
+            }
         }
 
         return attribute.getAttribute().value().sanitizeValue(applied);

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
@@ -461,7 +461,7 @@ public class CommonEventListener {
     @SubscribeEvent
     public static void playerTickEvent(PlayerTickEvent.Pre event) {
         Player player = event.getEntity();
-        if (!player.level().isClientSide) {
+        if (!player.level().isClientSide && ConfigHolder.INSTANCE.gameplay.blockSpeedChange) {
             var speedAttrib = player.getAttribute(Attributes.MOVEMENT_SPEED);
             if (speedAttrib == null) return;
             var speedMod = speedAttrib.getModifier(GTAttributeModifierIds.BLOCK_SPEED_BOOST);

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -744,6 +744,9 @@ public class ConfigHolder {
         @Configurable.Comment({ "List of domains that are allowed in the image module" })
         public String[] allowedImageDomains = new String[] { "imgur.com", "discord.com", "github.com",
                 "raw.githubusercontent.com" };
+        @Configurable
+        @Configurable.Comment({ "Whether or not speed-modifying blocks should change player's speed." })
+        public boolean blockSpeedChange = true;
     }
 
     public static class ClientConfigs {
@@ -798,6 +801,9 @@ public class ConfigHolder {
         public RendererOptions renderer = new RendererOptions();
         @Configurable
         public TankItemFluidPreview tankItemFluidPreview = new TankItemFluidPreview();
+        @Configurable
+        @Configurable.Comment({ "Whether or not speed-modifying blocks should change player's FOV." })
+        public boolean blockFovChange = true;
 
         public int getDefaultPaintingColor() {
             // OR with full alpha to differentiate from a machine that's painted white (map color 0xffffff)


### PR DESCRIPTION
### What
Adds 2 configs:
1. Allows players to disable FOV changes from blocks that modify player speed.
2. Allows players to disable speed change from blocks that modify player speed.

### Implementation Details
- Readded @YoungOnionMC's Concrete Block FOV speed code and modified it to not break due to null `.get`.
- Added one client and one gameplay config in `ConfigHolder.java`
- Added an early return in `playerTickEvent(TickEvent.PlayerTickEvent event)`
- Added a config check in `getValueWithoutWalkingBoost(AttributeInstance attrib)` that sets FOV to normal as it forces BLOCK_SPEED_BOOST to be included in the calculations.

### How Was This Tested
- Tested in runClient, sorry for the long video: https://cdn.kitsuryuki.net/Videos/gtceu_config_video_1_21.mp4

### Additional Information
- I am not that great at naming things so, if there are any issues, do tell me.
- 1.20 PR: #4843 