### PR TITLE
Fixed KubeJS Oreveins breaking in Registration/Validation

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/ItemMaterialData.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.data.tags.TagsHandler;
 import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 import com.gregtechceu.gtceu.utils.memoization.MemoizedBlockSupplier;
 
+import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.tags.TagKey;
@@ -156,9 +157,11 @@ public class ItemMaterialData {
 
         // Load new data
         TagsHandler.initExtraUnificationEntries();
-        for (TagPrefix prefix : GTRegistries.TAG_PREFIXES) {
-            prefix.getIgnored().forEach((mat, items) -> registerMaterialEntries(items, prefix, mat));
-        }
+        GTRegistries.TAG_PREFIXES.holders()
+                .filter(h -> h != null && h.isBound())
+                .map(Holder::value)
+                .forEach(prefix -> prefix.getIgnored()
+                        .forEach((material, item) -> registerMaterialEntries(item, prefix, material)));
         GTMaterialItems.toUnify
                 .forEach((materialEntry, supplier) -> registerMaterialEntry(supplier, materialEntry));
         WoodMachineRecipes.registerMaterialInfo();

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/RecyclingRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/RecyclingRecipeHandler.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.data.recipe.misc.RecyclingRecipes;
 
+import net.minecraft.core.Holder;
 import net.minecraft.data.recipes.RecipeOutput;
 
 import org.jetbrains.annotations.NotNull;
@@ -27,11 +28,13 @@ public final class RecyclingRecipeHandler {
 
     public static void run(@NotNull RecipeOutput provider, @NotNull Material material) {
         // registers universal maceration recipes for specified ore prefixes
-        for (TagPrefix prefix : GTRegistries.TAG_PREFIXES) {
-            if (prefix.generateRecycling()) {
-                processCrushing(provider, prefix, material);
-            }
-        }
+        GTRegistries.TAG_PREFIXES.holders()
+                .filter(h -> h != null && h.isBound())
+                .map(Holder::value)
+                .filter(TagPrefix::generateRecycling)
+                .forEach(tagPrefix -> {
+                    processCrushing(provider, tagPrefix, material);
+                });
     }
 
     private static void processCrushing(@NotNull RecipeOutput provider, @NotNull TagPrefix prefix,

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -419,8 +419,12 @@ public class GregTechKubeJSPlugin implements KubeJSPlugin {
 
         registry.register(IWorldGenLayer.RuleTestSupplier.class, (cx, o, t) -> {
             if (o instanceof IWorldGenLayer.RuleTestSupplier supplier) return supplier;
+            if (o instanceof CharSequence) {
+                return () -> BlockStatePredicate.wrap(cx, o).asRuleTest();
+            } ;
             return () -> BlockStatePredicate.wrapRuleTest(cx, o);
         });
+
         registry.register(CraftingComponent.class, o -> {
             if (o instanceof CraftingComponent comp) return comp;
             if (o instanceof CharSequence str) return CraftingComponent.ALL_COMPONENTS.get(str.toString());

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilder.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.data.worldgen.generator.VeinGenerator;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.indicators.SurfaceIndicatorGenerator;
 import com.gregtechceu.gtceu.api.data.worldgen.generator.veins.*;
 
+import net.minecraft.core.HolderGetter;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -57,7 +58,7 @@ public class OreVeinDefinitionBuilder extends BuilderBase<GTOreDefinition> {
     @Nullable
     private VeinGenerator veinGenerator;
     @Setter
-    private List<IndicatorGenerator> indicatorGenerators;
+    private List<IndicatorGenerator> indicatorGenerators = new ArrayList<>();;
 
     public OreVeinDefinitionBuilder(ResourceLocation id) {
         super(id);
@@ -77,9 +78,20 @@ public class OreVeinDefinitionBuilder extends BuilderBase<GTOreDefinition> {
         return this;
     }
 
-    public OreVeinDefinitionBuilder dimensions(Collection<ResourceKey<Level>> dimensions) {
-        this.dimensionFilter = new HashSet<>(dimensions);
+    public OreVeinDefinitionBuilder dimensions(Collection<?> dimensions) {
+        Set<ResourceKey<Level>> keys = new HashSet<>();
+        for (Object dim : dimensions) {
+            keys.add(wrapDimension(dim));
+        }
+        this.dimensionFilter = keys;
         return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ResourceKey<Level> wrapDimension(Object dim) {
+        if (dim instanceof ResourceKey<?> key) return (ResourceKey<Level>) key;
+        if (dim instanceof ResourceLocation rl) return ResourceKey.create(Registries.DIMENSION, rl);
+        return ResourceKey.create(Registries.DIMENSION, ResourceLocation.parse(dim.toString()));
     }
 
     public OreVeinDefinitionBuilder heightRangeUniform(int min, int max) {
@@ -213,9 +225,14 @@ public class OreVeinDefinitionBuilder extends BuilderBase<GTOreDefinition> {
     @SuppressWarnings("UnstableApiUsage")
     @Override
     public GTOreDefinition createObject() {
+        var registries = RegistryAccessContainer.current;
+        HolderGetter<Biome> biomeParse = registries == null ? null :
+                registries.access().lookupOrThrow(Registries.BIOME);
         return new GTOreDefinition(clusterSize, density, weight, layer,
                 Set.copyOf(dimensionFilter), heightRange, discardChanceOnAirExposure,
-                biomes, biomeWeightModifier, veinGenerator, indicatorGenerators,
-                RegistryAccessContainer.current.access().lookupOrThrow(Registries.BIOME));
+                biomes == null ? HolderSet.empty() : biomes,
+                biomeWeightModifier == null ? BiomeWeightModifier.EMPTY : biomeWeightModifier,
+                veinGenerator, indicatorGenerators,
+                biomeParse);
     }
 }


### PR DESCRIPTION
## What
As it says on the tin, fixed oregen where there was weak guards on relevant code.

## Implementation Details
Fixed up the for loop in ItemMaterialData#ReinitalizeMaterialData to now be a stream on the relevant holders and filtering null/bound entries. did the same case for a RecipeHandler that used similar code
Added extra handling for reslocs into resource keys in OreVeinDefinitionBuilder#dimensions
Added a instanceOf check for CharSequences in the IWorldgenlayer registration.



### AI Usage 
- [ x ] Yes AI driven tools were used for this pull request.
#### Agent Used
Claude Opus 4.8 
#### Agent Usage Description
Allowed it to parse multiple stacktraces from crashes to identify hard to notice failure points, aiding in debugging
Allowed it to read through our registration pipeline and identify potential weakpoints that could have been causing our worldgen issues. The changes made above are the 3 I found to actual impact anything. 
tldr; assistive debugger
  
## Outcome
Oregen with KubeJS works again on 1.21 after.... many months.

## How Was This Tested
Tested every change and verified all errors resolve with kubeJS scripts, as well as tested with existing and fresh worlds, dynamically updating veins on the fly before reloading, etc.

Onion was also present with me the entire time I worked on this, he not only saw the code i wrote and gave feedback on what to do.

## Additional Information
:)
<img width="1842" height="1401" alt="image" src="https://github.com/user-attachments/assets/0d300523-a1b4-436a-b069-f2a2fc6543aa" />
