### PR TITLE
Fix lang key datagen for Surface Rocks

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -1743,7 +1743,7 @@
     "block.gtceu.zpm_transformer_4a": "ɹǝɯɹoɟsuɐɹ⟘ )xㄣ( dɯⱯ-ıH ɹ§ǝbɐʇןoΛ WԀZɔ§",
     "block.gtceu.zpm_wiremill": "ɹ§III ןןıɯǝɹıM ǝʇıןƎɔ§",
     "block.gtceu.zpm_world_accelerator": "ɹ§III ɹoʇɐɹǝןǝɔɔⱯ pןɹoM ǝʇıןƎɔ§",
-    "block.surface_rock": "ʞɔoᴚ ǝɔɐɟɹnS %s",
+    "block.gtceu.surface_rock": "ʞɔoᴚ ǝɔɐɟɹnS %s",
     "button.gtceu.mark_as_depleted.name": "pǝʇǝןdǝᗡ sɐ ʞɹɐW",
     "button.gtceu.toggle_waypoint.name": "ʇuıodʎɐM ǝןbbo⟘",
     "command.gtceu.cape.failure.does_not_exist": "ʇsıxǝ ʇou sǝop %s ǝdɐƆ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -1743,7 +1743,7 @@
     "block.gtceu.zpm_transformer_4a": "§cZPM Voltage§r Hi-Amp (4x) Transformer",
     "block.gtceu.zpm_wiremill": "§cElite Wiremill III§r",
     "block.gtceu.zpm_world_accelerator": "§cElite World Accelerator III§r",
-    "block.surface_rock": "%s Surface Rock",
+    "block.gtceu.surface_rock": "%s Surface Rock",
     "button.gtceu.mark_as_depleted.name": "Mark as Depleted",
     "button.gtceu.toggle_waypoint.name": "Toggle Waypoint",
     "command.gtceu.cape.failure.does_not_exist": "Cape %s does not exist",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/LangHandler.java
@@ -627,7 +627,7 @@ public class LangHandler {
         replace(provider, GTBlocks.BATTERY_ULTIMATE_UHV.get().getDescriptionId(), "UHV Ultimate Capacitor");
 
         provider.add("item.netherrack_nether_quartz", "Nether Quartz Ore");
-        provider.add("block.surface_rock", "%s Surface Rock");
+        provider.add("block.gtceu.surface_rock", "%s Surface Rock");
 
         provider.add("item.gtceu.tiny_gunpowder_dust", "Tiny Pile of Gunpowder");
         provider.add("item.gtceu.small_gunpowder_dust", "Small Pile of Gunpowder");

--- a/src/main/resources/assets/gtceu/lang/de_de.json
+++ b/src/main/resources/assets/gtceu/lang/de_de.json
@@ -1723,7 +1723,7 @@
     "block.gtceu.zpm_wiremill": "§bZPM Drahtwerk",
     "block.gtceu.zpm_world_accelerator": "§cElite World Accelerator III§r",
     "block.sterilizing_filter_casing.tooltip": "Erstellt eine §asterilisierte§7 Umgebung",
-    "block.surface_rock": "%s Oberflächengestein",
+    "block.gtceu.surface_rock": "%s Oberflächengestein",
     "button.gtceu.mark_as_depleted.name": "Als erschöpft markieren",
     "button.gtceu.toggle_waypoint.name": "Wegpunkt umschalten",
     "command.gtceu.cape.failure.does_not_exist": "Kap %s existiert nicht",

--- a/src/main/resources/assets/gtceu/lang/ja_jp.json
+++ b/src/main/resources/assets/gtceu/lang/ja_jp.json
@@ -1707,7 +1707,7 @@
   "block.gtceu.zpm_wiremill": "§c精鋭型ワイヤー作製機 III§r",
   "block.gtceu.zpm_world_accelerator": "§c精鋭型世界加速機 III§r",
   "block.sterilizing_filter_casing.tooltip": "§a滅菌§7環境を構築する",
-  "block.surface_rock": "%sの小石",
+  "block.gtceu.surface_rock": "%sの小石",
   "button.gtceu.mark_as_depleted.name": "枯渇済みとしてマーク",
   "button.gtceu.toggle_waypoint.name": "ウェイポイントを切り替え",
   "command.gtceu.cape.failure.does_not_exist": "マント %s は存在しません",

--- a/src/main/resources/assets/gtceu/lang/pt_br.json
+++ b/src/main/resources/assets/gtceu/lang/pt_br.json
@@ -1722,7 +1722,7 @@
   "block.gtceu.zpm_wiremill": "§cTrefiladora de Elite III§r",
   "block.gtceu.zpm_world_accelerator": "§cAcelerador de Mundo de Elite III§r",
   "block.sterilizing_filter_casing.tooltip": "Cria um ambiente §aEsterilizado§7",
-  "block.surface_rock": "Rocha de Superfície de %s",
+  "block.gtceu.surface_rock": "Rocha de Superfície de %s",
   "button.gtceu.mark_as_depleted.name": "Marcar como Esgotado",
   "button.gtceu.toggle_waypoint.name": "Alternar Waypoint",
   "command.gtceu.cape.failure.does_not_exist": "A capa %s não existe",

--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -1238,7 +1238,7 @@
     "block.gtceu.zpm_transformer_2a": "Высокотоковый трансформатор (2А §cZPM§r)",
     "block.gtceu.zpm_transformer_4a": "Высокотоковый трансформатор (4А §cZPM§r)",
     "block.gtceu.zpm_wiremill": "§cПревосходный волочильный станок III§r",
-    "block.surface_rock": "Поверхностная порода (%s)",
+    "block.gtceu.surface_rock": "Поверхностная порода (%s)",
     "config.gtceu.option.allUniqueStoneTypes": "allUniqueStoneTypes",
     "config.gtceu.option.bedrockOreDropTagPrefix": "bedrockOreDropTagPrefix",
     "config.gtceu.option.cleanMultiblocks": "cleanMultiblocks",

--- a/src/main/resources/assets/gtceu/lang/uk_ua.json
+++ b/src/main/resources/assets/gtceu/lang/uk_ua.json
@@ -1708,7 +1708,7 @@
   "block.gtceu.zpm_wiremill": "§cЕлітний волок III§r",
   "block.gtceu.zpm_world_accelerator": "§cЕлітний світовий прискорювач III§r",
   "block.sterilizing_filter_casing.tooltip": "Створює§a стерильне§7 середовище",
-  "block.surface_rock": "%s (поверхневий поклад)",
+  "block.gtceu.surface_rock": "%s (поверхневий поклад)",
   "button.gtceu.mark_as_depleted.name": "Позначити як виснажений",
   "button.gtceu.toggle_waypoint.name": "Перемикнути маршрутну точку",
   "command.gtceu.cape.failure.does_not_exist": "Плаща «%s» не існує",

--- a/src/main/resources/assets/gtceu/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceu/lang/zh_cn.json
@@ -1722,7 +1722,7 @@
     "block.gtceu.zpm_wiremill": "§c精英线材轧机 III§r",
     "block.gtceu.zpm_world_accelerator": "§c精英世界加速器 III§r",
     "block.sterilizing_filter_casing.tooltip": "创造一个§a无菌§r环境",
-    "block.surface_rock": "地表岩石（%s）",
+    "block.gtceu.surface_rock": "地表岩石（%s）",
     "button.gtceu.mark_as_depleted.name": "标记为枯竭",
     "button.gtceu.toggle_waypoint.name": "切换路径点",
     "command.gtceu.cape.failure.does_not_exist": "披风%s不存在",

--- a/src/main/resources/assets/gtceu/lang/zh_tw.json
+++ b/src/main/resources/assets/gtceu/lang/zh_tw.json
@@ -1699,7 +1699,7 @@
     "block.gtceu.zpm_wiremill": "§c精英線材軋機 III§r",
     "block.gtceu.zpm_world_accelerator": "§c精英世界加速器 III§r",
     "block.sterilizing_filter_casing.tooltip": "創造一個§a無菌§r環境",
-    "block.surface_rock": "地表岩石（%s）",
+    "block.gtceu.surface_rock": "地表岩石（%s）",
     "button.gtceu.mark_as_depleted.name": "標記為枯竭",
     "button.gtceu.toggle_waypoint.name": "切換路徑點",
     "command.gtceu.dump_data.success": "已將登錄檔%2$s中的%1$s個資源轉儲到%3$s",


### PR DESCRIPTION
## What
Surface rocks' lang key pointed to `block.surface_rock` on 1.20. On 1.21, this was changed to `block.gtceu.surface_rock` , but the localisation wasn't updated to match that

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
<img width="440" height="124" alt="image" src="https://github.com/user-attachments/assets/1a6d02f6-822a-4e7b-8c80-1c6dce5e66b2" />

No more brokey lang

## How Was This Tested
See above