### PR TITLE
Fix the cable overloading effect

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/blockentity/PipeBlockEntity.java
@@ -255,8 +255,7 @@ public abstract class PipeBlockEntity<PipeType extends Enum<PipeType> & IPipeTyp
                 if (cover != null && cover.canPipePassThrough()) return;
             }
 
-            connections = withSideConnection(connections, side, connected);
-            syncDataHolder.markClientSyncFieldDirty("connections");
+            setConnections(withSideConnection(connections, side, connected));
             updateNetworkConnection(side, connected);
             // notify neighbor of change so Auto Output updates its ticking status
             getLevel().neighborChanged(getBlockPos().relative(side), getPipeBlock(), getBlockPos());

--- a/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/ClientProxy.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.client.model.item.FacadeUnbakedModel;
 import com.gregtechceu.gtceu.client.model.machine.MachineModelLoader;
 import com.gregtechceu.gtceu.client.model.pipe.PipeModel;
 import com.gregtechceu.gtceu.client.model.pipe.PipeModelLoader;
+import com.gregtechceu.gtceu.client.particle.GTParticleManager;
 import com.gregtechceu.gtceu.client.particle.HazardParticle;
 import com.gregtechceu.gtceu.client.particle.MufflerParticle;
 import com.gregtechceu.gtceu.client.renderer.block.MaterialBlockRenderer;
@@ -65,6 +66,7 @@ import net.minecraft.client.renderer.entity.ThrownItemRenderer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.client.event.*;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -99,6 +101,8 @@ public class ClientProxy extends CommonProxy {
         }
         initializeDynamicRenders();
         ModelEventHelper.initInternalAssetReloadListeners();
+
+        MinecraftForge.EVENT_BUS.register(GTParticleManager.INSTANCE);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
@@ -140,9 +140,7 @@ public class BloomRenderer {
         mainTarget.bindWrite(false);
 
         RenderSystem.enableBlend();
-        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA,
-                GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
-                GlStateManager.SourceFactor.ZERO, GlStateManager.DestFactor.ONE);
+        RenderSystem.blendFunc(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
 
         BLOOM_TARGET.blitToScreen(mainTarget.viewWidth, mainTarget.viewHeight, false);
         BLOOM_TARGET.unbindRead();

--- a/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
@@ -220,6 +220,9 @@ public class BloomRenderer {
         private static void drawBlockBloom(Camera camera, PoseStack poseStack, Frustum frustum,
                                            Matrix4f projectionMatrix,
                                            LevelRenderer levelRenderer, ProfilerFiller profilerFiller) {
+            // re-setup in case someone touched-a my spaghetti
+            GTRenderTypes.bloom().setupRenderState();
+
             Vec3 camPos = camera.getPosition();
             profilerFiller.push("safe_mode");
 

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.client.util.RenderBufferHelper;
 import com.gregtechceu.gtceu.client.util.RenderUtil;
 import com.gregtechceu.gtceu.common.blockentity.CableBlockEntity;
 
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.phys.AABB;
@@ -18,7 +19,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * @author brachy84
@@ -159,7 +159,7 @@ public class GTOverheatParticle extends GTBloomParticle {
 
         this.pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
                 CollisionContext.empty());
-        this.pipeBounds = pipeShape.bounds().move(posX, posY, posZ);
+        this.pipeBounds = pipeShape.bounds().inflate(0.001).move(posX, posY, posZ);
     }
 
     public void setTemperature(int temperature) {
@@ -194,7 +194,7 @@ public class GTOverheatParticle extends GTBloomParticle {
         // update pipeShape every tick so it doesn't desync if the pipe is disconnected
         pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
                 CollisionContext.empty());
-        pipeBounds = pipeShape.bounds().move(posX, posY, posZ);
+        pipeBounds = pipeShape.bounds().inflate(0.001).move(posX, posY, posZ);
 
         updateColor();
 
@@ -225,19 +225,29 @@ public class GTOverheatParticle extends GTBloomParticle {
     }
 
     @Override
-    public @Nullable IRenderSetup getRenderSetup() {
-        return SETUP;
+    public boolean shouldRender(EffectRenderContext context) {
+        return this.shouldRenderBloomEffect(context);
     }
 
     @Override
-    public boolean shouldRender(EffectRenderContext context) {
+    public boolean shouldRenderBloomEffect(EffectRenderContext context) {
         if (this.insulated) return false;
         return context.frustum().isVisible(pipeBounds);
     }
 
     @Override
-    protected @Nullable IRenderSetup getBloomRenderSetup() {
-        return SETUP;
+    public IRenderSetup getRenderSetup() {
+        return NO_BLOOM_SETUP;
+    }
+
+    @Override
+    protected IRenderSetup getBloomRenderSetup() {
+        return BLOOM_SETUP;
+    }
+
+    @Override
+    public void renderParticle(PoseStack poseStack, BufferBuilder buffer, EffectRenderContext context) {
+        renderBloomEffect(poseStack, buffer, context);
     }
 
     @Override
@@ -250,19 +260,23 @@ public class GTOverheatParticle extends GTBloomParticle {
         poseStack.translate(posX, posY, posZ);
         pipeShape.forAllBoxes((x1, y1, z1, x2, y2, z2) -> {
             RenderBufferHelper.renderColorCube(poseStack, buffer,
-                    (float) x1, (float) y1, (float) z1, (float) x2, (float) y2, (float) z2,
+                    (float) x1 - 0.001f, (float) y1 - 0.001f, (float) z1 - 0.001f,
+                    (float) x2 + 0.001f, (float) y2 + 0.001f, (float) z2 + 0.001f,
                     red, green, blue, alpha, true);
         });
         poseStack.popPose();
     }
 
-    private static final IRenderSetup SETUP = new IRenderSetup() {
+    private static final IRenderSetup NO_BLOOM_SETUP = new IRenderSetup() {
 
         @Override
         @OnlyIn(Dist.CLIENT)
         public void preDraw(BufferBuilder buffer) {
-            RenderSystem.setShaderColor(1, 1, 1, 1);
             RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
+            RenderSystem.setShader(GameRenderer::getPositionColorShader);
+            RenderSystem.setShaderColor(1, 1, 1, 1);
+
             buffer.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
         }
 
@@ -271,6 +285,25 @@ public class GTOverheatParticle extends GTBloomParticle {
         public void postDraw(BufferBuilder buffer) {
             BufferUploader.drawWithShader(buffer.end());
             RenderSystem.disableBlend();
+        }
+    };
+
+    private static final IRenderSetup BLOOM_SETUP = new IRenderSetup() {
+
+        @Override
+        @OnlyIn(Dist.CLIENT)
+        public void preDraw(BufferBuilder buffer) {
+            RenderSystem.disableBlend();
+            RenderSystem.setShader(GameRenderer::getPositionColorShader);
+            RenderSystem.setShaderColor(1, 1, 1, 1);
+
+            buffer.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+        }
+
+        @Override
+        @OnlyIn(Dist.CLIENT)
+        public void postDraw(BufferBuilder buffer) {
+            BufferUploader.drawWithShader(buffer.end());
         }
     };
 }

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -25,8 +25,6 @@ import org.jetbrains.annotations.Nullable;
  */
 public class GTOverheatParticle extends GTBloomParticle {
 
-    public static final int TEMPERATURE_CUTOFF = 400;
-
     /**
      * <a href="http://www.vendian.org/mncharity/dir3/blackbody/">Source</a>
      */
@@ -143,7 +141,7 @@ public class GTOverheatParticle extends GTBloomParticle {
     private final CableBlockEntity blockEntity;
 
     protected final int meltTemp;
-    protected int temperature = 293;
+    protected int temperature;
     protected final boolean insulated;
 
     protected VoxelShape pipeShape;
@@ -156,6 +154,7 @@ public class GTOverheatParticle extends GTBloomParticle {
         super(blockEntity.getBlockPos().getX(), blockEntity.getBlockPos().getY(), blockEntity.getBlockPos().getZ());
         this.blockEntity = blockEntity;
         this.meltTemp = meltTemp;
+        this.setTemperature(blockEntity.getTemperature());
         this.insulated = insulated;
 
         this.pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
@@ -169,7 +168,7 @@ public class GTOverheatParticle extends GTBloomParticle {
     }
 
     public void updateColor() {
-        if (temperature <= TEMPERATURE_CUTOFF || temperature > meltTemp) {
+        if (temperature <= blockEntity.getDefaultTemp() || temperature > meltTemp) {
             setExpired();
             return;
         }

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -164,10 +164,6 @@ public class GTOverheatParticle extends GTBloomParticle {
 
     public void setTemperature(int temperature) {
         this.temperature = temperature;
-        updateColor();
-    }
-
-    public void updateColor() {
         if (temperature <= blockEntity.getDefaultTemp() || temperature > meltTemp) {
             setExpired();
             return;
@@ -205,8 +201,6 @@ public class GTOverheatParticle extends GTBloomParticle {
             blockEntity.killParticle();
             return;
         }
-
-        updateColor();
 
         if (temperature > 400 && blockEntity.getLevel().random.nextFloat() < 0.04f) {
             spawnSmoke();

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -168,11 +168,12 @@ public class GTOverheatParticle extends GTBloomParticle {
             setExpired();
             return;
         }
-        if (temperature < 500) {
+        if (temperature < 300) {
             alpha = 0.0f;
+        } else if (temperature < 600) {
+            alpha = 0.16f * (temperature - 300f) / 300f;
         } else if (temperature < 1000) {
-            alpha = (temperature - 500f) / 500f;
-            alpha *= 0.8f;
+            alpha = 0.8f * (temperature - 500f) / 500f;
         } else {
             alpha = 0.8f;
         }

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.client.particle;
 
-import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.client.bloom.EffectRenderContext;
 import com.gregtechceu.gtceu.client.bloom.IRenderSetup;
 import com.gregtechceu.gtceu.client.bloom.particle.GTBloomParticle;
@@ -17,6 +16,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 
@@ -268,7 +268,9 @@ public class GTOverheatParticle extends GTBloomParticle {
         @OnlyIn(Dist.CLIENT)
         public void preDraw(BufferBuilder buffer) {
             RenderSystem.enableBlend();
-            RenderSystem.defaultBlendFunc();
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA,
+                    GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
             RenderSystem.setShader(GameRenderer::getPositionColorShader);
             RenderSystem.setShaderColor(1, 1, 1, 1);
 
@@ -280,6 +282,7 @@ public class GTOverheatParticle extends GTBloomParticle {
         public void postDraw(BufferBuilder buffer) {
             BufferUploader.drawWithShader(buffer.end());
             RenderSystem.disableBlend();
+            RenderSystem.defaultBlendFunc();
         }
     };
 

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -11,7 +11,7 @@ import com.gregtechceu.gtceu.common.blockentity.CableBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.phys.AABB;
-import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -19,8 +19,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 /**
  * @author brachy84
@@ -146,61 +144,37 @@ public class GTOverheatParticle extends GTBloomParticle {
 
     protected final int meltTemp;
     protected int temperature = 293;
-    protected VoxelShape pipeBoxes;
-    protected boolean insulated;
+    protected final boolean insulated;
 
-    protected float alpha = 0;
+    protected VoxelShape pipeShape;
+    protected AABB pipeBounds;
+
+    protected float alpha = 0.0f;
     protected int color = blackBodyColors[0];
 
-    public GTOverheatParticle(CableBlockEntity blockEntity, int meltTemp, VoxelShape pipeBoxes, boolean insulated) {
+    public GTOverheatParticle(CableBlockEntity blockEntity, int meltTemp, boolean insulated) {
         super(blockEntity.getBlockPos().getX(), blockEntity.getBlockPos().getY(), blockEntity.getBlockPos().getZ());
         this.blockEntity = blockEntity;
         this.meltTemp = meltTemp;
-        this.pipeBoxes = pipeBoxes;
-        updatePipeBoxes(pipeBoxes);
         this.insulated = insulated;
+
+        this.pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
+                CollisionContext.empty());
+        this.pipeBounds = pipeShape.bounds().move(posX, posY, posZ);
     }
 
     public void setTemperature(int temperature) {
         this.temperature = temperature;
-        if (temperature <= 293 || temperature > meltTemp) {
-            setExpired();
-            return;
-        }
-        if (temperature < 500) {
-            alpha = 0f;
-        } else if (temperature < 1000) {
-            alpha = (temperature - 500f) / 500f;
-            alpha *= 0.8f;
-        } else {
-            alpha = 0.8f;
-        }
-        color = getBlackBodyColor(temperature);
+        updateColor();
     }
 
-    public void updatePipeBoxes(VoxelShape pipeBoxes) {
-        List<AABB> boxes = pipeBoxes.toAabbs();
-        this.pipeBoxes = boxes.stream()
-                .map(aabb -> aabb.inflate(0.001))
-                .map(Shapes::create)
-                .reduce(Shapes.empty(), Shapes::or)
-                .optimize();
-    }
-
-    @Override
-    public void onUpdate() {
-        if (blockEntity.isRemoved() || !blockEntity.isParticleAlive()) {
-            setExpired();
-            blockEntity.killParticle();
-            return;
-        }
-
+    public void updateColor() {
         if (temperature <= TEMPERATURE_CUTOFF || temperature > meltTemp) {
             setExpired();
             return;
         }
         if (temperature < 500) {
-            alpha = 0f;
+            alpha = 0.0f;
         } else if (temperature < 1000) {
             alpha = (temperature - 500f) / 500f;
             alpha *= 0.8f;
@@ -208,6 +182,22 @@ public class GTOverheatParticle extends GTBloomParticle {
             alpha = 0.8f;
         }
         color = getBlackBodyColor(temperature);
+    }
+
+    @Override
+    public void onUpdate() {
+        // if this isn't the block entity's particle, remove both
+        if (blockEntity.isRemoved() || !blockEntity.isParticleAlive()) {
+            setExpired();
+            blockEntity.killParticle();
+            return;
+        }
+        // update pipeShape every tick so it doesn't desync if the pipe is disconnected
+        pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
+                CollisionContext.empty());
+        pipeBounds = pipeShape.bounds().move(posX, posY, posZ);
+
+        updateColor();
 
         if (GTValues.RNG.nextFloat() < 0.04) {
             spawnSmoke();
@@ -227,8 +217,8 @@ public class GTOverheatParticle extends GTBloomParticle {
     @Override
     public String toString() {
         return "GTOverheatParticle{" +
-                "tileEntity=" + blockEntity +
-                ", pipeBoxes=" + pipeBoxes +
+                "blockEntity=" + blockEntity +
+                ", pipeShape=" + pipeShape +
                 ", insulated=" + insulated +
                 ", alpha=" + alpha +
                 ", color=" + color +
@@ -243,12 +233,7 @@ public class GTOverheatParticle extends GTBloomParticle {
     @Override
     public boolean shouldRender(EffectRenderContext context) {
         if (this.insulated) return false;
-        for (AABB cuboid : pipeBoxes.toAabbs()) {
-            if (!context.frustum().isVisible(cuboid.move(posX, posY, posZ))) {
-                return false;
-            }
-        }
-        return true;
+        return context.frustum().isVisible(pipeBounds);
     }
 
     @Override
@@ -256,6 +241,7 @@ public class GTOverheatParticle extends GTBloomParticle {
         return SETUP;
     }
 
+    @Override
     public void renderBloomEffect(PoseStack poseStack, BufferBuilder buffer, EffectRenderContext context) {
         float red = ((color >> 16) & 0xFF) / 255f;
         float green = ((color >> 8) & 0xFF) / 255f;
@@ -263,9 +249,11 @@ public class GTOverheatParticle extends GTBloomParticle {
 
         poseStack.pushPose();
         poseStack.translate(posX, posY, posZ);
-        for (AABB cuboid : pipeBoxes.toAabbs()) {
-            RenderBufferHelper.renderColorCube(poseStack, buffer, cuboid, red, green, blue, alpha, true);
-        }
+        pipeShape.forAllBoxes((x1, y1, z1, x2, y2, z2) -> {
+            RenderBufferHelper.renderColorCube(poseStack, buffer,
+                    (float) x1, (float) y1, (float) z1, (float) x2, (float) y2, (float) z2,
+                    red, green, blue, alpha, true);
+        });
         poseStack.popPose();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -183,6 +183,20 @@ public class GTOverheatParticle extends GTBloomParticle {
         color = getBlackBodyColor(temperature);
     }
 
+    public void updateConnections() {
+        // if this isn't the block entity's particle, remove both
+        if (blockEntity.isRemoved() || !blockEntity.isParticleAlive()) {
+            setExpired();
+            blockEntity.killParticle();
+            return;
+        }
+
+        // update pipeShape every tick so it doesn't desync if the pipe is disconnected
+        pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
+                CollisionContext.empty());
+        pipeBounds = pipeShape.bounds().inflate(0.001).move(posX, posY, posZ);
+    }
+
     @Override
     public void onUpdate() {
         // if this isn't the block entity's particle, remove both
@@ -191,14 +205,10 @@ public class GTOverheatParticle extends GTBloomParticle {
             blockEntity.killParticle();
             return;
         }
-        // update pipeShape every tick so it doesn't desync if the pipe is disconnected
-        pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
-                CollisionContext.empty());
-        pipeBounds = pipeShape.bounds().inflate(0.001).move(posX, posY, posZ);
 
         updateColor();
 
-        if (GTValues.RNG.nextFloat() < 0.04) {
+        if (temperature > 400 && blockEntity.getLevel().random.nextFloat() < 0.04f) {
             spawnSmoke();
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -140,15 +140,15 @@ public class GTOverheatParticle extends GTBloomParticle {
 
     private final CableBlockEntity blockEntity;
 
-    protected final int meltTemp;
-    protected int temperature;
-    protected final boolean insulated;
+    private final int meltTemp;
+    private int temperature;
+    private final boolean insulated;
 
-    protected VoxelShape pipeShape;
-    protected AABB pipeBounds;
+    private VoxelShape pipeShape;
+    private AABB pipeBounds;
 
-    protected float alpha = 0.0f;
-    protected int color = blackBodyColors[0];
+    private float alpha = 0.0f;
+    private int color = blackBodyColors[0];
 
     public GTOverheatParticle(CableBlockEntity blockEntity, int meltTemp, boolean insulated) {
         super(blockEntity.getBlockPos().getX(), blockEntity.getBlockPos().getY(), blockEntity.getBlockPos().getZ());

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTOverheatParticle.java
@@ -180,20 +180,6 @@ public class GTOverheatParticle extends GTBloomParticle {
         color = getBlackBodyColor(temperature);
     }
 
-    public void updateConnections() {
-        // if this isn't the block entity's particle, remove both
-        if (blockEntity.isRemoved() || !blockEntity.isParticleAlive()) {
-            setExpired();
-            blockEntity.killParticle();
-            return;
-        }
-
-        // update pipeShape every tick so it doesn't desync if the pipe is disconnected
-        pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
-                CollisionContext.empty());
-        pipeBounds = pipeShape.bounds().inflate(0.001).move(posX, posY, posZ);
-    }
-
     @Override
     public void onUpdate() {
         // if this isn't the block entity's particle, remove both
@@ -202,6 +188,10 @@ public class GTOverheatParticle extends GTBloomParticle {
             blockEntity.killParticle();
             return;
         }
+        // update pipeShape every tick so it doesn't desync if the pipe is disconnected
+        pipeShape = blockEntity.getBlockState().getVisualShape(blockEntity.getLevel(), blockEntity.getBlockPos(),
+                CollisionContext.empty());
+        pipeBounds = pipeShape.bounds().inflate(0.001).move(posX, posY, posZ);
 
         if (temperature > 400 && blockEntity.getLevel().random.nextFloat() < 0.04f) {
             spawnSmoke();

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
@@ -172,6 +172,16 @@ public final class GTParticleManager {
     }
 
     @SubscribeEvent
+    public void clientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || Minecraft.getInstance().isPaused()) {
+            return;
+        }
+        if (Minecraft.getInstance().level != null) {
+            INSTANCE.updateEffects();
+        }
+    }
+
+    @SubscribeEvent
     public void onClientLevelLoad(LevelEvent.Load event) {
         if (!(event.getLevel() instanceof ClientLevel newLevel)) {
             return;
@@ -179,10 +189,6 @@ public final class GTParticleManager {
         ClientLevel oldLevel = Minecraft.getInstance().level;
         if (oldLevel != newLevel) {
             this.clearAllEffects(oldLevel != null);
-        }
-
-        if (oldLevel != null) {
-            INSTANCE.updateEffects();
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
@@ -31,8 +31,8 @@ public final class GTParticleManager {
 
     public static final GTParticleManager INSTANCE = new GTParticleManager();
 
-    private final Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> depthEnabledParticles = new Object2ObjectLinkedOpenHashMap<>();
-    private final Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> depthDisabledParticles = new Object2ObjectLinkedOpenHashMap<>();
+    private final Map<@Nullable IRenderSetup, Queue<GTParticle>> depthEnabledParticles = new Object2ObjectLinkedOpenHashMap<>();
+    private final Map<@Nullable IRenderSetup, Queue<GTParticle>> depthDisabledParticles = new Object2ObjectLinkedOpenHashMap<>();
 
     private final List<GTParticle> newParticleQueue = new ArrayList<>();
 
@@ -54,11 +54,11 @@ public final class GTParticleManager {
             for (GTParticle particle : newParticleQueue) {
                 var queue = particle.shouldDisableDepth() ? this.depthDisabledParticles : this.depthEnabledParticles;
 
-                ArrayDeque<GTParticle> particles = queue.computeIfAbsent(particle.getRenderSetup(),
+                Queue<GTParticle> particles = queue.computeIfAbsent(particle.getRenderSetup(),
                         setup -> new ArrayDeque<>());
 
                 if (particles.size() > 6000) {
-                    particles.removeFirst().setExpired();
+                    particles.remove().setExpired();
                 }
                 particles.add(particle);
             }
@@ -67,10 +67,10 @@ public final class GTParticleManager {
         }
     }
 
-    private void updateQueue(Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> renderQueue) {
-        Iterator<ArrayDeque<GTParticle>> it = renderQueue.values().iterator();
+    private void updateQueue(Map<@Nullable IRenderSetup, Queue<GTParticle>> renderQueue) {
+        Iterator<Queue<GTParticle>> it = renderQueue.values().iterator();
         while (it.hasNext()) {
-            ArrayDeque<GTParticle> particlesForSetup = it.next();
+            Queue<GTParticle> particlesForSetup = it.next();
 
             Iterator<GTParticle> particles = particlesForSetup.iterator();
             while (particles.hasNext()) {
@@ -102,12 +102,12 @@ public final class GTParticleManager {
             }
             this.newParticleQueue.clear();
         }
-        for (ArrayDeque<GTParticle> particles : this.depthEnabledParticles.values()) {
+        for (Queue<GTParticle> particles : this.depthEnabledParticles.values()) {
             for (GTParticle particle : particles) {
                 particle.setExpired();
             }
         }
-        for (ArrayDeque<GTParticle> particles : this.depthDisabledParticles.values()) {
+        for (Queue<GTParticle> particles : this.depthDisabledParticles.values()) {
             for (GTParticle particle : particles) {
                 particle.setExpired();
             }
@@ -137,10 +137,10 @@ public final class GTParticleManager {
     }
 
     private static void renderParticlesInLayer(PoseStack poseStack,
-                                               Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> renderQueue,
+                                               Map<@Nullable IRenderSetup, Queue<GTParticle>> renderQueue,
                                                EffectRenderContext context) {
         for (var entry : renderQueue.entrySet()) {
-            ArrayDeque<GTParticle> particles = entry.getValue();
+            Queue<GTParticle> particles = entry.getValue();
             if (particles.isEmpty()) continue;
 
             IRenderSetup handler = entry.getKey();
@@ -211,11 +211,7 @@ public final class GTParticleManager {
         }
     }
 
-    private static int count(Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> renderQueue) {
-        int total = 0;
-        for (Deque<GTParticle> queue : renderQueue.values()) {
-            total += queue.size();
-        }
-        return total;
+    private static int count(Map<@Nullable IRenderSetup, Queue<GTParticle>> renderQueue) {
+        return renderQueue.values().stream().mapToInt(Queue::size).sum();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.client.bloom.EffectRenderContext;
 import com.gregtechceu.gtceu.client.bloom.IRenderSetup;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
@@ -12,9 +13,9 @@ import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.level.LevelEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -116,24 +117,28 @@ public final class GTParticleManager {
         this.depthDisabledParticles.clear();
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public void renderParticles(RenderLevelStageEvent event) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES) return;
         if (this.depthEnabledParticles.isEmpty() && this.depthDisabledParticles.isEmpty()) return;
 
-        EffectRenderContext instance = EffectRenderContext.getInstance()
-                .update(event.getCamera(), event.getFrustum(), event.getPartialTick());
+        Camera camera = event.getCamera();
 
-        RenderSystem.enableBlend();
-        RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        PoseStack poseStack = event.getPoseStack();
+        poseStack.pushPose();
+        poseStack.translate(-camera.getPosition().x, -camera.getPosition().y, -camera.getPosition().z);
+
+        EffectRenderContext instance = EffectRenderContext.getInstance()
+                .update(camera, event.getFrustum(), event.getPartialTick());
 
         if (!this.depthDisabledParticles.isEmpty()) {
             RenderSystem.depthMask(false);
-            renderParticlesInLayer(event.getPoseStack(), this.depthDisabledParticles, instance);
+            renderParticlesInLayer(poseStack, this.depthDisabledParticles, instance);
             RenderSystem.depthMask(true);
         }
-        renderParticlesInLayer(event.getPoseStack(), this.depthEnabledParticles, instance);
+        renderParticlesInLayer(poseStack, this.depthEnabledParticles, instance);
 
-        RenderSystem.disableBlend();
+        poseStack.popPose();
     }
 
     private static void renderParticlesInLayer(PoseStack poseStack,

--- a/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/particle/GTParticleManager.java
@@ -5,18 +5,14 @@ import com.gregtechceu.gtceu.client.bloom.EffectRenderContext;
 import com.gregtechceu.gtceu.client.bloom.IRenderSetup;
 
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
-import net.minecraft.client.renderer.culling.Frustum;
-import net.minecraft.world.entity.Entity;
-import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.CustomizeGuiOverlayEvent;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.Mod;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -31,8 +27,7 @@ import java.util.*;
 /**
  * Singleton class responsible for managing, updating and rendering {@link GTParticle} instances.
  */
-@Mod.EventBusSubscriber(modid = GTCEu.MOD_ID, value = Dist.CLIENT)
-public class GTParticleManager {
+public final class GTParticleManager {
 
     public static final GTParticleManager INSTANCE = new GTParticleManager();
 
@@ -40,6 +35,8 @@ public class GTParticleManager {
     private final Map<@Nullable IRenderSetup, ArrayDeque<GTParticle>> depthDisabledParticles = new Object2ObjectLinkedOpenHashMap<>();
 
     private final List<GTParticle> newParticleQueue = new ArrayList<>();
+
+    private GTParticleManager() {}
 
     public void addEffect(GTParticle particles) {
         newParticleQueue.add(particles);
@@ -119,21 +116,22 @@ public class GTParticleManager {
         this.depthDisabledParticles.clear();
     }
 
-    public void renderParticles(PoseStack poseStack, Camera camera, Frustum frustum, float partialTicks) {
+    @SubscribeEvent
+    public void renderParticles(RenderLevelStageEvent event) {
         if (this.depthEnabledParticles.isEmpty() && this.depthDisabledParticles.isEmpty()) return;
 
         EffectRenderContext instance = EffectRenderContext.getInstance()
-                .update(camera, frustum, partialTicks);
+                .update(event.getCamera(), event.getFrustum(), event.getPartialTick());
 
         RenderSystem.enableBlend();
         RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
 
         if (!this.depthDisabledParticles.isEmpty()) {
             RenderSystem.depthMask(false);
-            renderParticlesInLayer(poseStack, this.depthDisabledParticles, instance);
+            renderParticlesInLayer(event.getPoseStack(), this.depthDisabledParticles, instance);
             RenderSystem.depthMask(true);
         }
-        renderParticlesInLayer(poseStack, this.depthEnabledParticles, instance);
+        renderParticlesInLayer(event.getPoseStack(), this.depthEnabledParticles, instance);
 
         RenderSystem.disableBlend();
     }
@@ -174,13 +172,13 @@ public class GTParticleManager {
     }
 
     @SubscribeEvent
-    public static void onClientLevelLoad(LevelEvent.Load event) {
+    public void onClientLevelLoad(LevelEvent.Load event) {
         if (!(event.getLevel() instanceof ClientLevel newLevel)) {
             return;
         }
         ClientLevel oldLevel = Minecraft.getInstance().level;
         if (oldLevel != newLevel) {
-            INSTANCE.clearAllEffects(oldLevel != null);
+            this.clearAllEffects(oldLevel != null);
         }
 
         if (oldLevel != null) {
@@ -189,34 +187,21 @@ public class GTParticleManager {
     }
 
     @SubscribeEvent
-    public static void onClientLevelUnload(ClientPlayerNetworkEvent.LoggingOut event) {
+    public void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
         if (event.getPlayer() != null) {
-            INSTANCE.clearAllEffects(true);
+            this.clearAllEffects(true);
         }
     }
 
     @SubscribeEvent
-    public static void renderWorld(RenderLevelStageEvent event) {
-        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_CUTOUT_BLOCKS) {
-            Entity entity = Minecraft.getInstance().getCameraEntity();
-            if (entity == null) {
-                entity = Minecraft.getInstance().player;
-            }
-            if (entity != null) {
-                INSTANCE.renderParticles(event.getPoseStack(), event.getCamera(), event.getFrustum(),
-                        event.getPartialTick());
-            }
-        }
-    }
-
-    @SubscribeEvent
-    public static void debugOverlay(CustomizeGuiOverlayEvent.DebugText event) {
-        if (event.getLeft().size() >= 5) {
-            String particleTxt = event.getLeft().get(4);
-            particleTxt += "." + ChatFormatting.GOLD +
-                    " PARTICLE-BACK: " + count(INSTANCE.depthEnabledParticles) +
-                    "PARTICLE-FRONT: " + count(INSTANCE.depthDisabledParticles);
-            event.getLeft().set(4, particleTxt);
+    public void debugOverlay(CustomizeGuiOverlayEvent.DebugText event) {
+        List<String> gameInfo = event.getLeft();
+        if (gameInfo.size() >= 5) {
+            String countStatsLine = gameInfo.get(4);
+            countStatsLine += ". " + ChatFormatting.GOLD +
+                    "P-BACK: " + count(this.depthEnabledParticles) +
+                    " P-FRONT: " + count(this.depthDisabledParticles);
+            gameInfo.set(4, countStatsLine);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/FusionRingRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/FusionRingRender.java
@@ -11,7 +11,6 @@ import com.gregtechceu.gtceu.common.machine.multiblock.electric.FusionReactorMac
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.ShaderInstance;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.Mth;
@@ -125,25 +124,19 @@ public class FusionRingRender extends DynamicRender<FusionReactorMachine, Fusion
 
         private final FusionReactorMachine machine;
 
-        private static final BufferBuilder lightRingBuffer = new BufferBuilder(GTRenderTypes.lightRing().bufferSize());
-
         private static final IRenderSetup SETUP = new IRenderSetup() {
 
             @Override
             @OnlyIn(Dist.CLIENT)
             public void preDraw(BufferBuilder buffer) {
-                lightRingBuffer.begin(GTRenderTypes.lightRing().mode(), GTRenderTypes.lightRing().format());
+                RenderSystem.setShader(GameRenderer::getPositionColorShader);
+                buffer.begin(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_COLOR);
             }
 
             @Override
             @OnlyIn(Dist.CLIENT)
             public void postDraw(BufferBuilder buffer) {
-                ShaderInstance lastShader = RenderSystem.getShader();
-                RenderSystem.setShader(GameRenderer::getPositionColorShader);
-
-                BufferUploader.drawWithShader(lightRingBuffer.end());
-
-                RenderSystem.setShader(() -> lastShader);
+                BufferUploader.drawWithShader(buffer.end());
             }
         };
 
@@ -153,9 +146,7 @@ public class FusionRingRender extends DynamicRender<FusionReactorMachine, Fusion
 
             poseStack.pushPose();
             poseStack.translate(pos.getX(), pos.getY(), pos.getZ());
-
-            FusionRingRender.this.renderLightRing(machine, context.partialTicks(), poseStack, lightRingBuffer);
-
+            FusionRingRender.this.renderLightRing(machine, context.partialTicks(), poseStack, buffer);
             poseStack.popPose();
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/block/CableBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/CableBlock.java
@@ -55,7 +55,7 @@ public class CableBlock extends MaterialPipeBlock<Insulation, WireProperties, Le
 
     @Override
     public int tinted(BlockState state, @Nullable BlockAndTintGetter level, @Nullable BlockPos pos, int index) {
-        if (pipeType.isCable && (index == 0 || index == 2)) {
+        if (pipeType.isCable() && (index == 0 || index == 2)) {
             return 0x404040;
         }
         return super.tinted(state, level, pos, index);
@@ -132,7 +132,7 @@ public class CableBlock extends MaterialPipeBlock<Insulation, WireProperties, Le
         if (level.isClientSide) return;
 
         Insulation insulation = getPipeTile(level, pos).getPipeType();
-        if (insulation.insulationLevel == -1 && entity instanceof LivingEntity entityLiving) {
+        if (!insulation.isCable() && entity instanceof LivingEntity entityLiving) {
             CableBlockEntity cable = (CableBlockEntity) getPipeTile(level, pos);
             if (cable != null && cable.getFrameMaterial().isNull() &&
                     cable.getNodeData().getLossPerBlock() > 0) {

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -353,6 +353,13 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
         }
     }
 
+    @ClientFieldChangeListener(fieldName = "connections")
+    private void onConnectionsUpdated() {
+        if (isParticleAlive()) {
+            particle.updateConnections();
+        }
+    }
+
     public static void onBlockEntityRegister(BlockEntityType<CableBlockEntity> cableBlockEntityBlockEntityType) {}
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -353,13 +353,6 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
         }
     }
 
-    @ClientFieldChangeListener(fieldName = "connections")
-    private void onConnectionsUpdated() {
-        if (isParticleAlive()) {
-            particle.updateConnections();
-        }
-    }
-
     public static void onBlockEntityRegister(BlockEntityType<CableBlockEntity> cableBlockEntityBlockEntityType) {}
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -243,9 +243,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
 
     @OnlyIn(Dist.CLIENT)
     public void createParticle() {
-        particle = new GTOverheatParticle(this, meltTemp,
-                getPipeBlock().getShape(getBlockState(), level, getBlockPos(), CollisionContext.empty()),
-                getPipeType().insulationLevel >= 0);
+        particle = new GTOverheatParticle(this, meltTemp, getPipeType().insulationLevel >= 0);
         GTParticleManager.INSTANCE.addEffect(particle);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.capability.GTCapability;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IEnergyContainer;
 import com.gregtechceu.gtceu.api.data.chemical.material.properties.WireProperties;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
@@ -36,7 +37,6 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.Capability;
@@ -243,7 +243,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
 
     @OnlyIn(Dist.CLIENT)
     public void createParticle() {
-        particle = new GTOverheatParticle(this, meltTemp, getPipeType().insulationLevel >= 0);
+        particle = new GTOverheatParticle(this, meltTemp, getPipeType().isCable());
         GTParticleManager.INSTANCE.addEffect(particle);
     }
 
@@ -279,7 +279,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
             return false;
         }
 
-        if (getPipeType().insulationLevel >= 0 && temperature >= 1500 && GTValues.RNG.nextFloat() < 0.1f) {
+        if (getPipeType().isCable() && temperature >= 1500 && GTValues.RNG.nextFloat() < 0.1f) {
             // insulation melted
             uninsulate();
             return false;
@@ -370,7 +370,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
     }
 
     @Override
-    public @NotNull List<Component> getDataInfo(PortableScannerBehavior.DisplayMode mode) {
+    public List<Component> getDataInfo(PortableScannerBehavior.DisplayMode mode) {
         List<Component> list = new ArrayList<>();
 
         if (mode == PortableScannerBehavior.DisplayMode.SHOW_ALL ||

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -41,8 +41,6 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
@@ -61,7 +59,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
 
     protected WeakReference<EnergyNet> currentEnergyNet = new WeakReference<>(null);
 
-    @SideOnly(Side.CLIENT)
+    @OnlyIn(Dist.CLIENT)
     private GTOverheatParticle particle;
     private static final int meltTemp = 3000;
 
@@ -174,7 +172,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
 
     private void subscribeHeat() {
         if (this.heatSubs == null) {
-            this.heatSubs = subscribeServerTick(this::update);
+            this.heatSubs = subscribeServerTick(this::updateHeat);
         }
     }
 
@@ -266,7 +264,7 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
         }
     }
 
-    private boolean update() {
+    private boolean updateHeat() {
         if (heatQueue > 0) {
             // if received heat from overvolting or overamping, add heat
             setTemperature(temperature + heatQueue);
@@ -283,18 +281,17 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
             return false;
         }
 
-        if (getPipeType().insulationLevel >= 0 && temperature >= 1500 && GTValues.RNG.nextFloat() < 0.1) {
+        if (getPipeType().insulationLevel >= 0 && temperature >= 1500 && GTValues.RNG.nextFloat() < 0.1f) {
             // insulation melted
             uninsulate();
             return false;
         }
 
-        if (heatQueue == 0) {
+        if (heatQueue <= 0) {
             // otherwise cool down
-            setTemperature((int) (temperature - Math.pow(temperature - getDefaultTemp(), 0.35)));
-        } else {
-            heatQueue = 0;
+            setTemperature((int) (temperature - Math.pow(temperature - getDefaultTemp(), 0.35f)));
         }
+        heatQueue = 0;
         return true;
     }
 
@@ -329,6 +326,17 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
 
     @ClientFieldChangeListener(fieldName = "temperature")
     public void onTemperatureUpdated() {
+        if (temperature <= getDefaultTemp()) {
+            if (isParticleAlive()) {
+                particle.setExpired();
+            }
+        } else {
+            if (!isParticleAlive()) {
+                createParticle();
+            }
+            particle.setTemperature(temperature);
+        }
+
         if (this.temperature >= meltTemp) {
             float xPos = Direction.UP.getStepX() * 0.76f + getBlockPos().getX() + 0.25f;
             float yPos = Direction.UP.getStepY() * 0.76f + getBlockPos().getY() + 0.25f;

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -10,6 +10,7 @@ import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.feature.IDataInfoProvider;
+import com.gregtechceu.gtceu.api.sync_system.annotations.ClientFieldChangeListener;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.client.particle.GTOverheatParticle;
@@ -31,6 +32,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -323,23 +325,25 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
         this.temperature = temperature;
         syncDataHolder.markClientSyncFieldDirty("temperature");
         level.getLightEngine().checkBlock(worldPosition);
-        if (!level.isClientSide && temperature >= meltTemp) {
-            var facing = Direction.UP;
-            float xPos = facing.getStepX() * 0.76F + worldPosition.getX() + 0.25F;
-            float yPos = facing.getStepY() * 0.76F + worldPosition.getY() + 0.25F;
-            float zPos = facing.getStepZ() * 0.76F + worldPosition.getZ() + 0.25F;
+    }
 
-            float ySpd = facing.getStepY() * 0.1F + 0.2F + 0.1F * GTValues.RNG.nextFloat();
-            float temp = GTValues.RNG.nextFloat() * 2 * (float) Math.PI;
-            float xSpd = (float) Math.sin(temp) * 0.1F;
-            float zSpd = (float) Math.cos(temp) * 0.1F;
+    @ClientFieldChangeListener(fieldName = "temperature")
+    public void onTemperatureUpdated() {
+        if (this.temperature >= meltTemp) {
+            float xPos = Direction.UP.getStepX() * 0.76f + getBlockPos().getX() + 0.25f;
+            float yPos = Direction.UP.getStepY() * 0.76f + getBlockPos().getY() + 0.25f;
+            float zPos = Direction.UP.getStepZ() * 0.76f + getBlockPos().getZ() + 0.25f;
 
-            ((ServerLevel) level).sendParticles(ParticleTypes.SMOKE,
-                    xPos + GTValues.RNG.nextFloat() * 0.5F,
-                    yPos + GTValues.RNG.nextFloat() * 0.5F,
-                    zPos + GTValues.RNG.nextFloat() * 0.5F,
-                    0,
-                    xSpd, ySpd, zSpd, 1);
+            float horizontalDirection = level.random.nextFloat() * 2 * Mth.PI;
+            float xSpd = Mth.sin(horizontalDirection) * 0.1f;
+            float ySpd = Direction.UP.getStepY() * 0.1f + 0.2f + 0.1f * level.random.nextFloat();
+            float zSpd = Mth.cos(horizontalDirection) * 0.1f;
+
+            level.addParticle(ParticleTypes.SMOKE,
+                    xPos + level.random.nextFloat() * 0.5f,
+                    yPos + level.random.nextFloat() * 0.5f,
+                    zPos + level.random.nextFloat() * 0.5f,
+                    xSpd, ySpd, zSpd);
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/CableBlockEntity.java
@@ -294,16 +294,16 @@ public class CableBlockEntity extends PipeBlockEntity<Insulation, WireProperties
     }
 
     private void uninsulate() {
-        int temp = temperature;
+        int oldTemperature = temperature;
         setTemperature(getDefaultTemp());
-        int index = getPipeType().insulationLevel;
-        CableBlock newBlock = GTMaterialBlocks.CABLE_BLOCKS
-                .get(Insulation.values()[index].tagPrefix, getPipeBlock().material)
-                .get();
+
+        TagPrefix uninsulatedPrefix = getPipeType().getUninsulated().tagPrefix;
+        CableBlock newBlock = GTMaterialBlocks.CABLE_BLOCKS.get(uninsulatedPrefix, getPipeBlock().material).get();
         level.setBlockAndUpdate(getBlockPos(), newBlock.defaultBlockState());
+
         CableBlockEntity newCable = (CableBlockEntity) level.getBlockEntity(getBlockPos());
         if (newCable != null) { // should never be null
-            newCable.setTemperature(temp);
+            newCable.setTemperature(oldTemperature);
             newCable.subscribeHeat();
             for (Direction facing : GTUtil.DIRECTIONS) {
                 if (isConnected(facing)) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialBlocks.java
@@ -188,7 +188,7 @@ public class GTMaterialBlocks {
 
     private static boolean allowCableBlock(Material material, Insulation insulation) {
         return material.hasProperty(PropertyKey.WIRE) && !insulation.tagPrefix.isIgnored(material) &&
-                !(insulation.isCable && material.getProperty(PropertyKey.WIRE).isSuperconductor());
+                !(insulation.isCable() && material.getProperty(PropertyKey.WIRE).isSuperconductor());
     }
 
     private static void registerCableBlock(Material material, Insulation insulation, GTRegistrate registrate) {

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/Insulation.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/Insulation.java
@@ -19,17 +19,17 @@ import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.*;
 
 public enum Insulation implements IMaterialPipeType<WireProperties> {
 
-    WIRE_SINGLE("single_wire", 0.1875f, 1, 2, wireGtSingle, -1, false),
-    WIRE_DOUBLE("double_wire", 0.3125f, 2, 2, wireGtDouble, -1, false),
-    WIRE_QUADRUPLE("quadruple_wire", 0.4375f, 4, 3, wireGtQuadruple, -1, false),
-    WIRE_OCTAL("octal_wire", 0.5625f, 8, 3, wireGtOctal, -1, false),
-    WIRE_HEX("hex_wire", 0.8125f, 16, 3, wireGtHex, -1, false),
+    WIRE_SINGLE("single_wire", 0.1875f, 1, 2, wireGtSingle, -1),
+    WIRE_DOUBLE("double_wire", 0.3125f, 2, 2, wireGtDouble, -1),
+    WIRE_QUADRUPLE("quadruple_wire", 0.4375f, 4, 3, wireGtQuadruple, -1),
+    WIRE_OCTAL("octal_wire", 0.5625f, 8, 3, wireGtOctal, -1),
+    WIRE_HEX("hex_wire", 0.8125f, 16, 3, wireGtHex, -1),
 
-    CABLE_SINGLE("single_cable", 0.25f, 1, 1, cableGtSingle, 0, true),
-    CABLE_DOUBLE("double_cable", 0.375f, 2, 1, cableGtDouble, 1, true),
-    CABLE_QUADRUPLE("quadruple_cable", 0.5f, 4, 1, cableGtQuadruple, 2, true),
-    CABLE_OCTAL("octal_cable", 0.625f, 8, 1, cableGtOctal, 3, true),
-    CABLE_HEX("hex_cable", 0.875f, 16, 1, cableGtHex, 4, true);
+    CABLE_SINGLE("single_cable", 0.25f, 1, 1, cableGtSingle, 0),
+    CABLE_DOUBLE("double_cable", 0.375f, 2, 1, cableGtDouble, 1),
+    CABLE_QUADRUPLE("quadruple_cable", 0.5f, 4, 1, cableGtQuadruple, 2),
+    CABLE_OCTAL("octal_cable", 0.625f, 8, 1, cableGtOctal, 3),
+    CABLE_HEX("hex_cable", 0.875f, 16, 1, cableGtHex, 4);
 
     public static final ResourceLocation TYPE_ID = GTCEu.id("insulation");
 
@@ -40,17 +40,20 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
     @Getter
     public final TagPrefix tagPrefix;
     public final int insulationLevel;
+    /// @deprecated Use {@link #isCable() Insulation.isCable()}
+    @Deprecated(forRemoval = true, since = "8.0.0")
     public final boolean isCable;
 
-    Insulation(String name, float thickness, int amperage, int lossMultiplier, TagPrefix TagPrefix, int insulated,
-               boolean isCable) {
+    Insulation(String name, float thickness, int amperage, int lossMultiplier, TagPrefix TagPrefix,
+               int insulationLevel) {
         this.name = name;
         this.thickness = thickness;
         this.amperage = amperage;
         this.tagPrefix = TagPrefix;
-        this.insulationLevel = insulated;
+        this.insulationLevel = insulationLevel;
         this.lossMultiplier = lossMultiplier;
-        this.isCable = isCable;
+
+        this.isCable = insulationLevel >= 0;
     }
 
     @Override
@@ -70,7 +73,7 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
     }
 
     public boolean isCable() {
-        return ordinal() > 4;
+        return insulationLevel >= 0;
     }
 
     @Override
@@ -90,7 +93,7 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
                 .getBlockTexturePath(material.getMaterialIconSet(), "end", true);
 
         PipeModel model = new PipeModel(block, provider, thickness,
-                isCable ? GTCEu.id("block/cable/insulation_5") : side, end);
+                isCable() ? GTCEu.id("block/cable/insulation_5") : side, end);
 
         ResourceLocation sideSecondary = MaterialIconType.wire
                 .getBlockTexturePath(material.getMaterialIconSet(), "side_overlay", true);
@@ -103,7 +106,7 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
         if (endSecondary != null && !endSecondary.equals(GTModels.BLANK_TEXTURE)) {
             model.setEndSecondary(endSecondary);
         }
-        if (isCable) {
+        if (isCable()) {
             model.setEndOverlay(GTCEu.id("block/cable/insulation_%s".formatted(insulationLevel)));
         }
         return model;

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/Insulation.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/Insulation.java
@@ -72,6 +72,14 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
         return insulationLevel >= 0;
     }
 
+    public Insulation getUninsulated() {
+        if (isCable()) {
+            return values()[insulationLevel];
+        } else {
+            return this;
+        }
+    }
+
     @Override
     public boolean isPaintable() {
         return true;

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/Insulation.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/cable/Insulation.java
@@ -34,6 +34,7 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
     public static final ResourceLocation TYPE_ID = GTCEu.id("insulation");
 
     public final String name;
+    @Getter
     public final float thickness;
     public final int amperage;
     public final int lossMultiplier;
@@ -54,11 +55,6 @@ public enum Insulation implements IMaterialPipeType<WireProperties> {
         this.lossMultiplier = lossMultiplier;
 
         this.isCable = insulationLevel >= 0;
-    }
-
-    @Override
-    public float getThickness() {
-        return thickness;
     }
 
     @Override


### PR DESCRIPTION
## What
Turns out I broke it a year ago and didn't notice!

## Implementation Details
The commits' names describe their changes.

### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes, AI driven tools were used for this pull request.

## Outcome
Cables glow when melting

## How Was This Tested
https://github.com/user-attachments/assets/f38de26f-9fb7-4a88-a74d-223b5988c938
https://github.com/user-attachments/assets/4855d9fd-5fc3-4c69-b6c5-76f044571a8d
###### gee thanks github for not embedding uploaded videos

## Potential Compatibility Issues
None, as none of the (possibly) broken API in this is even a day old.
