### PR TITLE
Make machine renderers instanced per machine entity

### DIFF
--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -135,3 +135,4 @@ A large number of machine feature interfaces have been removed, and have had the
 - `ChargerMachine` has been merged into `BatteryBufferMachine`.
   - Calling the battery buffer constructor with the following args gives the same behaviour as a charger machine: `(info, tier, inventorySize, BatteryBufferMachine.AMPS_PER_BATTERY_CHARGER, 0)`
 - Refactored Jade provider code. Use the `MachineInfoProvider` class for jade providers for a specific machine type, and `MachineTraitProvider` for providers for a specific machine trait. 
+- `DynamicRender<?,?>`s are now instanced per-machine instead of having one instance globally.

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -37,7 +37,9 @@ import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
 import com.gregtechceu.gtceu.client.model.IBlockEntityRendererBakedModel;
+import com.gregtechceu.gtceu.client.model.machine.MachineModel;
 import com.gregtechceu.gtceu.client.model.machine.MachineRenderState;
+import com.gregtechceu.gtceu.client.renderer.machine.DynamicRender;
 import com.gregtechceu.gtceu.client.util.ModelUtils;
 import com.gregtechceu.gtceu.common.cover.FluidFilterCover;
 import com.gregtechceu.gtceu.common.cover.ItemFilterCover;
@@ -99,6 +101,7 @@ import org.jetbrains.annotations.*;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * The base BlockEntity for all GT machines.
@@ -681,6 +684,21 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
         for (var property : renderState.getValues().entrySet()) {
             lines.accept(ModelUtils.getPropertyValueString(property));
         }
+    }
+
+    private @Nullable List<DynamicRender<?, ?>> renderers;
+
+    public List<DynamicRender<?, ?>> getOrInitDynamicRenderers(List<Supplier<DynamicRender<?, ?>>> rendererSuppliers,
+                                                               MachineModel model) {
+        if (renderers == null) {
+            renderers = new ArrayList<>();
+            for (var supplier : rendererSuppliers) {
+                var renderer = supplier.get();
+                renderer.setParent(model);
+                renderers.add(renderer);
+            }
+        }
+        return renderers;
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -686,8 +686,10 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
         }
     }
 
+    @OnlyIn(Dist.CLIENT)
     private @Nullable List<DynamicRender<?, ?>> renderers;
 
+    @OnlyIn(Dist.CLIENT)
     public List<DynamicRender<?, ?>> getOrInitDynamicRenderers(List<Supplier<DynamicRender<?, ?>>> rendererSuppliers,
                                                                MachineModel model) {
         if (renderers == null) {

--- a/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModel.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModel.java
@@ -58,6 +58,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public final class MachineModel extends BaseBakedModel implements ICoverableRenderer,
@@ -85,8 +86,26 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
     private final MachineDefinition definition;
     private final Map<MachineRenderState, BakedModel> modelsByState;
     private final @Nullable MultiPartBakedModel multiPart;
-    @Getter
-    private final List<DynamicRender<?, ?>> dynamicRenders;
+
+    private final List<Supplier<DynamicRender<?, ?>>> dynamicRenderSuppliers;
+
+    public List<DynamicRender<?, ?>> getOrInitDynamicRenderers(MetaMachine machine) {
+        return machine.getOrInitDynamicRenderers(dynamicRenderSuppliers, this);
+    }
+
+    private List<DynamicRender<?, ?>> dynamicRenderersWithoutMachine;
+
+    public List<DynamicRender<?, ?>> getOrInitDynamicRenderersWithoutMachine() {
+        if (dynamicRenderersWithoutMachine == null) {
+            dynamicRenderersWithoutMachine = new ArrayList<>();
+            for (var supplier : dynamicRenderSuppliers) {
+                var renderer = supplier.get();
+                renderer.setParent(this);
+                dynamicRenderersWithoutMachine.add(renderer);
+            }
+        }
+        return dynamicRenderersWithoutMachine;
+    }
 
     @Getter
     private final ItemTransforms transforms;
@@ -108,13 +127,13 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
     public MachineModel(MachineDefinition definition,
                         Map<MachineRenderState, BakedModel> modelsByState,
                         @Nullable MultiPartBakedModel multiPart,
-                        List<DynamicRender<?, ?>> dynamicRenders,
+                        List<Supplier<DynamicRender<?, ?>>> dynamicRenders,
                         ItemTransforms transforms, Transformation rootTransform, ModelState modelState,
                         boolean isGui3d, boolean usesBlockLight, boolean useAmbientOcclusion) {
         this.definition = definition;
         this.modelsByState = modelsByState;
         this.multiPart = multiPart;
-        this.dynamicRenders = dynamicRenders;
+        this.dynamicRenderSuppliers = dynamicRenders;
 
         this.transforms = transforms;
         this.rootTransform = rootTransform;
@@ -122,10 +141,6 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
         this.isGui3d = isGui3d;
         this.usesBlockLight = usesBlockLight;
         this.useAmbientOcclusion = useAmbientOcclusion;
-
-        for (DynamicRender<?, ?> render : this.dynamicRenders) {
-            render.setParent(this);
-        }
     }
 
     public static void initSprites(TextureAtlas atlas) {
@@ -309,8 +324,10 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
         MachineRenderState renderState = machine != null ? machine.getRenderState() : definition.defaultRenderState();
         renderBaseModel(quads, renderState, blockState, side, rand, modelData, renderType);
 
-        for (DynamicRender render : dynamicRenders) {
-            quads.addAll(render.getRenderQuads(machine, level, pos, blockState, side, rand, modelData, renderType));
+        if (machine != null) {
+            for (DynamicRender render : getOrInitDynamicRenderers(machine)) {
+                quads.addAll(render.getRenderQuads(machine, level, pos, blockState, side, rand, modelData, renderType));
+            }
         }
         // the instanceof check also ensures it's not null
         if (machine instanceof IMultiPart part && part.replacePartModelWhenFormed()) {
@@ -379,7 +396,7 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
         var overrides = controllerModel.textureOverrides;
 
         List<BakedQuad> renderQuads = new LinkedList<>();
-        for (var render : controllerModel.getDynamicRenders()) {
+        for (var render : controllerModel.getOrInitDynamicRenderers(controller)) {
             if (render instanceof IControllerModelRenderer controllerRenderer) {
                 controllerRenderer.renderPartModel(renderQuads, controller, part, frontFacing, side,
                         rand, modelData, renderType);
@@ -437,10 +454,10 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
         ICoverableRenderer.super.renderDynamicCovers(machine, partialTick, poseStack, buffer,
                 packedLight,
                 packedOverlay);
-        if (dynamicRenders.isEmpty()) return;
+        if (dynamicRenderSuppliers.isEmpty()) return;
 
         Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
-        for (DynamicRender model : dynamicRenders) {
+        for (DynamicRender model : getOrInitDynamicRenderers(machine)) {
             if (!model.shouldRender(machine, cameraPos)) {
                 continue;
             }
@@ -452,8 +469,8 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
     public void renderByItem(ItemStack stack, ItemDisplayContext displayContext,
                              PoseStack poseStack, MultiBufferSource buffer,
                              int packedLight, int packedOverlay) {
-        if (dynamicRenders.isEmpty()) return;
-        for (DynamicRender<?, ?> model : dynamicRenders) {
+        if (dynamicRenderSuppliers.isEmpty()) return;
+        for (DynamicRender<?, ?> model : getOrInitDynamicRenderersWithoutMachine()) {
             model.renderByItem(stack, displayContext, poseStack, buffer, packedLight, packedOverlay);
         }
     }
@@ -465,9 +482,9 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
 
         if (!(blockEntity instanceof MetaMachine machine)) return bounds;
         if (machine.getDefinition() != getDefinition()) return bounds;
-        if (dynamicRenders.isEmpty()) return bounds;
+        if (dynamicRenderSuppliers.isEmpty()) return bounds;
 
-        for (DynamicRender model : dynamicRenders) {
+        for (DynamicRender model : getOrInitDynamicRenderers(machine)) {
             bounds = bounds.minmax(model.getRenderBoundingBox(machine));
         }
         return bounds;
@@ -478,9 +495,9 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
     public boolean shouldRenderOffScreen(BlockEntity blockEntity) {
         if (!(blockEntity instanceof MetaMachine machine)) return false;
         if (machine.getDefinition() != getDefinition()) return false;
-        if (dynamicRenders.isEmpty()) return false;
+        if (dynamicRenderSuppliers.isEmpty()) return false;
 
-        for (DynamicRender render : dynamicRenders) {
+        for (DynamicRender render : getOrInitDynamicRenderers(machine)) {
             if (render.shouldRenderOffScreen(machine)) return true;
         }
         return false;
@@ -492,9 +509,9 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
         if (!(blockEntity instanceof MetaMachine machine)) return false;
         if (machine.getDefinition() != getDefinition()) return false;
         if (machine.getCoverContainer().hasDynamicCovers()) return true;
-        if (dynamicRenders.isEmpty()) return false;
+        if (dynamicRenderSuppliers.isEmpty()) return false;
 
-        for (DynamicRender model : dynamicRenders) {
+        for (DynamicRender model : getOrInitDynamicRenderers(machine)) {
             if (model.shouldRender(machine, Minecraft.getInstance().gameRenderer.getMainCamera().getPosition())) {
                 return true;
             }
@@ -505,7 +522,7 @@ public final class MachineModel extends BaseBakedModel implements ICoverableRend
     @Override
     public int getViewDistance() {
         int distance = 0;
-        for (DynamicRender<?, ?> model : dynamicRenders) {
+        for (DynamicRender<?, ?> model : getOrInitDynamicRenderersWithoutMachine()) {
             distance = Math.max(distance, model.getViewDistance());
         }
         return distance;

--- a/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModelLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/machine/MachineModelLoader.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 @Mod.EventBusSubscriber(modid = GTCEu.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class MachineModelLoader implements IGeometryLoader<UnbakedMachineModel> {
@@ -138,13 +139,14 @@ public class MachineModelLoader implements IGeometryLoader<UnbakedMachineModel> 
         }
 
         // load dynamic renders
-        List<DynamicRender<?, ?>> dynamicRenders = new ArrayList<>();
+        List<Supplier<DynamicRender<?, ?>>> dynamicRenders = new ArrayList<>();
         JsonArray array = GsonHelper.getAsJsonArray(json, "dynamic_renders", null);
         if (array != null) {
             for (JsonElement entry : array) {
-                var render = DynamicRender.CODEC.parse(JsonOps.INSTANCE, entry)
-                        .getOrThrow(true, LOGGER::error);
-                dynamicRenders.add(render);
+                dynamicRenders.add(() -> {
+                    return DynamicRender.CODEC.parse(JsonOps.INSTANCE, entry)
+                            .getOrThrow(true, LOGGER::error);
+                });
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/model/machine/UnbakedMachineModel.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/model/machine/UnbakedMachineModel.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class UnbakedMachineModel implements IUnbakedGeometry<UnbakedMachineModel> {
 
@@ -29,14 +30,14 @@ public class UnbakedMachineModel implements IUnbakedGeometry<UnbakedMachineModel
     @Getter
     private final MultiPartUnbakedModel multiPart;
     @Getter
-    private final List<DynamicRender<?, ?>> dynamicRenders;
+    private final List<Supplier<DynamicRender<?, ?>>> dynamicRenders;
     private final Set<String> replaceableTextures;
     private final Map<String, ResourceLocation> textureOverrides;
 
     public UnbakedMachineModel(MachineDefinition definition,
                                Map<MachineRenderState, UnbakedModel> models,
                                @Nullable MultiPartUnbakedModel multiPart,
-                               List<DynamicRender<?, ?>> dynamicRenders,
+                               List<Supplier<DynamicRender<?, ?>>> dynamicRenders,
 
                                Set<String> replaceableTextures,
                                Map<String, ResourceLocation> textureOverrides) {


### PR DESCRIPTION
## What
Machine renderers only had one global instance, causing e.g. fusion rings to all light up if one machine is on because of the global "delta" field in the renderer.
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/1f6d8d13-44cf-43a0-b461-812d93c07158" />

This splits that out to one (list of) renderers per machine, and one list globally on the model for when no machine is available/needed:
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/ee422836-b859-49a7-a97d-fc45d0f9952a" />


## Implementation Details
Will need review by mint, but it does work. I'm not sure if we want to keep this inside the 
### AI Usage 
- [x] No AI driven tools were used for this pull request.

## How Was This Tested
See screenshots

## Potential Compatibility Issues
Renderers that assume one instance for all machines will need to make it per-machine based

We also could have decided to say "there is only one renderer globally and people should write their renderers to work that way" but that feels worse imo