### PR TITLE
Fixed a Accessor missing a prefix.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/IMaterialRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/IMaterialRegistry.java
@@ -83,7 +83,7 @@ public interface IMaterialRegistry extends Iterable<Material> {
     /**
      *
      * @return {@code true} if this registry is frozen, {@code false} otherwise
-     * @see MappedRegistryAccessor#isFrozen()
+     * @see MappedRegistryAccessor#gtceu$isFrozen()
      */
     boolean isFrozen();
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/registry/MaterialRegistry.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/material/registry/MaterialRegistry.java
@@ -111,7 +111,7 @@ public final class MaterialRegistry extends MappedRegistry<Material> implements 
 
     @Override
     public boolean isFrozen() {
-        return ((MappedRegistryAccessor) (Object) this).isFrozen();
+        return ((MappedRegistryAccessor) (Object) this).gtceu$isFrozen();
     }
 
     public void close() {

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/MappedRegistryAccessor.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/MappedRegistryAccessor.java
@@ -8,6 +8,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 @Mixin(MappedRegistry.class)
 public interface MappedRegistryAccessor {
 
-    @Accessor
-    boolean isFrozen();
+    @Accessor("frozen")
+    boolean gtceu$isFrozen();
 }


### PR DESCRIPTION
Accessors that reference themselves will infinitely loop without this.
the `gtceu$` part is mandatory and was omitted by PR #5037

- No AI
- Tested by verifying this loads with an rather large addon mod that touches materials.
