### PR TITLE
Make the `ConfigWidget` method protected

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/ConfigWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/widget/ConfigWidget.java
@@ -84,7 +84,7 @@ public abstract class ConfigWidget extends WidgetGroup {
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
-    abstract void init();
+    protected abstract void init();
 
     public abstract boolean hasStackInConfig(GenericStack stack);
 


### PR DESCRIPTION
## What
Changed the abstract `init` method in `ConfigWidget` to protected for addon mods to override.

## Implementation Details
protected!

### AI Usage 
_The usage of AI tools requires honest disclosure, please refer to our [AI Policy](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/AI_POLICY.md.)._

The purpose of this section is to not guilt trip users who engage with these tools but to give us a better understanding of how they were used as well to what extent.
Users who contribute AI written code are held responsible for the quality of the code as well as understanding the implemented code written by these tools.

**All machine code MUST be reviewed by the pull request submitter before opening. **

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

_If you answered no and it is discovered the pull request in question used AI tooling, users will be restricted from submitting future pull requests_

## Outcome
Addons will be able to override, like integration for Mekanism gases which I'm working on.
