### PR TITLE
Fix the GTCEu EMI plugin failing to initialize on dedicated servers

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/customlogic/BreweryLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/customlogic/BreweryLogic.java
@@ -338,10 +338,10 @@ public enum BreweryLogic implements GTRecipeType.ICustomRecipeLogic {
     }
 
     private static PotionBrewing getPotionBrewing() {
-        if (GTCEu.isClientThread()) {
-            return Minecraft.getInstance().getConnection().potionBrewing();
-        } else {
+        if (GTCEu.getMinecraftServer() != null) {
             return GTCEu.getMinecraftServer().potionBrewing();
+        } else {
+            return Minecraft.getInstance().getConnection().potionBrewing();
         }
     }
 }


### PR DESCRIPTION
## What
This check is 1.21 specific, it is not present in 1.20.1, checked the branch.
When connected to a dedicated server, in `BreweryLogic#getPotionBrewing()`, the `GTCEu.isClientThread()` check falls through, and `GTCEu.getMinecraftServer()` gets called, which returns null, because the client is not connected to an internal server.

## Implementation Details
The check has been rewritten to check if `GTCEu.getMinecraftServer()` is not null, and if it is, runs the client side check.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
  
## Outcome
Players or people testing out the 1.21 branch can see recipes when testing on a dedicated server.

## How Was This Tested
Ran a dedicated server with just GT; then after observing the issue on the client, made this change, put the fixed jar on both the server and client, and observed the EMI plugin initializing correctly.