### PR TITLE
Fix accidental dependence on AE2

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/HullMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/HullMachine.java
@@ -107,8 +107,10 @@ public class HullMachine extends TieredPartMachine implements IMonitorComponent 
     }
 
     static {
-        ClassSyncData.getClassData(HullMachine.class).setCustomTransformerForField("gridNodeHost",
-                new GridNodeHostTransformer());
+        if (GTCEu.Mods.isAE2Loaded()) {
+            ClassSyncData.getClassData(HullMachine.class).setCustomTransformerForField("gridNodeHost",
+                    new GridNodeHostTransformer());
+        }
     }
 
     @Override


### PR DESCRIPTION
## What
Fixed an accidental dependence on AE2 in the sync for hulls

## Implementation Details
Added an if check

### AI Usage 
- [x] No AI driven tools were used for this pull request.

## Outcome
Can now place a hull without ae2 installed

## How Was This Tested
Tested in an obf build in prism with and without ae2, checking that hulls still function as apart of an ae networking

## Additional Information
Done in neovim and terminal gradle as i dont have intellij installed on this laptop :trollface: 

## Potential Compatibility Issues
Can now place a hull without ae2 installed
