### PR TITLE
Add jade warning if generator output is smaller than EU/t generated

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2584,6 +2584,7 @@
   "gtceu.jade.days": "sʎɐp %s",
   "gtceu.jade.energy_stored": "∩Ǝ %d / %d",
   "gtceu.jade.fluid_use": "ʇ/ᗺɯ %s",
+  "gtceu.jade.generator.too_small": "¡ןןɐɯs ooʇ ʇndʇnO ʎbɹǝuƎ",
   "gtceu.jade.hours": "sɹnoɥ %s",
   "gtceu.jade.minutes": "sǝʇnuıɯ %s",
   "gtceu.jade.progress_computation": "∩MƆ %s / %s",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2584,6 +2584,7 @@
   "gtceu.jade.days": "%s days",
   "gtceu.jade.energy_stored": "%d / %d EU",
   "gtceu.jade.fluid_use": "%s mB/t",
+  "gtceu.jade.generator.too_small": "Energy Output too small!",
   "gtceu.jade.hours": "%s hours",
   "gtceu.jade.minutes": "%s minutes",
   "gtceu.jade.progress_computation": "%s / %s CWU",

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleGeneratorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/SimpleGeneratorMachine.java
@@ -105,4 +105,9 @@ public class SimpleGeneratorMachine extends WorkableTieredMachine {
     public long getDisplayRecipeVoltage() {
         return GTValues.V[this.tier];
     }
+
+    @Override
+    public long getDisplayGeneratorPower() {
+        return energyContainer.getOutputVoltage() * energyContainer.getOutputAmperage();
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/IRecipeLogicMachine.java
@@ -133,6 +133,14 @@ public interface IRecipeLogicMachine extends IRecipeCapabilityHolder, IMachineFe
         return -1;
     }
 
+    /**
+     * Max output EU/t of a generator
+     * is negative when it is not a generator
+     */
+    default long getDisplayGeneratorPower() {
+        return -1;
+    }
+
     //////////////////////////////////////
     // ******* IWorkable ********//
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -239,6 +239,21 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
         return voltage;
     }
 
+    @Override
+    public long getDisplayGeneratorPower() {
+        if (this.isGenerator()) {
+            long power = -1;
+            var handlers = getCapabilitiesFlat(IO.OUT, EURecipeCapability.CAP);
+            for (IRecipeHandler<?> handler : handlers) {
+                if (handler instanceof IEnergyContainer container) {
+                    power += container.getOutputVoltage() * container.getOutputAmperage();
+                }
+            }
+            return power;
+        }
+        return -1;
+    }
+
     /**
      * Is this multiblock a generator?
      * Used for max voltage calculations.

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -111,6 +111,7 @@ public class IntegrationLang {
         provider.add("gtceu.jade.hours", "%s hours");
         provider.add("gtceu.jade.days", "%s days");
         provider.add("gtceu.jade.years", "%s years");
+        provider.add("gtceu.jade.generator.too_small", "Energy Output too small!");
 
         provider.add("gtceu.top.energy_stored", " / %d EU");
         provider.add("gtceu.top.progress_computation", " / %s CWU");

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -123,7 +123,8 @@ public class RecipeLogicProvider extends MachineTraitProvider<RecipeLogic, Compo
                         tooltip.add(Component.translatable("gtceu.top.energy_production").append(" ").append(text));
                         long generatorPower = recipeInfo.getLong("generatorPower");
                         if (generatorPower > 0 && generatorPower < EUt) {
-                            tooltip.add(Component.literal("Energy Output too small!").withStyle(ChatFormatting.RED));
+                            tooltip.add(Component.translatable("gtceu.jade.generator.too_small")
+                                    .withStyle(ChatFormatting.RED));
                         }
                     }
                 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeLogicProvider.java
@@ -46,6 +46,12 @@ public class RecipeLogicProvider extends MachineTraitProvider<RecipeLogic, Compo
             recipeInfo.putBoolean("isInput", EUt.isInput());
         }
 
+        // Returns -1 if not a generator
+        long generatorPower = capability.getRLMachine().getDisplayGeneratorPower();
+        if (generatorPower > 0) {
+            recipeInfo.putLong("generatorPower", generatorPower);
+        }
+
         if (!recipeInfo.isEmpty()) {
             data.put("Recipe", recipeInfo);
         }
@@ -115,6 +121,10 @@ public class RecipeLogicProvider extends MachineTraitProvider<RecipeLogic, Compo
                         tooltip.add(Component.translatable("gtceu.top.energy_consumption").append(" ").append(text));
                     } else {
                         tooltip.add(Component.translatable("gtceu.top.energy_production").append(" ").append(text));
+                        long generatorPower = recipeInfo.getLong("generatorPower");
+                        if (generatorPower > 0 && generatorPower < EUt) {
+                            tooltip.add(Component.literal("Energy Output too small!").withStyle(ChatFormatting.RED));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What
Add jade warning if generator output is smaller than EU/t generated

## Implementation Details
added a new default function to `IRecipeLogicMachine`

### AI Usage 
- [x] No AI driven tools were used for this pull request.

## Outcome
<img width="480" height="314" alt="image" src="https://github.com/user-attachments/assets/dfb5bf0f-b04f-495d-9318-319aa90231ab" />

## How Was This Tested
ingame

## Potential Compatibility Issues
people with custom generators that dont extend `SimpleGeneratorMachine` or `WorkableElectricMultiblockMachine` will have to implement it themself