### PR TITLE
Onion UI cleanup PT 2

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanel.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanel.java
@@ -29,8 +29,17 @@ public class MachineUIPanel extends ModularPanel<MachineUIPanel> {
                           boolean addTitleBar, boolean drawGTLogo, UITexture gtLogoTexture) {
         super(machine.getDefinition().getId().getPath());
 
-        UITexture themeBackground = (UITexture) ThemeAPI.INSTANCE.getTheme(settings.getTheme()).getPanelTheme()
-                .theme().getBackground();
+        UITexture themeBackground = null;
+        if (!machine.getDefinition().getThemeId().equals(ThemeAPI.DEFAULT_ID)) {
+            themeBackground = (UITexture) ThemeAPI.INSTANCE.getTheme(machine.getDefinition().getThemeId())
+                    .getPanelTheme()
+                    .theme().getBackground();
+        }
+        if (themeBackground == null) {
+            themeBackground = (UITexture) ThemeAPI.INSTANCE.getTheme(settings.getTheme()).getPanelTheme()
+                    .theme().getBackground();
+        }
+
         if (themeBackground == null) themeBackground = GTGuiTextures.BACKGROUND;
         leftConfiguratorPanel = Flow.col()
                 .coverChildren()

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.machine.trait.feature.IAttachConfiguratorsTrait
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.common.mui.widgets.SteamDialWidget;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.network.chat.Component;
 
@@ -126,7 +127,8 @@ public class MachineUIPanelBuilder {
                             .size(32, 32)
                             .tooltipAutoUpdate(true)
                             .tooltipDynamic(r -> r.addLine(Component.translatable("gtceu.multiblock.steam.steam_stored",
-                                    steamAmount.getIntValue(), steamCapacity.getIntValue()))))
+                                    FormattingUtil.formatNumbers(steamAmount.getIntValue()),
+                                    FormattingUtil.formatNumbers(steamCapacity.getIntValue())))))
                     .child(new SteamDialWidget(steamProgress)
                             .setMinAngle((float) Math.PI)
                             .setMaxAngle((float) 0.0f)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -41,7 +41,6 @@ import brachy.modularui.drawable.ItemDrawable;
 import brachy.modularui.drawable.progress.ProgressDrawable;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
-import brachy.modularui.utils.Alignment;
 import brachy.modularui.value.BoolValue;
 import brachy.modularui.value.sync.DoubleSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
@@ -293,7 +292,7 @@ public class FisherMachine extends TieredEnergyMachine
                                 .value(new BoolValue.Dynamic(this::isJunkEnabled, this::setJunkEnabled))
                                 .overlay(new ItemDrawable(Items.NAME_TAG))
                                 .tooltipAutoUpdate(true)
-                                .tooltipBuilder((r) -> {
+                                .tooltipDynamic((r) -> {
                                     var lines = LangHandler.getMultiLang("gtceu.gui.fisher_mode.tooltip",
                                             GTValues.VNF[getTier()], GTValues.VNF[getTier()]);
                                     for (var line : lines) {
@@ -310,18 +309,23 @@ public class FisherMachine extends TieredEnergyMachine
         DoubleSyncValue progressPercent = syncManager.getOrCreateSyncHandler("progressPercent", DoubleSyncValue.class,
                 () -> new DoubleSyncValue(() -> progress / (double) maxProgress));
 
-        mainWidget.child(Flow.row()
+        mainWidget
+                .name("content")
                 .coverChildren()
-                .center()
-                .margin(0, 15)
-                .crossAxisAlignment(Alignment.CrossAxis.CENTER)
-                .child(new ItemSlot().slot(new ModularSlot(baitHandler, 0))
-                        .background(GTGuiTextures.SLOT, GTGuiTextures.STRING_SLOT_OVERLAY).marginRight(2))
-                .child(new ProgressWidget()
-                        .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)
-                        .value(progressPercent))
-                .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache,
-                        "output_item_inv", cache.getSize(), 'i',
-                        syncManager, outputItemGrid).marginLeft(2)));
+                .child(Flow.row()
+                        .name("mainRow")
+                        .horizontalCenter()
+                        .coverChildren()
+                        .margin(0, 3)
+                        .childPadding(4)
+                        .child(new ItemSlot().slot(new ModularSlot(baitHandler, 0))
+                                .background(GTGuiTextures.SLOT, GTGuiTextures.STRING_SLOT_OVERLAY).marginRight(2))
+                        .child(new ProgressWidget()
+                                .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)
+                                .value(progressPercent))
+                        .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache,
+                                "output_item_inv", cache.getSize(), 'i',
+                                syncManager, outputItemGrid).marginLeft(2))
+                        .padding(4, 0));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/SteamParallelMultiblockMachine.java
@@ -140,11 +140,11 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
-        mainWidget.size(170, 70).background(GuiTextures.DISPLAY);
+        mainWidget.size(170, 76).background(GuiTextures.DISPLAY);
 
         var listWidget = new ListWidget<>()
                 .width(170 - 6)
-                .height(70 - 6)
+                .height(76)
                 .childSeparator(Icon.EMPTY_2PX)
                 .crossAxisAlignment(Alignment.CrossAxis.START)
                 .posRel(Alignment.CenterLeft);
@@ -152,6 +152,7 @@ public class SteamParallelMultiblockMachine extends WorkableMultiblockMachine im
         listWidget
                 .child(GTMultiblockTextUtil.addUnformedWarning(this, syncManager))
                 .child(GTMultiblockTextUtil.addSteamUsageLine(this.steamEnergy, syncManager))
+                .child(GTMultiblockTextUtil.addWorkingStatusLine(this, syncManager))
                 .child(GTMultiblockTextUtil.addProgressLine(this, syncManager))
                 .child(GTMultiblockTextUtil.addParallelLine(this, syncManager))
                 .child(GTMultiblockTextUtil.addOutputLines(this, syncManager));

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -483,7 +483,9 @@ public class GTMultiblockTextUtil {
                     Flow.row()
                             .coverChildren()
                             .childPadding(2)
-                            .child(new ItemDrawable(stack).asWidget())
+                            .child(new ItemDrawable(stack).asWidget()
+                                    .size(16)
+                                    .tooltip(r -> r.addFromItem(stack)))
                             .child(
                                     Text.lang(
                                             key, stack.getHoverName(), displaycount,
@@ -495,7 +497,9 @@ public class GTMultiblockTextUtil {
                     Flow.row()
                             .coverChildren()
                             .childPadding(2)
-                            .child(new ItemDrawable(stack).asWidget())
+                            .child(new ItemDrawable(stack).asWidget()
+                                    .size(16)
+                                    .tooltip(r -> r.addFromItem(stack)))
                             .child(
                                     Text.lang(
                                             key, stack.getHoverName(), displaycount,
@@ -551,7 +555,9 @@ public class GTMultiblockTextUtil {
                     Flow.row()
                             .coverChildren()
                             .childPadding(2)
-                            .child(new FluidDrawable(stack).asWidget())
+                            .child(new FluidDrawable(stack).asWidget()
+                                    .size(16)
+                                    .tooltip(r -> r.add(stack.getDisplayName())))
                             .child(
                                     Text.lang(
                                             key, stack.getDisplayName(), displaycount,
@@ -563,7 +569,9 @@ public class GTMultiblockTextUtil {
                     Flow.row()
                             .coverChildren()
                             .childPadding(2)
-                            .child(new FluidDrawable(stack).asWidget())
+                            .child(new FluidDrawable(stack).asWidget()
+                                    .size(16)
+                                    .tooltip(r -> r.add(stack.getDisplayName())))
                             .child(
                                     Text.lang(key, stack.getDisplayName(), displaycount,
                                             FormattingUtil.formatNumber2Places(amountD / maxDurationSec))

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/emi/EmiApiAccessor.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/emi/EmiApiAccessor.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 import java.util.List;
 import java.util.Map;
 
-@Mixin(EmiApi.class)
+@Mixin(value = EmiApi.class, remap = false)
 public interface EmiApiAccessor {
 
     @Invoker("setPages")


### PR DESCRIPTION


## What
steam parallel machines, fisher ui, steam dial, fix the emi api accessor
<img width="461" height="407" alt="image" src="https://github.com/user-attachments/assets/2f0efff2-6038-42c1-a09c-3ef8ca12ceb1" />
<img width="426" height="414" alt="image" src="https://github.com/user-attachments/assets/01657f1c-4a6c-4e72-bdc0-9bd18d339013" />
<img width="381" height="120" alt="image" src="https://github.com/user-attachments/assets/00985598-c8a2-48b4-8af6-6e6fbb38e08d" />


## Implementation Details
ui :)

### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
cleanliness

## How Was This Tested
ingame
