### PR TITLE
Fix and Update Boilers/UI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/customlogic/SteamBoilerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/customlogic/SteamBoilerLogic.java
@@ -1,0 +1,116 @@
+package com.gregtechceu.gtceu.api.machine.trait.customlogic;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.capability.recipe.IRecipeCapabilityHolder;
+import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
+import com.gregtechceu.gtceu.utils.memoization.GTMemoizer;
+
+import net.minecraft.Util;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.neoforged.neoforge.common.util.ItemStackMap;
+import net.neoforged.neoforge.fluids.FluidUtil;
+import net.neoforged.neoforge.items.IItemHandlerModifiable;
+import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public abstract class SteamBoilerLogic implements GTRecipeType.ICustomRecipeLogic {
+
+    private static final Set<SteamBoilerLogic> ALL_BOILER_LOGICS = new HashSet<>();
+    private static final ResourceLocation EMPTY_MARKER_ID = GTCEu.id("invalid_recipe");
+    private static final ItemStack EMPTY_MARKER_ITEM = Util.make(new ItemStack(Items.BARRIER), stack -> {
+        stack.set(DataComponents.CUSTOM_NAME,
+                Component.literal("Invalid Recipe! Contact developers for help!"));
+    });
+
+    private final Map<ItemStack, GTRecipe> recipeCache = ItemStackMap.createTypeAndTagMap();
+    private final Supplier<GTRecipe> emptyMarker = GTMemoizer
+            .memoize(() -> new GTRecipeBuilder(EMPTY_MARKER_ID, getRecipeType())
+                    .inputItems(EMPTY_MARKER_ITEM.copy())
+                    .build());
+
+    public SteamBoilerLogic() {
+        ALL_BOILER_LOGICS.add(this);
+    }
+
+    public static void clearBoilerRecipeCaches() {
+        for (SteamBoilerLogic logic : ALL_BOILER_LOGICS) {
+            logic.recipeCache.clear();
+        }
+    }
+
+    protected abstract GTRecipeType getRecipeType();
+
+    protected abstract int modifyBurnTime(int originalBurnTime);
+
+    private GTRecipe makeRecipe(ItemStack input, int burnTime) {
+        ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(input.getItem());
+        return getRecipeType().recipeBuilder(GTCEu.id(itemId.toDebugFileName()))
+                .inputItems(input.copyWithCount(1))
+                .duration(modifyBurnTime(burnTime))
+                .build();
+    }
+
+    @Override
+    public @Nullable GTRecipe createCustomRecipe(IRecipeCapabilityHolder holder) {
+        var itemInputs = holder.getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP).stream()
+                .filter(IItemHandlerModifiable.class::isInstance).map(IItemHandlerModifiable.class::cast)
+                .toArray(IItemHandlerModifiable[]::new);
+        var inputs = new CombinedInvWrapper(itemInputs);
+        for (int i = 0; i < inputs.getSlots(); ++i) {
+            ItemStack input = inputs.getStackInSlot(i);
+            GTRecipe cached = recipeCache.get(input);
+            if (cached == emptyMarker.get()) {
+                continue;
+            } else if (cached != null) {
+                return cached;
+            }
+
+            if (input.isEmpty() || FluidUtil.getFluidContained(input).isPresent()) {
+                recipeCache.put(input, emptyMarker.get());
+                continue;
+            }
+            int burnTime = input.getBurnTime(RecipeType.SMELTING);
+            if (burnTime <= 0) {
+                recipeCache.put(input, emptyMarker.get());
+                continue;
+            }
+            GTRecipe recipe = makeRecipe(input, burnTime);
+            recipeCache.put(input, recipe);
+            return recipe;
+        }
+        return null;
+    }
+
+    @Override
+    public void buildRepresentativeRecipes() {
+        for (Item item : BuiltInRegistries.ITEM) {
+            ItemStack input = item.getDefaultInstance();
+            if (input.isEmpty() || FluidUtil.getFluidContained(input).isPresent()) {
+                continue;
+            }
+            int burnTime = input.getBurnTime(RecipeType.SMELTING);
+            if (burnTime <= 0) {
+                continue;
+            }
+            GTRecipe recipe = makeRecipe(input, burnTime);
+            getRecipeType().addToMainCategory(recipe);
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeTypes.java
@@ -60,6 +60,7 @@ public class GTRecipeTypes {
                     GTRecipeTypes.LARGE_BOILER_RECIPES.copyFrom(builder).duration(duration).save(provider);
                 }
             })
+            .addCustomRecipeLogic(SmallBoilerLogic.INSTANCE)
             .setMaxTooltips(1)
             .setSound(GTSoundEntries.FURNACE);
 
@@ -520,6 +521,7 @@ public class GTRecipeTypes {
     public final static GTRecipeType LARGE_BOILER_RECIPES = register("large_boiler", MULTIBLOCK)
             .setMaxIOSize(1, 0, 1, 1)
             .UI(builder -> builder.setProgressBar(GTGuiTextures.PROGRESS_BOILER_FUEL_STEEL))
+            .addCustomRecipeLogic(LargeBoilerLogic.INSTANCE)
             .setMaxTooltips(1)
             .setSound(GTSoundEntries.FURNACE);
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -15,7 +15,7 @@ import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
-import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
+import com.gregtechceu.gtceu.common.mui.GTMultiblockTextUtil;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -27,6 +27,8 @@ import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import brachy.modularui.api.drawable.Text;
+import brachy.modularui.api.widget.IWidget;
+import brachy.modularui.drawable.GuiTextures;
 import brachy.modularui.drawable.Icon;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.UISettings;
@@ -188,6 +190,11 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
         return value;
     }
 
+    private void setThrottle(int newThrottle) {
+        this.throttle = newThrottle;
+        ((LargeBoilerRecipeLogic) (this.recipeLogic)).setCurrentThrottle(newThrottle);
+    }
+
     /**
      * Recipe Modifier for <b>Large Boiler Machines</b> - can be used as a valid {@link RecipeModifier}
      * <p>
@@ -206,14 +213,8 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
-        mainWidget.child(new ParentWidget<>()
-                .widthRel(0.95f)
-                .heightRel(.65f)
-                .margin(4, 0)
-                .left(3).top(2)
-                .horizontalCenter()
-                .child(Flow.row()
-                        .child(getMainTextPanel(syncManager, 186, 146))));
+        mainWidget.child(getMainTextPanel(syncManager, 186, 146)
+                .margin(4, 2));
     }
 
     public Widget<?> getMainTextPanel(PanelSyncManager syncManager, int width, int height) {
@@ -224,12 +225,22 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
                 .height(height - 6)
                 .childSeparator(Icon.EMPTY_2PX)
                 .crossAxisAlignment(Alignment.CrossAxis.START)
+                .collapseDisabledChildren()
                 .posRel(Alignment.CenterLeft)
                 .left(3)
                 .top(3);
         parentWidget.size(width, height)
-                .background(GTGuiTextures.DISPLAY);
+                .background(GuiTextures.DISPLAY);
 
+        listWidget.children(getWidgetsForDisplay(syncManager));
+        parentWidget.child(listWidget.left(3).top(3));
+        return parentWidget;
+    }
+
+    @Override
+    public List<IWidget> getWidgetsForDisplay(PanelSyncManager syncManager) {
+        List<IWidget> widgets = new ArrayList<>();
+        widgets.add(GTMultiblockTextUtil.addUnformedWarning(this, syncManager));
         // Machine generic sync handlers
         BooleanSyncValue isFormed = syncManager.getOrCreateSyncHandler("isFormed", BooleanSyncValue.class,
                 () -> new BooleanSyncValue(this::isFormed));
@@ -247,31 +258,30 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
         IntSyncValue steamGenerated = new IntSyncValue(() -> this.steamGenerated);
         syncManager.syncValue("steamGenerated", steamGenerated);
 
-        IntSyncValue throttle = new IntSyncValue(() -> this.throttle, newValue -> this.throttle = newValue);
+        IntSyncValue throttle = new IntSyncValue(() -> this.throttle, this::setThrottle).allowC2S();
         syncManager.syncValue("throttle", throttle);
 
-        listWidget
-                .child(Text.dynamic(() -> {
-                    if (!isFormed.getBoolValue()) return Component.empty();
-                    return Component.translatable("gtceu.multiblock.large_boiler.temperature",
-                            currentTemperature.getIntValue() + 274, maxTemperature.getIntValue() + 274)
-                            .withStyle(ChatFormatting.WHITE);
-                })
-                        .asWidget())
-                .child(Text.dynamic(() -> {
-                    if (!isFormed.getBoolValue()) return Component.empty();
-                    return Component.translatable("gtceu.multiblock.large_boiler.steam_output",
-                            steamGenerated.getIntValue() / TICKS_PER_STEAM_GENERATION).withStyle(ChatFormatting.WHITE);
-                })
-                        .asWidget())
-                .child(Text.of(Component.translatable("gtceu.multiblock.large_boiler.throttle_modify")
-                        .withStyle(ChatFormatting.WHITE))
-                        .asWidget())
-                .child(createIntInputWithButtons(throttle))
-
-                .setEnabledIf((widget) -> isFormed.getBoolValue());
-        parentWidget.child(listWidget);
-        return parentWidget;
+        widgets.add(Text.dynamic(() -> {
+            if (!isFormed.getBoolValue()) return Component.empty();
+            return Component.translatable("gtceu.multiblock.large_boiler.temperature",
+                    currentTemperature.getIntValue() + 274, maxTemperature.getIntValue() + 274)
+                    .withStyle(ChatFormatting.WHITE);
+        })
+                .asWidget()
+                .setEnabledIf((w) -> isFormed.getBoolValue()));
+        widgets.add(Text.dynamic(() -> {
+            if (!isFormed.getBoolValue()) return Component.empty();
+            return Component.translatable("gtceu.multiblock.large_boiler.steam_output",
+                    steamGenerated.getIntValue() / TICKS_PER_STEAM_GENERATION).withStyle(ChatFormatting.WHITE);
+        })
+                .asWidget()
+                .setEnabledIf((w) -> isFormed.getBoolValue()));
+        widgets.add(Text.of(Component.translatable("gtceu.multiblock.large_boiler.throttle_modify")
+                .withStyle(ChatFormatting.WHITE))
+                .asWidget().setEnabledIf((w) -> isFormed.getBoolValue()));
+        widgets.add(createIntInputWithButtons(throttle)
+                .setEnabledIf((w) -> isFormed.getBoolValue()));
+        return widgets;
     }
 
     public static ParentWidget<?> createIntInputWithButtons(IntSyncValue syncValue) {
@@ -282,7 +292,7 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
 
             @Override
             public boolean onMouseScrolled(double scrollX, double scrollY) {
-                int inc = (int) ((int) scrollX + scrollY);
+                int inc = (int) ((int) scrollX + scrollY) * (MouseData.create(-1).shift() ? 5 : 1);
                 int val = Mth.clamp(syncValue.getIntValue() + inc, 25, 100);
                 syncValue.setIntValue(val, true, true);
                 return true;
@@ -363,8 +373,9 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
             return List.of(LargeBoilerMachine.class);
         }
 
-        public void setCurrentThrottle(int currentThrottle) {
-            this.currentThrottle = currentThrottle;
+        public void setCurrentThrottle(int newThrottle) {
+            this.modifyFuelBurnTime(newThrottle);
+            this.currentThrottle = newThrottle;
             syncDataHolder.markClientSyncFieldDirty("currentThrottle");
         }
 
@@ -373,7 +384,6 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
             super.setupRecipe(recipe);
             if (lastRecipe != null) {
                 setCurrentThrottle(getMachine().getThrottle());
-                duration = (int) Math.round(lastRecipe.duration / (currentThrottle / 100.0));
             }
         }
 
@@ -383,7 +393,6 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
                 duration = (int) Math.round(lastRecipe.duration / (newThrottle / 100.0));
                 progress = (int) Math.round(newThrottleMultiplier * progress);
             }
-            setCurrentThrottle(newThrottle);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamSolidBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamSolidBoilerMachine.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.world.item.Item;
@@ -32,7 +33,6 @@ import brachy.modularui.widgets.slot.ModularSlot;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -53,17 +53,7 @@ public class SteamSolidBoilerMachine extends SteamBoilerMachine {
             if (FluidUtil.getFluidContained(itemStack).isPresent()) {
                 return false;
             }
-            return FUEL_CACHE.computeIfAbsent(itemStack.getItem(), item -> {
-                if (isRemote()) return true;
-                return recipeLogic.getRecipeManager().getAllRecipesFor(getRecipeType()).stream().anyMatch(recipe -> {
-                    var list = recipe.value().inputs.getOrDefault(ItemRecipeCapability.CAP, Collections.emptyList());
-                    if (!list.isEmpty()) {
-                        return Arrays.stream(ItemRecipeCapability.CAP.of(list.getFirst().content()).getItems())
-                                .map(ItemStack::getItem).anyMatch(i -> i == item);
-                    }
-                    return false;
-                });
-            });
+            return FUEL_CACHE.computeIfAbsent(itemStack.getItem(), item -> GTUtil.getItemBurnTime((Item) item) > 0);
         });
         this.ashHandler = attachTrait(new NotifiableItemStackHandler(1, IO.OUT, IO.OUT));
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/customlogic/LargeBoilerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/customlogic/LargeBoilerLogic.java
@@ -1,0 +1,23 @@
+package com.gregtechceu.gtceu.common.machine.trait.customlogic;
+
+import com.gregtechceu.gtceu.api.machine.trait.customlogic.SteamBoilerLogic;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+
+import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.LARGE_BOILER_RECIPES;
+
+public class LargeBoilerLogic extends SteamBoilerLogic {
+
+    public static final LargeBoilerLogic INSTANCE = new LargeBoilerLogic();
+
+    private LargeBoilerLogic() {}
+
+    @Override
+    protected GTRecipeType getRecipeType() {
+        return LARGE_BOILER_RECIPES;
+    }
+
+    @Override
+    protected int modifyBurnTime(int originalBurnTime) {
+        return originalBurnTime / 4;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/customlogic/SmallBoilerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/customlogic/SmallBoilerLogic.java
@@ -1,0 +1,23 @@
+package com.gregtechceu.gtceu.common.machine.trait.customlogic;
+
+import com.gregtechceu.gtceu.api.machine.trait.customlogic.SteamBoilerLogic;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+
+import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.STEAM_BOILER_RECIPES;
+
+public class SmallBoilerLogic extends SteamBoilerLogic {
+
+    public static final SmallBoilerLogic INSTANCE = new SmallBoilerLogic();
+
+    private SmallBoilerLogic() {}
+
+    @Override
+    protected GTRecipeType getRecipeType() {
+        return STEAM_BOILER_RECIPES;
+    }
+
+    @Override
+    protected int modifyBurnTime(int originalBurnTime) {
+        return originalBurnTime;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ReloadableServerResourcesMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ReloadableServerResourcesMixin.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.core.mixins;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.machine.trait.customlogic.SteamBoilerLogic;
 import com.gregtechceu.gtceu.common.data.GTRecipes;
 import com.gregtechceu.gtceu.core.MixinHelpers;
 import com.gregtechceu.gtceu.data.loot.DungeonLootLoader;
@@ -50,6 +51,7 @@ public abstract class ReloadableServerResourcesMixin {
         // Register recipes & unification data again
         long startTime = System.currentTimeMillis();
         GTCraftingComponents.init();
+        SteamBoilerLogic.clearBoilerRecipeCaches();
         GTRecipes.recipeAddition(new RecipeOutput() {
 
             @Override

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -14,7 +14,7 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.*;
 public class FuelRecipes {
 
     public static void init(RecipeOutput provider) {
-        // furnace fuel-based recipes are handled in SteamBoilerLogic for dynamic burn time (and data map) support.
+        // furnace fuel-based recipes are handled by BoilerFuelLogic for dynamic burn time + data map support.
 
         // override the default fluid recipes for lava and creosote
         STEAM_BOILER_RECIPES.recipeBuilder("minecraft_lava")


### PR DESCRIPTION
## What
Boilers once again, notably, burn solid fuel, and large boilers now have their 1.20 UI ported upwards.

_Linking an issue can be used alternatively to writing a description._


## Implementation Details
Stole the majority of it from Java files Mint gave me. Works well ingame, has caching and rebuilding for KubeJS

### AI Usage

- [ x] Yes AI driven tools were used for this pull request.
#### Agent Used
Opus 4.8 Max
#### Agent Usage Description
debugging/checking against 1.20 as well
## Outcome
Boiler work.

## How Was This Tested
Built both small and large boilers, full of water and fuel, both work, right balance game times too


Boiler.