### PR TITLE
Add index check to getRecipeType()

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -197,7 +197,8 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
     }
 
     public GTRecipeType getRecipeType() {
-        return recipeTypes[activeRecipeType];
+        int index = activeRecipeType >= 0 && activeRecipeType < recipeTypes.length ? activeRecipeType : 0;
+        return recipeTypes[index];
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableMultiblockMachine.java
@@ -290,7 +290,8 @@ public abstract class WorkableMultiblockMachine extends MultiblockControllerMach
     }
 
     public GTRecipeType getRecipeType() {
-        return recipeTypes[activeRecipeType];
+        int index = activeRecipeType >= 0 && activeRecipeType < recipeTypes.length ? activeRecipeType : 0;
+        return recipeTypes[index];
     }
 
     /**


### PR DESCRIPTION
## What

Fixed a bug where when the machine mode gets removed, the invalid index is still used, causing game to crash.

## Implementation Details

If the mode is out-of-bound, it use the 0-indexed mode.

## Additional Information

Discovered in https://github.com/StarT-Dev-Team/Star-Technology/issues/510
