### PR TITLE
MUI cover and filter ui cleanup/fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/IMuiCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/IMuiCover.java
@@ -50,14 +50,18 @@ public interface IMuiCover extends IUIHolder<SidedPosGuiData> {
         ItemStack stack = this.self().coverHolder.getCoverAtSide(this.self().attachedSide).getAttachItem();
         panel.child(GTMuiWidgets.createTitleBar(() -> stack, 176, GTGuiTextures.BACKGROUND));
 
+        panel.coverChildrenHeight();
+
         Flow column = Flow.column()
-                .top(7).margin(7, 0)
+                .margin(7)
                 .childPadding(2)
-                .widthRel(1.0f).coverChildrenHeight();
+                .widthRel(1.0f)
+                .coverChildrenHeight();
 
         createCoverUIRows(column, data, syncManager, settings);
-        return panel.child(column)
-                .child(SlotGroupWidget.playerInventory(false).left(7).bottom(7));
+
+        column.child(SlotGroupWidget.playerInventory(0, false).marginTop(2));
+        return panel.child(column);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/Filter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/Filter.java
@@ -1,17 +1,18 @@
 package com.gregtechceu.gtceu.api.cover.filter;
 
-import brachy.modularui.widgets.Dialog;
-import brachy.modularui.widgets.SlotGroupWidget;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
+
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
 
 import brachy.modularui.factory.GuiData;
 import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.PanelSyncManager;
+import brachy.modularui.widgets.Dialog;
+import brachy.modularui.widgets.SlotGroupWidget;
 import brachy.modularui.widgets.layout.Flow;
-import net.minecraft.world.item.ItemStack;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -21,8 +22,8 @@ public interface Filter<T, S extends Filter<T, S>> extends Predicate<T> {
     /**
      * @return Filter panel when opened by itself (including the player inventory)
      */
-    default ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings, boolean showPlayerInventory) {
-
+    default ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings,
+                                     boolean showPlayerInventory) {
         return new Dialog<>(getFilterItem().getItem().toString())
                 .disablePanelsBelow(false)
                 .draggable(true)
@@ -30,7 +31,8 @@ public interface Filter<T, S extends Filter<T, S>> extends Predicate<T> {
                 .child(GTMuiWidgets.createTitleBar(this::getFilterItem, 176, GTGuiTextures.BACKGROUND))
                 .child(Flow.col().coverChildrenHeight()
                         .child(getFilterUI(data, syncManager, settings).marginTop(10).marginBottom(10))
-                        .childIf(showPlayerInventory, () -> SlotGroupWidget.playerInventory(false).marginLeft(7).marginBottom(7)));
+                        .childIf(showPlayerInventory,
+                                () -> SlotGroupWidget.playerInventory(false).marginLeft(7).marginBottom(7)));
     }
 
     ItemStack getFilterItem();

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/Filter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/Filter.java
@@ -1,5 +1,9 @@
 package com.gregtechceu.gtceu.api.cover.filter;
 
+import brachy.modularui.widgets.Dialog;
+import brachy.modularui.widgets.SlotGroupWidget;
+import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
+import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import net.minecraft.nbt.CompoundTag;
 
 import brachy.modularui.factory.GuiData;
@@ -7,6 +11,7 @@ import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;
+import net.minecraft.world.item.ItemStack;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -16,7 +21,19 @@ public interface Filter<T, S extends Filter<T, S>> extends Predicate<T> {
     /**
      * @return Filter panel when opened by itself (including the player inventory)
      */
-    ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings);
+    default ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings, boolean showPlayerInventory) {
+
+        return new Dialog<>(getFilterItem().getItem().toString())
+                .disablePanelsBelow(false)
+                .draggable(true)
+                .coverChildrenHeight()
+                .child(GTMuiWidgets.createTitleBar(this::getFilterItem, 176, GTGuiTextures.BACKGROUND))
+                .child(Flow.col().coverChildrenHeight()
+                        .child(getFilterUI(data, syncManager, settings).marginTop(10).marginBottom(10))
+                        .childIf(showPlayerInventory, () -> SlotGroupWidget.playerInventory(false).marginLeft(7).marginBottom(7)));
+    }
+
+    ItemStack getFilterItem();
 
     Flow getFilterUI(GuiData data, PanelSyncManager syncManager, UISettings settings);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FluidFilter.java
@@ -6,7 +6,6 @@ import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.fluids.FluidStack;
 
 import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FluidFilter.java
@@ -57,7 +57,7 @@ public interface FluidFilter extends Filter<FluidStack, FluidFilter> {
         }
 
         @Override
-        public ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings) {
+        public ItemStack getFilterItem() {
             return null;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/ItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/ItemFilter.java
@@ -56,7 +56,7 @@ public interface ItemFilter extends Filter<ItemStack, ItemFilter> {
         }
 
         @Override
-        public ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings) {
+        public ItemStack getFilterItem() {
             return null;
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/ItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/ItemFilter.java
@@ -5,7 +5,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 
 import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
@@ -118,14 +118,8 @@ public class SimpleFluidFilter implements FluidFilter {
     }
 
     @Override
-    public ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings) {
-        return new Dialog<>("simple_fluid_filter")
-                .disablePanelsBelow(false)
-                .draggable(true)
-                .closeOnOutOfBoundsClick(true)
-                .child(GTMuiWidgets.createTitleBar(() -> GTItems.FLUID_FILTER.asStack(), 176, GTGuiTextures.BACKGROUND))
-                .child(getFilterUI(data, syncManager, settings).top(10))
-                .child(SlotGroupWidget.playerInventory(false).left(7).bottom(7));
+    public ItemStack getFilterItem() {
+        return GTItems.FLUID_FILTER.asStack();
     }
 
     public Flow getFilterUI(GuiData data, PanelSyncManager syncManager, UISettings settings) {

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.api.cover.filter;
 import com.gregtechceu.gtceu.api.transfer.fluid.CustomFluidTank;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
-import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
@@ -13,13 +12,10 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.BooleanSyncValue;
 import brachy.modularui.value.sync.FluidSlotSyncHandler;
 import brachy.modularui.value.sync.PanelSyncManager;
-import brachy.modularui.widgets.Dialog;
-import brachy.modularui.widgets.SlotGroupWidget;
 import brachy.modularui.widgets.ToggleButton;
 import brachy.modularui.widgets.layout.Flow;
 import brachy.modularui.widgets.layout.Grid;

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.api.cover.filter;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
-import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -13,13 +12,10 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
 
 import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.BooleanSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.PhantomItemSlotSyncHandler;
-import brachy.modularui.widgets.Dialog;
-import brachy.modularui.widgets.SlotGroupWidget;
 import brachy.modularui.widgets.ToggleButton;
 import brachy.modularui.widgets.layout.Flow;
 import brachy.modularui.widgets.layout.Grid;
@@ -110,14 +106,8 @@ public class SimpleItemFilter implements ItemFilter {
     }
 
     @Override
-    public ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings) {
-        return new Dialog<>("simple_item_filter")
-                .disablePanelsBelow(false)
-                .draggable(true)
-                .closeOnOutOfBoundsClick(true)
-                .child(GTMuiWidgets.createTitleBar(() -> GTItems.ITEM_FILTER.asStack(), 176, GTGuiTextures.BACKGROUND))
-                .child(getFilterUI(data, syncManager, settings).top(10))
-                .child(SlotGroupWidget.playerInventory(false).left(7).bottom(7));
+    public ItemStack getFilterItem() {
+        return GTItems.ITEM_FILTER.asStack();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
@@ -6,8 +6,6 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
-import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
-import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.utils.ItemStackHashStrategy;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -22,14 +20,11 @@ import brachy.modularui.drawable.DynamicDrawable;
 import brachy.modularui.drawable.GuiTextures;
 import brachy.modularui.drawable.UITexture;
 import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.BoolValue;
 import brachy.modularui.value.sync.EnumSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
-import brachy.modularui.widgets.Dialog;
 import brachy.modularui.widgets.ListWidget;
-import brachy.modularui.widgets.SlotGroupWidget;
 import brachy.modularui.widgets.ToggleButton;
 import brachy.modularui.widgets.layout.Flow;
 import brachy.modularui.widgets.menu.ContextMenuButton;
@@ -63,6 +58,11 @@ public class SmartItemFilter implements ItemFilter {
     }
 
     @Override
+    public ItemStack getFilterItem() {
+        return GTItems.SMART_ITEM_FILTER.asStack();
+    }
+
+    @Override
     public void setOnUpdated(Consumer<ItemFilter> onUpdated) {
         this.onUpdated = filter -> {
             this.itemWriter.accept(filter);
@@ -88,18 +88,6 @@ public class SmartItemFilter implements ItemFilter {
     private void setFilterMode(SmartFilteringMode filterMode) {
         this.filterMode = filterMode;
         onUpdated.accept(this);
-    }
-
-    @Override
-    public ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings) {
-        return new Dialog<>("smart_item_filter")
-                .disablePanelsBelow(false)
-                .draggable(true)
-                .closeOnOutOfBoundsClick(true)
-                .child(GTMuiWidgets.createTitleBar(() -> GTItems.SMART_ITEM_FILTER.asStack(), 176,
-                        GTGuiTextures.BACKGROUND))
-                .child(getFilterUI(data, syncManager, settings))
-                .child(SlotGroupWidget.playerInventory(false).left(7).bottom(7));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
@@ -97,7 +97,7 @@ public class SmartItemFilter implements ItemFilter {
 
         syncManager.syncValue("mode", mode);
 
-        return Flow.row().coverChildrenHeight().width(166)
+        return Flow.row().coverChildrenHeight().width(162)
                 .child(new ContextMenuButton<>("smart_filter")
                         .size(18)
                         .requiresClick()

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
@@ -97,7 +97,7 @@ public class SmartItemFilter implements ItemFilter {
 
         syncManager.syncValue("mode", mode);
 
-        return Flow.row()
+        return Flow.row().coverChildrenHeight().width(166)
                 .child(new ContextMenuButton<>("smart_filter")
                         .size(18)
                         .requiresClick()

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
@@ -1,20 +1,15 @@
 package com.gregtechceu.gtceu.api.cover.filter;
 
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
-import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.utils.TagExprFilter;
 
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.item.ItemStack;
 
 import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.ModularPanel;
 import brachy.modularui.screen.RichTooltip;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.StringSyncValue;
-import brachy.modularui.widgets.Dialog;
-import brachy.modularui.widgets.SlotGroupWidget;
 import brachy.modularui.widgets.layout.Flow;
 import brachy.modularui.widgets.textfield.TextFieldWidget;
 import lombok.Getter;
@@ -53,29 +48,15 @@ public abstract class TagFilter<T, S extends Filter<T, S>> implements Filter<T, 
         onUpdated.accept((S) this);
     }
 
-    protected abstract ItemStack getFilterItem();
-
-    @Override
-    public ModularPanel<?> getPanel(GuiData data, PanelSyncManager syncManager, UISettings settings) {
-        return new Dialog<>("tag_filter")
-                .disablePanelsBelow(false)
-                .draggable(true)
-                .closeOnOutOfBoundsClick(true)
-                .child(GTMuiWidgets.createTitleBar(() -> getFilterItem(), 176, GTGuiTextures.BACKGROUND))
-                .child(getFilterUI(data, syncManager, settings).margin(7).horizontalCenter())
-                .child(SlotGroupWidget.playerInventory(false).left(7).bottom(7));
-    }
-
     @Override
     public Flow getFilterUI(GuiData data, PanelSyncManager syncManager, UISettings settings) {
         StringSyncValue filterString = new StringSyncValue(this::getFilterString, this::setFilterString).allowC2S();
         RichTooltip infoTooltip = new RichTooltip().add("cover.tag_filter.info");
 
-        var inputRow = Flow.row()
+        return Flow.row().marginLeft(5)
                 .coverChildren()
                 .child(new TextFieldWidget().width(140).value(filterString))
                 .child(GTGuiTextures.INFO.asWidget().tooltip(infoTooltip));
-        return inputRow;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
@@ -53,7 +53,7 @@ public abstract class TagFilter<T, S extends Filter<T, S>> implements Filter<T, 
         StringSyncValue filterString = new StringSyncValue(this::getFilterString, this::setFilterString).allowC2S();
         RichTooltip infoTooltip = new RichTooltip().add("cover.tag_filter.info");
 
-        return Flow.row().marginLeft(5)
+        return Flow.row()
                 .coverChildren()
                 .child(new TextFieldWidget().width(140).value(filterString))
                 .child(GTGuiTextures.INFO.asWidget().tooltip(infoTooltip));

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
@@ -45,7 +45,7 @@ public class TagFluidFilter extends TagFilter<FluidStack, FluidFilter> implement
     }
 
     @Override
-    protected ItemStack getFilterItem() {
+    public ItemStack getFilterItem() {
         return GTItems.TAG_FLUID_FILTER.asStack();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
@@ -62,11 +62,6 @@ public class TagFluidFilter extends TagFilter<FluidStack, FluidFilter> implement
     }
 
     @Override
-    public Flow getFilterUI(GuiData data, PanelSyncManager syncManager, UISettings settings) {
-        return super.getFilterUI(data, syncManager, settings);
-    }
-
-    @Override
     public int testFluidAmount(FluidStack fluidStack) {
         return test(fluidStack) ? Integer.MAX_VALUE : 0;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFluidFilter.java
@@ -8,10 +8,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.UISettings;
-import brachy.modularui.value.sync.PanelSyncManager;
-import brachy.modularui.widgets.layout.Flow;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
@@ -44,11 +44,6 @@ public class TagItemFilter extends TagFilter<ItemStack, ItemFilter> implements I
     }
 
     @Override
-    public Flow getFilterUI(GuiData data, PanelSyncManager syncManager, UISettings settings) {
-        return super.getFilterUI(data, syncManager, settings);
-    }
-
-    @Override
     public ItemStack getFilterItem() {
         return GTItems.TAG_FILTER.asStack();
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
@@ -49,7 +49,7 @@ public class TagItemFilter extends TagFilter<ItemStack, ItemFilter> implements I
     }
 
     @Override
-    protected ItemStack getFilterItem() {
+    public ItemStack getFilterItem() {
         return GTItems.TAG_FILTER.asStack();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagItemFilter.java
@@ -7,10 +7,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
-import brachy.modularui.factory.GuiData;
-import brachy.modularui.screen.UISettings;
-import brachy.modularui.value.sync.PanelSyncManager;
-import brachy.modularui.widgets.layout.Flow;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidFilterCover.java
@@ -86,8 +86,7 @@ public class FluidFilterCover extends CoverBehavior implements IMuiCover {
         syncManager.syncValue("filterMode", filterMode);
         syncManager.syncValue("ioMode", ioMode);
 
-        column.coverChildrenHeight();
-        column.child(getFluidFilter().getFilterUI(data, syncManager, settings).marginBottom(4));
+        column.child(getFluidFilter().getFilterUI(data, syncManager, settings));
 
         GTMuiCoverUtil.addFilterModeRow(column, filterMode);
         GTMuiCoverUtil.addManualIORow(column, ioMode);

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
@@ -96,7 +96,6 @@ public class ItemFilterCover extends CoverBehavior implements IMuiCover {
         syncManager.syncValue("filterMode", filterMode);
         syncManager.syncValue("ioMode", ioMode);
 
-        column.coverChildrenHeight();
         column.child(getItemFilter().getFilterUI(data, syncManager, settings).marginBottom(2));
 
         GTMuiCoverUtil.addFilterModeRow(column, filterMode);
@@ -110,7 +109,7 @@ public class ItemFilterCover extends CoverBehavior implements IMuiCover {
         }
 
         @Override
-        public @NotNull ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
             if (filterMode == FilterMode.FILTER_EXTRACT) {
                 if (allowFlow == ManualIOMode.DISABLED) {
                     return stack;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ItemFilterCover.java
@@ -96,7 +96,7 @@ public class ItemFilterCover extends CoverBehavior implements IMuiCover {
         syncManager.syncValue("filterMode", filterMode);
         syncManager.syncValue("ioMode", ioMode);
 
-        column.child(getItemFilter().getFilterUI(data, syncManager, settings).marginBottom(2));
+        column.child(getItemFilter().getFilterUI(data, syncManager, settings));
 
         GTMuiCoverUtil.addFilterModeRow(column, filterMode);
         GTMuiCoverUtil.addManualIORow(column, ioMode);

--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/FluidFilterBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/FluidFilterBehaviour.java
@@ -38,6 +38,6 @@ public record FluidFilterBehaviour(Function<ItemStack, FluidFilter> filterCreato
 
     @Override
     public ModularPanel<?> buildUI(PlayerInventoryGuiData<?> data, PanelSyncManager syncManager, UISettings settings) {
-        return FluidFilter.loadFilter(data.getUsedItemStack()).getPanel(data, syncManager, settings);
+        return FluidFilter.loadFilter(data.getUsedItemStack()).getPanel(data, syncManager, settings, true);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/ItemFilterBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/ItemFilterBehaviour.java
@@ -40,7 +40,7 @@ public record ItemFilterBehaviour(Function<ItemStack, ItemFilter> filterCreator)
 
     @Override
     public ModularPanel<?> buildUI(PlayerInventoryGuiData<?> data, PanelSyncManager syncManager, UISettings settings) {
-        return ItemFilter.loadFilter(data.getUsedItemStack()).getPanel(data, syncManager, settings);
+        return ItemFilter.loadFilter(data.getUsedItemStack()).getPanel(data, syncManager, settings, true);
     }
 
     // @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -382,6 +382,8 @@ public class GTMuiWidgets {
                 (sm, sh) -> filterHandler.loadFilter(filterSlotHandler.getSlot().getItem()).getPanel(data, sm,
                         settings, false));
 
+        modSlot.changeListener((newItem, onlyAmountChanged, client, init) -> panelHandler.closePanel());
+
         return existingRow
                 .child(new ItemSlot().syncHandler(filterSlotHandler))
                 .child(new ButtonWidget<>()

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -69,7 +69,7 @@ public class GTMuiWidgets {
     }
 
     public static Flow createTitleBar(MachineDefinition definition, int panelWidth, UITexture background) {
-        return createTitleBar(() -> definition.asStack(), panelWidth, background);
+        return createTitleBar(definition::asStack, panelWidth, background);
     }
 
     public static Flow createTitleBar(Supplier<ItemStack> stackSupplier, int panelWidth, UITexture background) {
@@ -92,6 +92,7 @@ public class GTMuiWidgets {
         int rowWidth = Math.min((int) (0.9 * panelWidth), (iconSize + (borderRadius * 4) + textTitleWidth));
 
         return Flow.row()
+                .decoration()
                 .coverChildrenHeight()
                 .mainAxisAlignment(Alignment.MainAxis.CENTER)
                 .crossAxisAlignment(Alignment.CrossAxis.CENTER)
@@ -379,7 +380,7 @@ public class GTMuiWidgets {
 
         IPanelHandler panelHandler = syncManager.syncedPanel("filterPanel", true,
                 (sm, sh) -> filterHandler.loadFilter(filterSlotHandler.getSlot().getItem()).getPanel(data, sm,
-                        settings));
+                        settings, false));
 
         return existingRow
                 .child(new ItemSlot().syncHandler(filterSlotHandler))

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -382,8 +382,10 @@ public class GTMuiWidgets {
                 (sm, sh) -> filterHandler.loadFilter(filterSlotHandler.getSlot().getItem()).getPanel(data, sm,
                         settings, false));
 
-        modSlot.changeListener((newItem, onlyAmountChanged, client, init) -> panelHandler.closePanel());
-
+        modSlot.changeListener((newItem, onlyAmountChanged, client, init) -> {
+            panelHandler.closePanel();
+            panelHandler.deleteCachedPanel();
+        });
         return existingRow
                 .child(new ItemSlot().syncHandler(filterSlotHandler))
                 .child(new ButtonWidget<>()


### PR DESCRIPTION
## What
- Fixes a bunch of UI issues related to covers and filters
- Removes the inventory from filters when they are opened as a subpanel in a ui with an inventory.
- Makes the title bar widget a decoration widget so it isn't counted in panel resizer calculations

- [X] No AI driven tools were used for this pull request.