### PR TITLE
Add nullability checks with proper errors in TagPrefix BlockProperties

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -981,8 +981,8 @@ public class TagPrefix {
                           Supplier<BlockBehaviour.Properties> template, ResourceLocation baseModelLocation,
                           boolean isDoubleDrops, boolean isSand, boolean shouldDropAsItem) {}
 
-    public record BlockProperties(Supplier<Supplier<RenderType>> renderType,
-                                  UnaryOperator<BlockBehaviour.Properties> properties) {}
+    public record BlockProperties(@NotNull Supplier<Supplier<RenderType>> renderType,
+                                  @NotNull UnaryOperator<BlockBehaviour.Properties> properties) {}
 
     @Getter
     public final ResourceLocation id;
@@ -1024,7 +1024,6 @@ public class TagPrefix {
     @Setter
     private BlockItemConstructor blockItemConstructor = MaterialBlockItem::new;
     @Getter
-    @Setter
     private BlockProperties blockProperties = new BlockProperties(() -> RenderType::translucent,
             UnaryOperator.identity());
 
@@ -1177,6 +1176,19 @@ public class TagPrefix {
 
     public TagPrefix miningToolTag(TagKey<Block> tag) {
         this.miningToolTag.add(tag);
+        return this;
+    }
+
+    public TagPrefix blockProperties(BlockProperties blockProperties) {
+        if (blockProperties.renderType() == null) {
+            throw new IllegalArgumentException(
+                    "Could not set blockProperties with null renderType in TagPrefix " + this.id());
+        }
+        if (blockProperties.properties() == null) {
+            throw new IllegalArgumentException(
+                    "Could not set blockProperties with null properties in TagPrefix " + this.id());
+        }
+        this.blockProperties = blockProperties;
         return this;
     }
 


### PR DESCRIPTION
## What
Add null check and errors for blockProperties in tagPrefix

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

## Outcome
Helps in debugging, would have saved @Phoenixvine32908 some time lol

## How Was This Tested
Game runs

## Potential Compatibility Issues
Can't think of any valid reasons why either of these would be null instead of identity. there's also a valid default, shrimply don't set it
