### PR TITLE
Fix Synthetic Recipe Warning Spam due to Boiler Autogen Recipes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/customlogic/SteamBoilerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/customlogic/SteamBoilerLogic.java
@@ -61,10 +61,12 @@ public abstract class SteamBoilerLogic implements GTRecipeType.ICustomRecipeLogi
 
     private GTRecipe makeRecipe(ItemStack input, int burnTime) {
         ResourceLocation itemId = BuiltInRegistries.ITEM.getKey(input.getItem());
-        return getRecipeType().recipeBuilder(GTCEu.id(itemId.toDebugFileName()))
+        GTRecipe recipe = getRecipeType().recipeBuilder(GTCEu.id(itemId.toDebugFileName()))
                 .inputItems(input.copyWithCount(1))
                 .duration(modifyBurnTime(burnTime))
                 .build();
+        recipe.id = recipe.id.withPrefix("/");
+        return recipe;
     }
 
     @Override


### PR DESCRIPTION
- No AI
- Fixes EMI vomit in logs.
- Tested by reading the logs (rare GT player that can read)
- No more spam :)