### PR TITLE
Fix Quarktech Leggings consumign EU when creative

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/armor/QuarkTechSuite.java
@@ -136,7 +136,9 @@ public class QuarkTechSuite extends ArmorLogicSuite implements IStepAssist {
             if (canUseEnergy && sprinting) {
                 if (runningTimer == 0) {
                     runningTimer = RUNNING_TIMER;
-                    item.discharge(energyPerUse / 100, item.getTier(), true, false, false);
+                    if (!player.isCreative()) {
+                        item.discharge(energyPerUse / 100, item.getTier(), true, false, false);
+                    }
                 }
             }
             if (canUseEnergy && (player.onGround() || player.isInWater()) && sprinting) {


### PR DESCRIPTION
## What
Fixes #2438 


## Implementation Details
adds a creative mode check

### AI Usage 

**All machine code MUST be reviewed by the pull request submitter before opening. **

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
no more eu drain when creative mode

## How Was This Tested
ingame
