### PR TITLE
Fix incorrect `WAYPOINT_BACKGROUNDS` reference to `WAYPOINTS`

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/ore/OreVeinElementRenderProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/minimap/ore/OreVeinElementRenderProvider.java
@@ -22,7 +22,7 @@ public class OreVeinElementRenderProvider extends MinimapElementRenderProvider<O
     @Override
     public void begin(MinimapElementRenderLocation location, OreVeinElementContext context) {
         if (WorldMap.INSTANCE.getConfigs().getClientConfigManager().getEffective(
-                WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS)) {
+                WorldMapProfiledConfigOptions.WAYPOINTS)) {
             ResourceKey<Level> currentDim = Minecraft.getInstance().level.dimension();
             this.iterator = XaerosRenderer.oreElements.row(currentDim).values().iterator();
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/map/xaeros/worldmap/ore/OreVeinElementRenderProvider.java
@@ -20,7 +20,7 @@ public class OreVeinElementRenderProvider extends MapElementRenderProvider<OreVe
 
     public void begin(int location, OreVeinElementContext context) {
         if (WorldMap.INSTANCE.getConfigs().getClientConfigManager().getEffective(
-                WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS)) {
+                WorldMapProfiledConfigOptions.WAYPOINTS)) {
             ResourceKey<Level> currentDim = Minecraft.getInstance().level.dimension();
             this.iterator = XaerosRenderer.oreElements.row(currentDim).values()
                     .stream()


### PR DESCRIPTION
## What

fix a bug about https://github.com/GregTechCEu/GregTech-Modern/pull/4685
where `WorldMap.settings.waypoints` was mistakenly replaced with `WorldMap.INSTANCE.getConfigs().getClientConfigManager().getEffective(WorldMapProfiledConfigOptions.WAYPOINT_BACKGROUNDS)`

## Implementation Details

change `WAYPOINT_BACKGROUNDS` back to `WAYPOINTS`

### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## How Was This Tested

I tested it in the game and it behaved as expected.

## Other info

I think 1.21 ver. has the same problem (see https://github.com/GregTechCEu/GregTech-Modern/pull/4642)