### PR TITLE
 Fix molten fluids not existing since #4655 

### DIFF
--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -136,3 +136,4 @@ A large number of machine feature interfaces have been removed, and have had the
 - `ChargerMachine` has been merged into `BatteryBufferMachine`.
   - Calling the battery buffer constructor with the following args gives the same behaviour as a charger machine: `(info, tier, inventorySize, BatteryBufferMachine.AMPS_PER_BATTERY_CHARGER, 0)`
 - Refactored Jade provider code. Use the `MachineInfoProvider` class for jade providers for a specific machine type, and `MachineTraitProvider` for providers for a specific machine trait. 
+- `GTUtil.getMoltenFluid(Material)` has been moved to `Material.getHotFluid()`.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/Material.java
@@ -263,7 +263,9 @@ public class Material implements Comparable<Material> {
      * @see #getFluid(FluidStorageKey, int)
      */
     public FluidStack getFluid(int amount) {
-        return new FluidStack(getFluid(), amount);
+        Fluid fluid = getFluid();
+        if (fluid != null) return new FluidStack(fluid, amount);
+        else return FluidStack.EMPTY;
     }
 
     /**
@@ -272,7 +274,9 @@ public class Material implements Comparable<Material> {
      * @return a FluidStack with the fluid and amount
      */
     public FluidStack getFluid(@NotNull FluidStorageKey key, int amount) {
-        return new FluidStack(getFluid(key), amount);
+        Fluid fluid = getFluid(key);
+        if (fluid != null) return new FluidStack(fluid, amount);
+        else return FluidStack.EMPTY;
     }
 
     /**
@@ -333,14 +337,23 @@ public class Material implements Comparable<Material> {
         return prop.getTier(this);
     }
 
+    /**
+     * @return the correct "molten" fluid for a material
+     */
     public Fluid getHotFluid() {
-        AlloyBlastProperty prop = properties.getProperty(PropertyKey.ALLOY_BLAST);
-        return prop == null ? null : prop.getFluid();
+        if (hasProperty(PropertyKey.ALLOY_BLAST)) {
+            return getFluid(FluidStorageKeys.MOLTEN);
+        }
+        if (!TagPrefix.ingotHot.doGenerateItem(this) && hasProperty(PropertyKey.FLUID)) {
+            return getFluid(FluidStorageKeys.LIQUID);
+        }
+        return null;
     }
 
     public FluidStack getHotFluid(int amount) {
-        AlloyBlastProperty prop = properties.getProperty(PropertyKey.ALLOY_BLAST);
-        return prop == null ? null : new FluidStack(prop.getFluid(), amount);
+        Fluid fluid = getHotFluid();
+        if (fluid != null) return new FluidStack(fluid, amount);
+        else return FluidStack.EMPTY;
     }
 
     public Item getBucket() {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/AlloyBlastProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/AlloyBlastProperty.java
@@ -2,57 +2,22 @@ package com.gregtechceu.gtceu.api.data.chemical.material.properties;
 
 import com.gregtechceu.gtceu.data.recipe.misc.alloyblast.AlloyBlastRecipeProducer;
 
-import net.minecraft.world.level.material.Fluid;
-
-import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.function.Supplier;
-
 public class AlloyBlastProperty implements IMaterialProperty {
-
-    /**
-     * Internal material fluid field
-     */
-    private Supplier<? extends Fluid> fluidSupplier;
-    private int temperature;
 
     @Getter
     @Setter
     @NotNull
     private AlloyBlastRecipeProducer recipeProducer = AlloyBlastRecipeProducer.DEFAULT_PRODUCER;
 
-    public AlloyBlastProperty(int temperature) {
-        this.temperature = temperature;
-    }
+    public AlloyBlastProperty() {}
 
     @Override
     public void verifyProperty(MaterialProperties materialProperties) {
         materialProperties.ensureSet(PropertyKey.BLAST);
         materialProperties.ensureSet(PropertyKey.FLUID);
-        this.temperature = materialProperties.getProperty(PropertyKey.BLAST).getBlastTemperature();
-    }
-
-    /**
-     * internal usage only
-     */
-    public void setFluid(@NotNull Supplier<? extends Fluid> materialFluid) {
-        Preconditions.checkNotNull(materialFluid);
-        this.fluidSupplier = materialFluid;
-    }
-
-    public Fluid getFluid() {
-        return fluidSupplier.get();
-    }
-
-    public void setTemperature(int fluidTemperature) {
-        Preconditions.checkArgument(fluidTemperature > 0, "Invalid temperature");
-        this.temperature = fluidTemperature;
-    }
-
-    public int getTemperature() {
-        return temperature;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/AlloyBlastProperty.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/properties/AlloyBlastProperty.java
@@ -10,8 +10,7 @@ public class AlloyBlastProperty implements IMaterialProperty {
 
     @Getter
     @Setter
-    @NotNull
-    private AlloyBlastRecipeProducer recipeProducer = AlloyBlastRecipeProducer.DEFAULT_PRODUCER;
+    private @NotNull AlloyBlastRecipeProducer recipeProducer = AlloyBlastRecipeProducer.DEFAULT_PRODUCER;
 
     public AlloyBlastProperty() {}
 

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
@@ -9,20 +9,12 @@ import com.gregtechceu.gtceu.api.capability.compat.EUToFEProvider;
 import com.gregtechceu.gtceu.api.cosmetics.CapeRegistry;
 import com.gregtechceu.gtceu.api.cosmetics.event.RegisterGTCapesEvent;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
-import com.gregtechceu.gtceu.api.data.chemical.material.event.PostMaterialEvent;
-import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
-import com.gregtechceu.gtceu.api.data.chemical.material.properties.AlloyBlastProperty;
-import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.HazardProperty;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialEntry;
-import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.data.medicalcondition.Symptom;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
-import com.gregtechceu.gtceu.api.fluids.FluidBuilder;
-import com.gregtechceu.gtceu.api.fluids.FluidState;
-import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKeys;
 import com.gregtechceu.gtceu.api.item.armor.ArmorComponentItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
@@ -58,7 +50,6 @@ import com.gregtechceu.gtceu.data.loader.BedrockFluidLoader;
 import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.GTOreLoader;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
-import com.gregtechceu.gtceu.data.recipe.misc.alloyblast.CustomAlloyBlastRecipeProducer;
 import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
 import com.gregtechceu.gtceu.integration.map.WaypointManager;
 import com.gregtechceu.gtceu.integration.map.cache.server.ServerCache;
@@ -108,9 +99,7 @@ import net.minecraftforge.registries.MissingMappingsEvent;
 
 import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.entry.ItemEntry;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -543,45 +532,6 @@ public class CommonEventListener {
             // mimic how AttributeInstance handles MULTIPLY_BASE modifiers
             event.setNewSpeed(event.getNewSpeed() + event.getNewSpeed() * miningFatigueModifier);
         }
-    }
-
-    @SubscribeEvent
-    public static void addAlloyBlastProperties(PostMaterialEvent event) {
-        for (Material material : GTRegistries.MATERIALS.values()) {
-            if (!material.hasFlag(MaterialFlags.DISABLE_ALLOY_PROPERTY)) {
-                addAlloyBlastProperty(material);
-            }
-        }
-        // Alloy Blast Overriding
-        GTMaterials.NiobiumNitride.getProperty(PropertyKey.ALLOY_BLAST)
-                .setRecipeProducer(new CustomAlloyBlastRecipeProducer(1, 11, -1));
-
-        GTMaterials.IndiumTinBariumTitaniumCuprate.getProperty(PropertyKey.ALLOY_BLAST)
-                .setRecipeProducer(new CustomAlloyBlastRecipeProducer(-1, -1, 16));
-    }
-
-    public static void addAlloyBlastProperty(@NotNull Material material) {
-        final List<MaterialStack> components = material.getMaterialComponents();
-        // ignore materials which are not alloys
-        if (components.size() < 2) return;
-
-        BlastProperty blastProperty = material.getProperty(PropertyKey.BLAST);
-        if (blastProperty == null) return;
-
-        if (!material.hasProperty(PropertyKey.FLUID)) return;
-
-        // if there are more than 2 fluid-only components in the material, do not generate a hot fluid
-        if (components.stream().filter(CommonEventListener::isMaterialStackFluidOnly).limit(3).count() > 2) {
-            return;
-        }
-
-        material.setProperty(PropertyKey.ALLOY_BLAST, new AlloyBlastProperty(material.getBlastTemperature()));
-        material.getProperty(PropertyKey.FLUID).getStorage().enqueueRegistration(FluidStorageKeys.MOLTEN,
-                new FluidBuilder().state(FluidState.LIQUID));
-    }
-
-    private static boolean isMaterialStackFluidOnly(@NotNull MaterialStack ms) {
-        return !ms.material().hasProperty(PropertyKey.DUST) && ms.material().hasProperty(PropertyKey.FLUID);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -28,6 +28,7 @@ import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.common.data.*;
 import com.gregtechceu.gtceu.common.data.GTPlaceholders;
 import com.gregtechceu.gtceu.common.data.machines.GTMachineUtils;
+import com.gregtechceu.gtceu.common.data.materials.AlloyBlastPropertyAddition;
 import com.gregtechceu.gtceu.common.data.materials.GTFoods;
 import com.gregtechceu.gtceu.common.item.tool.rotation.CustomBlockRotations;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMachine;
@@ -102,6 +103,8 @@ public class CommonProxy {
         GTCommandArguments.init(eventBus);
         GTMobEffects.init(eventBus);
         GTParticleTypes.init(eventBus);
+
+        eventBus.addListener(AlloyBlastPropertyAddition::addAlloyBlastProperties);
     }
 
     public static void init() {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/AlloyBlastPropertyAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/AlloyBlastPropertyAddition.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.event.PostMaterialEvent;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.AlloyBlastProperty;
-import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
 import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.fluids.FluidBuilder;
@@ -47,9 +46,7 @@ public class AlloyBlastPropertyAddition {
         // ignore materials which are not alloys
         if (components.size() < 2) return;
 
-        BlastProperty blastProperty = material.getProperty(PropertyKey.BLAST);
-        if (blastProperty == null) return;
-
+        if (!material.hasProperty(PropertyKey.BLAST)) return;
         if (!material.hasProperty(PropertyKey.FLUID)) return;
 
         // if there are more than 2 fluid-only components in the material, do not generate a hot fluid
@@ -57,8 +54,8 @@ public class AlloyBlastPropertyAddition {
             return;
         }
 
-        material.setProperty(PropertyKey.ALLOY_BLAST, new AlloyBlastProperty(material.getBlastTemperature()));
-        material.getProperty(PropertyKey.FLUID).getStorage()
+        material.setProperty(PropertyKey.ALLOY_BLAST, new AlloyBlastProperty());
+        material.getProperty(PropertyKey.FLUID)
                 .enqueueRegistration(FluidStorageKeys.MOLTEN, new FluidBuilder().state(FluidState.LIQUID));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/materials/AlloyBlastPropertyAddition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/materials/AlloyBlastPropertyAddition.java
@@ -1,0 +1,68 @@
+package com.gregtechceu.gtceu.common.data.materials;
+
+import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.data.chemical.material.event.PostMaterialEvent;
+import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialFlags;
+import com.gregtechceu.gtceu.api.data.chemical.material.properties.AlloyBlastProperty;
+import com.gregtechceu.gtceu.api.data.chemical.material.properties.BlastProperty;
+import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
+import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
+import com.gregtechceu.gtceu.api.fluids.FluidBuilder;
+import com.gregtechceu.gtceu.api.fluids.FluidState;
+import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKeys;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
+import com.gregtechceu.gtceu.common.data.GTMaterials;
+import com.gregtechceu.gtceu.data.recipe.misc.alloyblast.CustomAlloyBlastRecipeProducer;
+
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Listen to PostMaterialEvent instead of adding the property to all materials manually because it's a lot cleaner this
+ * way.
+ */
+public class AlloyBlastPropertyAddition {
+
+    @SubscribeEvent
+    public static void addAlloyBlastProperties(PostMaterialEvent event) {
+        for (Material material : GTRegistries.MATERIALS.values()) {
+            if (!material.hasFlag(MaterialFlags.DISABLE_ALLOY_PROPERTY)) {
+                addAlloyBlastProperty(material);
+            }
+        }
+
+        // Manual overrides
+        GTMaterials.NiobiumNitride.getProperty(PropertyKey.ALLOY_BLAST)
+                .setRecipeProducer(new CustomAlloyBlastRecipeProducer(1, 11, -1));
+
+        GTMaterials.IndiumTinBariumTitaniumCuprate.getProperty(PropertyKey.ALLOY_BLAST)
+                .setRecipeProducer(new CustomAlloyBlastRecipeProducer(-1, -1, 16));
+    }
+
+    public static void addAlloyBlastProperty(@NotNull Material material) {
+        final List<MaterialStack> components = material.getMaterialComponents();
+        // ignore materials which are not alloys
+        if (components.size() < 2) return;
+
+        BlastProperty blastProperty = material.getProperty(PropertyKey.BLAST);
+        if (blastProperty == null) return;
+
+        if (!material.hasProperty(PropertyKey.FLUID)) return;
+
+        // if there are more than 2 fluid-only components in the material, do not generate a hot fluid
+        if (components.stream().filter(AlloyBlastPropertyAddition::isMaterialStackFluidOnly).limit(3).count() > 2) {
+            return;
+        }
+
+        material.setProperty(PropertyKey.ALLOY_BLAST, new AlloyBlastProperty(material.getBlastTemperature()));
+        material.getProperty(PropertyKey.FLUID).getStorage()
+                .enqueueRegistration(FluidStorageKeys.MOLTEN, new FluidBuilder().state(FluidState.LIQUID));
+    }
+
+    private static boolean isMaterialStackFluidOnly(@NotNull MaterialStack ms) {
+        return !ms.material().hasProperty(PropertyKey.DUST) && ms.material().hasProperty(PropertyKey.FLUID);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/alloyblast/AlloyBlastRecipeProducer.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/alloyblast/AlloyBlastRecipeProducer.java
@@ -14,7 +14,6 @@ import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
-import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.world.level.material.Fluid;
@@ -49,8 +48,10 @@ public class AlloyBlastRecipeProducer {
         // get the output fluid
         Fluid molten;
         if (ingotHot.doGenerateItem(material)) {
-            molten = GTUtil.getMoltenFluid(material);
-            addFreezerRecipes(material, molten, property.getBlastTemperature(), provider);
+            molten = material.getHotFluid();
+            if (molten != null) {
+                addFreezerRecipes(material, molten, property.getBlastTemperature(), provider);
+            }
         } else {
             molten = material.getFluid();
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/alloyblast/AlloyBlastRecipeProducer.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/alloyblast/AlloyBlastRecipeProducer.java
@@ -97,19 +97,26 @@ public class AlloyBlastRecipeProducer {
     protected int addInputs(@NotNull Material material, @NotNull GTRecipeBuilder builder) {
         // calculate the output amount and add inputs
         int outputAmount = 0;
-        int fluidAmount = 0;
+        int fluids = 0;
         for (MaterialStack materialStack : material.getMaterialComponents()) {
-            final Material msMat = materialStack.material();
+            final Material component = materialStack.material();
             final int msAmount = (int) materialStack.amount();
 
-            if (msMat.hasProperty(PropertyKey.DUST)) {
-                builder.inputItems(TagPrefix.dust, msMat, msAmount);
-            } else if (msMat.hasProperty(PropertyKey.FLUID)) {
-                if (fluidAmount >= 2) return -1; // more than 2 fluids won't fit in the machine
-                fluidAmount++;
+            if (component.hasProperty(PropertyKey.DUST)) {
+                builder.inputItems(TagPrefix.dust, component, msAmount);
+            } else if (component.hasProperty(PropertyKey.FLUID)) {
+                if (fluids >= 2) {
+                    // more than 2 fluids won't fit in the machine
+                    return -1;
+                }
+                fluids++;
+
                 // assume all fluids have 1000mB/mol, since other quantities should be as an item input
-                builder.inputFluids(msMat.getFluid(1000 * msAmount));
-            } else return -1; // no fluid or item prop means no valid recipe
+                builder.inputFluids(component.getFluid(1000 * msAmount));
+            } else {
+                // no fluid or item prop means no valid recipe
+                return -1;
+            }
             outputAmount += msAmount;
         }
         return outputAmount;
@@ -123,9 +130,10 @@ public class AlloyBlastRecipeProducer {
      * @param outputAmount    the amount of material to output
      * @param componentAmount the amount of different components in the material
      * @param builder         the builder to continue
+     * @param provider        the recipe "provider"
      */
-    protected void buildRecipes(@NotNull BlastProperty property, @NotNull Fluid molten, int outputAmount,
-                                int componentAmount,
+    protected void buildRecipes(@NotNull BlastProperty property, @NotNull Fluid molten,
+                                int outputAmount, int componentAmount,
                                 @NotNull GTRecipeBuilder builder, Consumer<FinishedRecipe> provider) {
         // add the fluid output with the correct amount
         builder.outputFluids(new FluidStack(molten, GTValues.L * outputAmount));

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -3,9 +3,6 @@ package com.gregtechceu.gtceu.utils;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
-import com.gregtechceu.gtceu.api.data.chemical.material.properties.PropertyKey;
-import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
-import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKeys;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
@@ -39,7 +36,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SnowLayerBlock;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.minecraftforge.common.ForgeHooks;
@@ -487,19 +483,6 @@ public class GTUtil {
         // preserve existing opacity if present
         if (((colorValue >> 24) & 0xFF) != 0) return colorValue;
         return opacity << 24 | colorValue;
-    }
-
-    /**
-     * @param material the material to use
-     * @return the correct "molten" fluid for a material
-     */
-    @Nullable
-    public static Fluid getMoltenFluid(@NotNull Material material) {
-        if (material.hasProperty(PropertyKey.ALLOY_BLAST))
-            return material.getProperty(PropertyKey.FLUID).getStorage().get(FluidStorageKeys.MOLTEN);
-        if (!TagPrefix.ingotHot.doGenerateItem(material) && material.hasProperty(PropertyKey.FLUID))
-            return material.getProperty(PropertyKey.FLUID).getStorage().get(FluidStorageKeys.LIQUID);
-        return null;
     }
 
     public static int getFluidColor(FluidStack fluid) {


### PR DESCRIPTION
## What
#4655 broke molten fluid registration by moving the event listener to `CommonEventListener` which is on the wrong event bus.

## Implementation Details
Moved the event listeners back to `AlloyBlastPropertyAddition` (so they don't clutter up `CommonProxy`).

### AI Usage 
- [x] No, AI driven tools were not used for this pull request.
- [ ] Yes, AI driven tools were used for this pull request.

## Outcome
Molten fluids and ABS recipes exist again

## How Was This Tested
Ran game, checked if molten fluids exist again. They do.

## Additional Information
I merged `GTUtil.getMoltenFluid(Material)` and `Material#getHotFluid`. IDK why they were separate. Same reasoning applies, only `AlloyBlastRecipeProducer` used that method.
I also fixed a (somewhat likely) possible crash in `Material.getFluid(int amount)` where it didn't check if the fluid is null before creating a fluid stack with it.

## Potential Compatibility Issues
I also removed the (completely unused) `temperature` and `fluidSupplier` fields from `AlloyBlastProperty`. I do not believe this change will break anything, though, as the first one was only ever set and the second wasn't ever updated or used by anything (and the setter is internal).

`GTUtil.getMoltenFluid(Material)` no longer exists. I've added a fix to the updating doc.