### PR TITLE
Category viewing in primitive machines

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CokeOvenMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CokeOvenMachine.java
@@ -4,14 +4,17 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.machine.feature.IMuiMachine;
 import com.gregtechceu.gtceu.api.machine.mui.MachineUIPanelBuilder;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.ExtendedUseOnContext;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
@@ -19,6 +22,8 @@ import net.minecraft.world.InteractionResult;
 import net.minecraftforge.fluids.FluidUtil;
 
 import brachy.modularui.api.ITheme;
+import brachy.modularui.api.drawable.Text;
+import brachy.modularui.api.widget.IGuiAction;
 import brachy.modularui.drawable.progress.ProgressDrawable;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
@@ -63,17 +68,26 @@ public class CokeOvenMachine extends PrimitiveWorkableMachine implements IMuiMac
 
         Flow row = Flow.row().coverChildren();
 
+        var progressWidget = new ProgressWidget()
+                .value(progressPercent)
+                .size(20, 20)
+                .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)
+                .margin(4, 0)
+                .tooltip(r -> r.add(Text.comp(Component.translatable("gtceu.recipe_type.show_recipes"))));
+
+        progressWidget.listenGuiAction((IGuiAction.MousePressed) (guiContext, i) -> {
+            if (!guiContext.isMouseAbove(progressWidget)) return false;
+            if (!GTRecipeTypes.COKE_OVEN_RECIPES.getCategory().isXEIVisible()) return false;
+            GTUtil.openRecipeViewerCategory(GTRecipeTypes.COKE_OVEN_RECIPES.getCategory());
+            return true;
+        });
+
         row.child(new ItemSlot().syncHandler(new ItemSlotSyncHandler(
                 new ModularSlot(importItems.storage, 0)
                         .slotGroup(new SlotGroup("import_items", 1))))
                 .background(uiTheme.getItemSlotTheme().theme().getBackground(),
                         GTGuiTextures.PRIMITIVE_FURNACE_OVERLAY))
-                .child(new ProgressWidget()
-                        .value(progressPercent)
-                        .size(20, 15)
-                        .texture(GTGuiTextures.PRIMITIVE_BLAST_FURNACE_PROGRESS_BAR, ProgressDrawable.Direction.RIGHT)
-                        .margin(4, 0))
-
+                .child(progressWidget)
                 .child(new ItemSlot().syncHandler(new ItemSlotSyncHandler(
                         new ModularSlot(exportItems.storage, 0)
                                 .slotGroup(new SlotGroup("export_items", 1))

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveBlastFurnaceMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveBlastFurnaceMachine.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.pattern.util.RelativeDirection;
 import com.gregtechceu.gtceu.api.sync_system.annotations.RerenderOnChanged;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.common.machine.trait.multiblock.MultiblockFluidRendererTrait;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.config.ConfigHolder;
@@ -21,6 +22,7 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.RandomSource;
@@ -30,6 +32,8 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import brachy.modularui.api.ITheme;
+import brachy.modularui.api.drawable.Text;
+import brachy.modularui.api.widget.IGuiAction;
 import brachy.modularui.drawable.progress.ProgressDrawable;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
@@ -155,12 +159,22 @@ public class PrimitiveBlastFurnaceMachine extends PrimitiveWorkableMachine imple
 
         var row = Flow.row().coverChildren().center();
 
+        var progressWidget = new ProgressWidget()
+                .value(progressPercent)
+                .size(20, 15)
+                .texture(GTGuiTextures.PRIMITIVE_BLAST_FURNACE_PROGRESS_BAR, ProgressDrawable.Direction.RIGHT)
+                .margin(5, 5, 0, 0)
+                .tooltip(r -> r.add(Text.comp(Component.translatable("gtceu.recipe_type.show_recipes"))));
+
+        progressWidget.listenGuiAction((IGuiAction.MousePressed) (guiContext, i) -> {
+            if (!guiContext.isMouseAbove(progressWidget)) return false;
+            if (!GTRecipeTypes.PRIMITIVE_BLAST_FURNACE_RECIPES.getCategory().isXEIVisible()) return false;
+            GTUtil.openRecipeViewerCategory(GTRecipeTypes.PRIMITIVE_BLAST_FURNACE_RECIPES.getCategory());
+            return true;
+        });
+
         row.child(createImportItemSlot(syncManager, theme))
-                .child(new ProgressWidget()
-                        .value(progressPercent)
-                        .size(20, 15)
-                        .texture(GTGuiTextures.PRIMITIVE_BLAST_FURNACE_PROGRESS_BAR, ProgressDrawable.Direction.RIGHT)
-                        .margin(5, 5, 0, 0))
+                .child(progressWidget)
                 .child(createExportItemSlot(syncManager, theme));
 
         mainWidget.child(row);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeEnergyContainerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeEnergyContainerMachine.java
@@ -209,10 +209,11 @@ public class CreativeEnergyContainerMachine extends TieredMachine
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
         // syncing
-        LongSyncValue voltage = new LongSyncValue(() -> this.voltage, (v) -> this.voltage = v);
-        IntSyncValue amps = new IntSyncValue(() -> this.amps, (a) -> this.amps = Math.max(a, 1));
-        IntSyncValue tier = new IntSyncValue(() -> this.tier, (t) -> this.setTier = t);
-        BooleanSyncValue sourceSync = new BooleanSyncValue(() -> this.source, (b) -> this.source = b);
+        LongSyncValue voltage = new LongSyncValue(() -> this.voltage, (v) -> this.voltage = v).allowC2S();
+        IntSyncValue amps = new IntSyncValue(() -> this.amps, (a) -> this.amps = Math.max(a, 1)).allowC2S();
+        IntSyncValue tier = new IntSyncValue(() -> this.tier, (t) -> this.setTier = t).allowC2S();
+        BooleanSyncValue sourceSync = new BooleanSyncValue(() -> this.source, (b) -> this.source = b).allowC2S();
+        BooleanSyncValue sinkSync = new BooleanSyncValue(() -> !this.source, (b) -> this.source = !b).allowC2S();
         syncManager.syncValue("tier", tier);
 
         IPanelHandler panelSyncHandler = syncManager.syncedPanel("voltage popup", false,
@@ -228,7 +229,7 @@ public class CreativeEnergyContainerMachine extends TieredMachine
                         .child(createAmpRow(amps))
                         .child(new Rectangle().color(0xFF555555).asWidget()
                                 .height(1).widthRel(0.95f).marginBottom(4).marginTop(4))
-                        .child(createSourceSelector(sourceSync)));
+                        .child(createSourceSelector(sourceSync, sinkSync)));
     }
 
     private Flow createVoltageRow(IPanelHandler panel, LongSyncValue voltage) {
@@ -306,12 +307,12 @@ public class CreativeEnergyContainerMachine extends TieredMachine
                         .marginLeft(4));
     }
 
-    private Flow createSourceSelector(BooleanSyncValue sourceSync) {
+    private Flow createSourceSelector(BooleanSyncValue sourceSync, BooleanSyncValue sinkSync) {
         return Flow.column()
                 .coverChildrenHeight()
                 .child(Flow.row()
                         .coverChildrenHeight()
-                        .name("button")
+                        .name("source")
                         .childPadding(2)
                         .child(new ToggleButton()
                                 .overlay(new DynamicDrawable(() -> {
@@ -325,17 +326,17 @@ public class CreativeEnergyContainerMachine extends TieredMachine
                         .paddingBottom(2))
                 .child(Flow.row()
                         .coverChildrenHeight()
-                        .name("button")
+                        .name("sink")
                         .coverChildrenHeight()
                         .childPadding(2)
                         .child(new ToggleButton()
                                 .overlay(new DynamicDrawable(() -> {
-                                    if (!sourceSync.getValue()) {
+                                    if (sinkSync.getValue()) {
                                         return GuiTextures.CHECK_BOX.getSubArea(0, .5f, 1, 1f);
                                     }
                                     return IDrawable.EMPTY;
                                 }))
-                                .value(new BooleanSyncValue(() -> !source, bool -> source = !bool)))
+                                .value(sinkSync))
                         .child(Text.lang("gtceu.creative.energy.sink").asWidget()));
     }
 


### PR DESCRIPTION
## What
cleans up the progress widgets for coke oven and PBF, also fix the sync issues for creative energy machine

## Implementation Details
typing

**All machine code MUST be reviewed by the pull request submitter before opening. **

- [no ] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
cleaner?

## How Was This Tested
i opened the game
