### PR TITLE
Onion Machine UI cleanup p3

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -140,7 +140,8 @@ public class MachineUIPanelBuilder {
                             .top(16)
                             .tooltipAutoUpdate(true)
                             .tooltipDynamic(r -> r.addLine(Component.translatable("gtceu.multiblock.steam.steam_stored",
-                                    steamAmount.getIntValue(), steamCapacity.getIntValue()))))
+                                    FormattingUtil.formatNumbers(steamAmount.getIntValue()),
+                                    FormattingUtil.formatNumbers(steamCapacity.getIntValue())))))
                     .leftRel(0.0f).left(-36).top(4));
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BlockBreakerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BlockBreakerMachine.java
@@ -9,13 +9,13 @@ import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.TieredEnergyMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IHasBatterySlot;
 import com.gregtechceu.gtceu.api.machine.feature.IMuiMachine;
-import com.gregtechceu.gtceu.api.machine.mui.MachineUIPanel;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.machine.trait.AutoOutputTrait;
 import com.gregtechceu.gtceu.common.mui.GTMuiMachineUtil;
+import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.ISubscription;
 
@@ -269,12 +269,20 @@ public class BlockBreakerMachine extends TieredEnergyMachine
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
-        var slotHeight = (int) Math.sqrt(inventorySize);
+        var outputItemGrid = GTMuiWidgets.createGrid(cache.getSize(), (int) Math.sqrt(cache.getSize()), true, 'i');
+
         mainWidget
-                .child(Flow.col()
-                        .size(MachineUIPanel.DEFAULT_CONTENT_WIDTH, 18 * slotHeight)
-                        .margin(0, 10)
-                        .child(GTMuiMachineUtil.createSquareSlotGroupFromInventory(this.cache, "output_cache",
-                                syncManager)));
+                .name("content")
+                .coverChildrenWidth()
+                .coverChildrenHeight(54)
+                .child(Flow.row()
+                        .name("mainRow")
+                        .center()
+                        .coverChildren()
+                        .margin(2, 3)
+                        .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache,
+                                "output_item_inv", cache.getSize(), 'i',
+                                syncManager, outputItemGrid))
+                        .padding(4, 0));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -115,7 +115,7 @@ public class FisherMachine extends TieredEnergyMachine
         this.energyPerTick = GTValues.V[tier - 1];
         this.cache = attachTrait(new NotifiableItemStackHandler(inventorySize, IO.BOTH, IO.OUT));
 
-        this.baitHandler = attachTrait(new NotifiableItemStackHandler(1, IO.BOTH, IO.IN));
+        this.baitHandler = attachTrait(new NotifiableItemStackHandler(1, IO.IN, IO.BOTH));
         baitHandler.setFilter(item -> item.is(Items.STRING));
 
         this.chargerInventory = new CustomItemStackHandler();
@@ -311,21 +311,23 @@ public class FisherMachine extends TieredEnergyMachine
 
         mainWidget
                 .name("content")
-                .coverChildren()
+                .coverChildrenWidth()
+                .coverChildrenHeight(54)
                 .child(Flow.row()
                         .name("mainRow")
-                        .horizontalCenter()
+                        .center()
                         .coverChildren()
-                        .margin(0, 3)
+                        .margin(2, 3)
                         .childPadding(4)
-                        .child(new ItemSlot().slot(new ModularSlot(baitHandler, 0))
-                                .background(GTGuiTextures.SLOT, GTGuiTextures.STRING_SLOT_OVERLAY).marginRight(2))
+                        .child(new ItemSlot()
+                                .slot(new ModularSlot(baitHandler, 0).singletonSlotGroup(0).accessibility(true, true))
+                                .background(GTGuiTextures.SLOT, GTGuiTextures.STRING_SLOT_OVERLAY))
                         .child(new ProgressWidget()
                                 .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)
                                 .value(progressPercent))
                         .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache,
                                 "output_item_inv", cache.getSize(), 'i',
-                                syncManager, outputItemGrid).marginLeft(2))
+                                syncManager, outputItemGrid))
                         .padding(4, 0));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/ItemCollectorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/ItemCollectorMachine.java
@@ -336,30 +336,5 @@ public class ItemCollectorMachine extends TieredEnergyMachine
                                         "output_item_inv", output.getSize(), 'i',
                                         syncManager, outputItemGrid))
                                 .padding(4, 0)));
-
-        /*
-         * mainWidget.child(Flow.column()
-         * .size(MachineUIPanel.DEFAULT_CONTENT_WIDTH, 150)
-         * .crossAxisAlignment(Alignment.CrossAxis.START)
-         * .child(Flow.row()
-         * .coverChildren()
-         * .childPadding(2)
-         * .margin(5)
-         * .horizontalCenter()
-         * .child(new TextWidget<>(Text.lang("gtceu.gui.item_collector.range")))
-         * .child(new TextFieldWidget()
-         * .setNumbers(1, maxRange)
-         * .value(SyncHandlers.intNumber(this::getRange, this::setRange))))
-         * .child(Flow.row()
-         * .coverChildrenHeight()
-         * .widthRel(1)
-         * .child(new ItemSlot()
-         * .slot(filterInventory, 0)
-         * .background(GTGuiTextures.SLOT, GTGuiTextures.FILTER_SLOT_OVERLAY)
-         * .margin(7))
-         * .child(GTMuiMachineUtil
-         * .createSquareSlotGroupFromInventory(output, "main_inv", syncManager)
-         * .horizontalCenter())));
-         */
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/ItemCollectorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/ItemCollectorMachine.java
@@ -8,7 +8,6 @@ import com.gregtechceu.gtceu.api.cover.filter.ItemFilter;
 import com.gregtechceu.gtceu.api.machine.TickableSubscription;
 import com.gregtechceu.gtceu.api.machine.TieredEnergyMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IMuiMachine;
-import com.gregtechceu.gtceu.api.machine.mui.MachineUIPanel;
 import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.sync_system.annotations.RerenderOnChanged;
@@ -19,6 +18,7 @@ import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.machine.trait.AutoOutputTrait;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiMachineUtil;
+import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.ISubscription;
 
@@ -34,7 +34,6 @@ import net.minecraft.world.phys.Vec3;
 import brachy.modularui.api.drawable.Text;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
-import brachy.modularui.utils.Alignment;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.SyncHandlers;
 import brachy.modularui.widget.ParentWidget;
@@ -307,27 +306,60 @@ public class ItemCollectorMachine extends TieredEnergyMachine
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
-        mainWidget.child(Flow.column()
-                .size(MachineUIPanel.DEFAULT_CONTENT_WIDTH, 150)
-                .crossAxisAlignment(Alignment.CrossAxis.START)
-                .child(Flow.row()
+        var outputItemGrid = GTMuiWidgets.createGrid(output.getSize(), (int) Math.sqrt(output.getSize()), true, 'i');
+
+        mainWidget
+                .name("content")
+                .coverChildren()
+                .child(Flow.col()
                         .coverChildren()
+                        .margin(0, 3)
                         .childPadding(2)
-                        .margin(5)
-                        .horizontalCenter()
-                        .child(new TextWidget<>(Text.lang("gtceu.gui.item_collector.range")))
-                        .child(new TextFieldWidget()
-                                .setNumbers(1, maxRange)
-                                .value(SyncHandlers.intNumber(this::getRange, this::setRange))))
-                .child(Flow.row()
-                        .coverChildrenHeight()
-                        .widthRel(1)
-                        .child(new ItemSlot()
-                                .slot(filterInventory, 0)
-                                .background(GTGuiTextures.SLOT, GTGuiTextures.FILTER_SLOT_OVERLAY)
-                                .margin(7))
-                        .child(GTMuiMachineUtil
-                                .createSquareSlotGroupFromInventory(output, "main_inv", syncManager)
-                                .horizontalCenter())));
+                        .child(Flow.row()
+                                .coverChildren()
+                                .childPadding(2)
+                                .horizontalCenter()
+                                .child(new TextWidget<>(Text.lang("gtceu.gui.item_collector.range")))
+                                .child(new TextFieldWidget()
+                                        .setNumbers(1, maxRange)
+                                        .value(SyncHandlers.intNumber(this::getRange, this::setRange))))
+                        .child(Flow.row()
+                                .name("mainRow")
+                                .horizontalCenter()
+                                .coverChildren()
+                                .margin(2, 3)
+                                .childPadding(3)
+                                .child(new ItemSlot()
+                                        .slot(filterInventory, 0)
+                                        .background(GTGuiTextures.SLOT, GTGuiTextures.FILTER_SLOT_OVERLAY))
+                                .child(GTMuiMachineUtil.createSlotGroupFromInventory(output,
+                                        "output_item_inv", output.getSize(), 'i',
+                                        syncManager, outputItemGrid))
+                                .padding(4, 0)));
+
+        /*
+         * mainWidget.child(Flow.column()
+         * .size(MachineUIPanel.DEFAULT_CONTENT_WIDTH, 150)
+         * .crossAxisAlignment(Alignment.CrossAxis.START)
+         * .child(Flow.row()
+         * .coverChildren()
+         * .childPadding(2)
+         * .margin(5)
+         * .horizontalCenter()
+         * .child(new TextWidget<>(Text.lang("gtceu.gui.item_collector.range")))
+         * .child(new TextFieldWidget()
+         * .setNumbers(1, maxRange)
+         * .value(SyncHandlers.intNumber(this::getRange, this::setRange))))
+         * .child(Flow.row()
+         * .coverChildrenHeight()
+         * .widthRel(1)
+         * .child(new ItemSlot()
+         * .slot(filterInventory, 0)
+         * .background(GTGuiTextures.SLOT, GTGuiTextures.FILTER_SLOT_OVERLAY)
+         * .margin(7))
+         * .child(GTMuiMachineUtil
+         * .createSquareSlotGroupFromInventory(output, "main_inv", syncManager)
+         * .horizontalCenter())));
+         */
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/MaintenanceHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/MaintenanceHatchPartMachine.java
@@ -347,7 +347,6 @@ public class MaintenanceHatchPartMachine extends TieredPartMachine
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
         InteractionSyncHandler syncHandler = new InteractionSyncHandler();
-        // syncManager.syncValue("button_idk", syncHandler);
         Flow maintenanceStatusWidget = Flow.column()
                 .crossAxisAlignment(Alignment.CrossAxis.START)
                 .coverChildren()
@@ -363,7 +362,7 @@ public class MaintenanceHatchPartMachine extends TieredPartMachine
                             .children(Stream.iterate(Byte.valueOf("0"), i -> i < 6, i -> ++i)
                                     .filter(i -> ((getMaintenanceProblems() >> i) & 1) == 0)
                                     .map(GTUtil::getMaintenanceText)
-                                    .map(i -> new IDrawable.DrawableWidget(new ItemDrawable(i.getA())))
+                                    .map(i -> new IDrawable.DrawableWidget(new ItemDrawable(i.getFirst())))
                                     .map(IWidget.class::cast)
                                     .toList()));
         };

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MaintenanceBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/MaintenanceBlockProvider.java
@@ -65,8 +65,8 @@ public class MaintenanceBlockProvider extends CapabilityBlockProvider<IMaintenan
                         if (((problems >> i) & 1) == 0) {
                             var tuple = GTUtil.getMaintenanceText(i);
                             IElementHelper helper = iTooltip.getElementHelper();
-                            iTooltip.add(helper.smallItem(tuple.getA()));
-                            iTooltip.append(tuple.getB());
+                            iTooltip.add(helper.smallItem(tuple.getFirst()));
+                            iTooltip.append(tuple.getSecond());
                         }
                     }
                 } else {

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -32,7 +32,6 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.util.RandomSource;
-import net.minecraft.util.Tuple;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
@@ -614,19 +613,19 @@ public class GTUtil {
         }
     }
 
-    public static Tuple<ItemStack, MutableComponent> getMaintenanceText(byte flag) {
+    public static Pair<ItemStack, MutableComponent> getMaintenanceText(byte flag) {
         return switch (flag) {
-            case 0 -> new Tuple<>(ToolItemHelper.getToolItem(GTToolType.WRENCH),
+            case 0 -> Pair.of(ToolItemHelper.getToolItem(GTToolType.WRENCH),
                     Component.translatable("gtceu.top.maintenance.wrench"));
-            case 1 -> new Tuple<>(ToolItemHelper.getToolItem(GTToolType.SCREWDRIVER),
+            case 1 -> Pair.of(ToolItemHelper.getToolItem(GTToolType.SCREWDRIVER),
                     Component.translatable("gtceu.top.maintenance.screwdriver"));
-            case 2 -> new Tuple<>(ToolItemHelper.getToolItem(GTToolType.SOFT_MALLET),
+            case 2 -> Pair.of(ToolItemHelper.getToolItem(GTToolType.SOFT_MALLET),
                     Component.translatable("gtceu.top.maintenance.soft_mallet"));
-            case 3 -> new Tuple<>(ToolItemHelper.getToolItem(GTToolType.HARD_HAMMER),
+            case 3 -> Pair.of(ToolItemHelper.getToolItem(GTToolType.HARD_HAMMER),
                     Component.translatable("gtceu.top.maintenance.hard_hammer"));
-            case 4 -> new Tuple<>(ToolItemHelper.getToolItem(GTToolType.WIRE_CUTTER),
+            case 4 -> Pair.of(ToolItemHelper.getToolItem(GTToolType.WIRE_CUTTER),
                     Component.translatable("gtceu.top.maintenance.wire_cutter"));
-            default -> new Tuple<>(ToolItemHelper.getToolItem(GTToolType.CROWBAR),
+            default -> Pair.of(ToolItemHelper.getToolItem(GTToolType.CROWBAR),
                     Component.translatable("gtceu.top.maintenance.crowbar"));
         };
     }


### PR DESCRIPTION
## What
clean up the fisher, block breaker, item collector, and prep for maintenance hatch machine uis


## Implementation Details
mui

### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
<img width="541" height="374" alt="image" src="https://github.com/user-attachments/assets/882a18b3-e33b-4534-b26d-e80e22c84c8d" />
<img width="456" height="362" alt="image" src="https://github.com/user-attachments/assets/22d5f075-9ade-49d0-b66c-145bbe796957" />
<img width="457" height="444" alt="image" src="https://github.com/user-attachments/assets/871071ad-af0b-4d87-a5a2-0d24bfbca8f4" />


## How Was This Tested
yes
