### PR TITLE
add isRemote clauses to setStatus and setWorkingEnabled

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -25,6 +25,8 @@ import com.gregtechceu.gtceu.api.sync_system.data_transformers.ValueTransformer;
 import com.gregtechceu.gtceu.common.cover.MachineControllerCover;
 import com.gregtechceu.gtceu.utils.GTMath;
 
+import com.lowdragmc.lowdraglib.utils.DummyWorld;
+
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -35,7 +37,6 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-import com.lowdragmc.lowdraglib.utils.DummyWorld;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -35,6 +35,7 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
+import com.lowdragmc.lowdraglib.utils.DummyWorld;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import lombok.Getter;
 import lombok.Setter;
@@ -427,6 +428,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
     }
 
     public void setStatus(Status status) {
+        if (isRemote() && !(getLevel() instanceof DummyWorld)) return;
         if (this.status != status) {
             if (this.status == Status.WORKING) {
                 this.totalContinuousRunningTime = 0;
@@ -484,6 +486,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
 
     @Override
     public void setWorkingEnabled(boolean isWorkingAllowed) {
+        if (isRemote() && !(getLevel() instanceof DummyWorld)) return;
         if (!isWorkingAllowed && getStatus() == Status.IDLE) {
             setStatus(Status.SUSPEND);
         } else {


### PR DESCRIPTION
## What
client side was calling these because of the workingEnabled sync values which was setting the local Status to idle because the recipe is null client side
because of that the sound and render state were being broken on UI open

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Opus 4.8 high

#### Agent Usage Description
Asked it to debug and fix, checked and reasoned through the code myself  

## Outcome
re-opening a machine no longer breaks sound and textures

## How Was This Tested
opened in game to verify, worked

