### PR TITLE
Show electric item charge in EMI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/IGTTool.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/IGTTool.java
@@ -80,6 +80,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.gregtechceu.gtceu.api.item.tool.ToolHelper.*;
+import static com.gregtechceu.gtceu.data.recipe.generated.ToolRecipeHandler.powerUnitItems;
 import static net.minecraft.world.item.Item.BASE_ATTACK_DAMAGE_UUID;
 import static net.minecraft.world.item.Item.BASE_ATTACK_SPEED_UUID;
 
@@ -661,6 +662,18 @@ public interface IGTTool extends HeldItemUIFactory.IHeldItemUIHolder, ItemLike, 
 
     default void definition$fillItemCategory(CreativeModeTab category, @NotNull NonNullList<ItemStack> items) {
         if (isElectric()) {
+            int tier = getElectricTier();
+            if (!powerUnitItems.containsKey(tier)) {
+                items.add(get(Integer.MAX_VALUE));
+                return;
+            }
+            var components = ((ComponentItem) powerUnitItems.get(tier).asItem()).getComponents();
+            for (var component : components) {
+                if (component instanceof ElectricStats electricStats) {
+                    items.add(get(electricStats.maxCharge));
+                    return;
+                }
+            }
             items.add(get(Integer.MAX_VALUE));
         } else {
             items.add(get());


### PR DESCRIPTION
## What
See title and outcome

## Implementation Details
I think this is implemented in a way that it shouldn't break anything, and just returns the default value if it cant find anything

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Fable 5

#### Agent Usage Description
Asked it to find where this was defined, thinking it was a bug. it was just a hardcoded value

  
## Outcome
before:
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/a6f1804f-637b-4416-bd55-b1f2dc9652b1" />

after:
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/4a74b846-9e4b-4b35-a477-8b56aadc6f07" />

