### PR TITLE
Change some registries to use resource locations, and move some static maps to be registries

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/addon/IGTAddon.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/IGTAddon.java
@@ -34,6 +34,7 @@ public interface IGTAddon {
 
     /**
      * Call init on your custom TagPrefix class(es) here
+     * 
      * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<String, TagPrefix>} register event instead
      */
     @Deprecated(forRemoval = true, since = "8.0.0")
@@ -41,6 +42,7 @@ public interface IGTAddon {
 
     /**
      * Call init on your custom Element class(es) here
+     * 
      * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, Element>} register event instead
      */
     @Deprecated(forRemoval = true, since = "8.0.0")
@@ -48,6 +50,7 @@ public interface IGTAddon {
 
     /**
      * Call init on your custom Sound class(es) here
+     * 
      * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, SoundEntry>} register event instead
      */
     @Deprecated(forRemoval = true, since = "8.0.0")
@@ -55,14 +58,18 @@ public interface IGTAddon {
 
     /**
      * Call init on your custom Cover class(es) here
-     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, CoverDefinition>} register event instead
+     * 
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, CoverDefinition>} register event
+     *             instead
      */
     @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerCovers() {}
 
     /**
      * Call init on your custom Recipe Capabilities here
-     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, RecipeCapability>} register event instead
+     * 
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, RecipeCapability>} register event
+     *             instead
      */
     @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerRecipeCapabilities() {}
@@ -104,6 +111,7 @@ public interface IGTAddon {
 
     /**
      * Register Material -> Casing block mappings here
+     * 
      * @deprecated Subscribe to the {@link MaterialCasingCollectionEvent} directly.
      */
     @Deprecated(forRemoval = true, since = "8.0.0")

--- a/src/main/java/com/gregtechceu/gtceu/api/addon/IGTAddon.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/IGTAddon.java
@@ -35,7 +35,7 @@ public interface IGTAddon {
     /**
      * Call init on your custom TagPrefix class(es) here
      * 
-     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<String, TagPrefix>} register event instead
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, TagPrefix>} register event instead
      */
     @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerTagPrefixes() {}

--- a/src/main/java/com/gregtechceu/gtceu/api/addon/IGTAddon.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/IGTAddon.java
@@ -34,27 +34,37 @@ public interface IGTAddon {
 
     /**
      * Call init on your custom TagPrefix class(es) here
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<String, TagPrefix>} register event instead
      */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerTagPrefixes() {}
 
     /**
      * Call init on your custom Element class(es) here
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, Element>} register event instead
      */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerElements() {}
 
     /**
      * Call init on your custom Sound class(es) here
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, SoundEntry>} register event instead
      */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerSounds() {}
 
     /**
      * Call init on your custom Cover class(es) here
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, CoverDefinition>} register event instead
      */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerCovers() {}
 
     /**
      * Call init on your custom Recipe Capabilities here
+     * @deprecated Subscribe to the {@code GTCEuAPI.RegisterEvent<ResourceLocation, RecipeCapability>} register event instead
      */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerRecipeCapabilities() {}
 
     /**
@@ -94,9 +104,15 @@ public interface IGTAddon {
 
     /**
      * Register Material -> Casing block mappings here
+     * @deprecated Subscribe to the {@link MaterialCasingCollectionEvent} directly.
      */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void collectMaterialCasings(MaterialCasingCollectionEvent event) {}
 
+    /**
+     * @deprecated Subscribe to the {@link KJSRecipeKeyEvent} directly.
+     */
+    @Deprecated(forRemoval = true, since = "8.0.0")
     default void registerRecipeKeys(KJSRecipeKeyEvent event) {}
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/addon/events/KJSRecipeKeyEvent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/events/KJSRecipeKeyEvent.java
@@ -4,10 +4,11 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.ContentJS;
 import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponents;
 
-import com.mojang.datafixers.util.Pair;
-import lombok.Getter;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.event.IModBusEvent;
+
+import com.mojang.datafixers.util.Pair;
+import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/gregtechceu/gtceu/api/addon/events/KJSRecipeKeyEvent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/events/KJSRecipeKeyEvent.java
@@ -6,12 +6,14 @@ import com.gregtechceu.gtceu.integration.kjs.recipe.components.GTRecipeComponent
 
 import com.mojang.datafixers.util.Pair;
 import lombok.Getter;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @SuppressWarnings("unused")
-public class KJSRecipeKeyEvent {
+public class KJSRecipeKeyEvent extends Event implements IModBusEvent {
 
     @Getter
     private final Map<RecipeCapability<?>, Pair<ContentJS<?>, ContentJS<?>>> registeredKeys = new HashMap<>();

--- a/src/main/java/com/gregtechceu/gtceu/api/addon/events/MaterialCasingCollectionEvent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/events/MaterialCasingCollectionEvent.java
@@ -3,11 +3,11 @@ package com.gregtechceu.gtceu.api.addon.events;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 
 import net.minecraft.world.level.block.Block;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
 
 import com.google.common.collect.ImmutableMap;
 import com.tterrag.registrate.util.entry.BlockEntry;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.fml.event.IModBusEvent;
 
 public class MaterialCasingCollectionEvent extends Event implements IModBusEvent {
 

--- a/src/main/java/com/gregtechceu/gtceu/api/addon/events/MaterialCasingCollectionEvent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/addon/events/MaterialCasingCollectionEvent.java
@@ -6,8 +6,10 @@ import net.minecraft.world.level.block.Block;
 
 import com.google.common.collect.ImmutableMap;
 import com.tterrag.registrate.util.entry.BlockEntry;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.fml.event.IModBusEvent;
 
-public class MaterialCasingCollectionEvent {
+public class MaterialCasingCollectionEvent extends Event implements IModBusEvent {
 
     private final ImmutableMap.Builder<Material, BlockEntry<Block>> builder;
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
@@ -125,11 +125,10 @@ public class MaterialIconSet {
             throw new IllegalArgumentException("MaterialIconSet id cannot have '/' %s".formatted(id));
 
         this.name = id.getPath();
-
-        GTRegistries.MATERIAL_ICON_SETS.register(this.id, this);
-
         this.isRootIconset = isRootIconset;
         this.parentIconset = parentIconset;
+
+        GTRegistries.MATERIAL_ICON_SETS.register(this.id, this);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
@@ -1,9 +1,13 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.info;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
+import com.gregtechceu.gtceu.api.data.chemical.Element;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 
 import com.google.common.base.Preconditions;
+import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +17,10 @@ import java.util.Map;
 
 public class MaterialIconSet {
 
-    public static final Map<String, MaterialIconSet> ICON_SETS = new HashMap<>();
+    static {
+        GTRegistries.MATERIAL_ICON_SETS.unfreeze();
+    }
+
     public static final MaterialIconSet DULL = new MaterialIconSet("dull", null, true);
     public static final MaterialIconSet METALLIC = new MaterialIconSet("metallic");
     public static final MaterialIconSet MAGNETIC = new MaterialIconSet("magnetic", METALLIC);
@@ -80,16 +87,20 @@ public class MaterialIconSet {
      */
     public MaterialIconSet(@NotNull String name, @Nullable MaterialIconSet parentIconset, boolean isRootIconset) {
         this.name = name.toLowerCase(Locale.ENGLISH);
-        Preconditions.checkArgument(!ICON_SETS.containsKey(this.name),
-                "MaterialIconSet " + this.name + " already registered!");
+
+        GTRegistries.MATERIAL_ICON_SETS.register(this.name, this);
+
         this.id = idCounter++;
         this.isRootIconset = isRootIconset;
         this.parentIconset = parentIconset;
-        ICON_SETS.put(this.name, this);
     }
 
+    /**
+     * @deprecated Use {@code GTRegistries.MATERIAL_ICON_SETS.get()}
+     */
+    @Deprecated(since = "8.0.0")
     public static MaterialIconSet getByName(@NotNull String name) {
-        return ICON_SETS.get(name.toLowerCase(Locale.ENGLISH));
+        return GTRegistries.MATERIAL_ICON_SETS.get(name.toLowerCase(Locale.ENGLISH));
     }
 
     @Override
@@ -98,8 +109,10 @@ public class MaterialIconSet {
     }
 
     public static void init() {
+        ModLoader.get().postEvent(new GTCEuAPI.RegisterEvent<>(GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class));
         if (GTCEu.Mods.isKubeJSLoaded()) {
-            GTRegistryInfo.registerFor(GTRegistryInfo.MATERIAL_ICON_SET.registryKey);
+            GTRegistryInfo.registerFor(GTRegistries.MATERIAL_ICON_SETS.getRegistryName());
         }
+        GTRegistries.MATERIAL_ICON_SETS.freeze();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
@@ -2,18 +2,13 @@ package com.gregtechceu.gtceu.api.data.chemical.material.info;
 
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
-import com.gregtechceu.gtceu.api.data.chemical.Element;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 
-import com.google.common.base.Preconditions;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
 
 public class MaterialIconSet {
 
@@ -21,76 +16,112 @@ public class MaterialIconSet {
         GTRegistries.MATERIAL_ICON_SETS.unfreeze();
     }
 
-    public static final MaterialIconSet DULL = new MaterialIconSet("dull", null, true);
-    public static final MaterialIconSet METALLIC = new MaterialIconSet("metallic");
-    public static final MaterialIconSet MAGNETIC = new MaterialIconSet("magnetic", METALLIC);
-    public static final MaterialIconSet SHINY = new MaterialIconSet("shiny", METALLIC);
-    public static final MaterialIconSet BRIGHT = new MaterialIconSet("bright", SHINY);
-    public static final MaterialIconSet DIAMOND = new MaterialIconSet("diamond", SHINY);
-    public static final MaterialIconSet EMERALD = new MaterialIconSet("emerald", DIAMOND);
-    public static final MaterialIconSet GEM_HORIZONTAL = new MaterialIconSet("gem_horizontal", EMERALD);
-    public static final MaterialIconSet GEM_VERTICAL = new MaterialIconSet("gem_vertical", EMERALD);
-    public static final MaterialIconSet RUBY = new MaterialIconSet("ruby", EMERALD);
-    public static final MaterialIconSet OPAL = new MaterialIconSet("opal", RUBY);
-    public static final MaterialIconSet GLASS = new MaterialIconSet("glass", RUBY);
-    public static final MaterialIconSet NETHERSTAR = new MaterialIconSet("netherstar", GLASS);
-    public static final MaterialIconSet FINE = new MaterialIconSet("fine");
-    public static final MaterialIconSet SAND = new MaterialIconSet("sand", FINE);
-    public static final MaterialIconSet WOOD = new MaterialIconSet("wood", FINE);
-    public static final MaterialIconSet ROUGH = new MaterialIconSet("rough", FINE);
-    public static final MaterialIconSet FLINT = new MaterialIconSet("flint", ROUGH);
-    public static final MaterialIconSet LIGNITE = new MaterialIconSet("lignite", ROUGH);
-    public static final MaterialIconSet QUARTZ = new MaterialIconSet("quartz", ROUGH);
-    public static final MaterialIconSet CERTUS = new MaterialIconSet("certus", QUARTZ);
-    public static final MaterialIconSet LAPIS = new MaterialIconSet("lapis", QUARTZ);
-    public static final MaterialIconSet FLUID = new MaterialIconSet("fluid");
-    public static final MaterialIconSet RADIOACTIVE = new MaterialIconSet("radioactive", METALLIC);
+    public static final MaterialIconSet DULL = new MaterialIconSet(GTCEu.id("dull"), null, true);
+    public static final MaterialIconSet METALLIC = new MaterialIconSet(GTCEu.id("metallic"));
+    public static final MaterialIconSet MAGNETIC = new MaterialIconSet(GTCEu.id("magnetic"), METALLIC);
+    public static final MaterialIconSet SHINY = new MaterialIconSet(GTCEu.id("shiny"), METALLIC);
+    public static final MaterialIconSet BRIGHT = new MaterialIconSet(GTCEu.id("bright"), SHINY);
+    public static final MaterialIconSet DIAMOND = new MaterialIconSet(GTCEu.id("diamond"), SHINY);
+    public static final MaterialIconSet EMERALD = new MaterialIconSet(GTCEu.id("emerald"), DIAMOND);
+    public static final MaterialIconSet GEM_HORIZONTAL = new MaterialIconSet(GTCEu.id("gem_horizontal"), EMERALD);
+    public static final MaterialIconSet GEM_VERTICAL = new MaterialIconSet(GTCEu.id("gem_vertical"), EMERALD);
+    public static final MaterialIconSet RUBY = new MaterialIconSet(GTCEu.id("ruby"), EMERALD);
+    public static final MaterialIconSet OPAL = new MaterialIconSet(GTCEu.id("opal"), RUBY);
+    public static final MaterialIconSet GLASS = new MaterialIconSet(GTCEu.id("glass"), RUBY);
+    public static final MaterialIconSet NETHERSTAR = new MaterialIconSet(GTCEu.id("netherstar"), GLASS);
+    public static final MaterialIconSet FINE = new MaterialIconSet(GTCEu.id("fine"));
+    public static final MaterialIconSet SAND = new MaterialIconSet(GTCEu.id("sand"), FINE);
+    public static final MaterialIconSet WOOD = new MaterialIconSet(GTCEu.id("wood"), FINE);
+    public static final MaterialIconSet ROUGH = new MaterialIconSet(GTCEu.id("rough"), FINE);
+    public static final MaterialIconSet FLINT = new MaterialIconSet(GTCEu.id("flint"), ROUGH);
+    public static final MaterialIconSet LIGNITE = new MaterialIconSet(GTCEu.id("lignite"), ROUGH);
+    public static final MaterialIconSet QUARTZ = new MaterialIconSet(GTCEu.id("quartz"), ROUGH);
+    public static final MaterialIconSet CERTUS = new MaterialIconSet(GTCEu.id("certus"), QUARTZ);
+    public static final MaterialIconSet LAPIS = new MaterialIconSet(GTCEu.id("lapis"), QUARTZ);
+    public static final MaterialIconSet FLUID = new MaterialIconSet(GTCEu.id("fluid"));
+    public static final MaterialIconSet RADIOACTIVE = new MaterialIconSet(GTCEu.id("radioactive"), METALLIC);
 
     // Implementation -----------------------------------------------------------------------------------------------
 
-    private static int idCounter = 0;
+    public final ResourceLocation id;
     public final String name;
-    public final int id;
     public final boolean isRootIconset;
 
     /**
      * This can be null if {@link MaterialIconSet#isRootIconset} is true,
      * otherwise it will be Nonnull
      */
+    @Nullable
     public final MaterialIconSet parentIconset;
 
     /**
      * Create a new MaterialIconSet whose parent is {@link MaterialIconSet#DULL}
-     *
+     * @deprecated Use {@link MaterialIconSet#MaterialIconSet(ResourceLocation)} instead
      * @param name the name of the iconset
      */
+    @Deprecated(since = "8.0.0")
     public MaterialIconSet(@NotNull String name) {
         this(name, MaterialIconSet.DULL);
     }
 
     /**
      * Create a new MaterialIconSet whose parent is one of your choosing
-     *
+     * @deprecated Use {@link MaterialIconSet#MaterialIconSet(ResourceLocation, MaterialIconSet)} instead
      * @param name          the name of the iconset
      * @param parentIconset the parent iconset
      */
+    @Deprecated(since = "8.0.0")
     public MaterialIconSet(@NotNull String name, @NotNull MaterialIconSet parentIconset) {
         this(name, parentIconset, false);
     }
 
     /**
      * Create a new MaterialIconSet which is a root
-     * 
+     * @deprecated Use {@link MaterialIconSet#MaterialIconSet(ResourceLocation, MaterialIconSet, boolean)} instead
      * @param name          the name of the iconset
      * @param parentIconset the parent iconset, should be null if this should be a root iconset
      * @param isRootIconset true if this should be a root iconset, otherwise false
      */
+    @Deprecated(since = "8.0.0")
     public MaterialIconSet(@NotNull String name, @Nullable MaterialIconSet parentIconset, boolean isRootIconset) {
-        this.name = name.toLowerCase(Locale.ENGLISH);
+        this(GTCEu.id(name), parentIconset, isRootIconset);
+    }
 
-        GTRegistries.MATERIAL_ICON_SETS.register(this.name, this);
+    /**
+     * Create a new MaterialIconSet whose parent is {@link MaterialIconSet#DULL}
+     *
+     * @param id the id of the iconset
+     */
+    public MaterialIconSet(@NotNull ResourceLocation id) {
+        this(id, MaterialIconSet.DULL);
+    }
 
-        this.id = idCounter++;
+    /**
+     * Create a new MaterialIconSet whose parent is one of your choosing
+     *
+     * @param id          the id of the iconset
+     * @param parentIconset the parent iconset
+     */
+    public MaterialIconSet(@NotNull ResourceLocation id, @NotNull MaterialIconSet parentIconset) {
+        this(id, parentIconset, false);
+    }
+
+    /**
+     * Create a new MaterialIconSet which is a root
+     *
+     * @param id          the id of the iconset
+     * @param parentIconset the parent iconset, should be null if this should be a root iconset
+     * @param isRootIconset true if this should be a root iconset, otherwise false
+     */
+    public MaterialIconSet(@NotNull ResourceLocation id, @Nullable MaterialIconSet parentIconset, boolean isRootIconset) {
+        this.id = id;
+
+        if (id.getPath().contains("/")) throw new IllegalArgumentException("MaterialIconSet id cannot have '/' %s".formatted(id));
+
+        this.name = id.getPath();
+
+        GTRegistries.MATERIAL_ICON_SETS.register(this.id, this);
+
         this.isRootIconset = isRootIconset;
         this.parentIconset = parentIconset;
     }
@@ -100,12 +131,16 @@ public class MaterialIconSet {
      */
     @Deprecated(since = "8.0.0")
     public static MaterialIconSet getByName(@NotNull String name) {
-        return GTRegistries.MATERIAL_ICON_SETS.get(name.toLowerCase(Locale.ENGLISH));
+        return GTRegistries.MATERIAL_ICON_SETS.get(GTCEu.id(name));
+    }
+
+    public String getName() {
+        return id.getPath();
     }
 
     @Override
     public String toString() {
-        return name;
+        return id.toString();
     }
 
     public static void init() {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconSet.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.ModLoader;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,6 +57,7 @@ public class MaterialIconSet {
 
     /**
      * Create a new MaterialIconSet whose parent is {@link MaterialIconSet#DULL}
+     * 
      * @deprecated Use {@link MaterialIconSet#MaterialIconSet(ResourceLocation)} instead
      * @param name the name of the iconset
      */
@@ -66,6 +68,7 @@ public class MaterialIconSet {
 
     /**
      * Create a new MaterialIconSet whose parent is one of your choosing
+     * 
      * @deprecated Use {@link MaterialIconSet#MaterialIconSet(ResourceLocation, MaterialIconSet)} instead
      * @param name          the name of the iconset
      * @param parentIconset the parent iconset
@@ -77,6 +80,7 @@ public class MaterialIconSet {
 
     /**
      * Create a new MaterialIconSet which is a root
+     * 
      * @deprecated Use {@link MaterialIconSet#MaterialIconSet(ResourceLocation, MaterialIconSet, boolean)} instead
      * @param name          the name of the iconset
      * @param parentIconset the parent iconset, should be null if this should be a root iconset
@@ -99,7 +103,7 @@ public class MaterialIconSet {
     /**
      * Create a new MaterialIconSet whose parent is one of your choosing
      *
-     * @param id          the id of the iconset
+     * @param id            the id of the iconset
      * @param parentIconset the parent iconset
      */
     public MaterialIconSet(@NotNull ResourceLocation id, @NotNull MaterialIconSet parentIconset) {
@@ -109,14 +113,16 @@ public class MaterialIconSet {
     /**
      * Create a new MaterialIconSet which is a root
      *
-     * @param id          the id of the iconset
+     * @param id            the id of the iconset
      * @param parentIconset the parent iconset, should be null if this should be a root iconset
      * @param isRootIconset true if this should be a root iconset, otherwise false
      */
-    public MaterialIconSet(@NotNull ResourceLocation id, @Nullable MaterialIconSet parentIconset, boolean isRootIconset) {
+    public MaterialIconSet(@NotNull ResourceLocation id, @Nullable MaterialIconSet parentIconset,
+                           boolean isRootIconset) {
         this.id = id;
 
-        if (id.getPath().contains("/")) throw new IllegalArgumentException("MaterialIconSet id cannot have '/' %s".formatted(id));
+        if (id.getPath().contains("/"))
+            throw new IllegalArgumentException("MaterialIconSet id cannot have '/' %s".formatted(id));
 
         this.name = id.getPath();
 

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("unused")
 public record MaterialIconType(String name) {
 
     public static final Map<String, MaterialIconType> ICON_TYPES = new HashMap<>();

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
@@ -1,7 +1,6 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.info;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.models.GTModels;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 
@@ -165,7 +164,8 @@ public record MaterialIconType(String name) {
             return GTModels.BLANK_TEXTURE; // check minecraft for null for CI environments
         if (!iconSet.isRootIconset) {
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String
+                        .format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -174,12 +174,14 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return GTModels.BLANK_TEXTURE;
         }
-        location = new ResourceLocation(iconSet.id.getNamespace(), String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+        location = new ResourceLocation(iconSet.id.getNamespace(),
+                String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
         if (suffix.isEmpty()) {
             BLOCK_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {
@@ -202,7 +204,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                        String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -211,7 +214,8 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -230,7 +234,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                        String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -239,7 +244,8 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -270,7 +276,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                        String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -286,7 +293,8 @@ public record MaterialIconType(String name) {
                 !ResourceHelper.isResourceExistRaw(location)) {
             return null;
         }
-        location = new ResourceLocation(iconSet.id.getNamespace(), String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+        location = new ResourceLocation(iconSet.id.getNamespace(),
+                String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
         if (suffix.isEmpty()) {
             ITEM_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
@@ -174,13 +174,15 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = iconSet.id.withPath(String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+        ResourceLocation location = iconSet.id.withPath(
+                String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
 
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return GTModels.BLANK_TEXTURE;
         }
-        location = iconSet.id.withPath(String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+        location = iconSet.id
+                .withPath(String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
 
         if (suffix.isEmpty()) {
             BLOCK_TEXTURE_CACHE.put(this, materialIconSet, location);
@@ -204,7 +206,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = iconSet.id.withPath(String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
+                ResourceLocation location = iconSet.id
+                        .withPath(String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -213,7 +216,8 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = iconSet.id.withPath(String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
+        ResourceLocation location = iconSet.id
+                .withPath(String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -232,7 +236,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = iconSet.id.withPath(String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
+                ResourceLocation location = iconSet.id
+                        .withPath(String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
 
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
@@ -242,7 +247,8 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = iconSet.id.withPath(String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
+        ResourceLocation location = iconSet.id
+                .withPath(String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
 
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
@@ -274,7 +280,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = iconSet.id.withPath(String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+                ResourceLocation location = iconSet.id.withPath(
+                        String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
 
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
@@ -284,13 +291,15 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = iconSet.id.withPath(String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+        ResourceLocation location = iconSet.id.withPath(
+                String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
 
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return null;
         }
-        location = iconSet.id.withPath(String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+        location = iconSet.id
+                .withPath(String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
         if (suffix.isEmpty()) {
             ITEM_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
@@ -164,7 +164,7 @@ public record MaterialIconType(String name) {
             return GTModels.BLANK_TEXTURE; // check minecraft for null for CI environments
         if (!iconSet.isRootIconset) {
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String
+                ResourceLocation location = iconSet.id.withPath(String
                         .format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
@@ -174,14 +174,14 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+        ResourceLocation location = iconSet.id.withPath(String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return GTModels.BLANK_TEXTURE;
         }
-        location = new ResourceLocation(iconSet.id.getNamespace(),
-                String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+        location = iconSet.id.withPath(String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+
         if (suffix.isEmpty()) {
             BLOCK_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {
@@ -204,8 +204,7 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                        String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
+                ResourceLocation location = iconSet.id.withPath(String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -214,8 +213,7 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
+        ResourceLocation location = iconSet.id.withPath(String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -234,8 +232,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                        String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
+                ResourceLocation location = iconSet.id.withPath(String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
+
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -244,8 +242,8 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
+        ResourceLocation location = iconSet.id.withPath(String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
+
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -276,8 +274,8 @@ public record MaterialIconType(String name) {
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
             while (iconSet != null && !iconSet.isRootIconset) {
-                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                        String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+                ResourceLocation location = iconSet.id.withPath(String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
@@ -286,15 +284,13 @@ public record MaterialIconType(String name) {
 
         Objects.requireNonNull(iconSet);
 
-        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
-                String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+        ResourceLocation location = iconSet.id.withPath(String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
 
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return null;
         }
-        location = new ResourceLocation(iconSet.id.getNamespace(),
-                String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
+        location = iconSet.id.withPath(String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
         if (suffix.isEmpty()) {
             ITEM_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/info/MaterialIconType.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.api.data.chemical.material.info;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.models.GTModels;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @SuppressWarnings("unused")
 public record MaterialIconType(String name) {
@@ -162,22 +164,22 @@ public record MaterialIconType(String name) {
                 Minecraft.getInstance().getResourceManager() == null)
             return GTModels.BLANK_TEXTURE; // check minecraft for null for CI environments
         if (!iconSet.isRootIconset) {
-            while (!iconSet.isRootIconset) {
-                ResourceLocation location = GTCEu
-                        .id(String.format("textures/block/material_sets/%s/%s%s.png", iconSet.name, this.name, suffix));
+            while (iconSet != null && !iconSet.isRootIconset) {
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
             }
         }
 
-        ResourceLocation location = GTCEu
-                .id(String.format("textures/block/material_sets/%s/%s%s.png", iconSet.name, this.name, suffix));
+        Objects.requireNonNull(iconSet);
+
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("textures/block/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return GTModels.BLANK_TEXTURE;
         }
-        location = GTCEu.id(String.format("block/material_sets/%s/%s%s", iconSet.name, this.name, suffix));
+        location = new ResourceLocation(iconSet.id.getNamespace(), String.format("block/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
         if (suffix.isEmpty()) {
             BLOCK_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {
@@ -199,16 +201,17 @@ public record MaterialIconType(String name) {
         // noinspection ConstantConditions
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
-            while (!iconSet.isRootIconset) {
-                ResourceLocation location = GTCEu
-                        .id(String.format("models/block/material_sets/%s/%s.json", iconSet.name, this.name));
+            while (iconSet != null && !iconSet.isRootIconset) {
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("models/block/material_sets/%s/%s.json", iconSet.getName(), this.name));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
             }
         }
 
-        ResourceLocation location = GTCEu.id(String.format("block/material_sets/%s/%s", iconSet.name, this.name));
+        Objects.requireNonNull(iconSet);
+
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("block/material_sets/%s/%s", iconSet.getName(), this.name));
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -226,16 +229,17 @@ public record MaterialIconType(String name) {
         // noinspection ConstantConditions
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
-            while (!iconSet.isRootIconset) {
-                ResourceLocation location = GTCEu
-                        .id(String.format("models/item/material_sets/%s/%s.json", iconSet.name, this.name));
+            while (iconSet != null && !iconSet.isRootIconset) {
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("models/item/material_sets/%s/%s.json", iconSet.getName(), this.name));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
             }
         }
 
-        ResourceLocation location = GTCEu.id(String.format("item/material_sets/%s/%s", iconSet.name, this.name));
+        Objects.requireNonNull(iconSet);
+
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("item/material_sets/%s/%s", iconSet.getName(), this.name));
         ITEM_MODEL_CACHE.put(this, materialIconSet, location);
 
         return location;
@@ -265,22 +269,24 @@ public record MaterialIconType(String name) {
         // noinspection ConstantConditions
         if (!iconSet.isRootIconset && GTCEu.isClientSide() && Minecraft.getInstance() != null &&
                 Minecraft.getInstance().getResourceManager() != null) { // check minecraft for null for CI environments
-            while (!iconSet.isRootIconset) {
-                ResourceLocation location = GTCEu
-                        .id(String.format("textures/item/material_sets/%s/%s%s.png", iconSet.name, this.name, suffix));
+            while (iconSet != null && !iconSet.isRootIconset) {
+                ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(), String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
                 if (ResourceHelper.isResourceExist(location) || ResourceHelper.isResourceExistRaw(location))
                     break;
                 iconSet = iconSet.parentIconset;
             }
         }
 
-        ResourceLocation location = GTCEu
-                .id(String.format("textures/item/material_sets/%s/%s%s.png", iconSet.name, this.name, suffix));
+        Objects.requireNonNull(iconSet);
+
+        ResourceLocation location = new ResourceLocation(iconSet.id.getNamespace(),
+                String.format("textures/item/material_sets/%s/%s%s.png", iconSet.getName(), this.name, suffix));
+
         if (!suffix.isEmpty() && !ResourceHelper.isResourceExist(location) &&
                 !ResourceHelper.isResourceExistRaw(location)) {
             return null;
         }
-        location = GTCEu.id(String.format("item/material_sets/%s/%s%s", iconSet.name, this.name, suffix));
+        location = new ResourceLocation(iconSet.id.getNamespace(), String.format("item/material_sets/%s/%s%s", iconSet.getName(), this.name, suffix));
         if (suffix.isEmpty()) {
             ITEM_TEXTURE_CACHE.put(this, materialIconSet, location);
         } else {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -97,30 +97,30 @@ public class TagPrefix {
         return this == NULL_PREFIX;
     }
 
-    public static final TagPrefix NULL_PREFIX = new TagPrefix("null");
+    public static final TagPrefix NULL_PREFIX = new TagPrefix(GTCEu.id("null"));
 
-    public static final TagPrefix ore = oreTagPrefix("stone", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix ore = oreTagPrefix(GTCEu.id("stone"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("%s Ore")
             .registerOre(
                     Blocks.STONE::defaultBlockState, () -> GTMaterials.Stone, BlockBehaviour.Properties.of()
                             .mapColor(MapColor.STONE).requiresCorrectToolForDrops().strength(3.0F, 3.0F),
                     new ResourceLocation("block/stone"), false, false, true);
 
-    public static final TagPrefix oreGranite = oreTagPrefix("granite", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreGranite = oreTagPrefix(GTCEu.id("granite"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Granite %s Ore")
             .registerOre(
                     Blocks.GRANITE::defaultBlockState, () -> GTMaterials.Granite, BlockBehaviour.Properties.of()
                             .mapColor(MapColor.DIRT).requiresCorrectToolForDrops().strength(3.0F, 3.0F),
                     new ResourceLocation("block/granite"));
 
-    public static final TagPrefix oreDiorite = oreTagPrefix("diorite", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreDiorite = oreTagPrefix(GTCEu.id("diorite"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Diorite %s Ore")
             .registerOre(
                     Blocks.DIORITE::defaultBlockState, () -> GTMaterials.Diorite, BlockBehaviour.Properties.of()
                             .mapColor(MapColor.QUARTZ).requiresCorrectToolForDrops().strength(3.0F, 3.0F),
                     new ResourceLocation("block/diorite"));
 
-    public static final TagPrefix oreAndesite = oreTagPrefix("andesite", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreAndesite = oreTagPrefix(GTCEu.id("andesite"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Andesite %s Ore")
             .registerOre(
                     Blocks.ANDESITE::defaultBlockState, () -> GTMaterials.Andesite, BlockBehaviour.Properties.of()
@@ -134,14 +134,14 @@ public class TagPrefix {
                             .strength(3.0F, 3.0F),
                     GTCEu.id("block/red_granite"));
 
-    public static final TagPrefix oreMarble = oreTagPrefix("marble", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreMarble = oreTagPrefix(GTCEu.id("marble"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Marble %s Ore")
             .registerOre(
                     () -> GTBlocks.MARBLE.getDefaultState(), () -> GTMaterials.Marble, BlockBehaviour.Properties.of()
                             .mapColor(MapColor.QUARTZ).requiresCorrectToolForDrops().strength(3.0F, 3.0F),
                     GTCEu.id("block/marble"));
 
-    public static final TagPrefix oreDeepslate = oreTagPrefix("deepslate", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreDeepslate = oreTagPrefix(GTCEu.id("deepslate"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Deepslate %s Ore")
             .registerOre(
                     Blocks.DEEPSLATE::defaultBlockState, () -> GTMaterials.Deepslate, BlockBehaviour.Properties.of()
@@ -149,7 +149,7 @@ public class TagPrefix {
                             .sound(SoundType.DEEPSLATE),
                     new ResourceLocation("block/deepslate"), false, false, true);
 
-    public static final TagPrefix oreTuff = oreTagPrefix("tuff", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreTuff = oreTagPrefix(GTCEu.id("tuff"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Tuff %s Ore")
             .registerOre(
                     Blocks.TUFF::defaultBlockState, () -> GTMaterials.Tuff, BlockBehaviour.Properties.of()
@@ -157,28 +157,28 @@ public class TagPrefix {
                             .sound(SoundType.TUFF),
                     new ResourceLocation("block/tuff"));
 
-    public static final TagPrefix oreSand = oreTagPrefix("sand", BlockTags.MINEABLE_WITH_SHOVEL)
+    public static final TagPrefix oreSand = oreTagPrefix(GTCEu.id("sand"), BlockTags.MINEABLE_WITH_SHOVEL)
             .langValue("Sand %s Ore")
             .registerOre(Blocks.SAND::defaultBlockState, () -> GTMaterials.SiliconDioxide,
                     BlockBehaviour.Properties.of().mapColor(MapColor.SAND).instrument(NoteBlockInstrument.SNARE)
                             .strength(0.5F).sound(SoundType.SAND),
                     new ResourceLocation("block/sand"), false, true, false);
 
-    public static final TagPrefix oreRedSand = oreTagPrefix("redSand", BlockTags.MINEABLE_WITH_SHOVEL)
+    public static final TagPrefix oreRedSand = oreTagPrefix(GTCEu.id("redSand"), BlockTags.MINEABLE_WITH_SHOVEL)
             .langValue("Red Sand %s Ore")
             .registerOre(Blocks.RED_SAND::defaultBlockState, () -> GTMaterials.SiliconDioxide,
                     BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_ORANGE).instrument(NoteBlockInstrument.SNARE)
                             .strength(0.5F).sound(SoundType.SAND),
                     new ResourceLocation("block/red_sand"), false, true, false);
 
-    public static final TagPrefix oreGravel = oreTagPrefix("gravel", BlockTags.MINEABLE_WITH_SHOVEL)
+    public static final TagPrefix oreGravel = oreTagPrefix(GTCEu.id("gravel"), BlockTags.MINEABLE_WITH_SHOVEL)
             .langValue("Gravel %s Ore")
             .registerOre(Blocks.GRAVEL::defaultBlockState, () -> GTMaterials.Flint,
                     BlockBehaviour.Properties.of().mapColor(MapColor.STONE).instrument(NoteBlockInstrument.SNARE)
                             .strength(0.6F).sound(SoundType.GRAVEL),
                     new ResourceLocation("block/gravel"), false, true, false);
 
-    public static final TagPrefix oreBasalt = oreTagPrefix("basalt", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreBasalt = oreTagPrefix(GTCEu.id("basalt"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Basalt %s Ore")
             .registerOre(Blocks.BASALT::defaultBlockState, () -> GTMaterials.Basalt,
                     BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_BLACK)
@@ -186,14 +186,14 @@ public class TagPrefix {
                             .sound(SoundType.BASALT),
                     new ResourceLocation("block/basalt"), true);
 
-    public static final TagPrefix oreNetherrack = oreTagPrefix("netherrack", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreNetherrack = oreTagPrefix(GTCEu.id("netherrack"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Nether %s Ore")
             .registerOre(Blocks.NETHERRACK::defaultBlockState, () -> GTMaterials.Netherrack,
                     BlockBehaviour.Properties.of().mapColor(MapColor.NETHER).instrument(NoteBlockInstrument.BASEDRUM)
                             .requiresCorrectToolForDrops().strength(3.0F, 3.0F).sound(SoundType.NETHER_ORE),
                     new ResourceLocation("block/netherrack"), true, false, true);
 
-    public static final TagPrefix oreBlackstone = oreTagPrefix("blackstone", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreBlackstone = oreTagPrefix(GTCEu.id("blackstone"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("Blackstone %s Ore")
             .registerOre(Blocks.BLACKSTONE::defaultBlockState, () -> GTMaterials.Blackstone,
                     BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_BLACK)
@@ -201,14 +201,14 @@ public class TagPrefix {
                             .strength(3.0F, 3.0F),
                     new ResourceLocation("block/blackstone"), true, false, false);
 
-    public static final TagPrefix oreEndstone = oreTagPrefix("endstone", BlockTags.MINEABLE_WITH_PICKAXE)
+    public static final TagPrefix oreEndstone = oreTagPrefix(GTCEu.id("endstone"), BlockTags.MINEABLE_WITH_PICKAXE)
             .langValue("End %s Ore")
             .registerOre(Blocks.END_STONE::defaultBlockState, () -> GTMaterials.Endstone,
                     BlockBehaviour.Properties.of().mapColor(MapColor.SAND).instrument(NoteBlockInstrument.BASEDRUM)
                             .requiresCorrectToolForDrops().strength(4.5F, 9.0F),
                     new ResourceLocation("block/end_stone"), true, false, true);
 
-    public static final TagPrefix rawOre = new TagPrefix("raw", true)
+    public static final TagPrefix rawOre = new TagPrefix(GTCEu.id("raw"), true)
             .idPattern("raw_%s")
             .defaultTagPath("raw_materials/%s")
             .unformattedTagPath("raw_materials")
@@ -218,7 +218,7 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix rawOreBlock = new TagPrefix("rawOreBlock")
+    public static final TagPrefix rawOreBlock = new TagPrefix(GTCEu.id("rawOreBlock"))
             .idPattern("raw_%s_block")
             .defaultTagPath("storage_blocks/raw_%s")
             .unformattedTagPath("storage_blocks")
@@ -229,7 +229,7 @@ public class TagPrefix {
             .generateBlock(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix crushedRefined = new TagPrefix("refinedOre")
+    public static final TagPrefix crushedRefined = new TagPrefix(GTCEu.id("refinedOre"))
             .idPattern("refined_%s_ore")
             .defaultTagPath("refined_ores/%s")
             .defaultTagPath("refined_ores")
@@ -239,7 +239,7 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix crushedPurified = new TagPrefix("purifiedOre")
+    public static final TagPrefix crushedPurified = new TagPrefix(GTCEu.id("purifiedOre"))
             .idPattern("purified_%s_ore")
             .defaultTagPath("purified_ores/%s")
             .defaultTagPath("purified_ores")
@@ -250,7 +250,7 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix crushed = new TagPrefix("crushedOre")
+    public static final TagPrefix crushed = new TagPrefix(GTCEu.id("crushedOre"))
             .idPattern("crushed_%s_ore")
             .defaultTagPath("crushed_ores/%s")
             .unformattedTagPath("crushed_ores")
@@ -262,7 +262,7 @@ public class TagPrefix {
             .tooltip((mat, tooltips) -> tooltips.add(Component.translatable("metaitem.crushed.tooltip.purify")));
 
     // A hot Ingot, which has to be cooled down by a Vacuum Freezer.
-    public static final TagPrefix ingotHot = new TagPrefix("hotIngot")
+    public static final TagPrefix ingotHot = new TagPrefix(GTCEu.id("hotIngot"))
             .idPattern("hot_%s_ingot")
             .defaultTagPath("hot_ingots/%s")
             .unformattedTagPath("hot_ingots")
@@ -275,7 +275,7 @@ public class TagPrefix {
                     hasBlastProperty.and(mat -> mat.getProperty(PropertyKey.BLAST).getBlastTemperature() > 1750));
 
     // A regular Ingot.
-    public static final TagPrefix ingot = new TagPrefix("ingot")
+    public static final TagPrefix ingot = new TagPrefix(GTCEu.id("ingot"))
             .defaultTagPath("ingots/%s")
             .unformattedTagPath("ingots")
             .materialAmount(GTValues.M)
@@ -286,7 +286,7 @@ public class TagPrefix {
             .generationCondition(hasIngotProperty);
 
     // A regular Gem worth one Dust.
-    public static final TagPrefix gem = new TagPrefix("gem")
+    public static final TagPrefix gem = new TagPrefix(GTCEu.id("gem"))
             .defaultTagPath("gems/%s")
             .unformattedTagPath("gems")
             .langValue("%s")
@@ -298,7 +298,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty);
 
     // A regular Gem worth one small Dust.
-    public static final TagPrefix gemChipped = new TagPrefix("chippedGem")
+    public static final TagPrefix gemChipped = new TagPrefix(GTCEu.id("chippedGem"))
             .idPattern("chipped_%s_gem")
             .defaultTagPath("chipped_gems/%s")
             .unformattedTagPath("chipped_gems")
@@ -311,7 +311,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty.and(unused -> ConfigHolder.INSTANCE.recipes.generateLowQualityGems));
 
     // A regular Gem worth two small Dusts.
-    public static final TagPrefix gemFlawed = new TagPrefix("flawedGem")
+    public static final TagPrefix gemFlawed = new TagPrefix(GTCEu.id("flawedGem"))
             .idPattern("flawed_%s_gem")
             .defaultTagPath("flawed_gems/%s")
             .unformattedTagPath("flawed_gems")
@@ -324,7 +324,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty.and(unused -> ConfigHolder.INSTANCE.recipes.generateLowQualityGems));
 
     // A regular Gem worth two Dusts.
-    public static final TagPrefix gemFlawless = new TagPrefix("flawlessGem")
+    public static final TagPrefix gemFlawless = new TagPrefix(GTCEu.id("flawlessGem"))
             .idPattern("flawless_%s_gem")
             .defaultTagPath("flawless_gems/%s")
             .unformattedTagPath("flawless_gems")
@@ -338,7 +338,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty);
 
     // A regular Gem worth four Dusts.
-    public static final TagPrefix gemExquisite = new TagPrefix("exquisiteGem")
+    public static final TagPrefix gemExquisite = new TagPrefix(GTCEu.id("exquisiteGem"))
             .idPattern("exquisite_%s_gem")
             .defaultTagPath("exquisite_gems/%s")
             .unformattedTagPath("exquisite_gems")
@@ -352,7 +352,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty);
 
     // 1/4th of a Dust.
-    public static final TagPrefix dustSmall = new TagPrefix("smallDust")
+    public static final TagPrefix dustSmall = new TagPrefix(GTCEu.id("smallDust"))
             .idPattern("small_%s_dust")
             .defaultTagPath("small_dusts/%s")
             .unformattedTagPath("small_dusts")
@@ -364,7 +364,7 @@ public class TagPrefix {
             .generationCondition(hasDustProperty);
 
     // 1/9th of a Dust.
-    public static final TagPrefix dustTiny = new TagPrefix("tinyDust")
+    public static final TagPrefix dustTiny = new TagPrefix(GTCEu.id("tinyDust"))
             .idPattern("tiny_%s_dust")
             .defaultTagPath("tiny_dusts/%s")
             .unformattedTagPath("tiny_dusts")
@@ -376,7 +376,7 @@ public class TagPrefix {
             .generationCondition(hasDustProperty);
 
     // Dust with impurities. 1 Unit of Main Material and 1/9 - 1/4 Unit of secondary Material
-    public static final TagPrefix dustImpure = new TagPrefix("impureDust")
+    public static final TagPrefix dustImpure = new TagPrefix(GTCEu.id("impureDust"))
             .idPattern("impure_%s_dust")
             .defaultTagPath("impure_dusts/%s")
             .unformattedTagPath("impure_dusts")
@@ -389,7 +389,7 @@ public class TagPrefix {
             .tooltip((mat, tooltips) -> tooltips.add(Component.translatable("metaitem.dust.tooltip.purify")));
 
     // Pure Dust worth of one Ingot or Gem.
-    public static final TagPrefix dustPure = new TagPrefix("pureDust")
+    public static final TagPrefix dustPure = new TagPrefix(GTCEu.id("pureDust"))
             .idPattern("pure_%s_dust")
             .defaultTagPath("pure_dusts/%s")
             .unformattedTagPath("pure_dusts")
@@ -401,7 +401,7 @@ public class TagPrefix {
             .generationCondition(hasOreProperty)
             .tooltip((mat, tooltips) -> tooltips.add(Component.translatable("metaitem.dust.tooltip.purify")));
 
-    public static final TagPrefix dust = new TagPrefix("dust")
+    public static final TagPrefix dust = new TagPrefix(GTCEu.id("dust"))
             .defaultTagPath("dusts/%s")
             .unformattedTagPath("dusts")
             .materialAmount(GTValues.M)
@@ -412,7 +412,7 @@ public class TagPrefix {
             .generationCondition(hasDustProperty);
 
     // A Nugget.
-    public static final TagPrefix nugget = new TagPrefix("nugget")
+    public static final TagPrefix nugget = new TagPrefix(GTCEu.id("nugget"))
             .defaultTagPath("nuggets/%s")
             .unformattedTagPath("nuggets")
             .materialAmount(GTValues.M / 9)
@@ -423,7 +423,7 @@ public class TagPrefix {
             .generationCondition(hasIngotProperty);
 
     // 9 Plates combined in one Item.
-    public static final TagPrefix plateDense = new TagPrefix("densePlate")
+    public static final TagPrefix plateDense = new TagPrefix(GTCEu.id("densePlate"))
             .idPattern("dense_%s_plate")
             .defaultTagPath("dense_plates/%s")
             .unformattedTagPath("dense_plates")
@@ -437,7 +437,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_DENSE));
 
     // 2 Plates combined in one Item
-    public static final TagPrefix plateDouble = new TagPrefix("doublePlate")
+    public static final TagPrefix plateDouble = new TagPrefix(GTCEu.id("doublePlate"))
             .idPattern("double_%s_plate")
             .defaultTagPath("double_plates/%s")
             .unformattedTagPath("double_plates")
@@ -452,7 +452,7 @@ public class TagPrefix {
                     .and(mat -> mat.hasFlag(MaterialFlags.GENERATE_PLATE) && !mat.hasFlag(MaterialFlags.NO_SMASHING)));
 
     // Regular Plate made of one Ingot/Dust.
-    public static final TagPrefix plate = new TagPrefix("plate")
+    public static final TagPrefix plate = new TagPrefix(GTCEu.id("plate"))
             .defaultTagPath("plates/%s")
             .unformattedTagPath("plates")
             .materialAmount(GTValues.M)
@@ -463,7 +463,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_PLATE));
 
     // Round made of 1 Nugget
-    public static final TagPrefix round = new TagPrefix("round")
+    public static final TagPrefix round = new TagPrefix(GTCEu.id("round"))
             .defaultTagPath("rounds/%s")
             .unformattedTagPath("rounds")
             .materialAmount(GTValues.M / 9)
@@ -474,7 +474,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_ROUND));
 
     // Foil made of 1/4 Ingot/Dust.
-    public static final TagPrefix foil = new TagPrefix("foil")
+    public static final TagPrefix foil = new TagPrefix(GTCEu.id("foil"))
             .defaultTagPath("foils/%s")
             .unformattedTagPath("foils")
             .materialAmount(GTValues.M / 4)
@@ -485,7 +485,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_FOIL));
 
     // Stick made of an Ingot.
-    public static final TagPrefix rodLong = new TagPrefix("longRod")
+    public static final TagPrefix rodLong = new TagPrefix(GTCEu.id("longRod"))
             .idPattern("long_%s_rod")
             .defaultTagPath("rods/long/%s")
             .unformattedTagPath("rods/long")
@@ -498,7 +498,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_LONG_ROD));
 
     // Stick made of half an Ingot.
-    public static final TagPrefix rod = new TagPrefix("rod")
+    public static final TagPrefix rod = new TagPrefix(GTCEu.id("rod"))
             .defaultTagPath("rods/%s")
             .unformattedTagPath("rods")
             .langValue("%s Rod")
@@ -510,7 +510,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_ROD));
 
     // consisting out of 1/8 Ingot or 1/4 Stick.
-    public static final TagPrefix bolt = new TagPrefix("bolt")
+    public static final TagPrefix bolt = new TagPrefix(GTCEu.id("bolt"))
             .defaultTagPath("bolts/%s")
             .unformattedTagPath("bolts")
             .materialAmount(GTValues.M / 8)
@@ -521,7 +521,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_BOLT_SCREW));
 
     // consisting out of 1/9 Ingot.
-    public static final TagPrefix screw = new TagPrefix("screw")
+    public static final TagPrefix screw = new TagPrefix(GTCEu.id("screw"))
             .defaultTagPath("screws/%s")
             .unformattedTagPath("screws")
             .materialAmount(GTValues.M / 9)
@@ -532,7 +532,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_BOLT_SCREW));
 
     // consisting out of 1/2 Stick.
-    public static final TagPrefix ring = new TagPrefix("ring")
+    public static final TagPrefix ring = new TagPrefix(GTCEu.id("ring"))
             .defaultTagPath("rings/%s")
             .unformattedTagPath("rings")
             .materialAmount(GTValues.M / 4)
@@ -543,7 +543,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_RING));
 
     // consisting out of 1 Fine Wire.
-    public static final TagPrefix springSmall = new TagPrefix("smallSpring")
+    public static final TagPrefix springSmall = new TagPrefix(GTCEu.id("smallSpring"))
             .idPattern("small_%s_spring")
             .defaultTagPath("small_springs/%s")
             .unformattedTagPath("small_springs")
@@ -557,7 +557,7 @@ public class TagPrefix {
                     mat -> mat.hasFlag(MaterialFlags.GENERATE_SPRING_SMALL) && !mat.hasFlag(MaterialFlags.NO_SMASHING));
 
     // consisting out of 2 Sticks.
-    public static final TagPrefix spring = new TagPrefix("spring")
+    public static final TagPrefix spring = new TagPrefix(GTCEu.id("spring"))
             .defaultTagPath("springs/%s")
             .unformattedTagPath("springs")
             .materialAmount(GTValues.M)
@@ -569,7 +569,7 @@ public class TagPrefix {
                     mat -> mat.hasFlag(MaterialFlags.GENERATE_SPRING) && !mat.hasFlag(MaterialFlags.NO_SMASHING));
 
     // consisting out of 1/8 Ingot or 1/4 Wire.
-    public static final TagPrefix wireFine = new TagPrefix("fineWire")
+    public static final TagPrefix wireFine = new TagPrefix(GTCEu.id("fineWire"))
             .idPattern("fine_%s_wire")
             .defaultTagPath("fine_wires/%s")
             .unformattedTagPath("fine_wires")
@@ -582,7 +582,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_FINE_WIRE));
 
     // consisting out of 4 Plates, 1 Ring and 1 Screw.
-    public static final TagPrefix rotor = new TagPrefix("rotor")
+    public static final TagPrefix rotor = new TagPrefix(GTCEu.id("rotor"))
             .defaultTagPath("rotors/%s")
             .unformattedTagPath("rotors")
             .materialAmount(GTValues.M * 4)
@@ -594,7 +594,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_ROTOR));
 
     // Consisting of 1 Plate.
-    public static final TagPrefix gearSmall = new TagPrefix("smallGear")
+    public static final TagPrefix gearSmall = new TagPrefix(GTCEu.id("smallGear"))
             .idPattern("small_%s_gear")
             .defaultTagPath("small_gears/%s")
             .unformattedTagPath("small_gears")
@@ -607,7 +607,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_SMALL_GEAR));
 
     // Consisting of 4 Plates.
-    public static final TagPrefix gear = new TagPrefix("gear")
+    public static final TagPrefix gear = new TagPrefix(GTCEu.id("gear"))
             .defaultTagPath("gears/%s")
             .unformattedTagPath("gears")
             .materialAmount(GTValues.M * 4)
@@ -619,7 +619,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_GEAR));
 
     // 3/4 of a Plate or Gem used to shape a Lens. Normally only used on Transparent Materials.
-    public static final TagPrefix lens = new TagPrefix("lens")
+    public static final TagPrefix lens = new TagPrefix(GTCEu.id("lens"))
             .defaultTagPath("lenses/%s")
             .unformattedTagPath("lenses")
             .materialAmount((GTValues.M * 3) / 4)
@@ -629,13 +629,13 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_LENS));
 
-    public static final TagPrefix dye = new TagPrefix("dye")
+    public static final TagPrefix dye = new TagPrefix(GTCEu.id("dye"))
             .defaultTagPath("dyes/%s")
             .unformattedTagPath("dyes")
             .materialAmount(-1);
 
     // made of 4 Ingots.
-    public static final TagPrefix toolHeadBuzzSaw = new TagPrefix("buzzSawBlade")
+    public static final TagPrefix toolHeadBuzzSaw = new TagPrefix(GTCEu.id("buzzSawBlade"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Buzzsaw Blade")
             .materialAmount(GTValues.M * 4)
@@ -648,7 +648,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.BUZZSAW)));
 
     // made of 1 Ingots.
-    public static final TagPrefix toolHeadScrewdriver = new TagPrefix("screwdriverTip")
+    public static final TagPrefix toolHeadScrewdriver = new TagPrefix(GTCEu.id("screwdriverTip"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Screwdriver Tip")
             .materialAmount(GTValues.M)
@@ -661,7 +661,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.SCREWDRIVER_LV)));
 
     // made of 4 Ingots.
-    public static final TagPrefix toolHeadDrill = new TagPrefix("drillHead")
+    public static final TagPrefix toolHeadDrill = new TagPrefix(GTCEu.id("drillHead"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Drill Head")
             .materialAmount(GTValues.M * 4)
@@ -674,7 +674,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.DRILL_LV)));
 
     // made of 2 Ingots.
-    public static final TagPrefix toolHeadChainsaw = new TagPrefix("chainsawHead")
+    public static final TagPrefix toolHeadChainsaw = new TagPrefix(GTCEu.id("chainsawHead"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Chainsaw Head")
             .materialAmount(GTValues.M * 2)
@@ -687,7 +687,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.CHAINSAW_LV)));
 
     // made of 4 Ingots.
-    public static final TagPrefix toolHeadWrench = new TagPrefix("wrenchTip")
+    public static final TagPrefix toolHeadWrench = new TagPrefix(GTCEu.id("wrenchTip"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Wrench Tip")
             .materialAmount(GTValues.M * 4)
@@ -699,7 +699,7 @@ public class TagPrefix {
             .generationCondition(hasNoCraftingToolProperty.and(mat -> mat.hasFlag(MaterialFlags.GENERATE_PLATE))
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.WRENCH_LV)));
 
-    public static final TagPrefix toolHeadWireCutter = new TagPrefix("wireCutterHead")
+    public static final TagPrefix toolHeadWireCutter = new TagPrefix(GTCEu.id("wireCutterHead"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Wire Cutter Head")
             .materialAmount(GTValues.M * 4)
@@ -712,7 +712,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.WIRE_CUTTER_LV)));
 
     // made of 5 Ingots.
-    public static final TagPrefix turbineBlade = new TagPrefix("turbineBlade")
+    public static final TagPrefix turbineBlade = new TagPrefix(GTCEu.id("turbineBlade"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Turbine Blade")
             .materialAmount(GTValues.M * 10)
@@ -725,7 +725,7 @@ public class TagPrefix {
                             !m.hasProperty(PropertyKey.GEM)));
 
     // Storage Block consisting out of 9 Ingots/Gems/Dusts.
-    public static final TagPrefix block = new TagPrefix("block")
+    public static final TagPrefix block = new TagPrefix(GTCEu.id("block"))
             .defaultTagPath("storage_blocks/%s")
             .unformattedTagPath("storage_blocks")
             .langValue("Block of %s")
@@ -738,24 +738,24 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix log = new TagPrefix("log")
+    public static final TagPrefix log = new TagPrefix(GTCEu.id("log"))
             .unformattedTagPath("logs", true);
-    public static final TagPrefix planks = new TagPrefix("planks")
+    public static final TagPrefix planks = new TagPrefix(GTCEu.id("planks"))
             .unformattedTagPath("planks", true);
-    public static final TagPrefix slab = new TagPrefix("slab")
+    public static final TagPrefix slab = new TagPrefix(GTCEu.id("slab"))
             .unformattedTagPath("slabs", true);
-    public static final TagPrefix stairs = new TagPrefix("stairs")
+    public static final TagPrefix stairs = new TagPrefix(GTCEu.id("stairs"))
             .unformattedTagPath("stairs", true);
-    public static final TagPrefix fence = new TagPrefix("fence")
+    public static final TagPrefix fence = new TagPrefix(GTCEu.id("fence"))
             .unformattedTagPath("fences");
-    public static final TagPrefix fenceGate = new TagPrefix("fenceGate")
+    public static final TagPrefix fenceGate = new TagPrefix(GTCEu.id("fenceGate"))
             .unformattedTagPath("fence_gates");
-    public static final TagPrefix door = new TagPrefix("door")
+    public static final TagPrefix door = new TagPrefix(GTCEu.id("door"))
             .unformattedTagPath("doors", true);
 
     // Prefix to determine which kind of Rock this is.
     // Also has a base tag path of only the material, for things like obsidian etc.
-    public static final TagPrefix rock = new TagPrefix("rock")
+    public static final TagPrefix rock = new TagPrefix(GTCEu.id("rock"))
             .defaultTagPath("%s")
             .langValue("%s")
             .miningToolTag(BlockTags.MINEABLE_WITH_PICKAXE)
@@ -763,7 +763,7 @@ public class TagPrefix {
             .generateBlock(true) // generate a block but not really, for TagPrefix#setIgnoredBlock
             .generationCondition((material) -> false);
 
-    public static final TagPrefix frameGt = new TagPrefix("frame")
+    public static final TagPrefix frameGt = new TagPrefix(GTCEu.id("frame"))
             .defaultTagPath("frames/%s")
             .unformattedTagPath("frames")
             .langValue("%s Frame")
@@ -778,35 +778,35 @@ public class TagPrefix {
                     material.hasFlag(MaterialFlags.GENERATE_FRAME));
 
     // Pipes
-    public static final TagPrefix pipeTinyFluid = new TagPrefix("pipeTinyFluid")
+    public static final TagPrefix pipeTinyFluid = new TagPrefix(GTCEu.id("pipeTinyFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Tiny %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M / 2)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeSmallFluid = new TagPrefix("pipeSmallFluid")
+    public static final TagPrefix pipeSmallFluid = new TagPrefix(GTCEu.id("pipeSmallFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Small %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNormalFluid = new TagPrefix("pipeNormalFluid")
+    public static final TagPrefix pipeNormalFluid = new TagPrefix(GTCEu.id("pipeNormalFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Normal %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 3)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeLargeFluid = new TagPrefix("pipeLargeFluid")
+    public static final TagPrefix pipeLargeFluid = new TagPrefix(GTCEu.id("pipeLargeFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Large %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 6)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeHugeFluid = new TagPrefix("pipeHugeFluid")
+    public static final TagPrefix pipeHugeFluid = new TagPrefix(GTCEu.id("pipeHugeFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Huge %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
@@ -814,14 +814,14 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix pipeQuadrupleFluid = new TagPrefix("pipeQuadrupleFluid")
+    public static final TagPrefix pipeQuadrupleFluid = new TagPrefix(GTCEu.id("pipeQuadrupleFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Quadruple %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 4)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNonupleFluid = new TagPrefix("pipeNonupleFluid")
+    public static final TagPrefix pipeNonupleFluid = new TagPrefix(GTCEu.id("pipeNonupleFluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Nonuple %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
@@ -829,28 +829,28 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix pipeSmallItem = new TagPrefix("pipeSmallItem")
+    public static final TagPrefix pipeSmallItem = new TagPrefix(GTCEu.id("pipeSmallItem"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Small %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNormalItem = new TagPrefix("pipeNormalItem")
+    public static final TagPrefix pipeNormalItem = new TagPrefix(GTCEu.id("pipeNormalItem"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Normal %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 3)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeLargeItem = new TagPrefix("pipeLargeItem")
+    public static final TagPrefix pipeLargeItem = new TagPrefix(GTCEu.id("pipeLargeItem"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Large %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 6)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeHugeItem = new TagPrefix("pipeHugeItem")
+    public static final TagPrefix pipeHugeItem = new TagPrefix(GTCEu.id("pipeHugeItem"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Huge %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
@@ -858,38 +858,39 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix pipeSmallRestrictive = new TagPrefix("pipeSmallRestrictive")
+    public static final TagPrefix pipeSmallRestrictive = new TagPrefix(GTCEu.id("pipeSmallRestrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Small Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNormalRestrictive = new TagPrefix("pipeNormalRestrictive")
+    public static final TagPrefix pipeNormalRestrictive = new TagPrefix(GTCEu.id("pipeNormalRestrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Normal Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH).materialAmount(GTValues.M * 3)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeLargeRestrictive = new TagPrefix("pipeLargeRestrictive")
+    public static final TagPrefix pipeLargeRestrictive = new TagPrefix(GTCEu.id("pipeLargeRestrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Large Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH).materialAmount(GTValues.M * 6)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeHugeRestrictive = new TagPrefix("pipeHugeRestrictive")
+    public static final TagPrefix pipeHugeRestrictive = new TagPrefix(GTCEu.id("pipeHugeRestrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Huge Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH).materialAmount(GTValues.M * 12)
             .unificationEnabled(true)
             .enableRecycling();
 
     // Wires and cables
-    public static final TagPrefix wireGtHex = new TagPrefix("wireGtHex").itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
+    public static final TagPrefix wireGtHex = new TagPrefix(GTCEu.id("wireGtHex"))
+            .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("16x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 8)
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtOctal = new TagPrefix("wireGtOctal")
+    public static final TagPrefix wireGtOctal = new TagPrefix(GTCEu.id("wireGtOctal"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("8x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -897,7 +898,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtQuadruple = new TagPrefix("wireGtQuadruple")
+    public static final TagPrefix wireGtQuadruple = new TagPrefix(GTCEu.id("wireGtQuadruple"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("4x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -905,7 +906,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtDouble = new TagPrefix("wireGtDouble")
+    public static final TagPrefix wireGtDouble = new TagPrefix(GTCEu.id("wireGtDouble"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("2x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -913,7 +914,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtSingle = new TagPrefix("wireGtSingle")
+    public static final TagPrefix wireGtSingle = new TagPrefix(GTCEu.id("wireGtSingle"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("1x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -922,34 +923,34 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix cableGtHex = new TagPrefix("cableGtHex")
+    public static final TagPrefix cableGtHex = new TagPrefix(GTCEu.id("cableGtHex"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("16x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 8)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtOctal = new TagPrefix("cableGtOctal")
+    public static final TagPrefix cableGtOctal = new TagPrefix(GTCEu.id("cableGtOctal"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("8x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 4)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtQuadruple = new TagPrefix("cableGtQuadruple")
+    public static final TagPrefix cableGtQuadruple = new TagPrefix(GTCEu.id("cableGtQuadruple"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS).langValue("4x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 2)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtDouble = new TagPrefix("cableGtDouble")
+    public static final TagPrefix cableGtDouble = new TagPrefix(GTCEu.id("cableGtDouble"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("2x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtSingle = new TagPrefix("cableGtSingle")
+    public static final TagPrefix cableGtSingle = new TagPrefix(GTCEu.id("cableGtSingle"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("1x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -957,7 +958,7 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix surfaceRock = new TagPrefix("surfaceRock")
+    public static final TagPrefix surfaceRock = new TagPrefix(GTCEu.id("surfaceRock"))
             .langValue("%s Surface Rock")
             .defaultTagPath("surface_rocks/%s")
             .unformattedTagPath("surface_rocks")
@@ -1057,12 +1058,24 @@ public class TagPrefix {
     @Getter
     protected final Set<TagKey<Block>> miningToolTag = new HashSet<>();
 
+    /**
+     * @deprecated Use {@link TagPrefix#TagPrefix(ResourceLocation)}
+     */
+    @Deprecated(since = "8.0.0")
     public TagPrefix(String name) {
         this(name, false);
     }
 
+    /**
+     * @deprecated Use {@link TagPrefix#TagPrefix(ResourceLocation, boolean)}
+     */
+    @Deprecated(since = "8.0.0")
     public TagPrefix(String name, boolean invertedName) {
         this(GTCEu.id(name), invertedName);
+    }
+
+    public TagPrefix(ResourceLocation id) {
+        this(id, false);
     }
 
     public TagPrefix(ResourceLocation id, boolean invertedName) {
@@ -1075,7 +1088,11 @@ public class TagPrefix {
     }
 
     public static TagPrefix oreTagPrefix(String name, TagKey<Block> miningToolTag) {
-        return new TagPrefix(name)
+        return oreTagPrefix(GTCEu.id(name), miningToolTag);
+    }
+
+    public static TagPrefix oreTagPrefix(ResourceLocation id, TagKey<Block> miningToolTag) {
+        return new TagPrefix(id)
                 .defaultTagPath("ores/%s")
                 .prefixOnlyTagPath("ores_in_ground/%s")
                 .unformattedTagPath("ores")

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.api.data.tag;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.addon.AddonFinder;
 import com.gregtechceu.gtceu.api.addon.IGTAddon;
@@ -16,6 +17,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.stack.MaterialStack;
 import com.gregtechceu.gtceu.api.item.MaterialBlockItem;
 import com.gregtechceu.gtceu.api.item.TagPrefixItem;
 import com.gregtechceu.gtceu.api.item.tool.GTToolType;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.common.data.GTMaterialItems;
@@ -48,14 +50,13 @@ import net.minecraft.world.level.material.MapColor;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Table;
-import com.mojang.serialization.Codec;
-import com.mojang.serialization.DataResult;
 import it.unimi.dsi.fastutil.objects.Object2FloatMap;
 import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
@@ -69,23 +70,27 @@ import static com.gregtechceu.gtceu.api.data.tag.TagPrefix.Conditions.*;
 @Accessors(chain = true, fluent = true)
 public class TagPrefix {
 
-    public final static Map<String, TagPrefix> PREFIXES = new HashMap<>();
-    public static final Map<TagPrefix, OreType> ORES = new Object2ObjectLinkedOpenHashMap<>();
+    static {
+        GTRegistries.TAG_PREFIXES.unfreeze();
+    }
 
-    public static final Codec<TagPrefix> CODEC = Codec.STRING.flatXmap(
-            str -> Optional.ofNullable(get(str)).map(DataResult::success)
-                    .orElseGet(() -> DataResult.error(() -> "invalid TagPrefix: " + str)),
-            prefix -> DataResult.success(prefix.name));
+    public static final Map<TagPrefix, OreType> ORES = new Object2ObjectLinkedOpenHashMap<>();
 
     public static void init() {
         AddonFinder.getAddons().forEach(IGTAddon::registerTagPrefixes);
+        ModLoader.get().postEvent(new GTCEuAPI.RegisterEvent<>(GTRegistries.TAG_PREFIXES, TagPrefix.class));
         if (GTCEu.Mods.isKubeJSLoaded()) {
-            GTRegistryInfo.registerFor(GTRegistryInfo.TAG_PREFIX.registryKey);
+            GTRegistryInfo.registerFor(GTRegistries.TAG_PREFIXES.getRegistryName());
         }
+        GTRegistries.TAG_PREFIXES.freeze();
     }
 
+    /**
+     * @deprecated Use {@code GTRegistries.TAG_PREFIXES.get(name)}
+     */
+    @Deprecated(since = "8.0.0")
     public static TagPrefix get(String name) {
-        return PREFIXES.get(name);
+        return GTRegistries.TAG_PREFIXES.get(name);
     }
 
     public boolean isEmpty() {
@@ -1058,7 +1063,7 @@ public class TagPrefix {
         this.idPattern = "%s_" + getLowerCaseName();
         this.invertedName = invertedName;
         this.langValue = "%s " + FormattingUtil.toEnglishName(getLowerCaseName());
-        PREFIXES.put(name, this);
+        GTRegistries.TAG_PREFIXES.register(name, this);
     }
 
     public static TagPrefix oreTagPrefix(String name, TagKey<Block> miningToolTag) {
@@ -1167,12 +1172,20 @@ public class TagPrefix {
         return (long) (GTValues.M * materialAmounts.getFloat(material));
     }
 
+    /**
+     * @deprecated Use {@code GTRegistries.TAG_PREFIXES.get(name)}
+     */
+    @Deprecated(since = "8.0.0")
     public static TagPrefix getPrefix(String prefixName) {
         return getPrefix(prefixName, null);
     }
 
+    /**
+     * @deprecated Use {@code GTRegistries.TAG_PREFIXES.getOrDefault(prefixName, replacement)}
+     */
+    @Deprecated(since = "8.0.0")
     public static TagPrefix getPrefix(String prefixName, @Nullable TagPrefix replacement) {
-        return PREFIXES.getOrDefault(prefixName, replacement);
+        return GTRegistries.TAG_PREFIXES.getOrDefault(prefixName, replacement);
     }
 
     public @Unmodifiable List<TagKey<Item>> getItemParentTags() {
@@ -1356,8 +1369,12 @@ public class TagPrefix {
         return name.hashCode();
     }
 
+    /**
+     * @deprecated Use {@code GTRegistries.TAG_PREFIXES.values()}
+     */
+    @Deprecated(since = "8.0.0")
     public static Collection<TagPrefix> values() {
-        return PREFIXES.values();
+        return GTRegistries.TAG_PREFIXES.values();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -47,6 +47,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import net.minecraft.world.level.material.MapColor;
+import net.minecraftforge.fml.ModLoader;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Table;
@@ -56,7 +57,6 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -90,7 +90,7 @@ public class TagPrefix {
      */
     @Deprecated(since = "8.0.0")
     public static TagPrefix get(String name) {
-        return GTRegistries.TAG_PREFIXES.get(name);
+        return GTRegistries.TAG_PREFIXES.get(GTCEu.id(name));
     }
 
     public boolean isEmpty() {
@@ -984,6 +984,9 @@ public class TagPrefix {
                                   UnaryOperator<BlockBehaviour.Properties> properties) {}
 
     @Getter
+    public final ResourceLocation id;
+
+    @Getter
     public final String name;
     @Getter
     @Setter
@@ -1059,11 +1062,16 @@ public class TagPrefix {
     }
 
     public TagPrefix(String name, boolean invertedName) {
-        this.name = name;
+        this(GTCEu.id(name), invertedName);
+    }
+
+    public TagPrefix(ResourceLocation id, boolean invertedName) {
+        this.id = id;
+        this.name = id.getPath();
         this.idPattern = "%s_" + getLowerCaseName();
         this.invertedName = invertedName;
         this.langValue = "%s " + FormattingUtil.toEnglishName(getLowerCaseName());
-        GTRegistries.TAG_PREFIXES.register(name, this);
+        GTRegistries.TAG_PREFIXES.register(id, this);
     }
 
     public static TagPrefix oreTagPrefix(String name, TagKey<Block> miningToolTag) {
@@ -1185,7 +1193,7 @@ public class TagPrefix {
      */
     @Deprecated(since = "8.0.0")
     public static TagPrefix getPrefix(String prefixName, @Nullable TagPrefix replacement) {
-        return GTRegistries.TAG_PREFIXES.getOrDefault(prefixName, replacement);
+        return GTRegistries.TAG_PREFIXES.getOrDefault(GTCEu.id(prefixName), replacement);
     }
 
     public @Unmodifiable List<TagKey<Item>> getItemParentTags() {

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/GeodeVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/GeodeVeinGenerator.java
@@ -341,7 +341,7 @@ public class GeodeVeinGenerator extends VeinGenerator {
                         .forGetter(config -> config.cannotReplace),
                 TagKey.hashedCodec(Registries.BLOCK).fieldOf("invalid_blocks")
                         .forGetter(config -> config.invalidBlocks),
-                TagPrefix.CODEC.optionalFieldOf("provider_material_prefix", TagPrefix.block)
+                        GTRegistries.TAG_PREFIXES.codec().optionalFieldOf("provider_material_prefix", TagPrefix.block)
                         .forGetter(config -> config.providerMaterialPrefix))
                 .apply(instance, GeodeBlockSettings::new));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/GeodeVeinGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/veins/GeodeVeinGenerator.java
@@ -341,7 +341,7 @@ public class GeodeVeinGenerator extends VeinGenerator {
                         .forGetter(config -> config.cannotReplace),
                 TagKey.hashedCodec(Registries.BLOCK).fieldOf("invalid_blocks")
                         .forGetter(config -> config.invalidBlocks),
-                        GTRegistries.TAG_PREFIXES.codec().optionalFieldOf("provider_material_prefix", TagPrefix.block)
+                GTRegistries.TAG_PREFIXES.codec().optionalFieldOf("provider_material_prefix", TagPrefix.block)
                         .forGetter(config -> config.providerMaterialPrefix))
                 .apply(instance, GeodeBlockSettings::new));
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/Placeholder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/Placeholder.java
@@ -14,19 +14,12 @@ public abstract class Placeholder {
 
     @Getter
     private final String name;
-    @Getter
-    private final int priority;
 
     public abstract MultiLineComponent apply(PlaceholderContext ctx,
                                              List<MultiLineComponent> args) throws PlaceholderException;
 
     public Placeholder(String name) {
-        this(name, 0);
-    }
-
-    public Placeholder(String name, int priority) {
         this.name = name;
-        this.priority = priority;
     }
 
     protected CompoundTag getData(PlaceholderContext ctx) {

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.placeholder.exceptions.PlaceholderException;
 import com.gregtechceu.gtceu.api.placeholder.exceptions.UnclosedBracketException;
 import com.gregtechceu.gtceu.api.placeholder.exceptions.UnexpectedBracketException;
 import com.gregtechceu.gtceu.api.placeholder.exceptions.UnknownPlaceholderException;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.client.renderer.monitor.IMonitorRenderer;
 import com.gregtechceu.gtceu.data.lang.LangHandler;
 import com.gregtechceu.gtceu.utils.GTStringUtils;
@@ -43,8 +44,6 @@ public class PlaceholderHandler {
     private static final char NEWLINE = '\n';
     private static final char ESCAPED_NEWLINE = 'n';
 
-    private static final Map<String, Placeholder> placeholders = new HashMap<>();
-
     @OnlyIn(Dist.CLIENT)
     private static final class RendererHolder {
 
@@ -52,15 +51,11 @@ public class PlaceholderHandler {
     }
 
     public static void addPlaceholder(Placeholder placeholder) {
-        if (placeholders.containsKey(placeholder.getName())) {
-            if (placeholders.get(placeholder.getName()).getPriority() <= placeholder.getPriority()) {
-                placeholders.put(placeholder.getName(), placeholder);
-            }
-        } else placeholders.put(placeholder.getName(), placeholder);
+        GTRegistries.PLACEHOLDERS.register(placeholder.getName(), placeholder);
     }
 
-    public static boolean placeholderExists(MultiLineComponent placeholder) {
-        return placeholders.containsKey(placeholder.toString());
+    public static void addOrOverridePlaceholder(Placeholder placeholder) {
+        GTRegistries.PLACEHOLDERS.registerOrOverride(placeholder.getName(), placeholder);
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -87,12 +82,12 @@ public class PlaceholderHandler {
     public static MultiLineComponent processPlaceholder(List<MultiLineComponent> placeholder,
                                                         PlaceholderContext context,
                                                         Object2IntOpenHashMap<String> indices) throws PlaceholderException {
-        if (!placeholderExists(placeholder.get(0)))
+        if (!GTRegistries.PLACEHOLDERS.containKey(placeholder.get(0).toString()))
             throw new UnknownPlaceholderException(placeholder.get(0).toString());
         String name = placeholder.get(0).toString();
         indices.addTo(name, 1);
         context.index(indices.getInt(name));
-        return placeholders.get(name).apply(context,
+        return Objects.requireNonNull(GTRegistries.PLACEHOLDERS.get(name)).apply(context,
                 placeholder.subList(1, placeholder.size()));
     }
 
@@ -188,16 +183,12 @@ public class PlaceholderHandler {
         return out.withStyle(ChatFormatting.DARK_RED);
     }
 
-    public static Set<String> getAllPlaceholderNames() {
-        return placeholders.keySet();
-    }
-
     public static Widget getPlaceholderHandlerUI(String filter) {
         DraggableScrollableWidgetGroup placeholderReference = new DraggableScrollableWidgetGroup(280, 15, 100, 200);
         Consumer<String> onSearch = (newSearch) -> {
             placeholderReference.clearAllWidgets();
             int y = 2;
-            ArrayList<String> placeholders = new ArrayList<>(getAllPlaceholderNames());
+            ArrayList<String> placeholders = new ArrayList<>(GTRegistries.PLACEHOLDERS.keys());
             placeholders.removeIf(s -> s == null || !s.contains(newSearch));
             placeholders.sort(String::compareTo);
             for (String placeholder : placeholders) {

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -6,7 +6,6 @@ import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.data.DimensionMarker;
 import com.gregtechceu.gtceu.api.data.chemical.Element;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet;
-import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconType;
 import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
@@ -89,7 +88,8 @@ public final class GTRegistries {
     public static final GTRegistry.RL<MedicalCondition> MEDICAL_CONDITIONS = new GTRegistry.RL<>(
             GTCEu.id("medical_condition"));
 
-    public static final GTRegistry.RL<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.RL<>(GTCEu.id("material_icon_set"));
+    public static final GTRegistry.RL<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.RL<>(
+            GTCEu.id("material_icon_set"));
 
     public static final DeferredRegister<TrunkPlacerType<?>> TRUNK_PLACER_TYPE = DeferredRegister
             .create(Registries.TRUNK_PLACER_TYPE, GTCEu.MOD_ID);

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -49,50 +49,30 @@ public final class GTRegistries {
 
     // GT Registry
 
+    // spotless:off
+
     public static final MaterialRegistry MATERIALS = new MaterialRegistry();
-
     public static final GTRegistry.RL<Element> ELEMENTS = new GTRegistry.RL<>(GTCEu.id("element"));
-
     public static final GTRegistry.RL<TagPrefix> TAG_PREFIXES = new GTRegistry.RL<>(GTCEu.id("tag_prefix"));
-
     public static final GTRegistry.RL<GTRecipeType> RECIPE_TYPES = new GTRegistry.RL<>(GTCEu.id("recipe_type"));
-
-    public static final GTRegistry.RL<GTRecipeCategory> RECIPE_CATEGORIES = new GTRegistry.RL<>(
-            GTCEu.id("recipe_category"));
-
+    public static final GTRegistry.RL<GTRecipeCategory> RECIPE_CATEGORIES = new GTRegistry.RL<>(GTCEu.id("recipe_category"));
     public static final GTRegistry.RL<CoverDefinition> COVERS = new GTRegistry.RL<>(GTCEu.id("cover"));
-
     public static final GTRegistry.RL<MachineDefinition> MACHINES = new GTRegistry.RL<>(GTCEu.id("machine"));
-
-    public static final GTRegistry.String<RecipeCapability<?>> RECIPE_CAPABILITIES = new GTRegistry.String<>(
-            GTCEu.id("recipe_capability"));
-
-    public static final GTRegistry.String<RecipeConditionType<?>> RECIPE_CONDITIONS = new GTRegistry.String<>(
-            GTCEu.id("recipe_condition"));
-
-    public static final GTRegistry.String<ChanceLogic> CHANCE_LOGICS = new GTRegistry.String<>(
-            GTCEu.id("chance_logic"));
-
+    public static final GTRegistry.String<RecipeCapability<?>> RECIPE_CAPABILITIES = new GTRegistry.String<>(GTCEu.id("recipe_capability"));
+    public static final GTRegistry.String<RecipeConditionType<?>> RECIPE_CONDITIONS = new GTRegistry.String<>(GTCEu.id("recipe_condition"));
+    public static final GTRegistry.String<ChanceLogic> CHANCE_LOGICS = new GTRegistry.String<>(GTCEu.id("chance_logic"));
     public static final GTRegistry.RL<SoundEntry> SOUNDS = new GTRegistry.RL<>(GTCEu.id("sound"));
-
-    public static final GTRegistry.RL<BedrockFluidDefinition> BEDROCK_FLUID_DEFINITIONS = new GTRegistry.RL<>(
-            GTCEu.id("bedrock_fluid"));
-
-    public static final GTRegistry.RL<BedrockOreDefinition> BEDROCK_ORE_DEFINITIONS = new GTRegistry.RL<>(
-            GTCEu.id("bedrock_ore"));
-
+    public static final GTRegistry.RL<BedrockFluidDefinition> BEDROCK_FLUID_DEFINITIONS = new GTRegistry.RL<>(GTCEu.id("bedrock_fluid"));
+    public static final GTRegistry.RL<BedrockOreDefinition> BEDROCK_ORE_DEFINITIONS = new GTRegistry.RL<>(GTCEu.id("bedrock_ore"));
     public static final GTRegistry.RL<GTOreDefinition> ORE_VEINS = new GTRegistry.RL<>(GTCEu.id("ore_vein"));
-
-    public static final GTRegistry.RL<DimensionMarker> DIMENSION_MARKERS = new GTRegistry.RL<>(
-            GTCEu.id("dimension_marker"));
-
-    public static final GTRegistry.RL<MedicalCondition> MEDICAL_CONDITIONS = new GTRegistry.RL<>(
-            GTCEu.id("medical_condition"));
-
-    public static final GTRegistry.RL<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.RL<>(
-            GTCEu.id("material_icon_set"));
-
+    public static final GTRegistry.RL<DimensionMarker> DIMENSION_MARKERS = new GTRegistry.RL<>(GTCEu.id("dimension_marker"));
+    public static final GTRegistry.RL<MedicalCondition> MEDICAL_CONDITIONS = new GTRegistry.RL<>(GTCEu.id("medical_condition"));
+    public static final GTRegistry.RL<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.RL<>(GTCEu.id("material_icon_set"));
     public static final GTRegistry.String<Placeholder> PLACEHOLDERS = new GTRegistry.String<>(GTCEu.id("placeholder"));
+
+    public static final GTRegistry<String, Function<FriendlyByteBuf, FluidIngredient>> FLUID_SERIALIZERS = new GTRegistry.String<>(GTCEu.id("fluid_serializers"));
+
+    // spotless:on
 
     public static final DeferredRegister<TrunkPlacerType<?>> TRUNK_PLACER_TYPE = DeferredRegister
             .create(Registries.TRUNK_PLACER_TYPE, GTCEu.MOD_ID);
@@ -100,8 +80,6 @@ public final class GTRegistries {
             .create(Registries.PLACEMENT_MODIFIER_TYPE, GTCEu.MOD_ID);
     public static final DeferredRegister<Codec<? extends IGlobalLootModifier>> GLOBAL_LOOT_MODIFIES = DeferredRegister
             .create(ForgeRegistries.Keys.GLOBAL_LOOT_MODIFIER_SERIALIZERS, GTCEu.MOD_ID);
-    public static final GTRegistry<String, Function<FriendlyByteBuf, FluidIngredient>> FLUID_SERIALIZERS = new GTRegistry.String<>(
-            GTCEu.id("fluid_serializers"));
 
     public static <V, T extends V> T register(Registry<V> registry, ResourceLocation name, T value) {
         ResourceKey<?> registryKey = registry.key();

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -51,9 +51,9 @@ public final class GTRegistries {
 
     public static final MaterialRegistry MATERIALS = new MaterialRegistry();
 
-    public static final GTRegistry.String<Element> ELEMENTS = new GTRegistry.String<>(GTCEu.id("element"));
+    public static final GTRegistry.RL<Element> ELEMENTS = new GTRegistry.RL<>(GTCEu.id("element"));
 
-    public static final GTRegistry.String<TagPrefix> TAG_PREFIXES = new GTRegistry.String<>(GTCEu.id("tag_prefix"));
+    public static final GTRegistry.RL<TagPrefix> TAG_PREFIXES = new GTRegistry.RL<>(GTCEu.id("tag_prefix"));
 
     public static final GTRegistry.RL<GTRecipeType> RECIPE_TYPES = new GTRegistry.RL<>(GTCEu.id("recipe_type"));
 
@@ -89,7 +89,7 @@ public final class GTRegistries {
     public static final GTRegistry.RL<MedicalCondition> MEDICAL_CONDITIONS = new GTRegistry.RL<>(
             GTCEu.id("medical_condition"));
 
-    public static final GTRegistry.String<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.String<>(GTCEu.id("material_icon_set"));
+    public static final GTRegistry.RL<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.RL<>(GTCEu.id("material_icon_set"));
 
     public static final DeferredRegister<TrunkPlacerType<?>> TRUNK_PLACER_TYPE = DeferredRegister
             .create(Registries.TRUNK_PLACER_TYPE, GTCEu.MOD_ID);

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.data.DimensionMarker;
 import com.gregtechceu.gtceu.api.data.chemical.Element;
 import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
+import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
@@ -49,6 +50,8 @@ public final class GTRegistries {
     public static final MaterialRegistry MATERIALS = new MaterialRegistry();
 
     public static final GTRegistry.String<Element> ELEMENTS = new GTRegistry.String<>(GTCEu.id("element"));
+
+    public static final GTRegistry.String<TagPrefix> TAG_PREFIXES = new GTRegistry.String<>(GTCEu.id("tag_prefix"));
 
     public static final GTRegistry.RL<GTRecipeType> RECIPE_TYPES = new GTRegistry.RL<>(GTCEu.id("recipe_type"));
     public static final GTRegistry.RL<GTRecipeCategory> RECIPE_CATEGORIES = new GTRegistry.RL<>(

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -5,6 +5,8 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.data.DimensionMarker;
 import com.gregtechceu.gtceu.api.data.chemical.Element;
+import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet;
+import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconType;
 import com.gregtechceu.gtceu.api.data.chemical.material.registry.MaterialRegistry;
 import com.gregtechceu.gtceu.api.data.medicalcondition.MedicalCondition;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
@@ -54,27 +56,40 @@ public final class GTRegistries {
     public static final GTRegistry.String<TagPrefix> TAG_PREFIXES = new GTRegistry.String<>(GTCEu.id("tag_prefix"));
 
     public static final GTRegistry.RL<GTRecipeType> RECIPE_TYPES = new GTRegistry.RL<>(GTCEu.id("recipe_type"));
+
     public static final GTRegistry.RL<GTRecipeCategory> RECIPE_CATEGORIES = new GTRegistry.RL<>(
             GTCEu.id("recipe_category"));
+
     public static final GTRegistry.RL<CoverDefinition> COVERS = new GTRegistry.RL<>(GTCEu.id("cover"));
 
     public static final GTRegistry.RL<MachineDefinition> MACHINES = new GTRegistry.RL<>(GTCEu.id("machine"));
+
     public static final GTRegistry.String<RecipeCapability<?>> RECIPE_CAPABILITIES = new GTRegistry.String<>(
             GTCEu.id("recipe_capability"));
+
     public static final GTRegistry.String<RecipeConditionType<?>> RECIPE_CONDITIONS = new GTRegistry.String<>(
             GTCEu.id("recipe_condition"));
+
     public static final GTRegistry.String<ChanceLogic> CHANCE_LOGICS = new GTRegistry.String<>(
             GTCEu.id("chance_logic"));
+
     public static final GTRegistry.RL<SoundEntry> SOUNDS = new GTRegistry.RL<>(GTCEu.id("sound"));
+
     public static final GTRegistry.RL<BedrockFluidDefinition> BEDROCK_FLUID_DEFINITIONS = new GTRegistry.RL<>(
             GTCEu.id("bedrock_fluid"));
+
     public static final GTRegistry.RL<BedrockOreDefinition> BEDROCK_ORE_DEFINITIONS = new GTRegistry.RL<>(
             GTCEu.id("bedrock_ore"));
+
     public static final GTRegistry.RL<GTOreDefinition> ORE_VEINS = new GTRegistry.RL<>(GTCEu.id("ore_vein"));
+
     public static final GTRegistry.RL<DimensionMarker> DIMENSION_MARKERS = new GTRegistry.RL<>(
             GTCEu.id("dimension_marker"));
+
     public static final GTRegistry.RL<MedicalCondition> MEDICAL_CONDITIONS = new GTRegistry.RL<>(
             GTCEu.id("medical_condition"));
+
+    public static final GTRegistry.String<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.String<>(GTCEu.id("material_icon_set"));
 
     public static final DeferredRegister<TrunkPlacerType<?>> TRUNK_PLACER_TYPE = DeferredRegister
             .create(Registries.TRUNK_PLACER_TYPE, GTCEu.MOD_ID);

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.api.data.worldgen.GTOreDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidDefinition;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreDefinition;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
+import com.gregtechceu.gtceu.api.placeholder.Placeholder;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.category.GTRecipeCategory;
 import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
@@ -90,6 +91,8 @@ public final class GTRegistries {
 
     public static final GTRegistry.RL<MaterialIconSet> MATERIAL_ICON_SETS = new GTRegistry.RL<>(
             GTCEu.id("material_icon_set"));
+
+    public static final GTRegistry.String<Placeholder> PLACEHOLDERS = new GTRegistry.String<>(GTCEu.id("placeholder"));
 
     public static final DeferredRegister<TrunkPlacerType<?>> TRUNK_PLACER_TYPE = DeferredRegister
             .create(Registries.TRUNK_PLACER_TYPE, GTCEu.MOD_ID);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
@@ -108,7 +108,8 @@ public class OreBlockRenderer {
                 .addProperty("parent", oreType.baseModelLocation().toString());
 
         GTDynamicResourcePack.addBlockModel(
-                iconSet.id.withPath(ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())),
+                iconSet.id
+                        .withPath(ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())),
                 newJson);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconSet;
 import com.gregtechceu.gtceu.api.data.chemical.material.info.MaterialIconType;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.data.pack.GTDynamicResourcePack;
 import com.gregtechceu.gtceu.utils.memoization.GTMemoizer;
 import com.gregtechceu.gtceu.utils.memoization.function.MemoizedBiFunction;
@@ -54,7 +55,7 @@ public class OreBlockRenderer {
     @ApiStatus.Internal
     public static void reinitModels() {
         // first set up all the stone types for all tag prefixes
-        for (MaterialIconSet iconSet : MaterialIconSet.ICON_SETS.values()) {
+        for (MaterialIconSet iconSet : GTRegistries.MATERIAL_ICON_SETS.values()) {
             for (var entry : TagPrefix.ORES.entrySet()) {
                 copyOreModelWithBaseStone(entry.getKey(), entry.getValue(), MaterialIconType.ore, iconSet);
                 copyOreModelWithBaseStone(entry.getKey(), entry.getValue(), MaterialIconType.oreEmissive, iconSet);

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
@@ -108,7 +108,9 @@ public class OreBlockRenderer {
                 .addProperty("parent", oreType.baseModelLocation().toString());
 
         GTDynamicResourcePack.addBlockModel(
-                new ResourceLocation(iconSet.id.getNamespace(), ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())), newJson);
+                new ResourceLocation(iconSet.id.getNamespace(),
+                        ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())),
+                newJson);
     }
 
     private static JsonObject loadTemplateOreModel(MaterialIconType iconType, MaterialIconSet iconSet) {

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
@@ -72,7 +72,7 @@ public class OreBlockRenderer {
             MaterialIconType iconType = tagPrefix.getMaterialIconType(material);
 
             ResourceLocation blockId = BuiltInRegistries.BLOCK.getKey(model.block);
-            ResourceLocation modelId = new ResourceLocation(iconSet.id.getNamespace(), ORE_MODEL_NAME_FORMAT
+            ResourceLocation modelId = iconSet.id.withPath(ORE_MODEL_NAME_FORMAT
                     .formatted(iconSet.getName(), tagPrefix.name, iconType.name()));
 
             GTDynamicResourcePack.addBlockState(blockId, BlockModelGenerators.createSimpleBlock(model.block, modelId));
@@ -108,8 +108,7 @@ public class OreBlockRenderer {
                 .addProperty("parent", oreType.baseModelLocation().toString());
 
         GTDynamicResourcePack.addBlockModel(
-                new ResourceLocation(iconSet.id.getNamespace(),
-                        ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())),
+                iconSet.id.withPath(ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())),
                 newJson);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/block/OreBlockRenderer.java
@@ -72,8 +72,8 @@ public class OreBlockRenderer {
             MaterialIconType iconType = tagPrefix.getMaterialIconType(material);
 
             ResourceLocation blockId = BuiltInRegistries.BLOCK.getKey(model.block);
-            ResourceLocation modelId = GTCEu.id(ORE_MODEL_NAME_FORMAT
-                    .formatted(iconSet.name, tagPrefix.name, iconType.name()));
+            ResourceLocation modelId = new ResourceLocation(iconSet.id.getNamespace(), ORE_MODEL_NAME_FORMAT
+                    .formatted(iconSet.getName(), tagPrefix.name, iconType.name()));
 
             GTDynamicResourcePack.addBlockState(blockId, BlockModelGenerators.createSimpleBlock(model.block, modelId));
             GTDynamicResourcePack.addItemModel(BuiltInRegistries.ITEM.getKey(model.block.asItem()),
@@ -92,7 +92,7 @@ public class OreBlockRenderer {
             original = TEMPLATE_MODEL_CACHE.apply(iconType, iconSet);
         } catch (RuntimeException e) {
             GTCEu.LOGGER.error("Could not load template block model for ore type {}, icon type '{}', icon set '{}'",
-                    tagPrefix.name, iconType.name(), iconSet.name, e);
+                    tagPrefix.name, iconType.name(), iconSet.id, e);
             return;
         }
         if (original == NULL_ELEMENT_MARKER) {
@@ -108,7 +108,7 @@ public class OreBlockRenderer {
                 .addProperty("parent", oreType.baseModelLocation().toString());
 
         GTDynamicResourcePack.addBlockModel(
-                GTCEu.id(ORE_MODEL_NAME_FORMAT.formatted(iconSet.name, tagPrefix.name, iconType.name())), newJson);
+                new ResourceLocation(iconSet.id.getNamespace(), ORE_MODEL_NAME_FORMAT.formatted(iconSet.getName(), tagPrefix.name, iconType.name())), newJson);
     }
 
     private static JsonObject loadTemplateOreModel(MaterialIconType iconType, MaterialIconSet iconSet) {

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -44,7 +44,6 @@ import com.gregtechceu.gtceu.data.pack.GTDynamicDataPack;
 import com.gregtechceu.gtceu.data.pack.GTDynamicResourcePack;
 import com.gregtechceu.gtceu.data.pack.GTPackSource;
 import com.gregtechceu.gtceu.data.recipe.GTCraftingComponents;
-import com.gregtechceu.gtceu.integration.ae2.GTAEPlaceholders;
 import com.gregtechceu.gtceu.integration.cctweaked.CCTweakedPlugin;
 import com.gregtechceu.gtceu.integration.create.GTCreateIntegration;
 import com.gregtechceu.gtceu.integration.kjs.GTCEuStartupEvents;
@@ -128,12 +127,10 @@ public class CommonProxy {
         TagPrefix.init();
         GTSoundEntries.init();
         GTDamageTypes.init();
-        GTPlaceholders.initPlaceholders();
+        GTPlaceholders.init();
+
         if (ConfigHolder.INSTANCE.compat.createCompat && GTCEu.Mods.isCreateLoaded()) {
             GTCreateIntegration.init();
-        }
-        if (GTCEu.Mods.isAE2Loaded()) {
-            GTAEPlaceholders.init();
         }
 
         GTCovers.init();

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -78,6 +78,7 @@ import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import com.tterrag.registrate.util.nullness.NonNullFunction;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -270,7 +271,7 @@ public class GTBlocks {
 
         MaterialCasingCollectionEvent event = new MaterialCasingCollectionEvent(builder);
         AddonFinder.getAddons().forEach(addon -> addon.collectMaterialCasings(event));
-
+        ModLoader.get().postEvent(event);
         MATERIALS_TO_CASINGS = builder.build();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTBlocks.java
@@ -68,6 +68,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.model.generators.ModelFile;
 import net.minecraftforge.client.model.generators.ModelProvider;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.fml.ModLoader;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableTable;
@@ -78,7 +79,6 @@ import com.tterrag.registrate.util.entry.BlockEntry;
 import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import com.tterrag.registrate.util.nullness.NonNullFunction;
 import com.tterrag.registrate.util.nullness.NonNullSupplier;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
@@ -17,141 +17,206 @@ public class GTElements {
         GTRegistries.ELEMENTS.unfreeze();
     }
 
-    public static final Element H = createAndRegister(1, 0, -1, null, "Hydrogen", "H", false);
-    public static final Element D = createAndRegister(1, 1, -1, "H", "Deuterium", "D", true);
-    public static final Element T = createAndRegister(1, 2, -1, "D", "Tritium", "T", true);
-    public static final Element He = createAndRegister(2, 2, -1, null, "Helium", "He", false);
-    public static final Element He3 = createAndRegister(2, 1, -1, "H&D", "Helium-3", "He-3", true);
-    public static final Element Li = createAndRegister(3, 4, -1, null, "Lithium", "Li", false);
-    public static final Element Be = createAndRegister(4, 5, -1, null, "Beryllium", "Be", false);
-    public static final Element B = createAndRegister(5, 5, -1, null, "Boron", "B", false);
-    public static final Element C = createAndRegister(6, 6, -1, null, "Carbon", "C", false);
-    public static final Element N = createAndRegister(7, 7, -1, null, "Nitrogen", "N", false);
-    public static final Element O = createAndRegister(8, 8, -1, null, "Oxygen", "O", false);
-    public static final Element F = createAndRegister(9, 9, -1, null, "Fluorine", "F", false);
-    public static final Element Ne = createAndRegister(10, 10, -1, null, "Neon", "Ne", false);
-    public static final Element Na = createAndRegister(11, 11, -1, null, "Sodium", "Na", false);
-    public static final Element Mg = createAndRegister(12, 12, -1, null, "Magnesium", "Mg", false);
-    public static final Element Al = createAndRegister(13, 13, -1, null, "Aluminium", "Al", false);
-    public static final Element Si = createAndRegister(14, 14, -1, null, "Silicon", "Si", false);
-    public static final Element P = createAndRegister(15, 15, -1, null, "Phosphorus", "P", false);
-    public static final Element S = createAndRegister(16, 16, -1, null, "Sulfur", "S", false);
-    public static final Element Cl = createAndRegister(17, 18, -1, null, "Chlorine", "Cl", false);
-    public static final Element Ar = createAndRegister(18, 22, -1, null, "Argon", "Ar", false);
-    public static final Element K = createAndRegister(19, 20, -1, null, "Potassium", "K", false);
-    public static final Element Ca = createAndRegister(20, 20, -1, null, "Calcium", "Ca", false);
-    public static final Element Sc = createAndRegister(21, 24, -1, null, "Scandium", "Sc", false);
-    public static final Element Ti = createAndRegister(22, 26, -1, null, "Titanium", "Ti", false);
-    public static final Element V = createAndRegister(23, 28, -1, null, "Vanadium", "V", false);
-    public static final Element Cr = createAndRegister(24, 28, -1, null, "Chrome", "Cr", false);
-    public static final Element Mn = createAndRegister(25, 30, -1, null, "Manganese", "Mn", false);
-    public static final Element Fe = createAndRegister(26, 30, -1, null, "Iron", "Fe", false);
-    public static final Element Co = createAndRegister(27, 32, -1, null, "Cobalt", "Co", false);
-    public static final Element Ni = createAndRegister(28, 30, -1, null, "Nickel", "Ni", false);
-    public static final Element Cu = createAndRegister(29, 34, -1, null, "Copper", "Cu", false);
-    public static final Element Zn = createAndRegister(30, 35, -1, null, "Zinc", "Zn", false);
-    public static final Element Ga = createAndRegister(31, 39, -1, null, "Gallium", "Ga", false);
-    public static final Element Ge = createAndRegister(32, 40, -1, null, "Germanium", "Ge", false);
-    public static final Element As = createAndRegister(33, 42, -1, null, "Arsenic", "As", false);
-    public static final Element Se = createAndRegister(34, 45, -1, null, "Selenium", "Se", false);
-    public static final Element Br = createAndRegister(35, 45, -1, null, "Bromine", "Br", false);
-    public static final Element Kr = createAndRegister(36, 48, -1, null, "Krypton", "Kr", false);
-    public static final Element Rb = createAndRegister(37, 48, -1, null, "Rubidium", "Rb", false);
-    public static final Element Sr = createAndRegister(38, 49, -1, null, "Strontium", "Sr", false);
-    public static final Element Y = createAndRegister(39, 50, -1, null, "Yttrium", "Y", false);
-    public static final Element Zr = createAndRegister(40, 51, -1, null, "Zirconium", "Zr", false);
-    public static final Element Nb = createAndRegister(41, 53, -1, null, "Niobium", "Nb", false);
-    public static final Element Mo = createAndRegister(42, 53, -1, null, "Molybdenum", "Mo", false);
-    public static final Element Tc = createAndRegister(43, 55, -1, null, "Technetium", "Tc", false);
-    public static final Element Ru = createAndRegister(44, 57, -1, null, "Ruthenium", "Ru", false);
-    public static final Element Rh = createAndRegister(45, 58, -1, null, "Rhodium", "Rh", false);
-    public static final Element Pd = createAndRegister(46, 60, -1, null, "Palladium", "Pd", false);
-    public static final Element Ag = createAndRegister(47, 60, -1, null, "Silver", "Ag", false);
-    public static final Element Cd = createAndRegister(48, 64, -1, null, "Cadmium", "Cd", false);
-    public static final Element In = createAndRegister(49, 65, -1, null, "Indium", "In", false);
-    public static final Element Sn = createAndRegister(50, 68, -1, null, "Tin", "Sn", false);
-    public static final Element Sb = createAndRegister(51, 70, -1, null, "Antimony", "Sb", false);
-    public static final Element Te = createAndRegister(52, 75, -1, null, "Tellurium", "Te", false);
-    public static final Element I = createAndRegister(53, 74, -1, null, "Iodine", "I", false);
-    public static final Element Xe = createAndRegister(54, 77, -1, null, "Xenon", "Xe", false);
-    public static final Element Cs = createAndRegister(55, 77, -1, null, "Caesium", "Cs", false);
-    public static final Element Ba = createAndRegister(56, 81, -1, null, "Barium", "Ba", false);
-    public static final Element La = createAndRegister(57, 81, -1, null, "Lanthanum", "La", false);
-    public static final Element Ce = createAndRegister(58, 82, -1, null, "Cerium", "Ce", false);
-    public static final Element Pr = createAndRegister(59, 81, -1, null, "Praseodymium", "Pr", false);
-    public static final Element Nd = createAndRegister(60, 84, -1, null, "Neodymium", "Nd", false);
-    public static final Element Pm = createAndRegister(61, 83, -1, null, "Promethium", "Pm", false);
-    public static final Element Sm = createAndRegister(62, 88, -1, null, "Samarium", "Sm", false);
-    public static final Element Eu = createAndRegister(63, 88, -1, null, "Europium", "Eu", false);
-    public static final Element Gd = createAndRegister(64, 93, -1, null, "Gadolinium", "Gd", false);
-    public static final Element Tb = createAndRegister(65, 93, -1, null, "Terbium", "Tb", false);
-    public static final Element Dy = createAndRegister(66, 96, -1, null, "Dysprosium", "Dy", false);
-    public static final Element Ho = createAndRegister(67, 97, -1, null, "Holmium", "Ho", false);
-    public static final Element Er = createAndRegister(68, 99, -1, null, "Erbium", "Er", false);
-    public static final Element Tm = createAndRegister(69, 99, -1, null, "Thulium", "Tm", false);
-    public static final Element Yb = createAndRegister(70, 103, -1, null, "Ytterbium", "Yb", false);
-    public static final Element Lu = createAndRegister(71, 103, -1, null, "Lutetium", "Lu", false);
-    public static final Element Hf = createAndRegister(72, 106, -1, null, "Hafnium", "Hf", false);
-    public static final Element Ta = createAndRegister(73, 107, -1, null, "Tantalum", "Ta", false);
-    public static final Element W = createAndRegister(74, 109, -1, null, "Tungsten", "W", false);
-    public static final Element Re = createAndRegister(75, 111, -1, null, "Rhenium", "Re", false);
-    public static final Element Os = createAndRegister(76, 114, -1, null, "Osmium", "Os", false);
-    public static final Element Ir = createAndRegister(77, 115, -1, null, "Iridium", "Ir", false);
-    public static final Element Pt = createAndRegister(78, 117, -1, null, "Platinum", "Pt", false);
-    public static final Element Au = createAndRegister(79, 117, -1, null, "Gold", "Au", false);
-    public static final Element Hg = createAndRegister(80, 120, -1, null, "Mercury", "Hg", false);
-    public static final Element Tl = createAndRegister(81, 123, -1, null, "Thallium", "Tl", false);
-    public static final Element Pb = createAndRegister(82, 125, -1, null, "Lead", "Pb", false);
-    public static final Element Bi = createAndRegister(83, 125, -1, null, "Bismuth", "Bi", false);
-    public static final Element Po = createAndRegister(84, 124, -1, null, "Polonium", "Po", false);
-    public static final Element At = createAndRegister(85, 124, -1, null, "Astatine", "At", false);
-    public static final Element Rn = createAndRegister(86, 134, -1, null, "Radon", "Rn", false);
-    public static final Element Fr = createAndRegister(87, 134, -1, null, "Francium", "Fr", false);
-    public static final Element Ra = createAndRegister(88, 136, -1, null, "Radium", "Ra", false);
-    public static final Element Ac = createAndRegister(89, 136, -1, null, "Actinium", "Ac", false);
-    public static final Element Th = createAndRegister(90, 140, -1, null, "Thorium", "Th", false);
-    public static final Element Pa = createAndRegister(91, 138, -1, null, "Protactinium", "Pa", false);
-    public static final Element U = createAndRegister(92, 146, -1, null, "Uranium", "U", false);
-    public static final Element U238 = createAndRegister(92, 146, -1, null, "Uranium-238", "U-238", false);
-    public static final Element U235 = createAndRegister(92, 143, -1, null, "Uranium-235", "U-235", true);
-    public static final Element Np = createAndRegister(93, 144, -1, null, "Neptunium", "Np", false);
-    public static final Element Pu = createAndRegister(94, 152, -1, null, "Plutonium", "Pu", false);
-    public static final Element Pu239 = createAndRegister(94, 145, -1, null, "Plutonium-239", "Pu-239", false);
-    public static final Element Pu241 = createAndRegister(94, 149, -1, null, "Plutonium-241", "Pu-241", true);
-    public static final Element Am = createAndRegister(95, 150, -1, null, "Americium", "Am", false);
-    public static final Element Cm = createAndRegister(96, 153, -1, null, "Curium", "Cm", false);
-    public static final Element Bk = createAndRegister(97, 152, -1, null, "Berkelium", "Bk", false);
-    public static final Element Cf = createAndRegister(98, 153, -1, null, "Californium", "Cf", false);
-    public static final Element Es = createAndRegister(99, 153, -1, null, "Einsteinium", "Es", false);
-    public static final Element Fm = createAndRegister(100, 157, -1, null, "Fermium", "Fm", false);
-    public static final Element Md = createAndRegister(101, 157, -1, null, "Mendelevium", "Md", false);
-    public static final Element No = createAndRegister(102, 157, -1, null, "Nobelium", "No", false);
-    public static final Element Lr = createAndRegister(103, 159, -1, null, "Lawrencium", "Lr", false);
-    public static final Element Rf = createAndRegister(104, 161, -1, null, "Rutherfordium", "Rf", false);
-    public static final Element Db = createAndRegister(105, 163, -1, null, "Dubnium", "Db", false);
-    public static final Element Sg = createAndRegister(106, 165, -1, null, "Seaborgium", "Sg", false);
-    public static final Element Bh = createAndRegister(107, 163, -1, null, "Bohrium", "Bh", false);
-    public static final Element Hs = createAndRegister(108, 169, -1, null, "Hassium", "Hs", false);
-    public static final Element Mt = createAndRegister(109, 167, -1, null, "Meitnerium", "Mt", false);
-    public static final Element Ds = createAndRegister(110, 171, -1, null, "Darmstadtium", "Ds", false);
-    public static final Element Rg = createAndRegister(111, 169, -1, null, "Roentgenium", "Rg", false);
-    public static final Element Cn = createAndRegister(112, 173, -1, null, "Copernicium", "Cn", false);
-    public static final Element Nh = createAndRegister(113, 171, -1, null, "Nihonium", "Nh", false);
-    public static final Element Fl = createAndRegister(114, 175, -1, null, "Flerovium", "Fl", false);
-    public static final Element Mc = createAndRegister(115, 173, -1, null, "Moscovium", "Mc", false);
-    public static final Element Lv = createAndRegister(116, 177, -1, null, "Livermorium", "Lv", false);
-    public static final Element Ts = createAndRegister(117, 177, -1, null, "Tennessine", "Ts", false);
-    public static final Element Og = createAndRegister(118, 176, -1, null, "Oganesson", "Og", false);
-    public static final Element Tr = createAndRegister(119, 178, -1, null, "Tritanium", "Tr", false);
-    public static final Element Dr = createAndRegister(120, 180, -1, null, "Duranium", "Dr", false);
-    public static final Element Ke = createAndRegister(125, 198, -1, null, "Trinium", "Ke", false);
-    public static final Element Nq = createAndRegister(174, 352, 140, null, "Naquadah", "Nq", true);
-    public static final Element Nq1 = createAndRegister(174, 354, 140, null, "NaquadahEnriched", "Nq+", true);
-    public static final Element Nq2 = createAndRegister(174, 348, 140, null, "Naquadria", "*Nq*", true);
-    public static final Element Nt = createAndRegister(0, 1000, -1, null, "Neutronium", "Nt", false);
-    public static final Element Sp = createAndRegister(1, 0, -1, null, "Space", "Sp", false);
-    public static final Element Ma = createAndRegister(1, 0, -1, null, "Magic", "Ma", false);
+    public static final Element H = createAndRegister(GTCEu.id("Hydrogen"), 1, 0, -1, null, "Hydrogen", "H", false);
+    public static final Element D = createAndRegister(GTCEu.id("Deuterium"), 1, 1, -1, "H", "Deuterium", "D", true);
+    public static final Element T = createAndRegister(GTCEu.id("Tritium"), 1, 2, -1, "D", "Tritium", "T", true);
+    public static final Element He = createAndRegister(GTCEu.id("Helium"), 2, 2, -1, null, "Helium", "He", false);
+    public static final Element He3 = createAndRegister(GTCEu.id("Helium-3"), 2, 1, -1, "H&D", "Helium-3", "He-3",
+            true);
+    public static final Element Li = createAndRegister(GTCEu.id("Lithium"), 3, 4, -1, null, "Lithium", "Li", false);
+    public static final Element Be = createAndRegister(GTCEu.id("Beryllium"), 4, 5, -1, null, "Beryllium", "Be", false);
+    public static final Element B = createAndRegister(GTCEu.id("Boron"), 5, 5, -1, null, "Boron", "B", false);
+    public static final Element C = createAndRegister(GTCEu.id("Carbon"), 6, 6, -1, null, "Carbon", "C", false);
+    public static final Element N = createAndRegister(GTCEu.id("Nitrogen"), 7, 7, -1, null, "Nitrogen", "N", false);
+    public static final Element O = createAndRegister(GTCEu.id("Oxygen"), 8, 8, -1, null, "Oxygen", "O", false);
+    public static final Element F = createAndRegister(GTCEu.id("Fluorine"), 9, 9, -1, null, "Fluorine", "F", false);
+    public static final Element Ne = createAndRegister(GTCEu.id("Neon"), 10, 10, -1, null, "Neon", "Ne", false);
+    public static final Element Na = createAndRegister(GTCEu.id("Sodium"), 11, 11, -1, null, "Sodium", "Na", false);
+    public static final Element Mg = createAndRegister(GTCEu.id("Magnesium"), 12, 12, -1, null, "Magnesium", "Mg",
+            false);
+    public static final Element Al = createAndRegister(GTCEu.id("Aluminium"), 13, 13, -1, null, "Aluminium", "Al",
+            false);
+    public static final Element Si = createAndRegister(GTCEu.id("Silicon"), 14, 14, -1, null, "Silicon", "Si", false);
+    public static final Element P = createAndRegister(GTCEu.id("Phosphorus"), 15, 15, -1, null, "Phosphorus", "P",
+            false);
+    public static final Element S = createAndRegister(GTCEu.id("Sulfur"), 16, 16, -1, null, "Sulfur", "S", false);
+    public static final Element Cl = createAndRegister(GTCEu.id("Chlorine"), 17, 18, -1, null, "Chlorine", "Cl", false);
+    public static final Element Ar = createAndRegister(GTCEu.id("Argon"), 18, 22, -1, null, "Argon", "Ar", false);
+    public static final Element K = createAndRegister(GTCEu.id("Potassium"), 19, 20, -1, null, "Potassium", "K", false);
+    public static final Element Ca = createAndRegister(GTCEu.id("Calcium"), 20, 20, -1, null, "Calcium", "Ca", false);
+    public static final Element Sc = createAndRegister(GTCEu.id("Scandium"), 21, 24, -1, null, "Scandium", "Sc", false);
+    public static final Element Ti = createAndRegister(GTCEu.id("Titanium"), 22, 26, -1, null, "Titanium", "Ti", false);
+    public static final Element V = createAndRegister(GTCEu.id("Vanadium"), 23, 28, -1, null, "Vanadium", "V", false);
+    public static final Element Cr = createAndRegister(GTCEu.id("Chrome"), 24, 28, -1, null, "Chrome", "Cr", false);
+    public static final Element Mn = createAndRegister(GTCEu.id("Manganese"), 25, 30, -1, null, "Manganese", "Mn",
+            false);
+    public static final Element Fe = createAndRegister(GTCEu.id("Iron"), 26, 30, -1, null, "Iron", "Fe", false);
+    public static final Element Co = createAndRegister(GTCEu.id("Cobalt"), 27, 32, -1, null, "Cobalt", "Co", false);
+    public static final Element Ni = createAndRegister(GTCEu.id("Nickel"), 28, 30, -1, null, "Nickel", "Ni", false);
+    public static final Element Cu = createAndRegister(GTCEu.id("Copper"), 29, 34, -1, null, "Copper", "Cu", false);
+    public static final Element Zn = createAndRegister(GTCEu.id("Zinc"), 30, 35, -1, null, "Zinc", "Zn", false);
+    public static final Element Ga = createAndRegister(GTCEu.id("Gallium"), 31, 39, -1, null, "Gallium", "Ga", false);
+    public static final Element Ge = createAndRegister(GTCEu.id("Germanium"), 32, 40, -1, null, "Germanium", "Ge",
+            false);
+    public static final Element As = createAndRegister(GTCEu.id("Arsenic"), 33, 42, -1, null, "Arsenic", "As", false);
+    public static final Element Se = createAndRegister(GTCEu.id("Selenium"), 34, 45, -1, null, "Selenium", "Se", false);
+    public static final Element Br = createAndRegister(GTCEu.id("Bromine"), 35, 45, -1, null, "Bromine", "Br", false);
+    public static final Element Kr = createAndRegister(GTCEu.id("Krypton"), 36, 48, -1, null, "Krypton", "Kr", false);
+    public static final Element Rb = createAndRegister(GTCEu.id("Rubidium"), 37, 48, -1, null, "Rubidium", "Rb", false);
+    public static final Element Sr = createAndRegister(GTCEu.id("Strontium"), 38, 49, -1, null, "Strontium", "Sr",
+            false);
+    public static final Element Y = createAndRegister(GTCEu.id("Yttrium"), 39, 50, -1, null, "Yttrium", "Y", false);
+    public static final Element Zr = createAndRegister(GTCEu.id("Zirconium"), 40, 51, -1, null, "Zirconium", "Zr",
+            false);
+    public static final Element Nb = createAndRegister(GTCEu.id("Niobium"), 41, 53, -1, null, "Niobium", "Nb", false);
+    public static final Element Mo = createAndRegister(GTCEu.id("Molybdenum"), 42, 53, -1, null, "Molybdenum", "Mo",
+            false);
+    public static final Element Tc = createAndRegister(GTCEu.id("Technetium"), 43, 55, -1, null, "Technetium", "Tc",
+            false);
+    public static final Element Ru = createAndRegister(GTCEu.id("Ruthenium"), 44, 57, -1, null, "Ruthenium", "Ru",
+            false);
+    public static final Element Rh = createAndRegister(GTCEu.id("Rhodium"), 45, 58, -1, null, "Rhodium", "Rh", false);
+    public static final Element Pd = createAndRegister(GTCEu.id("Palladium"), 46, 60, -1, null, "Palladium", "Pd",
+            false);
+    public static final Element Ag = createAndRegister(GTCEu.id("Silver"), 47, 60, -1, null, "Silver", "Ag", false);
+    public static final Element Cd = createAndRegister(GTCEu.id("Cadmium"), 48, 64, -1, null, "Cadmium", "Cd", false);
+    public static final Element In = createAndRegister(GTCEu.id("Indium"), 49, 65, -1, null, "Indium", "In", false);
+    public static final Element Sn = createAndRegister(GTCEu.id("Tin"), 50, 68, -1, null, "Tin", "Sn", false);
+    public static final Element Sb = createAndRegister(GTCEu.id("Antimony"), 51, 70, -1, null, "Antimony", "Sb", false);
+    public static final Element Te = createAndRegister(GTCEu.id("Tellurium"), 52, 75, -1, null, "Tellurium", "Te",
+            false);
+    public static final Element I = createAndRegister(GTCEu.id("Iodine"), 53, 74, -1, null, "Iodine", "I", false);
+    public static final Element Xe = createAndRegister(GTCEu.id("Xenon"), 54, 77, -1, null, "Xenon", "Xe", false);
+    public static final Element Cs = createAndRegister(GTCEu.id("Caesium"), 55, 77, -1, null, "Caesium", "Cs", false);
+    public static final Element Ba = createAndRegister(GTCEu.id("Barium"), 56, 81, -1, null, "Barium", "Ba", false);
+    public static final Element La = createAndRegister(GTCEu.id("Lanthanum"), 57, 81, -1, null, "Lanthanum", "La",
+            false);
+    public static final Element Ce = createAndRegister(GTCEu.id("Cerium"), 58, 82, -1, null, "Cerium", "Ce", false);
+    public static final Element Pr = createAndRegister(GTCEu.id("Praseodymium"), 59, 81, -1, null, "Praseodymium", "Pr",
+            false);
+    public static final Element Nd = createAndRegister(GTCEu.id("Neodymium"), 60, 84, -1, null, "Neodymium", "Nd",
+            false);
+    public static final Element Pm = createAndRegister(GTCEu.id("Promethium"), 61, 83, -1, null, "Promethium", "Pm",
+            false);
+    public static final Element Sm = createAndRegister(GTCEu.id("Samarium"), 62, 88, -1, null, "Samarium", "Sm", false);
+    public static final Element Eu = createAndRegister(GTCEu.id("Europium"), 63, 88, -1, null, "Europium", "Eu", false);
+    public static final Element Gd = createAndRegister(GTCEu.id("Gadolinium"), 64, 93, -1, null, "Gadolinium", "Gd",
+            false);
+    public static final Element Tb = createAndRegister(GTCEu.id("Terbium"), 65, 93, -1, null, "Terbium", "Tb", false);
+    public static final Element Dy = createAndRegister(GTCEu.id("Dysprosium"), 66, 96, -1, null, "Dysprosium", "Dy",
+            false);
+    public static final Element Ho = createAndRegister(GTCEu.id("Holmium"), 67, 97, -1, null, "Holmium", "Ho", false);
+    public static final Element Er = createAndRegister(GTCEu.id("Erbium"), 68, 99, -1, null, "Erbium", "Er", false);
+    public static final Element Tm = createAndRegister(GTCEu.id("Thulium"), 69, 99, -1, null, "Thulium", "Tm", false);
+    public static final Element Yb = createAndRegister(GTCEu.id("Ytterbium"), 70, 103, -1, null, "Ytterbium", "Yb",
+            false);
+    public static final Element Lu = createAndRegister(GTCEu.id("Lutetium"), 71, 103, -1, null, "Lutetium", "Lu",
+            false);
+    public static final Element Hf = createAndRegister(GTCEu.id("Hafnium"), 72, 106, -1, null, "Hafnium", "Hf", false);
+    public static final Element Ta = createAndRegister(GTCEu.id("Tantalum"), 73, 107, -1, null, "Tantalum", "Ta",
+            false);
+    public static final Element W = createAndRegister(GTCEu.id("Tungsten"), 74, 109, -1, null, "Tungsten", "W", false);
+    public static final Element Re = createAndRegister(GTCEu.id("Rhenium"), 75, 111, -1, null, "Rhenium", "Re", false);
+    public static final Element Os = createAndRegister(GTCEu.id("Osmium"), 76, 114, -1, null, "Osmium", "Os", false);
+    public static final Element Ir = createAndRegister(GTCEu.id("Iridium"), 77, 115, -1, null, "Iridium", "Ir", false);
+    public static final Element Pt = createAndRegister(GTCEu.id("Platinum"), 78, 117, -1, null, "Platinum", "Pt",
+            false);
+    public static final Element Au = createAndRegister(GTCEu.id("Gold"), 79, 117, -1, null, "Gold", "Au", false);
+    public static final Element Hg = createAndRegister(GTCEu.id("Mercury"), 80, 120, -1, null, "Mercury", "Hg", false);
+    public static final Element Tl = createAndRegister(GTCEu.id("Thallium"), 81, 123, -1, null, "Thallium", "Tl",
+            false);
+    public static final Element Pb = createAndRegister(GTCEu.id("Lead"), 82, 125, -1, null, "Lead", "Pb", false);
+    public static final Element Bi = createAndRegister(GTCEu.id("Bismuth"), 83, 125, -1, null, "Bismuth", "Bi", false);
+    public static final Element Po = createAndRegister(GTCEu.id("Polonium"), 84, 124, -1, null, "Polonium", "Po",
+            false);
+    public static final Element At = createAndRegister(GTCEu.id("Astatine"), 85, 124, -1, null, "Astatine", "At",
+            false);
+    public static final Element Rn = createAndRegister(GTCEu.id("Radon"), 86, 134, -1, null, "Radon", "Rn", false);
+    public static final Element Fr = createAndRegister(GTCEu.id("Francium"), 87, 134, -1, null, "Francium", "Fr",
+            false);
+    public static final Element Ra = createAndRegister(GTCEu.id("Radium"), 88, 136, -1, null, "Radium", "Ra", false);
+    public static final Element Ac = createAndRegister(GTCEu.id("Actinium"), 89, 136, -1, null, "Actinium", "Ac",
+            false);
+    public static final Element Th = createAndRegister(GTCEu.id("Thorium"), 90, 140, -1, null, "Thorium", "Th", false);
+    public static final Element Pa = createAndRegister(GTCEu.id("Protactinium"), 91, 138, -1, null, "Protactinium",
+            "Pa", false);
+    public static final Element U = createAndRegister(GTCEu.id("Uranium"), 92, 146, -1, null, "Uranium", "U", false);
+    public static final Element U238 = createAndRegister(GTCEu.id("Uranium-238"), 92, 146, -1, null, "Uranium-238",
+            "U-238", false);
+    public static final Element U235 = createAndRegister(GTCEu.id("Uranium-235"), 92, 143, -1, null, "Uranium-235",
+            "U-235", true);
+    public static final Element Np = createAndRegister(GTCEu.id("Neptunium"), 93, 144, -1, null, "Neptunium", "Np",
+            false);
+    public static final Element Pu = createAndRegister(GTCEu.id("Plutonium"), 94, 152, -1, null, "Plutonium", "Pu",
+            false);
+    public static final Element Pu239 = createAndRegister(GTCEu.id("Plutonium-239"), 94, 145, -1, null, "Plutonium-239",
+            "Pu-239", false);
+    public static final Element Pu241 = createAndRegister(GTCEu.id("Plutonium-241"), 94, 149, -1, null, "Plutonium-241",
+            "Pu-241", true);
+    public static final Element Am = createAndRegister(GTCEu.id("Americium"), 95, 150, -1, null, "Americium", "Am",
+            false);
+    public static final Element Cm = createAndRegister(GTCEu.id("Curium"), 96, 153, -1, null, "Curium", "Cm", false);
+    public static final Element Bk = createAndRegister(GTCEu.id("Berkelium"), 97, 152, -1, null, "Berkelium", "Bk",
+            false);
+    public static final Element Cf = createAndRegister(GTCEu.id("Californium"), 98, 153, -1, null, "Californium", "Cf",
+            false);
+    public static final Element Es = createAndRegister(GTCEu.id("Einsteinium"), 99, 153, -1, null, "Einsteinium", "Es",
+            false);
+    public static final Element Fm = createAndRegister(GTCEu.id("Fermium"), 100, 157, -1, null, "Fermium", "Fm", false);
+    public static final Element Md = createAndRegister(GTCEu.id("Mendelevium"), 101, 157, -1, null, "Mendelevium", "Md",
+            false);
+    public static final Element No = createAndRegister(GTCEu.id("Nobelium"), 102, 157, -1, null, "Nobelium", "No",
+            false);
+    public static final Element Lr = createAndRegister(GTCEu.id("Lawrencium"), 103, 159, -1, null, "Lawrencium", "Lr",
+            false);
+    public static final Element Rf = createAndRegister(GTCEu.id("Rutherfordium"), 104, 161, -1, null, "Rutherfordium",
+            "Rf", false);
+    public static final Element Db = createAndRegister(GTCEu.id("Dubnium"), 105, 163, -1, null, "Dubnium", "Db", false);
+    public static final Element Sg = createAndRegister(GTCEu.id("Seaborgium"), 106, 165, -1, null, "Seaborgium", "Sg",
+            false);
+    public static final Element Bh = createAndRegister(GTCEu.id("Bohrium"), 107, 163, -1, null, "Bohrium", "Bh", false);
+    public static final Element Hs = createAndRegister(GTCEu.id("Hassium"), 108, 169, -1, null, "Hassium", "Hs", false);
+    public static final Element Mt = createAndRegister(GTCEu.id("Meitnerium"), 109, 167, -1, null, "Meitnerium", "Mt",
+            false);
+    public static final Element Ds = createAndRegister(GTCEu.id("Darmstadtium"), 110, 171, -1, null, "Darmstadtium",
+            "Ds", false);
+    public static final Element Rg = createAndRegister(GTCEu.id("Roentgenium"), 111, 169, -1, null, "Roentgenium", "Rg",
+            false);
+    public static final Element Cn = createAndRegister(GTCEu.id("Copernicium"), 112, 173, -1, null, "Copernicium", "Cn",
+            false);
+    public static final Element Nh = createAndRegister(GTCEu.id("Nihonium"), 113, 171, -1, null, "Nihonium", "Nh",
+            false);
+    public static final Element Fl = createAndRegister(GTCEu.id("Flerovium"), 114, 175, -1, null, "Flerovium", "Fl",
+            false);
+    public static final Element Mc = createAndRegister(GTCEu.id("Moscovium"), 115, 173, -1, null, "Moscovium", "Mc",
+            false);
+    public static final Element Lv = createAndRegister(GTCEu.id("Livermorium"), 116, 177, -1, null, "Livermorium", "Lv",
+            false);
+    public static final Element Ts = createAndRegister(GTCEu.id("Tennessine"), 117, 177, -1, null, "Tennessine", "Ts",
+            false);
+    public static final Element Og = createAndRegister(GTCEu.id("Oganesson"), 118, 176, -1, null, "Oganesson", "Og",
+            false);
+    public static final Element Tr = createAndRegister(GTCEu.id("Tritanium"), 119, 178, -1, null, "Tritanium", "Tr",
+            false);
+    public static final Element Dr = createAndRegister(GTCEu.id("Duranium"), 120, 180, -1, null, "Duranium", "Dr",
+            false);
+    public static final Element Ke = createAndRegister(GTCEu.id("Trinium"), 125, 198, -1, null, "Trinium", "Ke", false);
+    public static final Element Nq = createAndRegister(GTCEu.id("Naquadah"), 174, 352, 140, null, "Naquadah", "Nq",
+            true);
+    public static final Element Nq1 = createAndRegister(GTCEu.id("NaquadahEnriched"), 174, 354, 140, null,
+            "NaquadahEnriched", "Nq+", true);
+    public static final Element Nq2 = createAndRegister(GTCEu.id("Naquadria"), 174, 348, 140, null, "Naquadria", "*Nq*",
+            true);
+    public static final Element Nt = createAndRegister(GTCEu.id("Neutronium"), 0, 1000, -1, null, "Neutronium", "Nt",
+            false);
+    public static final Element Sp = createAndRegister(GTCEu.id("Space"), 1, 0, -1, null, "Space", "Sp", false);
+    public static final Element Ma = createAndRegister(GTCEu.id("Magic"), 1, 0, -1, null, "Magic", "Ma", false);
 
+    /**
+     * @deprecated Use
+     *             {@link GTElements#createAndRegister(ResourceLocation, long, long, long, String, String, String, boolean)}
+     */
+    @Deprecated
     public static Element createAndRegister(long protons, long neutrons, long halfLifeSeconds, String decayTo,
                                             String name, String symbol, boolean isIsotope) {
         return createAndRegister(GTCEu.id(name), protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.data.chemical.Element;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.integration.kjs.GTRegistryInfo;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.fml.ModLoader;
 
 public class GTElements {
@@ -153,8 +154,13 @@ public class GTElements {
 
     public static Element createAndRegister(long protons, long neutrons, long halfLifeSeconds, String decayTo,
                                             String name, String symbol, boolean isIsotope) {
+        return createAndRegister(GTCEu.id(name), protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);
+    }
+
+    public static Element createAndRegister(ResourceLocation id, long protons, long neutrons, long halfLifeSeconds, String decayTo,
+                                            String name, String symbol, boolean isIsotope) {
         Element element = new Element(protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);
-        GTRegistries.ELEMENTS.register(name, element);
+        GTRegistries.ELEMENTS.register(id, element);
         return element;
     }
 
@@ -167,7 +173,11 @@ public class GTElements {
         GTRegistries.ELEMENTS.freeze();
     }
 
+    /**
+     * @deprecated Use {@code GTRegistries.ELEMENTS.get(name)} instead
+     */
+    @Deprecated(since = "8.0.0")
     public static Element get(String name) {
-        return GTRegistries.ELEMENTS.get(name);
+        return GTRegistries.ELEMENTS.get(GTCEu.id(name));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
@@ -157,7 +157,8 @@ public class GTElements {
         return createAndRegister(GTCEu.id(name), protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);
     }
 
-    public static Element createAndRegister(ResourceLocation id, long protons, long neutrons, long halfLifeSeconds, String decayTo,
+    public static Element createAndRegister(ResourceLocation id, long protons, long neutrons, long halfLifeSeconds,
+                                            String decayTo,
                                             String name, String symbol, boolean isIsotope) {
         Element element = new Element(protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);
         GTRegistries.ELEMENTS.register(id, element);

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTPlaceholders.java
@@ -1,5 +1,7 @@
 package com.gregtechceu.gtceu.common.data;
 
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.*;
 import com.gregtechceu.gtceu.api.cover.filter.ItemFilter;
@@ -14,12 +16,17 @@ import com.gregtechceu.gtceu.api.misc.virtualregistry.EntryTypes;
 import com.gregtechceu.gtceu.api.misc.virtualregistry.VirtualEnderRegistry;
 import com.gregtechceu.gtceu.api.placeholder.*;
 import com.gregtechceu.gtceu.api.placeholder.exceptions.*;
+import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.client.renderer.placeholder.ModulePlaceholderRenderer;
 import com.gregtechceu.gtceu.client.renderer.placeholder.QuadPlaceholderRenderer;
 import com.gregtechceu.gtceu.client.renderer.placeholder.RectPlaceholderRenderer;
 import com.gregtechceu.gtceu.common.blockentity.CableBlockEntity;
 import com.gregtechceu.gtceu.common.item.modules.ImageModuleBehaviour;
 import com.gregtechceu.gtceu.common.machine.multiblock.part.monitor.AdvancedMonitorPartMachine;
+import com.gregtechceu.gtceu.config.ConfigHolder;
+import com.gregtechceu.gtceu.integration.ae2.GTAEPlaceholders;
+import com.gregtechceu.gtceu.integration.cctweaked.CCTweakedPlugin;
+import com.gregtechceu.gtceu.integration.create.GTCreateIntegration;
 import com.gregtechceu.gtceu.utils.GTMath;
 import com.gregtechceu.gtceu.utils.GTStringUtils;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
@@ -47,6 +54,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.fml.ModLoader;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -56,6 +64,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class GTPlaceholders {
+
+    static {
+        GTRegistries.PLACEHOLDERS.unfreeze();
+    }
 
     public static int countItems(String id, @Nullable IItemHandler itemHandler) {
         if (itemHandler == null) return 0;
@@ -91,7 +103,7 @@ public class GTPlaceholders {
         return cnt;
     }
 
-    public static void initPlaceholders() {
+    public static void init() {
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> GTPlaceholders::initRenderers);
         PlaceholderHandler.addPlaceholder(new Placeholder("energy") {
 
@@ -1031,6 +1043,21 @@ public class GTPlaceholders {
                 return MultiLineComponent.literal(ctx.monitorGroup().getDataSlot() + 1);
             }
         });
+
+        if (GTCEu.Mods.isAE2Loaded()) {
+            GTAEPlaceholders.init();
+        }
+
+        if (GTCEu.Mods.isCCTweakedLoaded()) {
+            CCTweakedPlugin.initPlaceholders();
+        }
+
+        if (ConfigHolder.INSTANCE.compat.createCompat && GTCEu.Mods.isCreateLoaded()) {
+            GTCreateIntegration.initPlaceholders();
+        }
+
+        ModLoader.get().postEvent(new GTCEuAPI.RegisterEvent<>(GTRegistries.PLACEHOLDERS, Placeholder.class));
+        GTRegistries.PLACEHOLDERS.freeze();
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/gregtechceu/gtceu/integration/cctweaked/CCTweakedPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/cctweaked/CCTweakedPlugin.java
@@ -24,6 +24,9 @@ public class CCTweakedPlugin {
         ForgeComputerCraftAPI.registerGenericCapability(GTCapability.CAPABILITY_ENERGY_INFO_PROVIDER);
         ForgeComputerCraftAPI.registerGenericCapability(GTCapability.CAPABILITY_WORKABLE);
         ForgeComputerCraftAPI.registerGenericCapability(GTCapability.CAPABILITY_COVERABLE);
+    }
+
+    public static void initPlaceholders() {
         PlaceholderHandler.addPlaceholder(new Placeholder("bufferText") {
 
             @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/create/GTCreateIntegration.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/create/GTCreateIntegration.java
@@ -33,8 +33,10 @@ public class GTCreateIntegration {
     public static void init() {
         GTCreateDisplaySources.init();
         GTCreateDisplayTargets.init();
+    }
 
-        PlaceholderHandler.addPlaceholder(new Placeholder("redstone", 1) {
+    public static void initPlaceholders() {
+        PlaceholderHandler.addOrOverridePlaceholder(new Placeholder("redstone") {
 
             @Override
             public MultiLineComponent apply(PlaceholderContext ctx,

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
@@ -47,6 +47,7 @@ public class GTRegistryInfo<K, V> {
     public static final List<BuilderBase<?>> ALL_BUILDERS = new ArrayList<>();
 
     public static final GTRegistryInfo<String, Element> ELEMENT = add(GTRegistries.ELEMENTS, Element.class);
+
     public static final GTRegistryInfo<ResourceLocation, Material> MATERIAL = add(GTRegistries.MATERIALS,
             Material.class);
     public static final GTRegistryInfo<ResourceLocation, GTRecipeType> RECIPE_TYPE = add(GTRegistries.RECIPE_TYPES,
@@ -56,8 +57,7 @@ public class GTRegistryInfo<K, V> {
             GTRecipeCategory.class);
     public static final GTRegistryInfo<ResourceLocation, MachineDefinition> MACHINE = add(GTRegistries.MACHINES,
             MachineDefinition.class);
-    public static final GTRegistryInfo<String, MaterialIconSet> MATERIAL_ICON_SET = add(GTCEu.id("material_icon_set"),
-            () -> MaterialIconSet.ICON_SETS, MaterialIconSet.class);
+    public static final GTRegistryInfo<String, MaterialIconSet> MATERIAL_ICON_SET = add(GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
     public static final GTRegistryInfo<String, MaterialIconType> MATERIAL_ICON_TYPE = add(
             GTCEu.id("material_icon_type"), () -> MaterialIconType.ICON_TYPES, MaterialIconType.class);
     public static final GTRegistryInfo<String, IWorldGenLayer> WORLD_GEN_LAYER = add(GTCEu.id("world_gen_layer"),

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
@@ -62,8 +62,7 @@ public class GTRegistryInfo<K, V> {
             GTCEu.id("material_icon_type"), () -> MaterialIconType.ICON_TYPES, MaterialIconType.class);
     public static final GTRegistryInfo<String, IWorldGenLayer> WORLD_GEN_LAYER = add(GTCEu.id("world_gen_layer"),
             () -> WorldGeneratorUtils.WORLD_GEN_LAYERS, SimpleWorldGenLayer.class);
-    public static final GTRegistryInfo<String, TagPrefix> TAG_PREFIX = add(GTCEu.id("tag_prefix"),
-            () -> TagPrefix.PREFIXES, KJSTagPrefix.class);
+    public static final GTRegistryInfo<String, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES, KJSTagPrefix.class);
     public static final GTRegistryInfo<ResourceLocation, DimensionMarker> DIMENSION_MARKER = add(
             GTRegistries.DIMENSION_MARKERS, DimensionMarker.class);
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
@@ -47,14 +47,12 @@ public class GTRegistryInfo<K, V> {
     public static final List<BuilderBase<?>> ALL_BUILDERS = new ArrayList<>();
 
     public static final GTRegistryInfo<ResourceLocation, Element> ELEMENT = add(GTRegistries.ELEMENTS, Element.class);
-
     public static final GTRegistryInfo<ResourceLocation, Material> MATERIAL = add(GTRegistries.MATERIALS,
             Material.class);
     public static final GTRegistryInfo<ResourceLocation, GTRecipeType> RECIPE_TYPE = add(GTRegistries.RECIPE_TYPES,
             GTRecipeType.class);
     public static final GTRegistryInfo<ResourceLocation, GTRecipeCategory> RECIPE_CATEGORY = add(
-            GTRegistries.RECIPE_CATEGORIES,
-            GTRecipeCategory.class);
+            GTRegistries.RECIPE_CATEGORIES, GTRecipeCategory.class);
     public static final GTRegistryInfo<ResourceLocation, MachineDefinition> MACHINE = add(GTRegistries.MACHINES,
             MachineDefinition.class);
     public static final GTRegistryInfo<ResourceLocation, MaterialIconSet> MATERIAL_ICON_SET = add(

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
@@ -46,25 +46,20 @@ public class GTRegistryInfo<K, V> {
     public static final Map<ResourceLocation, List<GTRegistryInfo<?, ?>>> POST_AT = new HashMap<>();
     public static final List<BuilderBase<?>> ALL_BUILDERS = new ArrayList<>();
 
+    // spotless:off
+
     public static final GTRegistryInfo<ResourceLocation, Element> ELEMENT = add(GTRegistries.ELEMENTS, Element.class);
-    public static final GTRegistryInfo<ResourceLocation, Material> MATERIAL = add(GTRegistries.MATERIALS,
-            Material.class);
-    public static final GTRegistryInfo<ResourceLocation, GTRecipeType> RECIPE_TYPE = add(GTRegistries.RECIPE_TYPES,
-            GTRecipeType.class);
-    public static final GTRegistryInfo<ResourceLocation, GTRecipeCategory> RECIPE_CATEGORY = add(
-            GTRegistries.RECIPE_CATEGORIES, GTRecipeCategory.class);
-    public static final GTRegistryInfo<ResourceLocation, MachineDefinition> MACHINE = add(GTRegistries.MACHINES,
-            MachineDefinition.class);
-    public static final GTRegistryInfo<ResourceLocation, MaterialIconSet> MATERIAL_ICON_SET = add(
-            GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
-    public static final GTRegistryInfo<String, MaterialIconType> MATERIAL_ICON_TYPE = add(
-            GTCEu.id("material_icon_type"), () -> MaterialIconType.ICON_TYPES, MaterialIconType.class);
-    public static final GTRegistryInfo<String, IWorldGenLayer> WORLD_GEN_LAYER = add(GTCEu.id("world_gen_layer"),
-            () -> WorldGeneratorUtils.WORLD_GEN_LAYERS, SimpleWorldGenLayer.class);
-    public static final GTRegistryInfo<ResourceLocation, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES,
-            KJSTagPrefix.class);
-    public static final GTRegistryInfo<ResourceLocation, DimensionMarker> DIMENSION_MARKER = add(
-            GTRegistries.DIMENSION_MARKERS, DimensionMarker.class);
+    public static final GTRegistryInfo<ResourceLocation, Material> MATERIAL = add(GTRegistries.MATERIALS, Material.class);
+    public static final GTRegistryInfo<ResourceLocation, GTRecipeType> RECIPE_TYPE = add(GTRegistries.RECIPE_TYPES, GTRecipeType.class);
+    public static final GTRegistryInfo<ResourceLocation, GTRecipeCategory> RECIPE_CATEGORY = add(GTRegistries.RECIPE_CATEGORIES, GTRecipeCategory.class);
+    public static final GTRegistryInfo<ResourceLocation, MachineDefinition> MACHINE = add(GTRegistries.MACHINES, MachineDefinition.class);
+    public static final GTRegistryInfo<ResourceLocation, MaterialIconSet> MATERIAL_ICON_SET = add(GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
+    public static final GTRegistryInfo<String, MaterialIconType> MATERIAL_ICON_TYPE = add(GTCEu.id("material_icon_type"), () -> MaterialIconType.ICON_TYPES, MaterialIconType.class);
+    public static final GTRegistryInfo<String, IWorldGenLayer> WORLD_GEN_LAYER = add(GTCEu.id("world_gen_layer"), () -> WorldGeneratorUtils.WORLD_GEN_LAYERS, SimpleWorldGenLayer.class);
+    public static final GTRegistryInfo<ResourceLocation, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES, KJSTagPrefix.class);
+    public static final GTRegistryInfo<ResourceLocation, DimensionMarker> DIMENSION_MARKER = add(GTRegistries.DIMENSION_MARKERS, DimensionMarker.class);
+
+    // spotless:on
 
     /*
      * public static final GTRegistryInfo<String, RecipeCapability<?>> RECIPE_CAPABILITY =

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
@@ -46,7 +46,7 @@ public class GTRegistryInfo<K, V> {
     public static final Map<ResourceLocation, List<GTRegistryInfo<?, ?>>> POST_AT = new HashMap<>();
     public static final List<BuilderBase<?>> ALL_BUILDERS = new ArrayList<>();
 
-    public static final GTRegistryInfo<String, Element> ELEMENT = add(GTRegistries.ELEMENTS, Element.class);
+    public static final GTRegistryInfo<ResourceLocation, Element> ELEMENT = add(GTRegistries.ELEMENTS, Element.class);
 
     public static final GTRegistryInfo<ResourceLocation, Material> MATERIAL = add(GTRegistries.MATERIALS,
             Material.class);
@@ -57,12 +57,12 @@ public class GTRegistryInfo<K, V> {
             GTRecipeCategory.class);
     public static final GTRegistryInfo<ResourceLocation, MachineDefinition> MACHINE = add(GTRegistries.MACHINES,
             MachineDefinition.class);
-    public static final GTRegistryInfo<String, MaterialIconSet> MATERIAL_ICON_SET = add(GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
+    public static final GTRegistryInfo<ResourceLocation, MaterialIconSet> MATERIAL_ICON_SET = add(GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
     public static final GTRegistryInfo<String, MaterialIconType> MATERIAL_ICON_TYPE = add(
             GTCEu.id("material_icon_type"), () -> MaterialIconType.ICON_TYPES, MaterialIconType.class);
     public static final GTRegistryInfo<String, IWorldGenLayer> WORLD_GEN_LAYER = add(GTCEu.id("world_gen_layer"),
             () -> WorldGeneratorUtils.WORLD_GEN_LAYERS, SimpleWorldGenLayer.class);
-    public static final GTRegistryInfo<String, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES, KJSTagPrefix.class);
+    public static final GTRegistryInfo<ResourceLocation, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES, KJSTagPrefix.class);
     public static final GTRegistryInfo<ResourceLocation, DimensionMarker> DIMENSION_MARKER = add(
             GTRegistries.DIMENSION_MARKERS, DimensionMarker.class);
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GTRegistryInfo.java
@@ -57,12 +57,14 @@ public class GTRegistryInfo<K, V> {
             GTRecipeCategory.class);
     public static final GTRegistryInfo<ResourceLocation, MachineDefinition> MACHINE = add(GTRegistries.MACHINES,
             MachineDefinition.class);
-    public static final GTRegistryInfo<ResourceLocation, MaterialIconSet> MATERIAL_ICON_SET = add(GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
+    public static final GTRegistryInfo<ResourceLocation, MaterialIconSet> MATERIAL_ICON_SET = add(
+            GTRegistries.MATERIAL_ICON_SETS, MaterialIconSet.class);
     public static final GTRegistryInfo<String, MaterialIconType> MATERIAL_ICON_TYPE = add(
             GTCEu.id("material_icon_type"), () -> MaterialIconType.ICON_TYPES, MaterialIconType.class);
     public static final GTRegistryInfo<String, IWorldGenLayer> WORLD_GEN_LAYER = add(GTCEu.id("world_gen_layer"),
             () -> WorldGeneratorUtils.WORLD_GEN_LAYERS, SimpleWorldGenLayer.class);
-    public static final GTRegistryInfo<ResourceLocation, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES, KJSTagPrefix.class);
+    public static final GTRegistryInfo<ResourceLocation, TagPrefix> TAG_PREFIX = add(GTRegistries.TAG_PREFIXES,
+            KJSTagPrefix.class);
     public static final GTRegistryInfo<ResourceLocation, DimensionMarker> DIMENSION_MARKER = add(
             GTRegistries.DIMENSION_MARKERS, DimensionMarker.class);
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -414,7 +414,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
         typeWrappers.registerSimple(MaterialIconSet.class, o -> {
             if (o instanceof MaterialIconSet iconSet) return iconSet;
-            if (o instanceof CharSequence chars) return MaterialIconSet.getByName(chars.toString());
+            if (o instanceof CharSequence chars) return GTRegistries.MATERIAL_ICON_SETS.get(ResourceLocation.tryParse(GTCEu.appendIdString(chars.toString())));
             return null;
         });
         typeWrappers.registerSimple(MaterialStack.class, o -> {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -415,7 +415,7 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
         typeWrappers.registerSimple(MaterialIconSet.class, o -> {
             if (o instanceof MaterialIconSet iconSet) return iconSet;
             if (o instanceof CharSequence chars) return GTRegistries.MATERIAL_ICON_SETS
-                    .get(ResourceLocation.tryParse(GTCEu.appendIdString(chars.toString())));
+                    .get(GTCEu.id(chars.toString()));
             return null;
         });
         typeWrappers.registerSimple(MaterialStack.class, o -> {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/GregTechKubeJSPlugin.java
@@ -414,7 +414,8 @@ public class GregTechKubeJSPlugin extends KubeJSPlugin {
 
         typeWrappers.registerSimple(MaterialIconSet.class, o -> {
             if (o instanceof MaterialIconSet iconSet) return iconSet;
-            if (o instanceof CharSequence chars) return GTRegistries.MATERIAL_ICON_SETS.get(ResourceLocation.tryParse(GTCEu.appendIdString(chars.toString())));
+            if (o instanceof CharSequence chars) return GTRegistries.MATERIAL_ICON_SETS
+                    .get(ResourceLocation.tryParse(GTCEu.appendIdString(chars.toString())));
             return null;
         });
         typeWrappers.registerSimple(MaterialStack.class, o -> {

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/ElementBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/ElementBuilder.java
@@ -15,6 +15,8 @@ public class ElementBuilder extends BuilderBase<Element> {
 
     public transient final String name;
 
+    public transient final ResourceLocation id;
+
     @Setter
     public transient Component translatableName;
     @Setter
@@ -26,13 +28,14 @@ public class ElementBuilder extends BuilderBase<Element> {
 
     public ElementBuilder(ResourceLocation id) {
         super(id);
+        this.id = id;
         name = id.getPath();
         translatableName = Component.translatable(id.toLanguageKey("element"));
     }
 
     @Override
     public Element register() {
-        return value = GTElements.createAndRegister(protons, neutrons, halfLifeSeconds, decayTo, name, symbol,
+        return value = GTElements.createAndRegister(id, protons, neutrons, halfLifeSeconds, decayTo, name, symbol,
                 isIsotope);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
@@ -24,6 +24,7 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.fml.ModLoader;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -41,7 +42,6 @@ import dev.latvian.mods.kubejs.typings.desc.TypeDescJS;
 import dev.latvian.mods.kubejs.util.ListJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.mod.util.NBTUtils;
-import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/GTRecipeComponents.java
@@ -41,6 +41,7 @@ import dev.latvian.mods.kubejs.typings.desc.TypeDescJS;
 import dev.latvian.mods.kubejs.util.ListJS;
 import dev.latvian.mods.kubejs.util.UtilsJS;
 import dev.latvian.mods.rhino.mod.util.NBTUtils;
+import net.minecraftforge.fml.ModLoader;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -378,6 +379,7 @@ public class GTRecipeComponents {
 
         KJSRecipeKeyEvent event = new KJSRecipeKeyEvent();
         AddonFinder.getAddons().forEach(addon -> addon.registerRecipeKeys(event));
+        ModLoader.get().postEvent(event);
         VALID_CAPS.putAll(event.getRegisteredKeys());
     }
 


### PR DESCRIPTION
## What
- Switch tag prefixes, material icon sets and placeholders to be stored in registries.
- Convert element registry to a resource location registry

- Methods for getting/registering content which is now stored in a registry have been marked as deprecated.
- Methods for registering using string keys will default to GT namespace
### AI Usage 

- [X] No AI driven tools were used for this pull request.
  
## Potential Compatibility Issues
- All existing code should work fine, as all existing IDs which use strings will default to the gt namespace.
