### PR TITLE
1.21

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -93,7 +93,7 @@ dependencies {
 //    extraLocalRuntime(forge.worldstripper)
     localRuntime(forge.cc.tweaked.forge.impl)
 
-    extraLocalRuntime(forge.bundles.kjs)
+    localRuntime(forge.bundles.kjs)
 
     extraLocalRuntime(forge.ftblibrary)
     extraLocalRuntime(forge.ftbteams)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -1,10 +1,21 @@
 package com.gregtechceu.gtceu.data.recipe.misc;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.fluids.store.FluidStorageKeys;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidUtil;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.gregtechceu.gtceu.api.GTValues.*;
 import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.*;
@@ -13,8 +24,35 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.*;
 
 public class FuelRecipes {
 
+    private static void addBoilerFuel(RecipeOutput provider, Set<Item> added, Item item, int burnTime) {
+        if (added.contains(item) || burnTime <= 0) return;
+        added.add(item);
+
+        Optional<FluidStack> containedFluid = FluidUtil.getFluidContained(item.getDefaultInstance());
+        if (containedFluid.isEmpty()) {
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(item);
+            STEAM_BOILER_RECIPES.recipeBuilder(GTCEu.id(id.getNamespace() + "_" + id.getPath()))
+                    .inputItems(item)
+                    .duration(burnTime)
+                    .save(provider);
+        } else {
+            FluidStack fluid = containedFluid.get().copyWithAmount(250);
+            ResourceLocation id = BuiltInRegistries.FLUID.getKey(fluid.getFluid());
+            STEAM_BOILER_RECIPES.recipeBuilder(id.getNamespace() + "_" + id.getPath())
+                    .inputFluids(fluid)
+                    .duration(burnTime / 3)
+                    .save(provider);
+        }
+    }
+
     public static void init(RecipeOutput provider) {
-        // furnace fuel-based recipes are handled in SteamBoilerLogic for dynamic burn time (and data map) support.
+        Set<Item> addedItems = new HashSet<>();
+        for (var fuelEntry : AbstractFurnaceBlockEntity.getFuel().entrySet()) {
+            addBoilerFuel(provider, addedItems, fuelEntry.getKey(), fuelEntry.getValue());
+        }
+        for (Item item : BuiltInRegistries.ITEM) {
+            addBoilerFuel(provider, addedItems, item, GTUtil.getItemBurnTime(item));
+        }
 
         // override the default fluid recipes for lava and creosote
         STEAM_BOILER_RECIPES.recipeBuilder("minecraft_lava")


### PR DESCRIPTION
## What
Fixes the steam solid boiler not accepting solid fuel (coal, charcoal, etc.) on 1.21.

## Implementation Details
`FuelRecipes.init()` in the 1.21 port removed the loop that registered furnace fuels as `STEAM_BOILER_RECIPES` item recipes, leaving a comment that a "SteamBoilerLogic" class would handle it — which was never implemented.

Without item recipes in `STEAM_BOILER_RECIPES`, the `fuelHandler` filter in `SteamSolidBoilerMachine` returned `false` for all solid items server-side (client-side always returned `true`), so coal/charcoal could not be inserted.

Also fixes `runData` failing with `NoClassDefFoundError` on `BuilderBase` (KubeJS) after KubeJS was moved to `extraLocalRuntime` in #4826 — `runData` uses `runtimeClasspath` which only extends `localRuntime`.

### AI Usage

- [x] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Sonnet 4.6 (Claude Code)

#### Agent Usage Description
Used to investigate the root cause of the boiler bug and identify the missing fuel recipe registration. All code was reviewed by the PR submitter before opening.

## Outcome
- Fixes steam solid boiler not accepting coal/charcoal/wood as fuel
- Fixes `runData` task failing after #4826

## How Was This Tested
Tested in-game: coal and charcoal can be inserted into the solid boiler fuel slot and the boiler activates correctly.

## Potential Compatibility Issues
Recipe changes: all standard furnace fuels are now registered as `STEAM_BOILER_RECIPES` item recipes, same as in 1.20.1.
