### PR TITLE
Fix /gtceu share_prospection_data command

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/commands/GTClientCommands.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/commands/GTClientCommands.java
@@ -1,62 +1,13 @@
 package com.gregtechceu.gtceu.common.commands;
 
-import com.gregtechceu.gtceu.common.network.GTNetwork;
-import com.gregtechceu.gtceu.common.network.packets.SCPacketShareProspection;
-import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
-
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.arguments.EntityArgument;
-import net.minecraft.world.entity.player.Player;
 
 import com.mojang.brigadier.CommandDispatcher;
-
-import java.util.List;
-import java.util.UUID;
 
 import static net.minecraft.commands.Commands.*;
 
 public class GTClientCommands {
 
-    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext buildContext) {
-        dispatcher.register(literal("gtceu")
-                .then(literal("share_prospection_data")
-                        .then(argument("player", EntityArgument.player())
-                                .executes(ctx -> {
-                                    Player player = EntityArgument.getPlayer(ctx, "player");
-                                    Thread sendThread = new Thread(new ProspectingShareTask(
-                                            ctx.getSource().getPlayerOrException().getUUID(), player.getUUID()));
-                                    sendThread.start();
-                                    return 1;
-                                }))));
-    }
-
-    private static class ProspectingShareTask implements Runnable {
-
-        private final List<ClientCacheManager.ProspectionInfo> prospectionData;
-        private final UUID sender;
-        private final UUID receiver;
-
-        public ProspectingShareTask(UUID sender, UUID receiver) {
-            prospectionData = ClientCacheManager.getProspectionShareData();
-            this.sender = sender;
-            this.receiver = receiver;
-        }
-
-        @Override
-        public void run() {
-            boolean first = true;
-            for (ClientCacheManager.ProspectionInfo info : prospectionData) {
-                GTNetwork.sendToServer(new SCPacketShareProspection(sender, receiver, info.cacheName, info.key,
-                        info.isDimCache, info.dim, info.data, first));
-                first = false;
-
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-    }
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext buildContext) {}
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/commands/GTCommands.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/commands/GTCommands.java
@@ -12,10 +12,13 @@ import com.gregtechceu.gtceu.api.gui.factory.GTUIEditorFactory;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.registry.GTRegistry;
 import com.gregtechceu.gtceu.common.commands.arguments.GTRegistryArgument;
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.common.network.packets.SCPacketShareProspection;
 import com.gregtechceu.gtceu.data.loader.BedrockFluidLoader;
 import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.GTOreLoader;
 import com.gregtechceu.gtceu.data.pack.GTDynamicDataPack;
+import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
 
 import net.minecraft.commands.*;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -28,6 +31,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.BulkSectionAccess;
 import net.minecraft.world.level.levelgen.structure.templatesystem.AlwaysTrueTest;
@@ -162,7 +166,16 @@ public class GTCommands {
                                                 .executes(ctx -> {
                                                     ServerPlayer player = ctx.getSource().getPlayerOrException();
                                                     return setActiveCape(ctx.getSource(), player, null);
-                                                })))));
+                                                }))))
+                        .then(literal("share_prospection_data")
+                                .then(argument("player", EntityArgument.player())
+                                        .executes(ctx -> {
+                                            Player player = EntityArgument.getPlayer(ctx, "player");
+                                            Thread sendThread = new Thread(new GTCommands.ProspectingShareTask(
+                                                    ctx.getSource().getPlayerOrException().getUUID(), player.getUUID()));
+                                            sendThread.start();
+                                            return 1;
+                                        }))));
     }
     // spotless:on
 
@@ -339,5 +352,34 @@ public class GTCommands {
         }
 
         return 1;
+    }
+
+    private static class ProspectingShareTask implements Runnable {
+
+        private final List<ClientCacheManager.ProspectionInfo> prospectionData;
+        private final UUID sender;
+        private final UUID receiver;
+
+        public ProspectingShareTask(UUID sender, UUID receiver) {
+            prospectionData = ClientCacheManager.getProspectionShareData();
+            this.sender = sender;
+            this.receiver = receiver;
+        }
+
+        @Override
+        public void run() {
+            boolean first = true;
+            for (ClientCacheManager.ProspectionInfo info : prospectionData) {
+                GTNetwork.sendToServer(new SCPacketShareProspection(sender, receiver, info.cacheName, info.key,
+                        info.isDimCache, info.dim, info.data, first));
+                first = false;
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What
The `share_prospection_data` command is supposed to share map prospecting data with another player. Unfortunately, it never worked correctly because it was implemented as a client-only command when it should be a server command (since it needs to reference the server player list).

## Implementation Details
Moved the call from GTClientCommands to GTCommands. No other changes.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.
  
## Outcome
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/5459f3a4-caec-4d07-89b0-36fa2cd67969" />

## How Was This Tested
Ran the command in dev targeting myself to make sure it didn't error, then built an obfuscated copy of the .jar, hosted a LAN world with my wife, ran the command targeting her, and watched the map data populate on her side. Screenshot from her side above. (The chat message appears twice because I ran the command twice to verify.)
