### PR TITLE
Add Java documentation to Bedrock Ore and Fluid veins.

### DIFF
--- a/docs/content/Modpacks/Ore-Generation/Bedrock-Fluid-Veins.md
+++ b/docs/content/Modpacks/Ore-Generation/Bedrock-Fluid-Veins.md
@@ -5,26 +5,72 @@ title: Bedrock Fluid Veins
 
 # Bedrock Fluid Veins
 
-Bedrock Fluid Veins are invisable veins that exist under the bedrock, to find Fluid Veins you must have at least a HV tier Prospector. A Fluid Drilling Rig must be used to obtain the fluids out of the vein.
+Bedrock Fluid Veins are invisible veins that exist under the bedrock, to find Fluid Veins you must have at least a HV tier Prospector. A Fluid Drilling Rig must be used to obtain the fluids out of the vein.
 
 ## Creating a Bedrock Fluid Vein
 
-```js title="fluid_veins.js"
-// In server events
-GTCEuServerEvents.fluidVeins(event => {
-
-    event.add('gtceu:custom_bedrock_fluid_vein', vein => {
-        vein.dimensions('minecraft:overworld') // (1)
-        vein.fluid(() => Fluid.of('gtceu:custom_fluid').fluid) 
-        vein.weight(600)
-        vein.minimumYield(120)
-        vein.maximumYield(720)
-        vein.depletionAmount(2)
-        vein.depletionChance(1)
-        vein.depletedYield(50)
+=== "JavaScript"
+    ```js title="fluid_veins.js"
+    // In server events
+    GTCEuServerEvents.fluidVeins(event => {
+        event.add('gtceu:custom_bedrock_fluid_vein', vein => {
+            vein.dimensions('minecraft:overworld') // (1)
+            vein.fluid(() => Fluid.of('gtceu:custom_fluid').fluid) 
+            vein.weight(600)
+            vein.minimumYield(120)
+            vein.maximumYield(720)
+            vein.depletionAmount(2)
+            vein.depletionChance(1)
+            vein.depletedYield(50)
+        });
     });
-});
+    ```
+    
+    1. Dimension where fluid vein will spawn.
 
-```
+=== "Java"
+    In Java, `.dimensions()` only accepts a `Set<ResourceKey<Level>>`. For example, this is how you would assign the overworld a variable:
+    ```java
+    public static final Set<ResourceKey<Level>> DIM_OVERWORLD = Set.of(Level.OVERWORLD);
+    ```
+    To have multiple dimensions in the same set, simply add more `ResourceKey<Level>` instances into the set itself. Here's an example for all vanilla dimensions:
+    ```java
+    public static final Set<ResourceKey<Level>> DIM_ALL = Set.of(Level.OVERWORLD, Level.NETHER, Level.END);
+    ```
+    You can define this in any class you want (including the one with the bedrock fluid vein definitions themselves), as long as you're able to reference it in the class where you're defining the bedrock fluid veins.  
+    With this done, you can reference said variables in the `BedrockFluidDefinition` builder. Let's use `DIM_OVERWORLD` in this example.  
+    
+    ```java title="ExampleBedrockFluidVeins.java"
+    pubic class ExampleBedrockFluidVeins {
+        public static void init() {}
+        
+        public static final Set<ResourceKey<Level>> DIM_OVERWORLD = Set.of(Level.OVERWORLD);
+        
+        public static final BedrockFluidDefinition CUSTOM_BEDROCK_FLUID_VEIN = BedrockFluidDefinition.builder(ExampleMod.id("custom_bedrock_fluid_vein"))
+                .dimensions(DIM_OVERWORLD) // (1)
+                .fluid(CustomFluid::getFluid) // (2)
+                .weight(600)
+                .yield(120, 720)
+                .depletionAmount(2)
+                .depletionChance(1)
+                .depletedYield(50)
+                .register();
+    }
+    ```
 
-1. Dimension where fluid vein will spawn.
+    1. Dimension where fluid vein will spawn.
+    2. Replace `CustomFluid` with any GTMaterial you want to get the fluid from.
+
+    As the last step, you need to actually enable the registration of the veins in your class implementing IGTAddon.  
+    
+    ```java title="ExampleModGTAddon.java"
+    @GTAddon
+    public class ExampleModGTAddon implements IGTAddon {
+        // ...
+        @Override
+        public void registerFluidVeins() {
+            ExampleBedrockFluidVeins.init();
+        }
+        // ...
+    }
+    ```

--- a/docs/content/Modpacks/Ore-Generation/Bedrock-Ore-Veins.md
+++ b/docs/content/Modpacks/Ore-Generation/Bedrock-Ore-Veins.md
@@ -16,24 +16,73 @@ To enable this feature, you need to enable the config option **Machines -> doBed
 
 ## Adding Bedrock Veins
 
-By default, the mod doesn't include any bedrock ore veins.
+By default, the mod doesn't include any bedrock ore veins. You can add them in either KubeJS or Java using one of the following:
 
-You can add them using the `bedrockOreVeins` server event:
-
-```js
-GTCEuServerEvents.bedrockOreVeins(event => {
-    event.add('kubejs:overworld_bedrock_ore_vein_iron', vein => {
-        vein.weight(100)
-            .size(3) // (1)
-            .yield(10, 20)
-            .material(GTMaterials.Goethite, 5) // (2)
-            .material(GTMaterials.Limonite, 2)
-            .material(GTMaterials.Hematite, 2)
-            .material(GTMaterials.Malachite, 1)
-            .dimensions('minecraft:overworld')
+=== "JavaScript"
+    Using the `bedrockOreVeins` server event:
+    ```js
+    GTCEuServerEvents.bedrockOreVeins(event => {
+        event.add('kubejs:overworld_bedrock_ore_vein_iron', vein => {
+            vein.weight(100)
+                .size(3) // (1)
+                .yield(10, 20)
+                .material(GTMaterials.Goethite, 5) // (2)
+                .material(GTMaterials.Limonite, 2)
+                .material(GTMaterials.Hematite, 2)
+                .material(GTMaterials.Malachite, 1)
+                .dimensions('minecraft:overworld')
+        })
     })
-})
-```
+    ```
 
-1. The diameter of the bedrock vein in chunks
-2. The second parameter defines the chance of each material being mined on each cycle
+    1. The diameter of the bedrock vein in chunks
+    2. The second parameter defines the chance of each material being mined on each cycle
+=== "Java"
+    In Java, `.dimensions()` only accepts a `Set<ResourceKey<Level>>`. For example, this is how you would assign the overworld a variable:
+    ```java
+    public static final Set<ResourceKey<Level>> DIM_OVERWORLD = Set.of(Level.OVERWORLD);
+    ```
+    To have multiple dimensions in the same set, simply add more `ResourceKey<Level>` instances into the set itself. Here's an example for all vanilla dimensions:
+    ```java
+    public static final Set<ResourceKey<Level>> DIM_ALL = Set.of(Level.OVERWORLD, Level.NETHER, Level.END);
+    ```
+    You can define this in any class you want (including the one with the bedrock ore vein definitions themselves), as long as you're able to reference it in the class where you're defining the bedrock ore veins.  
+    With this done, you can reference said variables in the `BedrockOreDefinition` builder. Let's use `DIM_OVERWORLD` in this example.  
+    
+    ```java title="ExampleBedrockOreVeins.java"
+    pubic class ExampleBedrockOreVeins {
+        public static void init() {}
+        
+        public static final Set<ResourceKey<Level>> DIM_OVERWORLD = Set.of(Level.OVERWORLD);
+        
+        public static final BedrockOreDefinition OVERWORLD_BEDROCK_ORE_VEIN_IRON = BedrockOreDefinition.builder(ExampleMod.id("overworld_bedrock_ore_vein_iron"))
+                .weight(100)
+                .size(3) // (1)
+                .yield(10, 20)
+                .materials(List.of(
+                    new WeightedMaterial(Goethite, 5), // (2)
+                    new WeightedMaterial(Limonite, 2),
+                    new WeightedMaterial(Hematite, 2),
+                    new WeightedMaterial(Gold, 1)
+                ))
+                .dimensions(DIM_OVERWORLD)
+                .register();
+    }
+    ```
+    
+    1. The diameter of the bedrock vein in chunks
+    2. The second parameter defines the chance of each material being mined on each cycle
+
+    As the last step, you need to actually enable the registration of the veins in your class implementing IGTAddon.  
+    
+    ```java title="ExampleModGTAddon.java"
+    @GTAddon
+    public class ExampleModGTAddon implements IGTAddon {
+        // ...
+        @Override
+        public void registerBedrockOreVeins() {
+            ExampleBedrockOreVeins.init();
+        }
+        // ...
+    }
+    ```


### PR DESCRIPTION
## What
This commit adds a very basic overview of how to add Bedrock Ore Veins and Fluid Veins in Java. The Fluid Veins are basically a copypaste of the Bedrock Ore Veins, though.

### AI Usage 
- [x] No AI driven tools were used for this pull request.

## Outcome
People may (MAY, given the poor way I write docs, they may as well not) understand how to implement bedrock veins in Java.

## How Was This Tested
with mkdocs serve and my very own eyes

## Additional Information
The documentation assumes the person has either bothered to implement IGTAddon in any class or has used the Addon Template.