### PR TITLE
fix computation, overclock button, and scanner eu missing in recipe v…

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -105,10 +105,10 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
         this.proxyRecipes = map;
     }
 
-    public GTRecipeType setMaxIOSize(int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs) {
-        return setMaxSize(IO.IN, ItemRecipeCapability.CAP, maxInputs)
+    public GTRecipeType setMaxIOSize(int maxItemInputs, int maxItemOutputs, int maxFluidInputs, int maxFluidOutputs) {
+        return setMaxSize(IO.IN, ItemRecipeCapability.CAP, maxItemInputs)
                 .setMaxSize(IO.IN, FluidRecipeCapability.CAP, maxFluidInputs)
-                .setMaxSize(IO.OUT, ItemRecipeCapability.CAP, maxOutputs)
+                .setMaxSize(IO.OUT, ItemRecipeCapability.CAP, maxItemOutputs)
                 .setMaxSize(IO.OUT, FluidRecipeCapability.CAP, maxFluidOutputs);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/GTRecipeViewerWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/GTRecipeViewerWidget.java
@@ -88,7 +88,7 @@ public class GTRecipeViewerWidget extends ParentWidget<GTRecipeViewerWidget> {
         recipeContentRow = uiLayout.getCustomUIBuilder() == null ? buildDefaultLayout() :
                 uiLayout.getCustomUIBuilder().apply(recipe);
 
-        mainColumn.child(recipeContentRow.coverChildrenWidth().marginTop(5)
+        mainColumn.child(recipeContentRow.coverChildrenWidth().marginTop(5).marginBottom(3)
                 .paddingLeft(2).paddingRight(2));
         mainColumn.child(additionalRecipeContent.child(textComponents));
 
@@ -197,6 +197,7 @@ public class GTRecipeViewerWidget extends ParentWidget<GTRecipeViewerWidget> {
         textComponents.child(new ButtonWidget<>().background(IDrawable.NONE)
                 .hoverBackground(IDrawable.NONE)
                 .size(22, 12)
+                .rightRel(0.0f)
                 .overlay(Text.dynamic(() -> Component.literal(GTValues.VNF[tier])))
                 .tooltipBuilder(tooltip -> {
                     tooltip.addLine(Text.lang("gtceu.oc.tooltip.0", GTValues.VNF[minTier]));

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/GTRecipeViewerWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/GTRecipeViewerWidget.java
@@ -88,7 +88,7 @@ public class GTRecipeViewerWidget extends ParentWidget<GTRecipeViewerWidget> {
         recipeContentRow = uiLayout.getCustomUIBuilder() == null ? buildDefaultLayout() :
                 uiLayout.getCustomUIBuilder().apply(recipe);
 
-        mainColumn.child(recipeContentRow.coverChildrenWidth().marginTop(5).marginBottom(3)
+        mainColumn.child(recipeContentRow.coverChildrenWidth().marginTop(5)
                 .paddingLeft(2).paddingRight(2));
         mainColumn.child(additionalRecipeContent.child(textComponents));
 
@@ -184,7 +184,7 @@ public class GTRecipeViewerWidget extends ParentWidget<GTRecipeViewerWidget> {
         childIf(!FMLLoader.isProduction(), () -> new ButtonWidget<>()
                 .overlay(Text.str("ID"))
                 .decoration()
-                .bottom(16).right(3)
+                .bottom(3).right(3)
                 .size(15, 15)
                 .tooltip(r -> r.addLine("Click to copy recipe ID: " + baseRecipe.id))
                 .onMousePressed((ctx, b) -> {
@@ -194,36 +194,33 @@ public class GTRecipeViewerWidget extends ParentWidget<GTRecipeViewerWidget> {
     }
 
     private void attachOverclockButton() {
-        childIf(RecipeHelper.getRealEUtWithIO(baseRecipe).isInput(),
-                () -> new ButtonWidget<>().background(IDrawable.NONE)
-                        .hoverBackground(IDrawable.NONE)
-                        .size(22, 15)
-                        .bottomRel(0).rightRel(0)
-                        .decoration()
-                        .overlay(Text.dynamic(() -> Component.literal(GTValues.VNF[tier])))
-                        .tooltipBuilder(tooltip -> {
-                            tooltip.addLine(Text.lang("gtceu.oc.tooltip.0", GTValues.VNF[minTier]));
-                            tooltip.addLine(Text.lang("gtceu.oc.tooltip.1"));
-                            tooltip.addLine(Text.lang("gtceu.oc.tooltip.2"));
-                            tooltip.addLine(Text.lang("gtceu.oc.tooltip.3"));
-                            tooltip.addLine(Text.lang("gtceu.oc.tooltip.4"));
-                        })
-                        .onMousePressed((ctx, b) -> {
-                            var mouse = MouseData.create(b);
+        textComponents.child(new ButtonWidget<>().background(IDrawable.NONE)
+                .hoverBackground(IDrawable.NONE)
+                .size(22, 12)
+                .overlay(Text.dynamic(() -> Component.literal(GTValues.VNF[tier])))
+                .tooltipBuilder(tooltip -> {
+                    tooltip.addLine(Text.lang("gtceu.oc.tooltip.0", GTValues.VNF[minTier]));
+                    tooltip.addLine(Text.lang("gtceu.oc.tooltip.1"));
+                    tooltip.addLine(Text.lang("gtceu.oc.tooltip.2"));
+                    tooltip.addLine(Text.lang("gtceu.oc.tooltip.3"));
+                    tooltip.addLine(Text.lang("gtceu.oc.tooltip.4"));
+                })
+                .onMousePressed((ctx, b) -> {
+                    var mouse = MouseData.create(b);
 
-                            if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
-                                if (tier == GTValues.MAX) return true;
-                                tier++;
-                            } else if (b == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
-                                if (tier == minTier) return true;
-                                tier--;
-                            } else if (b == GLFW.GLFW_MOUSE_BUTTON_MIDDLE) {
-                                tier = minTier;
-                            }
+                    if (b == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+                        if (tier == GTValues.MAX) return true;
+                        tier++;
+                    } else if (b == GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+                        if (tier == minTier) return true;
+                        tier--;
+                    } else if (b == GLFW.GLFW_MOUSE_BUTTON_MIDDLE) {
+                        tier = minTier;
+                    }
 
-                            updateOverclock(mouse);
-                            return true;
-                        }));
+                    updateOverclock(mouse);
+                    return true;
+                }).setEnabledIf(w -> RecipeHelper.getRealEUtWithIO(baseRecipe).isInput()));
     }
 
     private void updateOverclock(MouseData data) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -470,6 +470,8 @@ public class GTRecipeTypes {
             .setSound(GTSoundEntries.COOLING);
 
     public static final GTRecipeType RESEARCH_STATION_RECIPES = register("research_station", ELECTRIC)
+            .setEUIO(IO.IN)
+            .setMaxSize(IO.IN, GTRecipeCapabilities.CWU, 1)
             .setMaxIOSize(2, 1, 0, 0)
             .UI(builder -> builder.setProgressBar(GTGuiTextures.PROGRESS_ARROW)
                     .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.SCANNER_OVERLAY)
@@ -491,6 +493,7 @@ public class GTRecipeTypes {
             .setSound(GTSoundEntries.FIRE);
 
     public static final GTRecipeType SCANNER_RECIPES = register("scanner", ELECTRIC)
+            .setEUIO(IO.IN)
             .setMaxIOSize(2, 1, 1, 0)
             .UI(builder -> builder.setProgressBar(GTGuiTextures.PROGRESS_ARROW)
                     .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.DATA_ORB_OVERLAY)


### PR DESCRIPTION
## What
Fixes computation and eu not showing up in scanner and research station recipes in the recipe viewer.
also shuffles around the overclock button a bit so it doesnt overlap


## Implementation Details
mui :okay:

### AI Usage 


- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
looks better, taken feedback from internal ux yap

## How Was This Tested
<img width="419" height="528" alt="image" src="https://github.com/user-attachments/assets/1ebc11cf-db85-4c81-9e08-1dac0d682ba0" />
<img width="422" height="591" alt="image" src="https://github.com/user-attachments/assets/aeb5e842-2c96-4021-aad3-e16140e637ed" />
