### PR TITLE
Miner UI, Fix CharcoalPileIgniter structure

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -38,7 +38,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.client.model.generators.BlockModelBuilder;
 import net.minecraftforge.client.model.generators.ConfiguredModel;
 
@@ -781,18 +780,7 @@ public class GTMultiMachines {
                     Component.translatable("gtceu.machine.charcoal_pile.tooltip.1"),
                     Component.translatable("gtceu.machine.charcoal_pile.tooltip.2"),
                     Component.translatable("gtceu.machine.charcoal_pile.tooltip.3"))
-            .pattern((def) -> MultiblockPatternBuilder.start()
-                    .slice("     ", " XXX ", " XXX ", " XXX ", "     ")
-                    .slice(" BBB ", "XCCCX", "XCCCX", "XCCCX", " DDD ")
-                    .slice(" BBB ", "XCCCX", "XCCCX", "XCCCX", " DSD ")
-                    .slice(" BBB ", "XCCCX", "XCCCX", "XCCCX", " DDD ")
-                    .slice("     ", " XXX ", " XXX ", " XXX ", "     ")
-                    .where('S', controller(blocks(def.getBlock())))
-                    .where('B', blocks(Blocks.BRICKS))
-                    .where('X', blocks(Blocks.DIRT))
-                    .where('D', blocks(Blocks.DIRT))
-                    .where('C', blocks(Blocks.OAK_LOG))
-                    .build())
+            .pattern(CharcoalPileIgniterMachine.getPattern())
             .allowFlip(false)
             .allowExtendedFacing(false)
             .workableCasingModel(GTCEu.id("block/casings/solid/machine_casing_bronze_plated_bricks"),

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/MinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/MinerMachine.java
@@ -15,7 +15,6 @@ import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.item.behavior.PortableScannerBehavior;
 import com.gregtechceu.gtceu.common.machine.trait.AutoOutputTrait;
 import com.gregtechceu.gtceu.common.machine.trait.miner.MinerLogic;
-import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiMachineUtil;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.ExtendedUseOnContext;
@@ -27,14 +26,16 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.world.InteractionResult;
 
+import brachy.modularui.api.drawable.IIcon;
 import brachy.modularui.api.drawable.Text;
+import brachy.modularui.drawable.GuiTextures;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.utils.Alignment;
-import brachy.modularui.utils.Color;
+import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widget.ParentWidget;
-import brachy.modularui.widgets.TextWidget;
+import brachy.modularui.widgets.ListWidget;
 import brachy.modularui.widgets.layout.Flow;
 import com.mojang.blaze3d.MethodsReturnNonnullByDefault;
 import lombok.Getter;
@@ -44,6 +45,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -73,6 +75,7 @@ public class MinerMachine extends WorkableTieredMachine
         this.chargerInventory = createChargerItemHandler();
         this.autoOutput = attachTrait(AutoOutputTrait.ofItems(exportItems));
         autoOutput.setItemOutputDirectionValidator(d -> d != Direction.DOWN);
+        getRecipeLogic().resetRecipeLogic();
     }
 
     //////////////////////////////////////
@@ -136,32 +139,6 @@ public class MinerMachine extends WorkableTieredMachine
         }
     }
 
-    private void addDisplayText(List<Component> textList) {
-        int workingArea = IMiner.getWorkingArea(getRecipeLogic().getCurrentRadius());
-        textList.add(recipeLogic.getCustomProgressLine());
-        textList.add(
-                Component.translatable("gtceu.machine.miner.x", getRecipeLogic().getX(), getRecipeLogic().getMineX()));
-        textList.add(
-                Component.translatable("gtceu.machine.miner.y", getRecipeLogic().getY(), getRecipeLogic().getMineY()));
-        textList.add(
-                Component.translatable("gtceu.machine.miner.x", getRecipeLogic().getZ(), getRecipeLogic().getMineZ()));
-        textList.add(Component.translatable("gtceu.universal.tooltip.working_area", workingArea, workingArea));
-        if (getRecipeLogic().isDone())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.done")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.GREEN)));
-        else if (getRecipeLogic().isWorking())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.working")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.GOLD)));
-        else if (!this.isWorkingEnabled())
-            textList.add(Component.translatable("gtceu.multiblock.work_paused"));
-        if (getRecipeLogic().isInventoryFull())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.invfull")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)));
-        if (!drainInput(true))
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.needspower")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)));
-    }
-
     @Override
     public boolean drainInput(boolean simulate) {
         long resultEnergy = energyContainer.getEnergyStored() - energyPerTick;
@@ -212,31 +189,75 @@ public class MinerMachine extends WorkableTieredMachine
         return new ArrayList<>();
     }
 
-    // TODO(Onion): fix the gui stuff for this
-
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
+        IntSyncValue startX = new IntSyncValue(() -> getRecipeLogic().getStartX()).allowC2S();
+        IntSyncValue startY = new IntSyncValue(() -> getRecipeLogic().getStartY()).allowC2S();
+        IntSyncValue startZ = new IntSyncValue(() -> getRecipeLogic().getStartZ()).allowC2S();
+        IntSyncValue mineX = new IntSyncValue(() -> getRecipeLogic().getMineX()).allowC2S();
+        IntSyncValue mineY = new IntSyncValue(() -> getRecipeLogic().getMineY()).allowC2S();
+        IntSyncValue mineZ = new IntSyncValue(() -> getRecipeLogic().getMineZ()).allowC2S();
+        IntSyncValue workingArea = new IntSyncValue(() -> IMiner.getWorkingArea(getRecipeLogic().getCurrentRadius()))
+                .allowC2S();
+
+        ListWidget<?, ?> textList = new ListWidget<>()
+                .heightRel(1.0f)
+                .collapseDisabledChildren()
+                .coverChildrenWidth()
+                .crossAxisAlignment(Alignment.CrossAxis.START)
+                .childSeparator(IIcon.EMPTY_2PX)
+                .child(Text
+                        .dynamic(() -> Objects.requireNonNull(
+                                getRecipeLogic().getCustomProgressLine().copy().withStyle(ChatFormatting.WHITE)))
+                        .asWidget())
+                .child(Text.dynamic(
+                        () -> Component.translatable("gtceu.machine.miner.x", startX.getIntValue(), mineX.getIntValue())
+                                .withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text.dynamic(
+                        () -> Component.translatable("gtceu.machine.miner.y", startY.getIntValue(), mineY.getIntValue())
+                                .withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text.dynamic(
+                        () -> Component.translatable("gtceu.machine.miner.z", startZ.getIntValue(), mineZ.getIntValue())
+                                .withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text
+                        .dynamic(() -> Component.translatable("gtceu.universal.tooltip.working_area",
+                                workingArea.getIntValue(), workingArea.getIntValue()).withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.done")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.GREEN))).asWidget()
+                        .setEnabledIf(w -> getRecipeLogic().isDone()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.working")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.GOLD))).asWidget()
+                        .setEnabledIf(w -> getRecipeLogic().isWorking()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.work_paused")).asWidget()
+                        .setEnabledIf(w -> !isWorkingEnabled()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.invfull")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.RED))).asWidget()
+                        .setEnabledIf(w -> getRecipeLogic().isInventoryFull()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.needspower")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.RED))).asWidget()
+                        .setEnabledIf(w -> !drainInput(true)));
+
         mainWidget
+                .name("content")
+                .coverChildrenWidth(170)
                 .child(Flow.row()
-                        .width(220)
-                        .coverChildrenHeight()
-                        .margin(5)
-                        .childPadding(5)
-                        .child(Flow.column()
-                                .crossAxisAlignment(Alignment.CrossAxis.START)
-                                .padding(5)
-                                .background(GTGuiTextures.DISPLAY)
-                                .widthRel(.6f)
-                                .child(new TextWidget<>(Text.dynamic(() -> {
-                                    List<Component> text = new ArrayList<>();
-                                    addDisplayText(text);
-                                    return text.stream()
-                                            .map(Component::copy)
-                                            .reduce((a, b) -> a.append("\n").append(b))
-                                            .orElse(Component.empty());
-                                })).color(Color.WHITE.main)))
-                        .child(GTMuiMachineUtil.createSquareSlotGroupFromInventory(exportItems, "export_inv",
-                                syncManager)));
+                        .name("mainRow")
+                        .coverChildrenWidth(170)
+                        .childPadding(4)
+                        .child(new ParentWidget<>()
+                                .name("displayScreen")
+                                .heightRel(1.0f)
+                                .coverChildrenWidth()
+                                .background(GuiTextures.DISPLAY)
+                                .child(textList.heightRel(1.0f).padding(3)))
+                        .child(GTMuiMachineUtil
+                                .createSquareSlotGroupFromInventory(exportItems, "export_inv", syncManager)
+                                .verticalCenter())
+                        .padding(4, 0));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CleanroomMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/CleanroomMachine.java
@@ -148,7 +148,6 @@ public class CleanroomMachine extends WorkableElectricMultiblockMachine
 
         initializeAbilities();
 
-        // var cache = getSubstructure(name).getCache();
         var cache = patternStates.get(substructureName).getCache();
         IFilterType filterType = null;
         for (var entry : cache.long2ObjectEntrySet()) {
@@ -225,15 +224,10 @@ public class CleanroomMachine extends WorkableElectricMultiblockMachine
 
     protected void initializeAbilities() {
         List<IEnergyContainer> energyContainers = new ArrayList<>();
-        // Long2ObjectMap<IO> ioMap = getMultiblockState().getMatchContext().getOrCreate("ioMap",
-        // Long2ObjectMaps::emptyMap);
         for (IMultiPart part : getParts()) {
             if (isPartIgnored(part)) continue;
-            // IO io = ioMap.getOrDefault(part.self().getPos().asLong(), IO.BOTH);
-            // if (io == IO.NONE || io == IO.OUT) continue;
             var handlerLists = part.getRecipeHandlers();
             for (var handlerList : handlerLists) {
-                // if (!handlerList.isValid(io)) continue;
                 handlerList.getCapability(EURecipeCapability.CAP).stream()
                         .filter(IEnergyContainer.class::isInstance)
                         .map(IEnergyContainer.class::cast)
@@ -279,55 +273,6 @@ public class CleanroomMachine extends WorkableElectricMultiblockMachine
 
             return new IntArrayList(new int[] { 0, d, l, r, f, b });
         };
-
-        /*
-         * BlockPos.MutableBlockPos lPos = getPos().mutable();
-         * BlockPos.MutableBlockPos rPos = getPos().mutable();
-         * BlockPos.MutableBlockPos fPos = getPos().mutable();
-         * BlockPos.MutableBlockPos bPos = getPos().mutable();
-         * BlockPos.MutableBlockPos hPos = getPos().mutable();
-         *
-         * // find the distances from the controller to the plascrete blocks on one horizontal axis and the Y axis
-         * // repeatable aisles take care of the second horizontal axis
-         * int lDist = 0;
-         * int rDist = 0;
-         * int bDist = 0;
-         * int fDist = 0;
-         * int hDist = 0;
-         *
-         * // find the left, right, back, and front distances for the structure pattern
-         * // maximum size is 15x15x15 including walls, so check 7 block radius around the controller for blocks
-         * for (int i = 1; i < 8; i++) {
-         * if (lDist == 0 && isBlockEdge(world, lPos, left)) lDist = i;
-         * if (rDist == 0 && isBlockEdge(world, rPos, right)) rDist = i;
-         * if (bDist == 0 && isBlockEdge(world, bPos, back)) bDist = i;
-         * if (fDist == 0 && isBlockEdge(world, fPos, front)) fDist = i;
-         * if (lDist != 0 && rDist != 0 && bDist != 0 && fDist != 0) break;
-         * }
-         *
-         * // height is diameter instead of radius, so it needs to be done separately
-         * for (int i = 1; i < 15; i++) {
-         * if (isBlockFloor(world, hPos, Direction.DOWN)) hDist = i;
-         * if (hDist != 0) break;
-         * }
-         *
-         * if (Math.abs(lDist - rDist) > 1 || Math.abs(bDist - fDist) > 1) {
-         * this.isFormed = false;
-         * return;
-         * }
-         *
-         * if (lDist < MIN_RADIUS || rDist < MIN_RADIUS || bDist < MIN_RADIUS || fDist < MIN_RADIUS || hDist <
-         * MIN_DEPTH) {
-         * this.isFormed = false;
-         * return;
-         * }
-         *
-         * this.lDist = lDist;
-         * this.rDist = rDist;
-         * this.bDist = bDist;
-         * this.fDist = fDist;
-         * this.hDist = hDist;
-         */
     }
 
     public static int findWallPos(Level level, Direction dir, BlockPos.MutableBlockPos pos) {
@@ -368,7 +313,7 @@ public class CleanroomMachine extends WorkableElectricMultiblockMachine
 
     public static Function<MultiblockMachineDefinition, IBlockPattern> getPattern() {
         return (definition) -> {
-            PatternPredicate wallPredicate = getValidFloorBlocks();
+            PatternPredicate wallPredicate = getValidFloorBlocks().or(states(getCasingState(), getGlassState()));
             PatternPredicate energyPredicate = autoAbilities(true, false, false).or(abilities(PartAbility.INPUT_ENERGY)
                     .setMinGlobalLimited(1).setMaxGlobalLimited(3));
 
@@ -388,7 +333,7 @@ public class CleanroomMachine extends WorkableElectricMultiblockMachine
                             IntIntPair.of(MIN_RADIUS, MAX_RADIUS), IntIntPair.of(MIN_RADIUS, MAX_RADIUS)))
                     .predicateProvider((bp, b) -> {
                         if (bp.equals(BlockPos.ZERO))
-                            return Predicates.controller(Predicates.blocks(definition.getBlock()));
+                            return Predicates.controller(definition);
 
                         int intersections = 0;
                         boolean topAisle = bp.getX() == b.get(0);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CharcoalPileIgniterMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CharcoalPileIgniterMachine.java
@@ -4,14 +4,15 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.IWorkable;
 import com.gregtechceu.gtceu.api.item.ComponentItem;
+import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 import com.gregtechceu.gtceu.api.multiblock.PatternPredicate;
 import com.gregtechceu.gtceu.api.multiblock.Predicates;
 import com.gregtechceu.gtceu.api.multiblock.error.PatternStringError;
 import com.gregtechceu.gtceu.api.multiblock.pattern.ExpandableMultiblockPatternBuilder;
+import com.gregtechceu.gtceu.api.multiblock.pattern.ExpandablePattern;
 import com.gregtechceu.gtceu.api.multiblock.pattern.IBlockPattern;
-import com.gregtechceu.gtceu.api.multiblock.pattern.PatternState;
 import com.gregtechceu.gtceu.api.multiblock.util.RelativeDirection;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.item.behavior.LighterBehavior;
@@ -29,15 +30,17 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.function.Function;
 
 public class CharcoalPileIgniterMachine extends WorkableMultiblockMachine implements IWorkable {
 
@@ -47,8 +50,8 @@ public class CharcoalPileIgniterMachine extends WorkableMultiblockMachine implem
     private static final int MAX_RADIUS = 5;
     private final Collection<BlockPos> logPos = new ObjectOpenHashSet<>();
 
-    private final IntList bounds = new IntArrayList(
-            new int[] { 0, MIN_DEPTH, MIN_RADIUS, MIN_RADIUS, MIN_RADIUS, MIN_RADIUS });
+    private List<Integer> bounds = new ArrayList<>(
+            List.of(0, MIN_DEPTH, MIN_RADIUS, MIN_RADIUS, MIN_RADIUS, MIN_RADIUS));
     private int maxTime = 0;
     private boolean hasAir = false;
 
@@ -70,6 +73,27 @@ public class CharcoalPileIgniterMachine extends WorkableMultiblockMachine implem
         this.getRecipeLogic().setDuration(Math.max(1, (int) Math.sqrt(logPos.size() * 240_000)));
     }
 
+    public static ExpandablePattern.BoundsProvider boundsFunction() {
+        return (level, controllerPos, front, up) -> {
+
+            BlockPos down = controllerPos.mutable().move(Direction.DOWN);
+            Direction back = front.getOpposite();
+            Direction left = front.getCounterClockWise();
+            Direction right = left.getOpposite();
+
+            int l = findWallPos(level, left, down.mutable());
+            int r = findWallPos(level, right, down.mutable());
+            int b = findWallPos(level, back, down.mutable());
+            int f = findWallPos(level, front, down.mutable());
+            int d = findFloorPos(level, up.getOpposite(), controllerPos.mutable());
+
+            if (d < MIN_DEPTH || l < MIN_RADIUS || r < MIN_RADIUS || b < MIN_RADIUS || f < MIN_RADIUS) {
+                return new IntArrayList(new int[] { 0, MIN_DEPTH, MIN_RADIUS, MIN_RADIUS, MIN_RADIUS, MIN_RADIUS });
+            }
+            return new IntArrayList(new int[] { 0, d, l, r, f, b });
+        };
+    }
+
     @Override
     public CharcoalRecipeLogic getRecipeLogic() {
         return (CharcoalRecipeLogic) super.getRecipeLogic();
@@ -88,54 +112,45 @@ public class CharcoalPileIgniterMachine extends WorkableMultiblockMachine implem
     @Override
     public void setWorkingEnabled(boolean isWorkingAllowed) {}
 
-    @Override
-    public PatternState checkStructurePattern(String name) {
-        getDefaultStructurePattern();
-        return super.checkStructurePattern(name);
+    public static Function<MultiblockMachineDefinition, IBlockPattern> getPattern() {
+        return (definition) -> {
+
+            var floor = Predicates.blocks(Blocks.BRICKS);
+            var logs = PatternPredicate.AIR.or(logPredicate());
+            var walls = wallPredicate();
+
+            return ExpandableMultiblockPatternBuilder
+                    .start(RelativeDirection.UP, RelativeDirection.RIGHT, RelativeDirection.FRONT)
+                    .boundsProvider(boundsFunction())
+                    .constraintProvider(() -> List.of(IntIntPair.of(0, 0), IntIntPair.of(MIN_DEPTH, MAX_DEPTH),
+                            IntIntPair.of(MIN_RADIUS, MAX_RADIUS), IntIntPair.of(MIN_RADIUS, MAX_RADIUS),
+                            IntIntPair.of(MIN_RADIUS, MAX_RADIUS), IntIntPair.of(MIN_RADIUS, MAX_RADIUS)))
+                    .predicateProvider((bp, b) -> {
+                        if (bp.equals(BlockPos.ZERO))
+                            return Predicates.controller(definition);
+
+                        int intersects = 0;
+                        boolean topAisle = bp.getX() == b.get(0);
+                        boolean bottomAisle = bp.getX() == -b.get(1);
+
+                        if (topAisle || bottomAisle) intersects++;
+
+                        if (bp.getY() == -b.get(2) || bp.getY() == b.get(3)) intersects++;
+                        if (bp.getZ() == b.get(4) || bp.getZ() == -b.get(5)) intersects++;
+
+                        if (intersects >= 2) return PatternPredicate.ANY;
+
+                        if (intersects == 1) {
+                            if (bottomAisle) return floor;
+                            return walls;
+                        }
+                        return logs;
+                    })
+                    .build();
+        };
     }
 
-    @Override
-    public IBlockPattern getDefaultStructurePattern() {
-        var floor = Predicates.blocks(Blocks.BRICKS);
-        var logs = PatternPredicate.AIR.or(logPredicate());
-        var walls = wallPredicate();
-
-        updateDimensions();
-
-        return ExpandableMultiblockPatternBuilder
-                .start(RelativeDirection.UP, RelativeDirection.RIGHT, RelativeDirection.FRONT)
-                .boundsProvider((l, b, f, u) -> bounds)
-                .predicateProvider((bp, b) -> {
-                    if (bp.equals(BlockPos.ZERO))
-                        return Predicates.controller(Predicates.blocks(getDefinition().getBlock()));
-
-                    int intersects = 0;
-
-                    // aisle dir is up, so its bounds[0] and bounds[1]
-                    // DOWN is negative
-                    boolean topAisle = bp.getX() == b.get(0);
-                    boolean bottomAisle = bp.getX() == -b.get(1);
-
-                    if (topAisle || bottomAisle) intersects++;
-
-                    // negative signs for the LEFT and BACK ordinals
-                    // string dir is right, so its bounds[2] and bounds[3]
-                    if (bp.getY() == -b.get(2) || bp.getY() == b.get(3)) intersects++;
-                    // char dir is front, so its bounds[4] and bounds[5]
-                    if (bp.getZ() == b.get(4) || bp.getZ() == -b.get(5)) intersects++;
-
-                    if (intersects >= 2) return PatternPredicate.ANY;
-
-                    if (intersects == 1) {
-                        if (bottomAisle) return floor;
-                        return walls;
-                    }
-                    return logs;
-                })
-                .build();
-    }
-
-    private PatternPredicate wallPredicate() {
+    private static PatternPredicate wallPredicate() {
         return new PatternPredicate("Wall Blocks",
                 multiblockState -> {
                     BlockPos p = multiblockState.getBlockPos();
@@ -145,55 +160,27 @@ public class CharcoalPileIgniterMachine extends WorkableMultiblockMachine implem
                 }, null);
     }
 
-    private PatternPredicate logPredicate() {
+    private static PatternPredicate logPredicate() {
         return new PatternPredicate(multiblockState -> {
             boolean match = multiblockState.getBlockState().is(BlockTags.LOGS_THAT_BURN);
             return match ? null : new PatternStringError(Component.translatable("gtceu.predicate_error.charcoal.logs"));
         }, null);
     }
 
-    public void updateDimensions() {
-        Level level = getLevel();
-        if (level == null) return;
-        Direction front = getFrontFacing();
-        Direction back = front.getOpposite();
-        Direction left = RelativeDirection.LEFT.getRelativeFacing(front, getUpwardsFacing(), false);
-        Direction right = RelativeDirection.RIGHT.getRelativeFacing(front, getUpwardsFacing(), false);
-
-        BlockPos down = getBlockPos().relative(Direction.DOWN);
-        int l = findWallPos(left, down.mutable());
-        int r = findWallPos(right, down.mutable());
-        int b = findWallPos(back, down.mutable());
-        int f = findWallPos(front, down.mutable());
-        int d = findFloorPos(getBlockPos().mutable());
-
-        if (d < MIN_DEPTH || l < MIN_RADIUS || r < MIN_RADIUS || b < MIN_RADIUS || f < MIN_RADIUS) {
-            invalidateStructure();
-            return;
-        }
-        bounds.clear();
-        bounds.add(0);
-        bounds.add(d);
-        bounds.add(l);
-        bounds.add(r);
-        bounds.add(f);
-        bounds.add(b);
-    }
-
-    private int findWallPos(Direction direction, BlockPos.MutableBlockPos bp) {
+    private static int findWallPos(Level level, Direction direction, BlockPos.MutableBlockPos pos) {
         for (int i = 1; i <= MAX_RADIUS; i++) {
-            var block = getLevel().getBlockState(bp.move(direction));
-            if (block.is(CustomTags.CHARCOAL_PILE_IGNITER_WALLS)) {
+            BlockState state = level.getBlockState(pos.move(direction));
+            if (state.is(CustomTags.CHARCOAL_PILE_IGNITER_WALLS)) {
                 return i;
             }
         }
         return -1;
     }
 
-    private int findFloorPos(BlockPos.MutableBlockPos bp) {
+    private static int findFloorPos(Level level, Direction dir, BlockPos.MutableBlockPos pos) {
         for (int i = 1; i <= MAX_DEPTH; i++) {
-            var block = getLevel().getBlockState(bp.move(Direction.DOWN));
-            if (block.is(Blocks.BRICKS)) {
+            BlockState state = level.getBlockState(pos.move(dir));
+            if (state.is(Blocks.BRICKS)) {
                 return i;
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamMinerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamMinerMachine.java
@@ -13,7 +13,6 @@ import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.common.item.behavior.PortableScannerBehavior;
 import com.gregtechceu.gtceu.common.machine.trait.ExhaustVentMachineTrait;
 import com.gregtechceu.gtceu.common.machine.trait.miner.SteamMinerLogic;
-import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiMachineUtil;
 import com.gregtechceu.gtceu.utils.GTTransferUtils;
 import com.gregtechceu.gtceu.utils.ISubscription;
@@ -27,14 +26,16 @@ import net.minecraft.network.chat.Style;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
+import brachy.modularui.api.drawable.IIcon;
 import brachy.modularui.api.drawable.Text;
+import brachy.modularui.drawable.GuiTextures;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.utils.Alignment;
-import brachy.modularui.utils.Color;
+import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widget.ParentWidget;
-import brachy.modularui.widgets.TextWidget;
+import brachy.modularui.widgets.ListWidget;
 import brachy.modularui.widgets.layout.Flow;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
@@ -42,6 +43,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -75,6 +77,7 @@ public class SteamMinerMachine extends SteamWorkableMachine implements IControll
         this.exhaustVentTrait = attachTrait(new ExhaustVentMachineTrait());
         exhaustVentTrait.setVentingDirection(Direction.UP);
         exhaustVentTrait.setVentingDamageAmount(isHighPressure() ? 12F : 6F);
+        getRecipeLogic().resetRecipeLogic();
     }
 
     @Override
@@ -148,57 +151,73 @@ public class SteamMinerMachine extends SteamWorkableMachine implements IControll
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
-        mainWidget.width(200)
-                .child(Flow.row()
-                        .coverChildrenHeight()
-                        .margin(5)
-                        .childPadding(5)
-                        .width(200)
-                        .child(Flow.column()
-                                .crossAxisAlignment(Alignment.CrossAxis.START)
-                                .padding(5)
-                                .background(GTGuiTextures.DISPLAY)
-                                .widthRel(.6f)
-                                .coverChildrenHeight()
-                                .child(new TextWidget<>(Text.dynamic(() -> {
-                                    List<Component> text = new ArrayList<>();
-                                    addDisplayText(text);
-                                    return text.stream()
-                                            .map(Component::copy)
-                                            .reduce((a, b) -> a.append("\n").append(b))
-                                            .orElse(Component.empty());
-                                })).color(Color.WHITE.main)))
-                        .child(GTMuiMachineUtil.createSquareSlotGroupFromInventory(exportItems, "export_inv",
-                                syncManager).posRel(0.875f, 0.5f)));
-    }
+        IntSyncValue startX = new IntSyncValue(() -> getRecipeLogic().getStartX()).allowC2S();
+        IntSyncValue startY = new IntSyncValue(() -> getRecipeLogic().getStartY()).allowC2S();
+        IntSyncValue startZ = new IntSyncValue(() -> getRecipeLogic().getStartZ()).allowC2S();
+        IntSyncValue mineX = new IntSyncValue(() -> getRecipeLogic().getMineX()).allowC2S();
+        IntSyncValue mineY = new IntSyncValue(() -> getRecipeLogic().getMineY()).allowC2S();
+        IntSyncValue mineZ = new IntSyncValue(() -> getRecipeLogic().getMineZ()).allowC2S();
+        IntSyncValue workingArea = new IntSyncValue(() -> IMiner.getWorkingArea(getRecipeLogic().getCurrentRadius()))
+                .allowC2S();
 
-    private void addDisplayText(List<Component> textList) {
-        int workingArea = IMiner.getWorkingArea(getRecipeLogic().getCurrentRadius());
-        textList.add(recipeLogic.getCustomProgressLine());
-        textList.add(
-                Component.translatable("gtceu.machine.miner.x", getRecipeLogic().getX(), getRecipeLogic().getMineX()));
-        textList.add(
-                Component.translatable("gtceu.machine.miner.y", getRecipeLogic().getY(), getRecipeLogic().getMineY()));
-        textList.add(
-                Component.translatable("gtceu.machine.miner.x", getRecipeLogic().getZ(), getRecipeLogic().getMineZ()));
-        textList.add(Component.translatable("gtceu.universal.tooltip.working_area", workingArea, workingArea));
-        if (getRecipeLogic().isDone())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.done")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.GREEN)));
-        else if (getRecipeLogic().isWorking())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.working")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.GOLD)));
-        else if (!this.isWorkingEnabled())
-            textList.add(Component.translatable("gtceu.multiblock.work_paused"));
-        if (getRecipeLogic().isInventoryFull())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.invfull")
-                    .setStyle(Style.EMPTY.withColor(ChatFormatting.RED)));
-        if (exhaustVentTrait.isVentingBlocked())
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.vent")
-                    .withStyle(ChatFormatting.RED));
-        else if (!drainInput(true))
-            textList.add(Component.translatable("gtceu.multiblock.large_miner.steam")
-                    .withStyle(ChatFormatting.RED));
+        ListWidget<?, ?> textList = new ListWidget<>()
+                .heightRel(1.0f)
+                .collapseDisabledChildren()
+                .coverChildrenWidth()
+                .crossAxisAlignment(Alignment.CrossAxis.START)
+                .childSeparator(IIcon.EMPTY_2PX)
+                .child(Text
+                        .dynamic(() -> Objects.requireNonNull(
+                                getRecipeLogic().getCustomProgressLine().copy().withStyle(ChatFormatting.WHITE)))
+                        .asWidget())
+                .child(Text.dynamic(
+                        () -> Component.translatable("gtceu.machine.miner.x", startX.getIntValue(), mineX.getIntValue())
+                                .withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text.dynamic(
+                        () -> Component.translatable("gtceu.machine.miner.y", startY.getIntValue(), mineY.getIntValue())
+                                .withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text.dynamic(
+                        () -> Component.translatable("gtceu.machine.miner.z", startZ.getIntValue(), mineZ.getIntValue())
+                                .withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text
+                        .dynamic(() -> Component.translatable("gtceu.universal.tooltip.working_area",
+                                workingArea.getIntValue(), workingArea.getIntValue()).withStyle(ChatFormatting.WHITE))
+                        .asWidget())
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.done")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.GREEN))).asWidget()
+                        .setEnabledIf(w -> getRecipeLogic().isDone()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.working")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.GOLD))).asWidget()
+                        .setEnabledIf(w -> getRecipeLogic().isWorking()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.work_paused")).asWidget()
+                        .setEnabledIf(w -> !isWorkingEnabled()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.invfull")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.RED))).asWidget()
+                        .setEnabledIf(w -> getRecipeLogic().isInventoryFull()))
+                .child(Text.dynamic(() -> Component.translatable("gtceu.multiblock.large_miner.needspower")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.RED))).asWidget()
+                        .setEnabledIf(w -> !drainInput(true)));
+
+        mainWidget
+                .name("content")
+                .coverChildrenWidth(170)
+                .child(Flow.row()
+                        .name("mainRow")
+                        .coverChildrenWidth(170)
+                        .childPadding(4)
+                        .child(new ParentWidget<>()
+                                .name("displayScreen")
+                                .heightRel(1.0f)
+                                .coverChildrenWidth()
+                                .background(GuiTextures.DISPLAY)
+                                .child(textList.heightRel(1.0f).padding(3)))
+                        .child(GTMuiMachineUtil
+                                .createSquareSlotGroupFromInventory(exportItems, "export_inv", syncManager)
+                                .verticalCenter())
+                        .padding(4, 0));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -107,8 +107,8 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
     @SaveField
     private int pipeLength = 0;
     @Getter
-    @Setter
     @SaveField
+    @SyncToClient
     private int currentRadius;
     @Getter
     @SaveField
@@ -304,6 +304,11 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
                 subscription = null;
             }
         }
+    }
+
+    public void setCurrentRadius(int currentRadius) {
+        this.currentRadius = currentRadius;
+        syncDataHolder.markClientSyncFieldDirty("currentRadius");
     }
 
     /**


### PR DESCRIPTION
## What
fixes the cleanroom wall predicate to only accept other mod floor blocks
clean up charcoal igniter structure definition to mirror cleanroom's
clean up miner UI, also make the needed fields synced 👍 


## Implementation Details
<img width="531" height="523" alt="image" src="https://github.com/user-attachments/assets/32f9eaf8-9375-485a-9f81-58bbda79298e" />
<img width="456" height="395" alt="image" src="https://github.com/user-attachments/assets/e46a5e9d-aa65-437e-ab5d-e59ba2a983b3" />
<img width="435" height="431" alt="image" src="https://github.com/user-attachments/assets/9714f9d9-f9b5-4b81-b4d1-d368a06c2a29" />
<img width="485" height="413" alt="image" src="https://github.com/user-attachments/assets/551038be-53a4-468b-973f-f4ba08e34a8c" />



### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
Miner ui looks better

## How Was This Tested
in game
