### PR TITLE
Repair KubeJS for Packdevs

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -26,6 +26,7 @@ import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientActionHolder;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.DecoderException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
@@ -122,8 +123,9 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         return map;
     }
 
-    @NotNull
+    @Nullable
     public static GTRecipe fromNetwork(@NotNull RegistryFriendlyByteBuf buf) {
+        if (!buf.readBoolean()) return null;
         ResourceLocation recipeType = buf.readResourceLocation();
         ResourceLocation id = buf.readResourceLocation();
         int duration = buf.readVarInt();
@@ -181,6 +183,8 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
     }
 
     public static void toNetwork(RegistryFriendlyByteBuf buf, GTRecipe recipe) {
+        buf.writeBoolean(recipe != null);
+        if (recipe == null) return;
         buf.writeResourceLocation(recipe.recipeType.registryName);
         buf.writeResourceLocation(recipe.id);
         buf.writeVarInt(recipe.duration);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/DecompositionRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/DecompositionRecipeHandler.java
@@ -51,11 +51,16 @@ public final class DecompositionRecipeHandler {
             if (component.material().hasProperty(PropertyKey.DUST)) {
                 outputs.add(ChemicalHelper.get(dust, component.material(), (int) component.amount()));
             } else if (component.material().hasProperty(PropertyKey.FLUID)) {
-                fluidOutputs.add(component.material().getFluid((int) (1000 * component.amount())));
+                FluidStack componentFluid = component.material().getFluid((int) (1000 * component.amount()));
+                if (!componentFluid.isEmpty()) {
+                    fluidOutputs.add(componentFluid);
+                }
             }
         }
 
         if (outputs.size() > 6 || fluidOutputs.size() > 6) return;
+
+        if (outputs.isEmpty() && fluidOutputs.isEmpty()) return;
 
         // only reduce items
         boolean hasDust = material.hasProperty(PropertyKey.DUST);
@@ -116,7 +121,9 @@ public final class DecompositionRecipeHandler {
         if (hasDust) {
             builder.inputItems(dust, material, GTMath.saturatedCast(totalInputAmount));
         } else {
-            builder.inputFluids(material.getFluid(1000));
+            FluidStack inputFluid = material.getFluid(1000);
+            if (inputFluid.isEmpty()) return;
+            builder.inputFluids(inputFluid);
         }
 
         // register recipe

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/CapabilityMapComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/CapabilityMapComponent.java
@@ -9,9 +9,11 @@ import com.mojang.serialization.Codec;
 import dev.latvian.mods.kubejs.recipe.RecipeScriptContext;
 import dev.latvian.mods.kubejs.recipe.component.RecipeComponent;
 import dev.latvian.mods.kubejs.recipe.component.RecipeComponentType;
+import dev.latvian.mods.kubejs.recipe.filter.RecipeMatchContext;
 import dev.latvian.mods.kubejs.recipe.match.ReplacementMatchInfo;
 import dev.latvian.mods.rhino.type.TypeInfo;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -40,6 +42,23 @@ public record CapabilityMapComponent() implements RecipeComponent<CapabilityMap>
     @Override
     public String toString() {
         return "capability_map";
+    }
+
+    @Override
+    public boolean matches(RecipeMatchContext cx, CapabilityMap value, ReplacementMatchInfo match) {
+        for (var entry : value.entrySet()) {
+            ContentJS<?> content = GTRecipeComponents.VALID_CAPS.get(entry.getKey());
+            if (content == null) {
+                continue;
+            }
+            List<Content> values = entry.getValue();
+            for (int i = 0; i < values.size(); i++) {
+                if (content.matches(cx, values.get(i), match)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/ContentJS.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/components/ContentJS.java
@@ -7,6 +7,7 @@ import com.mojang.serialization.Codec;
 import dev.latvian.mods.kubejs.recipe.RecipeScriptContext;
 import dev.latvian.mods.kubejs.recipe.component.RecipeComponent;
 import dev.latvian.mods.kubejs.recipe.component.RecipeComponentType;
+import dev.latvian.mods.kubejs.recipe.filter.RecipeMatchContext;
 import dev.latvian.mods.kubejs.recipe.match.ReplacementMatchInfo;
 import dev.latvian.mods.rhino.type.TypeInfo;
 
@@ -25,6 +26,12 @@ public record ContentJS<T>(RecipeComponentType<T> baseComponent, RecipeCapabilit
     @Override
     public TypeInfo typeInfo() {
         return TypeInfo.of(Content.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean matches(RecipeMatchContext cx, Content value, ReplacementMatchInfo match) {
+        return baseComponent.instance().matches(cx, (T) value.content(), match);
     }
 
     @Override


### PR DESCRIPTION
## What
Fixes a variety of KubeJS issues regarding
- Fluids Registering at all
- Decomp recipes with invalid fluids dying
- null checks on serializers'
- removals from GT Recipes not working at all



## Implementation Details
Added Relevant guards and match overrides as needed

### AI Usage 
- [ x ] Yes AI driven tools were used for this pull request.
#### Agent Used
Claude Opus 4.8 on Max
#### Agent Usage Description
General debugging discovery with KubeJS methods 
Code logic stress tester with scrutiny units alongside human review.
  
## Outcome
Packdevs can actually develop things.

## How Was This Tested
Various dummy kubeJS recipes, used to generate test materials with valid generating fluids, decomp, etc.

## Potential Compatibility Issues
Some decomp recipes like Macerator/Arc recycling still fall through the gaps, but onion told me to leave it alone as it's a larger V9 thing.