### PR TITLE
Fix url crash when searching creative inventory

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/modules/ImageModuleBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/modules/ImageModuleBehaviour.java
@@ -56,7 +56,7 @@ public class ImageModuleBehaviour implements IMonitorModuleItem, IAddInformation
     }
 
     public String getUrl(ItemStack stack) {
-        return stack.get(GTDataComponents.IMAGE_MODULE_URL);
+        return stack.getOrDefault(GTDataComponents.IMAGE_MODULE_URL, "");
     }
 
     public void setUrl(ItemStack stack, String url) {


### PR DESCRIPTION
## What
calling getUrl on a component without a url would give a null argument in a translatable, now it passes "" instead.

### AI Usage 
- [X] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## How Was This Tested
In game, searchign the creative tab now works instead of crashing

## Potential Compatibility Issues
There's now no way to discern between a url of "" and a lack of url, but I think that's fine. It didnt seem like a problem to me for any of the usages.