### PR TITLE
Misc MUI fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -6,8 +6,6 @@ import com.gregtechceu.gtceu.api.machine.feature.IHasBatterySlot;
 import com.gregtechceu.gtceu.api.machine.feature.IHasCircuitSlot;
 import com.gregtechceu.gtceu.api.machine.feature.IVoidable;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDistinctPart;
-import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.feature.IAttachConfiguratorsTrait;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -6,6 +6,9 @@ import com.gregtechceu.gtceu.api.machine.feature.IHasBatterySlot;
 import com.gregtechceu.gtceu.api.machine.feature.IHasCircuitSlot;
 import com.gregtechceu.gtceu.api.machine.feature.IVoidable;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDistinctPart;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.feature.IAttachConfiguratorsTrait;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
@@ -79,7 +82,7 @@ public class MachineUIPanelBuilder {
             if (machine instanceof IHasBatterySlot batterySlot) {
                 attachRight.child(GTMuiWidgets.createBatterySlot(batterySlot, syncManager));
             }
-            if (machine instanceof IVoidable voidable) {
+            if (machine instanceof IVoidable voidable && machine instanceof WorkableMultiblockMachine) {
                 attachRight.child(GTMuiWidgets.createVoidingButton(voidable));
             }
             if (machine instanceof IDistinctPart distinctPart) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -6,7 +6,6 @@ import com.gregtechceu.gtceu.api.machine.feature.IHasBatterySlot;
 import com.gregtechceu.gtceu.api.machine.feature.IHasCircuitSlot;
 import com.gregtechceu.gtceu.api.machine.feature.IVoidable;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDistinctPart;
-import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.feature.IAttachConfiguratorsTrait;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
@@ -80,7 +79,7 @@ public class MachineUIPanelBuilder {
             if (machine instanceof IHasBatterySlot batterySlot) {
                 attachRight.child(GTMuiWidgets.createBatterySlot(batterySlot, syncManager));
             }
-            if (machine instanceof IVoidable voidable && machine instanceof WorkableElectricMultiblockMachine) {
+            if (machine instanceof IVoidable voidable) {
                 attachRight.child(GTMuiWidgets.createVoidingButton(voidable));
             }
             if (machine instanceof IDistinctPart distinctPart) {

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiCoverUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiCoverUtil.java
@@ -24,7 +24,6 @@ public class GTMuiCoverUtil {
                 .buttonTooltipSupplier((v) -> () -> Component.translatable(v.getTooltip()))
                 .overlay(16, GTGuiTextures.MANUAL_IO_OVERLAY_IN)
                 .lang(Text.comp(Component.translatable(ManualIOMode.getTitle())))
-                .multiLangTooltip()
                 .multiLangTooltip(manualIODesc)
                 .build());
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -718,7 +718,7 @@ public class GTMuiWidgets {
                         button.overlay(this.overlay[enumVal.ordinal()]);
 
                     if (this.buttonTooltipSupplier != null) {
-                        button.addTooltipLine(Text.lang(buttonTooltipSupplier.apply(enumVal).get().getString()));
+                        button.addTooltipLine(Text.comp(buttonTooltipSupplier.apply(enumVal).get()));
                     } else if (enumVal instanceof StringRepresentable serializable) {
                         button.addTooltipLine(Text.lang(serializable.getSerializedName()));
                     }


### PR DESCRIPTION
## What
1. multiLangTooltip was being called twice

2. we were calling Text.lang() on a supplier which was being called with `.buttonTooltipSupplier((v) -> () -> Component.translatable(v.getTooltip()))`, being `Text.lang(Component.translatable(v.getTooltip())`. This works most of the time since Text.lang returns the key if it can't find a proper translation, and in this case the "key" would be the already-translated text, but it's a bug nonetheless.

3. IVoidable non-electirc multis wouldnt get voiding buttons

#### AI usage
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Opus 4.8
#### Agent Usage Description
Asked it to review all of mui2-refactor and am sniping off bugs lol
  

## How Was This Tested
Launched and looked at item voiding cover, looked good
