### PR TITLE
Fix DatagenModLoader from crashing other mods.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/config/GTEarlyConfig.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/config/GTEarlyConfig.java
@@ -41,7 +41,8 @@ public class GTEarlyConfig {
 
         // hidden rules for dev-only mixins
         addHiddenRule("dev", !FMLLoader.isProduction());
-        addHiddenRule("dev.datagen", DatagenModLoader.isRunningDataGen());
+        // mixins that target DatagenModLoader (MixinTargetAlreadyLoadedException).
+        addHiddenRule("dev.datagen", !FMLLoader.isProduction() && DatagenModLoader.isRunningDataGen());
 
         // bind non-empty parents
         for (Map.Entry<String, Option> entry : this.options.entrySet()) {


### PR DESCRIPTION
- No AI was used
- Fixes a small crash due to DatagenModLoader being accessed in prod and crashing.
- tested by compiling jar, sticking in a 240+ mod modpack that was confirmed to crash prior.

- could be other unknowns but so far is good.
