### PR TITLE
Add version sync log workflow

### DIFF
--- a/.github/workflows/log-commits-version-sync.yml
+++ b/.github/workflows/log-commits-version-sync.yml
@@ -7,78 +7,115 @@ on:
       - '1.21'
 
 permissions:
-  issues: write
   contents: read
-  pull-requests: read
 
 concurrency:
-  group: log-commits-to-issue
+  group: log-commits-to-project
   cancel-in-progress: false
 
 jobs:
   log:
     runs-on: ubuntu-latest
     steps:
-      - name: Append commit links to the branch's tracking issue
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Map the pushed branch to its tracking issue
-            const issueByBranch = {
-              '1.20.1': 5041,
-              '1.21': 5040,
-            };
-            const branch = context.ref.replace('refs/heads/', '');
-            const issueNumber = issueByBranch[branch];
+      - name: Create an issue on the project board for this push
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PROJECT_BOARD_URL: ${{ secrets.PROJECT_BOARD_URL }}
+          BRANCH: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          AFTER: ${{ github.event.after }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMITS_JSON: ${{ toJSON(github.event.commits) }}
+        run: |
+          set -euo pipefail
 
-            if (!issueNumber) {
-              core.info(`No tracking issue configured for branch '${branch}', skipping.`);
-              return;
-            }
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::PROJECT_TOKEN secret is not set; a PAT with the 'project' scope is required."
+            exit 1
+          fi
+          if ! gh api user --jq '.login' >/dev/null 2>&1; then
+            echo "::error::PROJECT_TOKEN failed to authenticate against the GitHub API."
+            exit 1
+          fi
 
-            // Build a markdown list item for each commit in this push, skipping
-            // any commit whose associated PR carries the "Ignore Version Sync" label
-            const lines = [];
-            for (const c of context.payload.commits) {
-              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: c.id,
-              });
+          if [ -z "${PROJECT_BOARD_URL:-}" ]; then
+            echo "::error::PROJECT_BOARD_URL secret is not set."
+            exit 1
+          fi
+          if [[ "$PROJECT_BOARD_URL" =~ github\.com/(users|orgs)/([^/]+)/projects/([0-9]+) ]]; then
+            OWNER="${BASH_REMATCH[2]}"
+            NUMBER="${BASH_REMATCH[3]}"
+          else
+            echo "::error::PROJECT_BOARD_URL '$PROJECT_BOARD_URL' is not a valid project board URL."
+            exit 1
+          fi
 
-              const ignored = prs.some((pr) =>
-                (pr.labels || []).some((l) => l.name === 'Ignore Version Sync')
-              );
-              if (ignored) {
-                core.info(`Commit ${c.id.substring(0, 7)} belongs to a PR labeled 'Ignore Version Sync', skipping.`);
-                continue;
-              }
+          # each branch's commits need porting to the other branch
+          case "$BRANCH" in
+            1.20.1) STATUS_NAME="To Port 1.20->1.21" ;;
+            1.21)   STATUS_NAME="To Port 1.21->1.20" ;;
+            *)      STATUS_NAME="" ;;
+          esac
 
-              const shortSha = c.id.substring(0, 7);
-              const title = c.message.split('\n')[0];
-              lines.push(`- [\`${shortSha}\`](${c.url}) ${title}`);
-            }
+          # build a markdown list item for each commit in this push, skipping any
+          # commit whose associated PR carries the "Ignore Version Sync" label
+          LINES_FILE="$(mktemp)"
+          while read -r commit; do
+            [ -n "$commit" ] || continue
+            sha="$(jq -r '.id' <<<"$commit")"
+            short="${sha:0:7}"
+            title="$(jq -r '.message' <<<"$commit" | head -n1)"
+            url="$(jq -r '.url' <<<"$commit")"
 
-            if (lines.length === 0) {
-              core.info('No commits to append.');
-              return;
-            }
+            ignored="$(gh api "repos/$REPO/commits/$sha/pulls" \
+              --jq 'any(.[]; .labels[].name == "Ignore Version Sync")')"
+            if [ "$ignored" = "true" ]; then
+              echo "Commit $short belongs to a PR labeled 'Ignore Version Sync', skipping."
+              continue
+            fi
 
-            const { data: issue } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
+            printf -- '- [`%s`](%s) %s\n' "$short" "$url" "$title" >>"$LINES_FILE"
+          done < <(jq -c '.[]' <<<"$COMMITS_JSON")
 
-            const body = issue.body || '';
-            const separator = body.length > 0 && !body.endsWith('\n') ? '\n' : '';
-            const newBody = body + separator + lines.join('\n') + '\n';
+          if [ ! -s "$LINES_FILE" ]; then
+            echo "No commits to add to the board."
+            exit 0
+          fi
+          COUNT="$(wc -l <"$LINES_FILE" | tr -d ' ')"
 
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body: newBody,
-            });
+          # resolve the project's node id and its "Status" field/option ids by name
+          PROJECT_ID="$(gh project view "$NUMBER" --owner "$OWNER" --format json --jq '.id')"
+          FIELDS_JSON="$(gh project field-list "$NUMBER" --owner "$OWNER" --format json)"
+          FIELD_ID="$(jq -r '.fields[] | select(.name == "Status") | .id' <<<"$FIELDS_JSON")"
+          OPTION_ID=""
+          if [ -n "$STATUS_NAME" ]; then
+            OPTION_ID="$(jq -r --arg n "$STATUS_NAME" \
+              '.fields[] | select(.name == "Status") | .options[] | select(.name == $n) | .id' \
+              <<<"$FIELDS_JSON")"
+            if [ -z "$OPTION_ID" ]; then
+              echo "::error::Board has no 'Status' option named '$STATUS_NAME'."
+              exit 1
+            fi
+          fi
 
-            core.info(`Appended ${lines.length} commit link(s) to issue #${issueNumber}.`);
+          # create a single issue for this push
+          BODY="$(printf 'Commits pushed to `%s` (up to `%s`):\n\n%s\n' \
+            "$BRANCH" "${AFTER:0:7}" "$(cat "$LINES_FILE")")"
+          HEAD_TITLE="$(printf '%s' "$HEAD_COMMIT_MSG" | head -n1)"
+          ISSUE_URL="$(gh issue create --repo "$REPO" \
+            --title "$HEAD_TITLE" \
+            --body "$BODY")"
+          echo "Created issue $ISSUE_URL"
+
+          # add it to the board
+          ITEM_ID="$(gh project item-add "$NUMBER" --owner "$OWNER" --url "$ISSUE_URL" \
+            --format json --jq '.id')"
+
+          # set its label to the correct port direction for this branch
+          if [ -n "$OPTION_ID" ]; then
+            gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" \
+              --field-id "$FIELD_ID" --single-select-option-id "$OPTION_ID"
+            echo "Set status to '$STATUS_NAME'."
+          fi
+
+          echo "Added issue to board with $COUNT commit(s)."

--- a/.github/workflows/log-commits-version-sync.yml
+++ b/.github/workflows/log-commits-version-sync.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - name: Create an issue on the project board for this push
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
-          PROJECT_BOARD_URL: ${{ secrets.PROJECT_BOARD_URL }}
+          GH_TOKEN: ${{ secrets.VERSION_SYNC_PROJECT_TOKEN }}
+          PROJECT_BOARD_URL: ${{ secrets.VERSION_SYNC_PROJECT_BOARD_URL }}
           BRANCH: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
           AFTER: ${{ github.event.after }}

--- a/.github/workflows/log-commits-version-sync.yml
+++ b/.github/workflows/log-commits-version-sync.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   issues: write
   contents: read
+  pull-requests: read
 
 concurrency:
   group: log-commits-to-issue
@@ -35,15 +36,31 @@ jobs:
               return;
             }
 
-            // Build a markdown list item for each commit in this push
-            const lines = context.payload.commits.map((c) => {
+            // Build a markdown list item for each commit in this push, skipping
+            // any commit whose associated PR carries the "Ignore Version Sync" label
+            const lines = [];
+            for (const c of context.payload.commits) {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: c.id,
+              });
+
+              const ignored = prs.some((pr) =>
+                (pr.labels || []).some((l) => l.name === 'Ignore Version Sync')
+              );
+              if (ignored) {
+                core.info(`Commit ${c.id.substring(0, 7)} belongs to a PR labeled 'Ignore Version Sync', skipping.`);
+                continue;
+              }
+
               const shortSha = c.id.substring(0, 7);
               const title = c.message.split('\n')[0];
-              return `- [\`${shortSha}\`](${c.url}) ${title}`;
-            });
+              lines.push(`- [\`${shortSha}\`](${c.url}) ${title}`);
+            }
 
             if (lines.length === 0) {
-              core.info('No commits in this push, nothing to append.');
+              core.info('No commits to append.');
               return;
             }
 

--- a/.github/workflows/log-commits-version-sync.yml
+++ b/.github/workflows/log-commits-version-sync.yml
@@ -1,0 +1,67 @@
+name: Log Commits for Version Sync
+
+on:
+  push:
+    branches:
+      - '1.20.1'
+      - '1.21'
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: log-commits-to-issue
+  cancel-in-progress: false
+
+jobs:
+  log:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Append commit links to the branch's tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Map the pushed branch to its tracking issue
+            const issueByBranch = {
+              '1.20.1': 5041,
+              '1.21': 5040,
+            };
+            const branch = context.ref.replace('refs/heads/', '');
+            const issueNumber = issueByBranch[branch];
+
+            if (!issueNumber) {
+              core.info(`No tracking issue configured for branch '${branch}', skipping.`);
+              return;
+            }
+
+            // Build a markdown list item for each commit in this push
+            const lines = context.payload.commits.map((c) => {
+              const shortSha = c.id.substring(0, 7);
+              const title = c.message.split('\n')[0];
+              return `- [\`${shortSha}\`](${c.url}) ${title}`;
+            });
+
+            if (lines.length === 0) {
+              core.info('No commits in this push, nothing to append.');
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            const body = issue.body || '';
+            const separator = body.length > 0 && !body.endsWith('\n') ? '\n' : '';
+            const newBody = body + separator + lines.join('\n') + '\n';
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: newBody,
+            });
+
+            core.info(`Appended ${lines.length} commit link(s) to issue #${issueNumber}.`);


### PR DESCRIPTION
## What
Add a PR that logs all commits made to 1.20 and 1.21 to tracking issues, this way we can keep track of what still needs to be merged (or remove it if not, with reasoning)

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Opus 4.8 High
#### Agent Usage Description
It wrote most of the workflow, I checked it, tidied it up and tested it

## Outcome
We can keep track of commits made to either branch

## How Was This Tested
https://github.com/jurrejelle/GregTech-Modern/issues/2

## Potential Compatibility Issues
If we're gonna make a 26.1 branch or w/e we can add it to the list both up top and in the issue mapping, should be fine
