### PR TITLE
Fix configurable maintenance hatches crashes with 1 tick recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMaintenanceMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IMaintenanceMachine.java
@@ -143,7 +143,7 @@ public interface IMaintenanceMachine extends IMultiPart {
             var durationMultiplier = getDurationMultiplier();
             if (durationMultiplier != 1) {
                 recipe = recipe.copy();
-                recipe.duration = (int) (recipe.duration * durationMultiplier);
+                recipe.duration = Math.max(1, Math.round(recipe.duration * durationMultiplier));
             }
         }
         return recipe;


### PR DESCRIPTION
## What
Configurable maintenance hatches crash the game with 1 tick recipes.

## Implementation Details
Basically just changed the math to round instead of flooring, and making sure 1 is always the minimum duration it can be.

### AI Usage 

- [X] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## How Was This Tested
Tested by users in the latest version of Star Technology, because it's already applied in the GTM fork of said modpack.

## Additional Information
This is an example crash report caused by this issue https://mclo.gs/UxO4BRO