### PR TITLE
Update common OC logic comment

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
@@ -44,8 +44,11 @@ public class GTRecipeModifiers {
                 }
                 return logic.getModifier(machine, recipe, overclockMachine.getOverclockVoltage());
             });
-
-    // Shortcuts for common OC logics
+    /*
+    Shortcuts for common OC logics
+    One of these modifiers must be present within .recipeModifiers() to enable normal overclocking
+    otherwise, the time discount will not be applied, regardless of the eu/t supplied
+    */
     public static final RecipeModifier OC_PERFECT = ELECTRIC_OVERCLOCK.apply(PERFECT_OVERCLOCK);
     public static final RecipeModifier OC_NON_PERFECT = ELECTRIC_OVERCLOCK.apply(NON_PERFECT_OVERCLOCK);
     public static final RecipeModifier OC_PERFECT_SUBTICK = ELECTRIC_OVERCLOCK.apply(PERFECT_OVERCLOCK_SUBTICK);


### PR DESCRIPTION
## What
adding any of the common OC logic modifiers to enable overclocking for any custom multiblock, otherwise, time discount isnt applied no matter the energy given/energy hatch used

### AI Usage 
- [ X ] No, AI driven tools weren't used for this pull request.
- [    ] Yes, AI driven tools were used for this pull request.

## Aditional information
Should avoid future issues when making a new multiblock in either Java or KubeJS