### PR TITLE
Display Bedrock (Fluid) Vein initial and depletion yield stats in EMI

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2539,6 +2539,8 @@
   "gtceu.jei.bedrock_fluid.salt_water_deposit": "ʇısodǝᗡ ɹǝʇɐM ʇןɐS",
   "gtceu.jei.bedrock_fluid_diagram": "ɯɐɹbɐıᗡ pınןℲ ʞɔoɹpǝᗺ",
   "gtceu.jei.bedrock_ore_diagram": "ɯɐɹbɐıᗡ ǝɹO ʞɔoɹpǝᗺ",
+  "gtceu.jei.bedrock_vein_diagram.depleted": "%s :pǝʇǝןdǝᗡ",
+  "gtceu.jei.bedrock_vein_diagram.yield": "%s :pןǝıʎ",
   "gtceu.jei.fluid.dep_amount_hover": "ʎq pǝʇǝןdǝp ǝq ןןıʍ uıǝʌ ǝɥʇ ʇunoɯɐ ǝɥ⟘",
   "gtceu.jei.fluid.dep_chance_hover": "ʇsǝʌɹɐɥ uodn pǝʇǝןdǝp ǝq oʇ uıǝʌ ǝɥʇ ɹoɟ ǝɔuɐɥɔ ǝbɐʇuǝɔɹǝd ǝɥ⟘",
   "gtceu.jei.fluid.dep_yield_hover": "pǝʇǝןdǝp ʎןןnɟ sı ʇı uǝɥʍ uıǝʌ ǝɥʇ ɟo pןǝıʎ ɯnɯıxɐɯ ǝɥ⟘",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2539,6 +2539,8 @@
   "gtceu.jei.bedrock_fluid.salt_water_deposit": "Salt Water Deposit",
   "gtceu.jei.bedrock_fluid_diagram": "Bedrock Fluid Diagram",
   "gtceu.jei.bedrock_ore_diagram": "Bedrock Ore Diagram",
+  "gtceu.jei.bedrock_vein_diagram.depleted": "Depleted: %s",
+  "gtceu.jei.bedrock_vein_diagram.yield": "Yield: %s",
   "gtceu.jei.fluid.dep_amount_hover": "The amount the vein will be depleted by",
   "gtceu.jei.fluid.dep_chance_hover": "The percentage chance for the vein to be depleted upon harvest",
   "gtceu.jei.fluid.dep_yield_hover": "The maximum yield of the vein when it is fully depleted",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -25,8 +25,8 @@ public class IntegrationLang {
         provider.add("gtceu.jei.programmed_circuit", "Programmed Circuit Page");
         provider.add("gtceu.jei.bedrock_fluid_diagram", "Bedrock Fluid Diagram");
         provider.add("gtceu.jei.bedrock_ore_diagram", "Bedrock Ore Diagram");
-        provider.add("gtceu.jei.bedrock_vein_diagram.yield", "Initial Yield: %s");
-        provider.add("gtceu.jei.bedrock_vein_diagram.depleted", "Depleted Yield: %s");
+        provider.add("gtceu.jei.bedrock_vein_diagram.yield", "Yield: %s");
+        provider.add("gtceu.jei.bedrock_vein_diagram.depleted", "Depleted: %s");
         provider.add("gtceu.jei.ore_vein_diagram.chance", "§eChance: %s§r");
         provider.add("gtceu.jei.ore_vein_diagram.spawn_range", "Spawn Range:");
         provider.add("gtceu.jei.ore_vein_diagram.weight", "Weight: %s");

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -25,6 +25,8 @@ public class IntegrationLang {
         provider.add("gtceu.jei.programmed_circuit", "Programmed Circuit Page");
         provider.add("gtceu.jei.bedrock_fluid_diagram", "Bedrock Fluid Diagram");
         provider.add("gtceu.jei.bedrock_ore_diagram", "Bedrock Ore Diagram");
+        provider.add("gtceu.jei.bedrock_vein_diagram.yield", "Initial Yield: %s");
+        provider.add("gtceu.jei.bedrock_vein_diagram.depleted", "Depleted Yield: %s");
         provider.add("gtceu.jei.ore_vein_diagram.chance", "§eChance: %s§r");
         provider.add("gtceu.jei.ore_vein_diagram.spawn_range", "Spawn Range:");
         provider.add("gtceu.jei.ore_vein_diagram.weight", "Weight: %s");

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTOreVeinWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTOreVeinWidget.java
@@ -118,7 +118,6 @@ public class GTOreVeinWidget extends WidgetGroup {
         return String.format("%dmB/s", depletion);
     }
 
-
     @SuppressWarnings("all")
     private String veinYield(BedrockOreDefinition oreDefinition) {
         IntProvider yieldProvider = oreDefinition.yield();

--- a/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTOreVeinWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/xei/widgets/GTOreVeinWidget.java
@@ -26,6 +26,7 @@ import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.valueproviders.IntProvider;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
@@ -49,6 +50,8 @@ public class GTOreVeinWidget extends WidgetGroup {
     private final String name;
     private final int weight;
     private final String range;
+    private final String veinYield;
+    private final String depleted;
     private final Set<ResourceKey<Level>> dimensionFilter;
     public final static int width = 120;
 
@@ -58,6 +61,8 @@ public class GTOreVeinWidget extends WidgetGroup {
         this.weight = oreDefinition.weight();
         this.dimensionFilter = oreDefinition.dimensionFilter();
         this.range = range(oreDefinition);
+        this.veinYield = "NULL";
+        this.depleted = "NULL";
         setClientSideWidget();
         setupBaseGui(oreDefinition);
         setupText(oreDefinition);
@@ -69,6 +74,8 @@ public class GTOreVeinWidget extends WidgetGroup {
         this.weight = fluid.getWeight();
         this.dimensionFilter = fluid.getDimensionFilter();
         this.range = "NULL";
+        this.veinYield = veinYield(fluid);
+        this.depleted = depletion(fluid);
         setClientSideWidget();
         setupBaseGui(fluid);
         setupText(fluid);
@@ -80,6 +87,8 @@ public class GTOreVeinWidget extends WidgetGroup {
         this.weight = bedrockOre.weight();
         this.dimensionFilter = bedrockOre.dimensionFilter();
         this.range = "NULL";
+        this.veinYield = veinYield(bedrockOre);
+        this.depleted = depletion(bedrockOre);
         setClientSideWidget();
         setupBaseGui(bedrockOre);
         setupText(bedrockOre);
@@ -94,6 +103,34 @@ public class GTOreVeinWidget extends WidgetGroup {
             maxHeight = uniform.maxInclusive.resolveY(null);
         }
         return String.format("%d - %d", minHeight, maxHeight);
+    }
+
+    @SuppressWarnings("all")
+    private String veinYield(BedrockFluidDefinition fluidDefinition) {
+        int minYield = fluidDefinition.getMinimumYield();
+        int maxYield = fluidDefinition.getMaximumYield();
+        return String.format("%d - %dmB/s", minYield, maxYield);
+    }
+
+    @SuppressWarnings("all")
+    private String depletion(BedrockFluidDefinition fluidDefinition) {
+        int depletion = fluidDefinition.getDepletedYield();
+        return String.format("%dmB/s", depletion);
+    }
+
+
+    @SuppressWarnings("all")
+    private String veinYield(BedrockOreDefinition oreDefinition) {
+        IntProvider yieldProvider = oreDefinition.yield();
+        int minYield = yieldProvider.getMinValue();
+        int maxYield = yieldProvider.getMaxValue();
+        return String.format("%d - %d", minYield, maxYield);
+    }
+
+    @SuppressWarnings("all")
+    private String depletion(BedrockOreDefinition oreDefinition) {
+        int depletion = oreDefinition.depletedYield();
+        return String.format("%d", depletion);
     }
 
     private void setupBaseGui(GTOreDefinition oreDefinition) {
@@ -163,10 +200,14 @@ public class GTOreVeinWidget extends WidgetGroup {
                 new TextTexture("gtceu.jei.bedrock_fluid." + name).setType(TextTexture.TextType.LEFT_ROLL)
                         .setWidth(width - 10)));
         addWidget(new LabelWidget(5, 40,
-                LocalizationUtils.format("gtceu.jei.ore_vein_diagram.weight", weight)));
+                LocalizationUtils.format("gtceu.jei.bedrock_vein_diagram.yield", veinYield)));
         addWidget(new LabelWidget(5, 50,
+                LocalizationUtils.format("gtceu.jei.bedrock_vein_diagram.depleted", depleted)));
+        addWidget(new LabelWidget(5, 60,
+                LocalizationUtils.format("gtceu.jei.ore_vein_diagram.weight", weight)));
+        addWidget(new LabelWidget(5, 70,
                 LocalizationUtils.format("gtceu.jei.ore_vein_diagram.dimensions")));
-        setupDimensionMarker(60);
+        setupDimensionMarker(80);
     }
 
     private void setupText(BedrockOreDefinition ignored) {
@@ -174,10 +215,14 @@ public class GTOreVeinWidget extends WidgetGroup {
                 new TextTexture("gtceu.jei.bedrock_ore." + name).setType(TextTexture.TextType.LEFT_ROLL)
                         .setWidth(width - 10)));
         addWidget(new LabelWidget(5, 40,
-                LocalizationUtils.format("gtceu.jei.ore_vein_diagram.weight", weight)));
+                LocalizationUtils.format("gtceu.jei.bedrock_vein_diagram.yield", veinYield)));
         addWidget(new LabelWidget(5, 50,
+                LocalizationUtils.format("gtceu.jei.bedrock_vein_diagram.depleted", depleted)));
+        addWidget(new LabelWidget(5, 60,
+                LocalizationUtils.format("gtceu.jei.ore_vein_diagram.weight", weight)));
+        addWidget(new LabelWidget(5, 70,
                 LocalizationUtils.format("gtceu.jei.ore_vein_diagram.dimensions")));
-        setupDimensionMarker(60);
+        setupDimensionMarker(80);
     }
 
     private void setupDimensionMarker(int yPosition) {


### PR DESCRIPTION
## What
The EMI display for Bedrock (Fluid) Veins does not display the range of Initial Yield values, nor the final Depleted value. These values aren't actually visible anywhere in game.

## Implementation Details
Adds a few lines to the EMI text displays, pulling that data from the vein stats

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
<img width="378" height="352" alt="image" src="https://github.com/user-attachments/assets/aa013222-bfaa-40ae-a67a-66921d57357c" />

## How Was This Tested
Visual

## Other Notes
Also as a result of #4879 I had to do the datagen for this by rolling back to a previous build and then cherry picking the lang files forward