### PR TITLE
Replace tag prefix items with those provided by AE2

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1919,6 +1919,7 @@
   "config.gtceu.option.tungstensteelBoilerMaxTemperature": "ǝɹnʇɐɹǝdɯǝ⟘xɐWɹǝןıoᗺןǝǝʇsuǝʇsbunʇ",
   "config.gtceu.option.universalHazards": "spɹɐzɐHןɐsɹǝʌıun",
   "config.gtceu.option.updateIntervals": "sןɐʌɹǝʇuIǝʇɐpdn",
+  "config.gtceu.option.useAE2Certus": "snʇɹǝƆᄅƎⱯǝsn",
   "config.gtceu.option.useVBO": "OᗺΛǝsn",
   "config.gtceu.option.voltageTierAdvImpeller": "ɹǝןןǝdɯIʌpⱯɹǝı⟘ǝbɐʇןoʌ",
   "config.gtceu.option.voltageTierAdvNanoSuit": "ʇınSouɐNʌpⱯɹǝı⟘ǝbɐʇןoʌ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1919,6 +1919,7 @@
   "config.gtceu.option.tungstensteelBoilerMaxTemperature": "tungstensteelBoilerMaxTemperature",
   "config.gtceu.option.universalHazards": "universalHazards",
   "config.gtceu.option.updateIntervals": "updateIntervals",
+  "config.gtceu.option.useAE2Certus": "useAE2Certus",
   "config.gtceu.option.useVBO": "useVBO",
   "config.gtceu.option.voltageTierAdvImpeller": "voltageTierAdvImpeller",
   "config.gtceu.option.voltageTierAdvNanoSuit": "voltageTierAdvNanoSuit",

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlag;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.common.data.materials.*;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.memoization.GTMemoizer;
 
 import net.minecraft.world.item.Items;
@@ -268,6 +269,15 @@ public class GTMaterials {
 
         rod.modifyMaterialAmount(Blaze, 4);
         rod.modifyMaterialAmount(Bone, 5);
+
+        if (GTCEu.Mods.isAE2Loaded() && ConfigHolder.INSTANCE.compat.ae2.useAE2Certus) {
+            gem.setIgnored(CertusQuartz,
+                    GTMemoizer.memoize(() -> appeng.core.definitions.AEItems.CERTUS_QUARTZ_CRYSTAL.asItem()));
+            dust.setIgnored(CertusQuartz,
+                    GTMemoizer.memoize(() -> appeng.core.definitions.AEItems.CERTUS_QUARTZ_DUST.asItem()));
+            block.setIgnored(CertusQuartz,
+                    GTMemoizer.memoize(() -> appeng.core.definitions.AEBlocks.QUARTZ_BLOCK.asItem()));
+        }
     }
 
     @NotNull

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterials.java
@@ -277,6 +277,8 @@ public class GTMaterials {
                     GTMemoizer.memoize(() -> appeng.core.definitions.AEItems.CERTUS_QUARTZ_DUST.asItem()));
             block.setIgnored(CertusQuartz,
                     GTMemoizer.memoize(() -> appeng.core.definitions.AEBlocks.QUARTZ_BLOCK.asItem()));
+            dust.setIgnored(EnderPearl,
+                    GTMemoizer.memoize(() -> appeng.core.definitions.AEItems.ENDER_DUST.asItem()));
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/config/ConfigHolder.java
@@ -266,6 +266,12 @@ public class ConfigHolder {
             @Configurable.DecimalRange(min = 0.0, max = Integer.MAX_VALUE)
             @Configurable.UpdateRestriction(UpdateRestrictions.MAIN_MENU)
             public double meHatchEnergyUsage = 4.0;
+
+            @Configurable
+            @Configurable.Comment({ "Use AE2 Certus Quartz, dust and blocks instead of creating new ones.",
+                    "Default: false" })
+            @Configurable.UpdateRestriction(UpdateRestrictions.GAME_RESTART)
+            public boolean useAE2Certus = false; // Default to false for backwards compatibility
         }
 
         public static class MinimapCompatConfig {

--- a/src/main/resources/assets/gtceu/lang/de_de.json
+++ b/src/main/resources/assets/gtceu/lang/de_de.json
@@ -1920,6 +1920,7 @@
     "config.gtceu.option.tungstensteelBoilerMaxTemperature": "WolframstahlBoilerMaxTemperature",
     "config.gtceu.option.universalHazards": "universelle Gefahren",
     "config.gtceu.option.updateIntervals": "updateIntervals",
+    "config.gtceu.option.useAE2Certus": "Verwende AE2 Certus",
     "config.gtceu.option.useVBO": "Verwende VBO",
     "config.gtceu.option.voltageTierAdvImpeller": "SpannungTierAdvImpeller",
     "config.gtceu.option.voltageTierAdvNanoSuit": "SpannungTierAdvNanoSuit",


### PR DESCRIPTION
## What
Adds a config option to use AE2 Certus Quartz items for the CertusQuartz material instead of generating tag prefix items for gem, dust and block (and AE2 Ender Dust instead of EnderPearl dust).

## How Was This Tested
The game was started with and without the config option set, and with or without AE2 loaded. Only if the config option is set and AE2 is loaded, the certus quartz tag prefix items for gem, dust and block are not registered and the AE2 items are used instead.

## Potential Compatibility Issues
This potentially refuses to compile or run if AE2 changes how it registers items and blocks.