### PR TITLE
Display Cable Overload warning in Jade

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3903,6 +3903,7 @@
   "gtceu.top.buffer_bound_pos": "%s :Z '%s :ʎ '%s :X - o⟘ punoᗺ",
   "gtceu.top.buffer_not_bound": "punoᗺ ʎןʇuǝɹɹnƆ ʇoN ɹǝɟɟnᗺ",
   "gtceu.top.cable_amperage": " :ǝbɐɹǝdɯⱯ",
+  "gtceu.top.cable_overloaded": "ɹʞ%s / ʞ%s :⅁NI⟘ⱯƎHᴚƎΛOㄣ§",
   "gtceu.top.cable_voltage": " :ǝbɐʇןoΛ",
   "gtceu.top.convert_eu": "ɹ§ƎℲɔ§ >- ɹ§∩Ǝǝ§ buıʇɹǝʌuoƆ",
   "gtceu.top.convert_fe": "ɹ§∩Ǝǝ§ >- ɹ§ƎℲɔ§ buıʇɹǝʌuoƆ",

--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3903,7 +3903,7 @@
   "gtceu.top.buffer_bound_pos": "%s :Z '%s :ʎ '%s :X - o⟘ punoᗺ",
   "gtceu.top.buffer_not_bound": "punoᗺ ʎןʇuǝɹɹnƆ ʇoN ɹǝɟɟnᗺ",
   "gtceu.top.cable_amperage": " :ǝbɐɹǝdɯⱯ",
-  "gtceu.top.cable_overloaded": "ɹ§ʞ%s / ʞ%s :⅁NI⟘ⱯƎHᴚƎΛOㄣ§",
+  "gtceu.top.cable_overloaded": "ɹ§%s%% :⅁NI⟘ⱯƎHᴚƎΛOㄣ§",
   "gtceu.top.cable_voltage": " :ǝbɐʇןoΛ",
   "gtceu.top.convert_eu": "ɹ§ƎℲɔ§ >- ɹ§∩Ǝǝ§ buıʇɹǝʌuoƆ",
   "gtceu.top.convert_fe": "ɹ§∩Ǝǝ§ >- ɹ§ƎℲɔ§ buıʇɹǝʌuoƆ",

--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3903,7 +3903,7 @@
   "gtceu.top.buffer_bound_pos": "%s :Z '%s :ʎ '%s :X - o⟘ punoᗺ",
   "gtceu.top.buffer_not_bound": "punoᗺ ʎןʇuǝɹɹnƆ ʇoN ɹǝɟɟnᗺ",
   "gtceu.top.cable_amperage": " :ǝbɐɹǝdɯⱯ",
-  "gtceu.top.cable_overloaded": "ɹʞ%s / ʞ%s :⅁NI⟘ⱯƎHᴚƎΛOㄣ§",
+  "gtceu.top.cable_overloaded": "ɹ§ʞ%s / ʞ%s :⅁NI⟘ⱯƎHᴚƎΛOㄣ§",
   "gtceu.top.cable_voltage": " :ǝbɐʇןoΛ",
   "gtceu.top.convert_eu": "ɹ§ƎℲɔ§ >- ɹ§∩Ǝǝ§ buıʇɹǝʌuoƆ",
   "gtceu.top.convert_fe": "ɹ§∩Ǝǝ§ >- ɹ§ƎℲɔ§ buıʇɹǝʌuoƆ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3903,7 +3903,7 @@
   "gtceu.top.buffer_bound_pos": "Bound To - X: %s, Y: %s, Z: %s",
   "gtceu.top.buffer_not_bound": "Buffer Not Currently Bound",
   "gtceu.top.cable_amperage": "Amperage: ",
-  "gtceu.top.cable_overloaded": "§4OVERHEATING: %sK / %sK§r",
+  "gtceu.top.cable_overloaded": "§4OVERHEATING: %s%%§r",
   "gtceu.top.cable_voltage": "Voltage: ",
   "gtceu.top.convert_eu": "Converting §eEU§r -> §cFE§r",
   "gtceu.top.convert_fe": "Converting §cFE§r -> §eEU§r",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3903,7 +3903,7 @@
   "gtceu.top.buffer_bound_pos": "Bound To - X: %s, Y: %s, Z: %s",
   "gtceu.top.buffer_not_bound": "Buffer Not Currently Bound",
   "gtceu.top.cable_amperage": "Amperage: ",
-  "gtceu.top.cable_overloaded": "§4OVERHEATING: %sK / %sKr",
+  "gtceu.top.cable_overloaded": "§4OVERHEATING: %sK / %sK§r",
   "gtceu.top.cable_voltage": "Voltage: ",
   "gtceu.top.convert_eu": "Converting §eEU§r -> §cFE§r",
   "gtceu.top.convert_fe": "Converting §cFE§r -> §eEU§r",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3903,6 +3903,7 @@
   "gtceu.top.buffer_bound_pos": "Bound To - X: %s, Y: %s, Z: %s",
   "gtceu.top.buffer_not_bound": "Buffer Not Currently Bound",
   "gtceu.top.cable_amperage": "Amperage: ",
+  "gtceu.top.cable_overloaded": "§4OVERHEATING: %sK / %sKr",
   "gtceu.top.cable_voltage": "Voltage: ",
   "gtceu.top.convert_eu": "Converting §eEU§r -> §cFE§r",
   "gtceu.top.convert_fe": "Converting §cFE§r -> §eEU§r",

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -61,7 +61,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
 
     @SideOnly(Side.CLIENT)
     private GTOverheatParticle particle;
-    private static final int meltTemp = 3000;
+    public static final int meltTemp = 3000;
 
     private final EnumMap<Direction, EnergyNetHandler> handlers = new EnumMap<>(Direction.class);
     private final PerTickLongCounter maxVoltageCounter = new PerTickLongCounter();
@@ -207,7 +207,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
         return getNodeData().getVoltage();
     }
 
-    public int getDefaultTemp() {
+    public static int getDefaultTemp() {
         return 293;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -84,7 +84,7 @@ public class IntegrationLang {
         provider.add("gtceu.top.allow_output_input", "Allow Input");
         provider.add("gtceu.top.cable_voltage", "Voltage: ");
         provider.add("gtceu.top.cable_amperage", "Amperage: ");
-        provider.add("gtceu.top.cable_overloaded", "§4OVERHEATING: %sK / %sKr");
+        provider.add("gtceu.top.cable_overloaded", "§4OVERHEATING: %sK / %sK§r");
         provider.add("gtceu.top.exhaust_vent_direction", "Exhaust Vent: %s");
         provider.add("gtceu.top.exhaust_vent_blocked", "Blocked");
         provider.add("gtceu.top.machine_mode", "Machine Mode: ");

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -84,7 +84,7 @@ public class IntegrationLang {
         provider.add("gtceu.top.allow_output_input", "Allow Input");
         provider.add("gtceu.top.cable_voltage", "Voltage: ");
         provider.add("gtceu.top.cable_amperage", "Amperage: ");
-        provider.add("gtceu.top.cable_overloaded", "§4OVERHEATING: %sK / %sK§r");
+        provider.add("gtceu.top.cable_overloaded", "§4OVERHEATING: %s%%§r");
         provider.add("gtceu.top.exhaust_vent_direction", "Exhaust Vent: %s");
         provider.add("gtceu.top.exhaust_vent_blocked", "Blocked");
         provider.add("gtceu.top.machine_mode", "Machine Mode: ");

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -84,6 +84,7 @@ public class IntegrationLang {
         provider.add("gtceu.top.allow_output_input", "Allow Input");
         provider.add("gtceu.top.cable_voltage", "Voltage: ");
         provider.add("gtceu.top.cable_amperage", "Amperage: ");
+        provider.add("gtceu.top.cable_overloaded", "§4OVERHEATING: %sK / %sKr");
         provider.add("gtceu.top.exhaust_vent_direction", "Exhaust Vent: %s");
         provider.add("gtceu.top.exhaust_vent_blocked", "Blocked");
         provider.add("gtceu.top.machine_mode", "Machine Mode: ");

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
@@ -46,7 +46,7 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
                 iTooltip.append(Component.translatable("gtceu.jade.amperage_use", DECIMAL_FORMAT_1F.format(tag.getDouble("maxAmperage"))));
 
                 if (temperature != CableBlockEntity.getDefaultTemp()){
-                    iTooltip.append(Component.translatable("gtceu.top.cable_overloaded", temperature, CableBlockEntity.getMeltTemp()));
+                    iTooltip.add(Component.translatable("gtceu.top.cable_overloaded", progressToFailure(CableBlockEntity.getDefaultTemp(),CableBlockEntity.getMeltTemp(),temperature)));
                 }
             }
         }
@@ -74,5 +74,9 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
     @Override
     public ResourceLocation getUid() {
         return GTCEu.id("cable_info");
+    }
+
+    private int progressToFailure(int base, int melt, int current){
+        return (100 * (current - base)) / (melt - base);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
@@ -31,6 +31,7 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
                 var tag = data.getCompound("cableData");
                 long voltage = tag.getLong("currentVoltage");
                 double amperage = tag.getDouble("currentAmperage");
+                int temperature = tag.getInt("temperature");
                 iTooltip.add(Component.translatable("gtceu.top.cable_voltage"));
                 if (voltage != 0) {
                     iTooltip.append(Component.literal(GTValues.VNF[GTUtil.getTierByVoltage(voltage)]));
@@ -43,6 +44,10 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
                     iTooltip.append(Component.literal(DECIMAL_FORMAT_1F.format(amperage) + "A / "));
                 }
                 iTooltip.append(Component.literal(DECIMAL_FORMAT_1F.format(tag.getDouble("maxAmperage")) + "A"));
+
+                if (temperature != CableBlockEntity.getDefaultTemp()){
+                    iTooltip.append(Component.translatable("gtceu.top.cable_overloaded", temperature, CableBlockEntity.getMeltTemp()));
+                }
             }
         }
     }
@@ -59,6 +64,7 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
                 cableData.putLong("currentVoltage", cable.getCurrentMaxVoltage());
                 cableData.putDouble("maxAmperage", cable.getMaxAmperage());
                 cableData.putDouble("currentAmperage", cable.getAverageAmperage());
+                cableData.putInt("temperature", cable.getTemperature());
                 data.put("cableData", cableData);
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
@@ -43,10 +43,12 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
                 if (amperage != 0) {
                     iTooltip.append(Component.literal(DECIMAL_FORMAT_1F.format(amperage) + "A / "));
                 }
-                iTooltip.append(Component.translatable("gtceu.jade.amperage_use", DECIMAL_FORMAT_1F.format(tag.getDouble("maxAmperage"))));
+                iTooltip.append(Component.translatable("gtceu.jade.amperage_use",
+                        DECIMAL_FORMAT_1F.format(tag.getDouble("maxAmperage"))));
 
-                if (temperature != CableBlockEntity.getDefaultTemp()){
-                    iTooltip.add(Component.translatable("gtceu.top.cable_overloaded", progressToFailure(CableBlockEntity.getDefaultTemp(),CableBlockEntity.getMeltTemp(),temperature)));
+                if (temperature != CableBlockEntity.getDefaultTemp()) {
+                    iTooltip.add(Component.translatable("gtceu.top.cable_overloaded", progressToFailure(
+                            CableBlockEntity.getDefaultTemp(), CableBlockEntity.getMeltTemp(), temperature)));
                 }
             }
         }
@@ -76,7 +78,7 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
         return GTCEu.id("cable_info");
     }
 
-    private int progressToFailure(int base, int melt, int current){
+    private int progressToFailure(int base, int melt, int current) {
         return (100 * (current - base)) / (melt - base);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/CableBlockProvider.java
@@ -43,7 +43,7 @@ public class CableBlockProvider implements IBlockComponentProvider, IServerDataP
                 if (amperage != 0) {
                     iTooltip.append(Component.literal(DECIMAL_FORMAT_1F.format(amperage) + "A / "));
                 }
-                iTooltip.append(Component.literal(DECIMAL_FORMAT_1F.format(tag.getDouble("maxAmperage")) + "A"));
+                iTooltip.append(Component.translatable("gtceu.jade.amperage_use", DECIMAL_FORMAT_1F.format(tag.getDouble("maxAmperage"))));
 
                 if (temperature != CableBlockEntity.getDefaultTemp()){
                     iTooltip.append(Component.translatable("gtceu.top.cable_overloaded", temperature, CableBlockEntity.getMeltTemp()));


### PR DESCRIPTION
## What
When cables are fed excessive voltage or amperage they don't fail instantly, they build up heat for a few moments before catching fire.

This accumulation is not displayed or warned; cables simply either fail or don't, making intermittently or accidentally overloaded cables unclear to diagnose.

This PR adds a line to the Jade provider for cables to show when a cable is about to overload and burn.

## Implementation Details
The overheat progress is calculated internally as a temperature from 293K (initial) to 3000K (failure). Cable fails instantly upon reaching 3000K; or at above 1500K it has a chance per tick to first lose its Insulation.
However, this temperature does not interact with any other parts of the world (thermal damage, cable material, etc.) so displaying it directly as a temperature is not really helpful to a player, and can be misleading as they may think the temperature is connected to other things.

As such I opted to display it as an integer calculated percentage where at 0% the Jade text is hidden, and at 100% the cable burns up.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
Cable is being fed power at 33V. Voltage drop is bringing it down to visibly 32V but because the connection is being overvolted the cable is heating up.
<img width="525" height="345" alt="image" src="https://github.com/user-attachments/assets/2e50fac7-e41f-4078-b978-054f60dfc9ea" />

## How Was This Tested
Jade visual readouts

## Additional Information
Cable initial and melt temperatures are both now public static rather than private or local.

## Potential Compatibility Issues
Uncertain if readout will work correctly if another mod tries to modify the initial or failure temperatures of a cable. Not that to my knowledge anyone does at present.
