### PR TITLE
[1.20] Fix chunk IO errors occurring when C2ME is installed (and async feature worldgen is enabled)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -146,10 +146,10 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
 
     private OreIndicatorPlacer createPlacer(WorldGenLevel level, List<BlockPos> positionsWithoutY,
                                             BlockState blockState) {
-        return (access) -> {
+        return (access, wglevel) -> {
             var positions = positionsWithoutY.stream()
-                    .map(pos -> placement.resolver.apply(level, access, pos))
-                    .filter(pos -> !level.isOutsideBuildHeight(pos))
+                    .map(pos -> placement.resolver.apply(wglevel, access, pos))
+                    .filter(pos -> !wglevel.isOutsideBuildHeight(pos))
                     .toList();
 
             for (BlockPos pos : positions) {
@@ -163,7 +163,7 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
                 if (!section.getBlockState(sectionX, sectionY, sectionZ).isAir())
                     return;
 
-                if (!blockState.canSurvive(level, pos))
+                if (!blockState.canSurvive(wglevel, pos))
                     return;
 
                 section.setBlockState(sectionX, sectionY, sectionZ, blockState, false);

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -141,15 +141,15 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
 
         return WorldGeneratorUtils.groupByChunks(positions).entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey,
-                        entry -> createPlacer(level, entry.getValue(), blockState)));
+                        entry -> createPlacer(entry.getValue(), blockState)));
     }
 
-    private OreIndicatorPlacer createPlacer(WorldGenLevel level, List<BlockPos> positionsWithoutY,
+    private OreIndicatorPlacer createPlacer(List<BlockPos> positionsWithoutY,
                                             BlockState blockState) {
-        return (access, wglevel) -> {
+        return (access, level) -> {
             var positions = positionsWithoutY.stream()
-                    .map(pos -> placement.resolver.apply(wglevel, access, pos))
-                    .filter(pos -> !wglevel.isOutsideBuildHeight(pos))
+                    .map(pos -> placement.resolver.apply(level, access, pos))
+                    .filter(pos -> !level.isOutsideBuildHeight(pos))
                     .toList();
 
             for (BlockPos pos : positions) {
@@ -163,7 +163,7 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
                 if (!section.getBlockState(sectionX, sectionY, sectionZ).isAir())
                     return;
 
-                if (!blockState.canSurvive(wglevel, pos))
+                if (!blockState.canSurvive(level, pos))
                     return;
 
                 section.setBlockState(sectionX, sectionY, sectionZ, blockState, false);

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OreIndicatorPlacer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OreIndicatorPlacer.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.api.data.worldgen.ores;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.chunk.BulkSectionAccess;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -10,5 +11,5 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @FunctionalInterface
 public interface OreIndicatorPlacer {
 
-    void placeIndicators(BulkSectionAccess access);
+    void placeIndicators(BulkSectionAccess access, WorldGenLevel level);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/ores/OrePlacer.java
@@ -54,7 +54,8 @@ public class OrePlacer {
 
         try (BulkSectionAccess access = new BulkSectionAccess(level)) {
             generatedVeins.forEach(generatedVein -> placeVein(chunk.getPos(), random, access, generatedVein, null));
-            generatedIndicators.forEach(generatedIndicator -> placeIndicators(chunk, access, generatedIndicator));
+            generatedIndicators
+                    .forEach(generatedIndicator -> placeIndicators(level, chunk, access, generatedIndicator));
         }
     }
 
@@ -87,10 +88,11 @@ public class OrePlacer {
                         Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
-    private void placeIndicators(ChunkAccess chunk, BulkSectionAccess access, GeneratedIndicators generatedVein) {
+    private void placeIndicators(WorldGenLevel level, ChunkAccess chunk, BulkSectionAccess access,
+                                 GeneratedIndicators generatedVein) {
         if (!ConfigHolder.INSTANCE.worldgen.oreVeins.oreIndicators) return;
         generatedVein.consumeIndicators(chunk.getPos()).forEach(placer -> {
-            placer.placeIndicators(access);
+            placer.placeIndicators(access, level);
         });
     }
 }


### PR DESCRIPTION
## What
This is a "port" of #4877 to the 1.20.1 branch, since the same bug affects 1.20 as well.

## Implementation Details
Modified the OreIndicatorPlacer interface to include the argument for WorldGenLevel as well, and changed createPlacer to use said argument instead of the one passed down.

### AI Usage 
- [x] No AI driven tools were used for this pull request.

## Outcome
Fixes: #4799 on the 1.20.1 branch

## How Was This Tested
This was tested against a copy of my private modpack's server by generating another big portion of the world again. Unlike before, the server's worldgen did not "crash" due to MC's getPersistedStatus() being null.

## Additional Information
Because of what this touches, it is technically an API breaking change.

## Potential Compatibility Issues
None found out; the pack it was tested in has 240 mods and there were no issues during world generation, or general gameplay. Of course, given the nature, it is possible that there is an edge case somewhere. Needs testing.
