### PR TITLE
Prevent inputting fluid from bottom valves on multiblock tanks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/TankValvePartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/TankValvePartMachine.java
@@ -31,7 +31,7 @@ public class TankValvePartMachine extends MultiblockPartMachine {
     public TankValvePartMachine(BlockEntityCreationInfo info, boolean isMetal) {
         super(info);
 
-        tankProxy = attachTrait(new FluidTankProxyTrait(IO.BOTH));
+        tankProxy = attachTrait(new FluidTankProxyTrait(getIO()));
         autoIOSubscription = new ConditionalSubscriptionHandler(this, this::autoIO, this::shouldAutoIO);
     }
 
@@ -103,5 +103,9 @@ public class TankValvePartMachine extends MultiblockPartMachine {
         if (getFrontFacing() != Direction.DOWN) return false;
         if (tankProxy.isEmpty()) return false;
         return getTargetTank() != null;
+    }
+
+    private IO getIO() {
+        return shouldAutoIO() ? IO.OUT : IO.BOTH;
     }
 }


### PR DESCRIPTION
## What
Prevent fluid input into downward-facing valves on multiblock tanks
Closes #4832 

### AI Usage
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## How Was This Tested
In-game