### PR TITLE
Fix gtmath min issue

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/utils/GTMath.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTMath.java
@@ -119,7 +119,7 @@ public class GTMath {
         if (values == null || values.length == 0) throw new IllegalArgumentException();
         if (values.length == 1) return values[0];
         if (values.length == 2) return Math.max(values[0], values[1]);
-        float max = Float.MIN_VALUE;
+        float max = -Float.MAX_VALUE;
         for (float i : values) {
             if (i > max) {
                 max = i;


### PR DESCRIPTION

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.
#### Agent Used
Opus 4.8
#### Agent Usage Description
Was using AI to mid-term-review yo/the-patterning and it found this bug, which is also present in 1.20.1
  
## Outcome
Before:
The GTMath.max of -1, -2, -3 is: 1.4E-45
After:
The GTMath.max of -1, -2, -3 is: -1
