### PR TITLE
Fix custom recipe category icons in EMI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/CategoryIcon.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/recipeviewer/CategoryIcon.java
@@ -47,7 +47,7 @@ public class CategoryIcon {
     private static class EmiCallWrapper {
 
         public static EmiRenderable getRenderable(ResourceLocation location) {
-            return new EmiTexture(location, 0, 0, 16, 16);
+            return new EmiTexture(location, 0, 0, 16, 16, 16, 16, 16, 16);
         }
 
         public static EmiRenderable getRenderable(ItemStack stack) {


### PR DESCRIPTION
## What
EMI category icons didnt work because it only rendered a slice of the image (it assumed 256px big texture instead of 16px).

### AI Usage 

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.


#### Agent Used
Opus 4.8

#### Agent Usage Description
I asked it to find the bug, it did and fixed it, I checked and the reasoning and code makes sense 
  
## Outcome
<img width="412" height="372" alt="image" src="https://github.com/user-attachments/assets/cc119736-a1b7-402a-b511-f407fe2af9a9" />
