### PR TITLE
Fix nullability on recipe serializer

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -406,6 +406,7 @@ public class GTMultiblockTextUtil {
                                 .getter(() -> rlmachine.getRecipeLogic().getLastRecipe())
                                 .setter((newRecipe) -> {})
                                 .adapter(GTByteBufAdapters.GTRECIPE)
+                                .nullable()
                                 .copy(GTRecipe::copy)
                                 .build());
 


### PR DESCRIPTION
## What
machines that havent had a recipe ran have a null getLastRecipe()
Also, TIL you have to specify .nullable on generic sync values

no AI