### PR TITLE
Fix server crash from outputting Ranged Fluids into ME Output Hatches

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -147,7 +147,10 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
         List<FluidIngredient> ingredients = new ArrayList<>(outputContents.size());
         for (var content : outputContents) {
             var ing = this.of(content.content);
-            maxAmount = Math.max(maxAmount, ing.getAmount());
+            int amount;
+            if (ing instanceof IntProviderFluidIngredient provider) amount = provider.getCountProvider().getMaxValue();
+            else amount = ing.getAmount();
+            maxAmount = Math.max(maxAmount, amount);
             ingredients.add(ing);
         }
         if (maxAmount == 0) return multiplier;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableFluidTank;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
+import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.transfer.fluid.CustomFluidTank;
 import com.gregtechceu.gtceu.integration.ae2.gui.widget.list.AEListGridWidget;
@@ -162,15 +163,28 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine {
                     continue;
                 }
 
-                var fluids = ingredient.getStacks();
+                FluidStack[] fluids;
+                if (ingredient instanceof IntProviderFluidIngredient provider) {
+                    provider.setFluidStacks(null);
+                    provider.setSampledCount(-1);
+
+                    if (simulate) {
+                        fluids = new FluidStack[] { provider.getMaxSizeStack() };
+                    } else {
+                        fluids = provider.getStacks();
+                    }
+                } else {
+                    fluids = ingredient.getStacks();
+                }
                 if (fluids.length == 0 || fluids[0].isEmpty()) {
                     it.remove();
                     continue;
                 }
 
                 FluidStack output = fluids[0];
-                ingredient.shrink(storage.fill(output, action));
-                if (ingredient.getAmount() <= 0) it.remove();
+                int filled = storage.fill(output, action);
+                ingredient.shrink(filled);
+                if (filled <= 0) it.remove();
             }
             return left.isEmpty() ? null : left;
         }


### PR DESCRIPTION
## What
Fixes #4927

ME Output Hatches were inappropriately calling .getAmount() on a Ranged Fluid which isn't valid. However, the crash only occurs when the server is being run with the GTM Debug config set to `true` because otherwise that call just silently returns -1.

Unrelated to this (but found while testing the fix for this), FluidRecipeCapability.limitMaxParallelByOutput() was also inappropriately calling .getAmount(). So I fixed that as well.

## Implementation Details
Applies the same checks as are present in the standard NotifiableFluidTank.handleRecipeInner() for getting ranged fluids by max-value in simulate and roll-value in execute; and not directly calling getAmount() on the ingredient.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.
  
## Outcome
Crashn't

## How Was This Tested
SMP dev world with a machine outputting to ME hatches and a recipe with a ranged fluid output. Debug traced to watch as it called the inappropriate function. Rewrote the call to not call the inappropriate function.
While testing the actual fix, also encountered the second unrelated call to that function, and fixed it as well.
