### PR TITLE
Force empty list over null for completed handleRecipeInner

### DIFF
--- a/docs/content/Development/Recipe-Logic/Custom-Ingredient.md
+++ b/docs/content/Development/Recipe-Logic/Custom-Ingredient.md
@@ -229,7 +229,7 @@ public class NotifiableBonkHandler extends NotifiableRecipeHandlerTrait<BonkIngr
                 break;
             }
         }
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -137,6 +137,8 @@ A few regexes for fixing all the MCMeta files is follows, run them in order:
 3. Match: `(\{\s*)"shimmer":(\s*\{\s*"bloom":.*)`  
    Replace with: `$1"gtceu":$2` 
 
+## IRecipeHandler nullability
+Previously, `handleRecipeInner` should return `null` when there's nothing left to process. This has been changed to requiring an empty list (e.g. the list of remaining ingredients). Returning `null` is now wrong and will crash (NPE).
 
 ## Other Changes
 

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/EURecipeCapability.java
@@ -71,9 +71,9 @@ public class EURecipeCapability extends RecipeCapability<EnergyStack> {
                 for (var handler : handlers) {
                     // noinspection unchecked
                     eu = (List<Long>) handler.handleRecipe(IO.OUT, recipe, eu, true);
-                    if (eu == null) break;
+                    if (eu.isEmpty()) break;
                 }
-                int[] bin = ParallelLogic.adjustMultiplier(eu == null, minMultiplier, multiplier, maxMultiplier);
+                int[] bin = ParallelLogic.adjustMultiplier(eu.isEmpty(), minMultiplier, multiplier, maxMultiplier);
                 minMultiplier = bin[0];
                 multiplier = bin[1];
                 maxMultiplier = bin[2];

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/FluidRecipeCapability.java
@@ -167,9 +167,9 @@ public class FluidRecipeCapability extends RecipeCapability<FluidIngredient> {
             for (var handler : handlers) {
                 // noinspection unchecked
                 copied = (List<FluidIngredient>) handler.handleRecipe(IO.OUT, recipe, copied, true);
-                if (copied == null) break;
+                if (copied.isEmpty()) break;
             }
-            int[] bin = ParallelLogic.adjustMultiplier(copied == null, minMultiplier, multiplier, maxMultiplier);
+            int[] bin = ParallelLogic.adjustMultiplier(copied.isEmpty(), minMultiplier, multiplier, maxMultiplier);
             minMultiplier = bin[0];
             multiplier = bin[1];
             maxMultiplier = bin[2];

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Comparator;
 import java.util.List;
@@ -33,9 +32,10 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
      * @param simulate simulate.
      * @return left contents for continue handling by other proxies.
      *         <br>
-     *         null - nothing left. handling successful/finish. you should always return null as a handling-done mark.
+     *         An empty list means nothing is left, i.e. handling finished successfully. Return the (now empty) input
+     *         list as the handling-done mark. Returning {@code null} is not allowed.
      */
-    @Nullable
+    @NotNull
     List<K> handleRecipeInner(IO io, GTRecipe recipe, List<K> left, boolean simulate);
 
     /**
@@ -74,7 +74,7 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
         return getCapability().copyInner((K) content);
     }
 
-    default @Nullable List<K> handleRecipe(IO io, GTRecipe recipe, List<?> left, boolean simulate) {
+    default @NotNull List<K> handleRecipe(IO io, GTRecipe recipe, List<?> left, boolean simulate) {
         List<K> contents = new ObjectArrayList<>(left.size());
         for (Object leftObj : left) {
             contents.add(copyContent(leftObj));

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/ItemRecipeCapability.java
@@ -187,9 +187,9 @@ public class ItemRecipeCapability extends RecipeCapability<Ingredient> {
             for (var handler : handlers) {
                 // noinspection unchecked
                 copied = (List<Ingredient>) handler.handleRecipe(IO.OUT, recipe, copied, true);
-                if (copied == null) break;
+                if (copied.isEmpty()) break;
             }
-            int[] bin = ParallelLogic.adjustMultiplier(copied == null, minMultiplier, multiplier, maxMultiplier);
+            int[] bin = ParallelLogic.adjustMultiplier(copied.isEmpty(), minMultiplier, multiplier, maxMultiplier);
             minMultiplier = bin[0];
             multiplier = bin[1];
             maxMultiplier = bin[2];

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamEnergyRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamEnergyRecipeHandler.java
@@ -29,7 +29,8 @@ public class SteamEnergyRecipeHandler implements IRecipeHandler<EnergyStack> {
     }
 
     @Override
-    public List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left, boolean simulate) {
+    public @NotNull List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left,
+                                                        boolean simulate) {
         for (var it = left.listIterator(); it.hasNext();) {
             EnergyStack stack = it.next();
             if (stack.isEmpty()) {
@@ -45,7 +46,7 @@ public class SteamEnergyRecipeHandler implements IRecipeHandler<EnergyStack> {
                 var list = new ArrayList<FluidIngredient>();
                 list.add(steam);
                 var leftSteam = steamTank.handleRecipeInner(io, recipe, list, simulate);
-                if (leftSteam == null || leftSteam.isEmpty()) {
+                if (leftSteam.isEmpty()) {
                     it.remove();
                 } else {
                     totalEU = (long) (leftSteam.get(0).getAmount() / conversionRate);
@@ -53,7 +54,7 @@ public class SteamEnergyRecipeHandler implements IRecipeHandler<EnergyStack> {
                 }
             }
         }
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableComputationContainer.java
@@ -17,6 +17,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -188,8 +189,8 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
     }
 
     @Override
-    public List<Integer> handleRecipeInner(IO io, GTRecipe recipe, List<Integer> left,
-                                           boolean simulate) {
+    public @NotNull List<Integer> handleRecipeInner(IO io, GTRecipe recipe, List<Integer> left,
+                                                    boolean simulate) {
         IOpticalComputationProvider provider = getOpticalNetProvider();
         if (provider == null) return left;
 
@@ -226,7 +227,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
             }
             sum = sum - canInput;
         }
-        return sum <= 0 ? null : Collections.singletonList(sum);
+        return sum <= 0 ? Collections.emptyList() : Collections.singletonList(sum);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableEnergyContainer.java
@@ -25,6 +25,7 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -310,8 +311,8 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
     }
 
     @Override
-    public @Nullable List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left,
-                                                         boolean simulate) {
+    public @NotNull List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left,
+                                                        boolean simulate) {
         for (var it = left.listIterator(); it.hasNext();) {
             EnergyStack stack = it.next();
             if (stack.isEmpty()) {
@@ -336,7 +337,7 @@ public class NotifiableEnergyContainer extends NotifiableRecipeHandlerTrait<Ener
 
         }
 
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidType;
 
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -90,10 +91,10 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
     }
 
     @Override
-    public @Nullable List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
-                                                             boolean simulate) {
+    public @NotNull List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
+                                                            boolean simulate) {
         if (io != handlerIO) return left;
-        if (io != IO.IN && io != IO.OUT) return left.isEmpty() ? null : left;
+        if (io != IO.IN && io != IO.OUT) return left;
 
         // Temporarily remove listeners so that we can broadcast the entire set of transactions once
         Runnable[] listeners = new Runnable[storages.length];
@@ -217,7 +218,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
             if (changed && action.execute()) listeners[i].run();
         }
 
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableItemStackHandler.java
@@ -23,6 +23,7 @@ import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -87,18 +88,18 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
     }
 
     @Override
-    public @Nullable List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
-                                                        boolean simulate) {
+    public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                       boolean simulate) {
         return handleRecipe(io, recipe, left, simulate, handlerIO, storage);
     }
 
     // TODO: See if implementable in outside callers and unstatic; or move to different common class if not
     // Notable caller is ItemRecipeHandler, used for MinerLogic
-    public static @Nullable List<Ingredient> handleRecipe(IO io, GTRecipe recipe, List<Ingredient> left,
-                                                          boolean simulate,
-                                                          IO handlerIO, CustomItemStackHandler storage) {
+    public static List<Ingredient> handleRecipe(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                boolean simulate,
+                                                IO handlerIO, CustomItemStackHandler storage) {
         if (io != handlerIO) return left;
-        if (io != IO.IN && io != IO.OUT) return left.isEmpty() ? null : left;
+        if (io != IO.IN && io != IO.OUT) return left;
 
         // Temporarily remove listener so that we can broadcast the entire set of transactions once
         Runnable listener = storage.getOnContentsChanged();
@@ -194,7 +195,7 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         storage.setOnContentsChanged(listener);
         if (changed && !simulate) listener.run();
 
-        return left.isEmpty() ? null : left;
+        return left;
     }
 
     private static @Nullable ItemStack getActioned(CustomItemStackHandler storage, int index, List<?> actions) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeHandlerList.java
@@ -184,7 +184,7 @@ public class RecipeHandlerList {
             var handlerList = getCapability(entry.getKey());
             for (var handler : handlerList) {
                 var left = handler.handleRecipe(io, recipe, entry.getValue(), simulate);
-                if (left == null) {
+                if (left.isEmpty()) {
                     it.remove();
                     break;
                 } else {

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/IgnoreEnergyRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/IgnoreEnergyRecipeHandler.java
@@ -9,13 +9,15 @@ import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 
 public class IgnoreEnergyRecipeHandler implements IRecipeHandler<EnergyStack> {
 
     @Override
-    public List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left, boolean simulate) {
-        return null;
+    public @NotNull List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left,
+                                                        boolean simulate) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
@@ -29,7 +29,8 @@ public class ItemRecipeHandler implements IRecipeHandler<Ingredient> {
     }
 
     @Override
-    public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, boolean simulate) {
+    public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                       boolean simulate) {
         return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, this.handlerIO, storage);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
@@ -108,7 +108,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
             if (!(currentBus instanceof NotifiableItemStackHandler itemBus)) throw new RuntimeException(
                     "Handler in Assline.consumeItemContent's ItemRecipeCapability.IN was not of type NotifiableItemStackHandler");
             var left = itemBus.handleRecipeInner(IO.IN, recipe, new ArrayList<>(List.of(recipeStack)), true);
-            if (!(left == null || left.isEmpty())) return ActionResult.FAIL_NO_REASON;
+            if (!left.isEmpty()) return ActionResult.FAIL_NO_REASON;
         }
         // If we get here, the recipe should be consumable
 
@@ -118,7 +118,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
             if (!(currentBus instanceof NotifiableItemStackHandler itemBus)) throw new RuntimeException(
                     "Handler in Assline.consumeItemContent's ItemRecipeCapability.IN was not of type NotifiableItemStackHandler");
             var left = itemBus.handleRecipeInner(IO.IN, recipe, new ArrayList<>(List.of(recipeStack)), false);
-            if (!(left == null || left.isEmpty())) {
+            if (!left.isEmpty()) {
                 GTCEu.LOGGER.error(
                         "Recipe in Assline.consumeItemContents was true when simulating, but false when consuming.");
                 return ActionResult.FAIL_NO_REASON;
@@ -178,7 +178,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
             if (!(currentBus instanceof NotifiableFluidTank fluidTank)) throw new RuntimeException(
                     "Handler in Assline.consumeItemContent's FluidRecipeCapability.IN was not of type NotifiableFluidTank");
             var left = fluidTank.handleRecipeInner(IO.IN, recipe, new ArrayList<>(List.of(recipeStack)), true);
-            if (!(left == null || left.isEmpty())) return ActionResult.FAIL_NO_REASON;
+            if (!left.isEmpty()) return ActionResult.FAIL_NO_REASON;
         }
         // If we get here, the recipe should be consumable
 
@@ -188,7 +188,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
             if (!(currentBus instanceof NotifiableFluidTank fluidTank)) throw new RuntimeException(
                     "Handler in Assline.consumeItemContent's FluidRecipeCapability.IN was not of type NotifiableFluidTank");
             var left = fluidTank.handleRecipeInner(IO.IN, recipe, new ArrayList<>(List.of(recipeStack)), false);
-            if (!(left == null || left.isEmpty())) {
+            if (!left.isEmpty()) {
                 GTCEu.LOGGER.error(
                         "Recipe in Assline.consumeFluidContents was true when simulating, but false when consuming.");
                 return ActionResult.FAIL_NO_REASON;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -120,12 +120,11 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IDi
                 inputTanks.addAll(getCapabilitiesFlat(IO.BOTH, FluidRecipeCapability.CAP));
                 for (IRecipeHandler<?> tank : inputTanks) {
                     drainWater = (List<FluidIngredient>) tank.handleRecipe(IO.IN, null, drainWater, false);
-                    if (drainWater == null || drainWater.isEmpty()) {
+                    if (drainWater.isEmpty()) {
                         break;
                     }
                 }
-                var drained = (drainWater == null || drainWater.isEmpty()) ? maxDrain :
-                        maxDrain - drainWater.get(0).getAmount();
+                var drained = drainWater.isEmpty() ? maxDrain : maxDrain - drainWater.get(0).getAmount();
 
                 steamGenerated = drained * ConfigHolder.INSTANCE.machines.largeBoilers.steamPerWater;
 
@@ -137,7 +136,7 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IDi
                     outputTanks.addAll(getCapabilitiesFlat(IO.BOTH, FluidRecipeCapability.CAP));
                     for (IRecipeHandler<?> tank : outputTanks) {
                         fillSteam = (List<FluidIngredient>) tank.handleRecipe(IO.OUT, null, fillSteam, false);
-                        if (fillSteam == null) break;
+                        if (fillSteam.isEmpty()) break;
                     }
                 }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEOutputHatchPartMachine.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import appeng.api.config.Actionable;
 import appeng.api.stacks.AEFluidKey;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
@@ -151,9 +151,8 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine {
         }
 
         @Override
-        @Nullable
-        public List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
-                                                       boolean simulate) {
+        public @NotNull List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
+                                                                boolean simulate) {
             if (io != IO.OUT) return left;
             FluidAction action = simulate ? FluidAction.SIMULATE : FluidAction.EXECUTE;
             for (var it = left.iterator(); it.hasNext();) {
@@ -186,7 +185,7 @@ public class MEOutputHatchPartMachine extends MEHatchPartMachine {
                 ingredient.shrink(filled);
                 if (filled <= 0) it.remove();
             }
-            return left.isEmpty() ? null : left;
+            return left;
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -553,7 +553,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
             onContentsChanged();
         }
 
-        public @Nullable List<Ingredient> handleItemInternal(List<Ingredient> left, boolean simulate) {
+        public List<Ingredient> handleItemInternal(List<Ingredient> left, boolean simulate) {
             boolean changed = false;
             for (var it = left.listIterator(); it.hasNext();) {
                 var ingredient = it.next();
@@ -602,10 +602,10 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
                 }
             }
             if (changed) onContentsChanged();
-            return left.isEmpty() ? null : left;
+            return left;
         }
 
-        public @Nullable List<FluidIngredient> handleFluidInternal(List<FluidIngredient> left, boolean simulate) {
+        public List<FluidIngredient> handleFluidInternal(List<FluidIngredient> left, boolean simulate) {
             boolean changed = false;
             for (var it = left.listIterator(); it.hasNext();) {
                 var ingredient = it.next();
@@ -651,7 +651,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
             }
 
             if (changed) onContentsChanged();
-            return left.isEmpty() ? null : left;
+            return left;
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/InternalSlotRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/InternalSlotRecipeHandler.java
@@ -15,7 +15,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.fluids.FluidStack;
 
 import lombok.Getter;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,8 +84,8 @@ public final class InternalSlotRecipeHandler {
         }
 
         @Override
-        public @Nullable List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
-                                                            boolean simulate) {
+        public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                           boolean simulate) {
             if (io != IO.IN || slot.isItemEmpty()) return left;
             return slot.handleItemInternal(left, simulate);
         }
@@ -128,8 +128,8 @@ public final class InternalSlotRecipeHandler {
         }
 
         @Override
-        public @Nullable List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
-                                                                 boolean simulate) {
+        public @NotNull List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
+                                                                boolean simulate) {
             if (io != IO.IN || slot.isFluidEmpty()) return left;
             return slot.handleFluidInternal(left, simulate);
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/ProxySlotRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/trait/ProxySlotRecipeHandler.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.utils.ISubscription;
 import net.minecraft.world.item.crafting.Ingredient;
 
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -123,7 +124,8 @@ public final class ProxySlotRecipeHandler {
         }
 
         @Override
-        public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, boolean simulate) {
+        public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                           boolean simulate) {
             if (proxy == null) return left;
             return proxy.handleRecipeInner(io, recipe, left, simulate);
         }
@@ -186,8 +188,8 @@ public final class ProxySlotRecipeHandler {
         }
 
         @Override
-        public List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
-                                                       boolean simulate) {
+        public @NotNull List<FluidIngredient> handleRecipeInner(IO io, GTRecipe recipe, List<FluidIngredient> left,
+                                                                boolean simulate) {
             if (proxy == null) return left;
             return proxy.handleRecipeInner(io, recipe, left, simulate);
         }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/ExportOnlyAEItemList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/ExportOnlyAEItemList.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -82,8 +83,8 @@ public class ExportOnlyAEItemList extends NotifiableItemStackHandler implements 
     }
 
     @Override
-    public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
-                                              boolean simulate) {
+    public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                       boolean simulate) {
         return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, this.handlerIO, getHandler());
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/DummyRecipeUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/DummyRecipeUtils.java
@@ -35,7 +35,8 @@ public class DummyRecipeUtils {
         }
 
         @Override
-        public List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left, boolean simulate) {
+        public @NotNull List<EnergyStack> handleRecipeInner(IO io, GTRecipe recipe, List<EnergyStack> left,
+                                                            boolean simulate) {
             for (var it = left.listIterator(); it.hasNext();) {
                 EnergyStack stack = it.next();
                 if (stack.isEmpty()) {
@@ -61,7 +62,7 @@ public class DummyRecipeUtils {
 
             }
 
-            return left.isEmpty() ? null : left;
+            return left;
         }
 
         @Override
@@ -98,7 +99,8 @@ public class DummyRecipeUtils {
         }
 
         @Override
-        public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left, boolean simulate) {
+        public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
+                                                           boolean simulate) {
             return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, handlerIO, storage);
         }
 


### PR DESCRIPTION
## What
Previously, IRecipeHandler.handleRecipeInner was forced to return `null` when there was no items left to process. This was an antipattern (for any non-null amount, you'd just return the list, so why force a null?). This PR makes it so you have to just return the processed list.

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Opus 4.8 High
#### Agent Usage Description
Helped workshop the feature and review the PR, as well as catching any missed callsites or bugs.

## Outcome
Cleaner code, fixed bugs in addons where they already just returned null

## How Was This Tested
Ran GameTests

## Potential Compatibility Issues
All addons with custom RecipeHandlers should change their `return left.isEmpty() ? null : left` line to just `return left`