### PR TITLE
exclude steam dial in xei

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -132,7 +132,8 @@ public class MachineUIPanelBuilder {
                             .tooltipDynamic(r -> r.addLine(Component.translatable("gtceu.multiblock.steam.steam_stored",
                                     FormattingUtil.formatNumbers(steamAmount.getIntValue()),
                                     FormattingUtil.formatNumbers(steamCapacity.getIntValue())))))
-                    .leftRel(0.0f).left(-36).top(4));
+                    .leftRel(0.0f).left(-36).top(4)
+                    .excludeAreaInRecipeViewer());
         }
 
         for (var cover : machine.getCoverContainer().getCovers()) {


### PR DESCRIPTION
No AI
before:
<img width="1745" height="1124" alt="image" src="https://github.com/user-attachments/assets/30de2695-c737-4080-9b7d-73cc66e1424f" />

after:
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/6521a952-fcb1-4e18-b5c6-16df161e6224" />
