### PR TITLE
Warn that Soft Mallets cannot disable Boilers

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -107,6 +107,7 @@
   "behaviour.soft_hammer.disabled": "pǝןqɐsıᗡ buıʞɹoM",
   "behaviour.soft_hammer.disabled_cycle": "ǝןɔʎɔ ʇuǝɹɹnɔ ɹǝʇɟɐ pǝןqɐsıᗡ buıʞɹoM",
   "behaviour.soft_hammer.enabled": "pǝןqɐuƎ buıʞɹoM",
+  "behaviour.soft_hammer.ignored": "pǝןqɐsıp ǝq ʇouuɐɔ ǝuıɥɔɐW",
   "behaviour.wrench": "ʞɔıןɔʇɥbıᴚ uo sʞɔoןᗺ sǝʇɐʇoᴚ",
   "block.filter_casing.tooltip": "ʇuǝɯuoɹıʌuǝ ㄥ§ǝǝɹℲ-ǝןɔıʇɹɐԀɐ§ ɐ sǝʇɐǝɹƆ",
   "block.gtceu.acid_hazard_sign_block": "ʞɔoןᗺ ubıS pɹɐzɐH pıɔⱯ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -107,6 +107,7 @@
   "behaviour.soft_hammer.disabled": "Working Disabled",
   "behaviour.soft_hammer.disabled_cycle": "Working Disabled after current cycle",
   "behaviour.soft_hammer.enabled": "Working Enabled",
+  "behaviour.soft_hammer.ignored": "Machine cannot be disabled",
   "behaviour.wrench": "Rotates Blocks on Rightclick",
   "block.filter_casing.tooltip": "Creates a §aParticle-Free§7 environment",
   "block.gtceu.acid_hazard_sign_block": "Acid Hazard Sign Block",

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
@@ -276,7 +276,10 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
 
     @Override
     protected InteractionResult onSoftMalletClick(ExtendedUseOnContext context) {
-        return InteractionResult.PASS;
+        if (!isRemote()) {
+            context.getPlayer().sendSystemMessage(Component.translatable("behaviour.soft_hammer.ignored"));
+        }
+        return InteractionResult.sidedSuccess(getLevel().isClientSide);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -748,6 +748,7 @@ public class LangHandler {
         provider.add("behaviour.soft_hammer.enabled", "Working Enabled");
         provider.add("behaviour.soft_hammer.disabled", "Working Disabled");
         provider.add("behaviour.soft_hammer.disabled_cycle", "Working Disabled after current cycle");
+        provider.add("behaviour.soft_hammer.ignored", "Machine cannot be disabled");
         provider.add("behaviour.lighter.tooltip.description", "Can light things on fire");
         provider.add("behaviour.lighter.tooltip.usage", "Shift-right click to open/close");
         provider.add("behaviour.lighter.fluid.tooltip", "Can light things on fire with Butane or Propane");


### PR DESCRIPTION
## What
#4912 is actually intended behavior (boilers cannot be disabled with soft mallets). However, this is not said in game and it just looks like the mallet doesn't work.

So now the mallet warns you that it doesn't work on boilers.

### Implementation Details
InteractionResult.FAIL caused the message to double-print so I reused .SidedSuccess()

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.
  
## Outcome
<img width="856" height="512" alt="image" src="https://github.com/user-attachments/assets/c8a8d19e-abd0-43eb-90aa-2de4bb2bcba8" />

