### PR TITLE
Fixed cover sync

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/ManagedSyncBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/ManagedSyncBlockEntity.java
@@ -74,9 +74,14 @@ public abstract class ManagedSyncBlockEntity extends BlockEntity implements ISyn
     }
 
     @Override
+    public final void handleUpdateTag(CompoundTag tag) {
+        this.clientLoad(tag);
+    }
+
+    @Override
     public final void onDataPacket(Connection net, ClientboundBlockEntityDataPacket pkt) {
-        var compound = pkt.getTag();
-        if (compound != null) clientLoad(compound);
+        CompoundTag tag = pkt.getTag();
+        if (tag != null) clientLoad(tag);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/SyncDataHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/SyncDataHolder.java
@@ -46,10 +46,7 @@ public class SyncDataHolder {
     }
 
     public CompoundTag serializeNBT(boolean writeClientFields) {
-        CompoundTag tag = serializeNBT(writeClientFields, resyncAll);
-        resyncAll = false;
-        dirtySyncFields.clear();
-        return tag;
+        return serializeNBT(writeClientFields, resyncAll);
     }
 
     public CompoundTag serializeNBT(boolean writeClientFields, boolean fullSync) {
@@ -63,6 +60,8 @@ public class SyncDataHolder {
                 tag.put(field.nbtSaveKey, nbtValue);
             }
         }
+        resyncAll = false;
+        dirtySyncFields.clear();
         return tag;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/gtceu/CoverBehaviorTransformer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/gtceu/CoverBehaviorTransformer.java
@@ -20,7 +20,7 @@ public class CoverBehaviorTransformer implements ValueTransformer<CoverBehavior>
     public Tag serializeNBT(@Nullable CoverBehavior value,
                             CoverBehaviorTransformer.TransformerContext<CoverBehavior> context) {
         if (value != null) {
-            return serialize(value, context.isClientSync());
+            return serialize(value, context.isClientSync(), context.isClientFullSyncUpdate());
         }
         return new CompoundTag();
     }
@@ -36,12 +36,12 @@ public class CoverBehaviorTransformer implements ValueTransformer<CoverBehavior>
         return null;
     }
 
-    private CompoundTag serialize(CoverBehavior cover, boolean isSync) {
+    private CompoundTag serialize(CoverBehavior cover, boolean isSync, boolean fullSync) {
         var compound = new CompoundTag();
 
         compound.putInt("side", cover.attachedSide.ordinal());
         compound.putString("coverType", cover.coverDefinition.getId().toString());
-        CompoundTag serializedCover = cover.getSyncDataHolder().serializeNBT(isSync);
+        CompoundTag serializedCover = cover.getSyncDataHolder().serializeNBT(isSync, fullSync);
         compound.put("data", serializedCover);
 
         return compound;
@@ -63,7 +63,7 @@ public class CoverBehaviorTransformer implements ValueTransformer<CoverBehavior>
             return null;
         }
         ResourceLocation coverType = ResourceLocation.tryParse(tag.getString("coverType"));
-        if (cover == null || cover.coverDefinition.getId() != coverType) {
+        if (cover == null || !cover.coverDefinition.getId().equals(coverType)) {
             var coverReg = GTRegistries.COVERS.get(coverType);
             if (coverReg == null) {
                 GTCEu.LOGGER.error("Error during NBT load: unknown cover type {} ({})", coverType,
@@ -75,8 +75,7 @@ public class CoverBehaviorTransformer implements ValueTransformer<CoverBehavior>
 
         CoverBehavior newCover = holder.getCoverAtSide(side);
         if (newCover == null) return null;
-        newCover.getSyncDataHolder().deserializeNBT(tag.getCompound("data"),
-                isSync);
+        newCover.getSyncDataHolder().deserializeNBT(tag.getCompound("data"), isSync);
 
         if (!isSync && newCover.getAttachItem() == ItemStack.EMPTY) {
             GTCEu.LOGGER.error("Invalid cover save state, this should never happen unless loading corrupted data.");

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FacadeCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FacadeCover.java
@@ -38,7 +38,8 @@ public class FacadeCover extends CoverBehavior {
     @Override
     public void onAttached(ItemStack itemStack, @Nullable ServerPlayer player) {
         super.onAttached(itemStack, player);
-        this.facadeState = FacadeItemBehaviour.getFacadeState(itemStack);
+
+        setFacadeState(FacadeItemBehaviour.getFacadeState(itemStack));
     }
 
     @Override


### PR DESCRIPTION
## What
Fixed covers not doing initial sync at all
Also fixed the ID being compared by reference which will never return true, deleting the existing cover and replacing it with a new one.

## Implementation Details
Added an implementation of `BlockEntity#handleUpdateTag` to `ManagedSyncBlockEntity` that also calls `#clientLoad`

## Outcome
Covers sync correctly

## How Was This Tested
Facades used to turn to stone facades on the client when relogging (removing them still dropped the correct one)
They no longer do that