### PR TITLE
Fix prospection data task

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/commands/GTClientCommands.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/commands/GTClientCommands.java
@@ -5,8 +5,6 @@ import net.minecraft.commands.CommandSourceStack;
 
 import com.mojang.brigadier.CommandDispatcher;
 
-import static net.minecraft.commands.Commands.*;
-
 public class GTClientCommands {
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext buildContext) {}

--- a/src/main/java/com/gregtechceu/gtceu/common/commands/GTCommands.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/commands/GTCommands.java
@@ -12,12 +12,11 @@ import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.api.registry.GTRegistry;
 import com.gregtechceu.gtceu.common.commands.arguments.GTRegistryArgument;
 import com.gregtechceu.gtceu.common.network.GTNetwork;
-import com.gregtechceu.gtceu.common.network.packets.SCPacketShareProspection;
+import com.gregtechceu.gtceu.common.network.packets.SPacketStartProspectionShare;
 import com.gregtechceu.gtceu.data.loader.BedrockFluidLoader;
 import com.gregtechceu.gtceu.data.loader.BedrockOreLoader;
 import com.gregtechceu.gtceu.data.loader.GTOreLoader;
 import com.gregtechceu.gtceu.data.pack.GTDynamicDataPack;
-import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
 
 import net.minecraft.commands.*;
 import net.minecraft.commands.arguments.EntityArgument;
@@ -30,7 +29,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.BulkSectionAccess;
 import net.minecraft.world.level.levelgen.structure.templatesystem.AlwaysTrueTest;
@@ -163,10 +161,12 @@ public class GTCommands {
                         .then(literal("share_prospection_data")
                                 .then(argument("player", EntityArgument.player())
                                         .executes(ctx -> {
-                                            Player player = EntityArgument.getPlayer(ctx, "player");
-                                            Thread sendThread = new Thread(new GTCommands.ProspectingShareTask(
-                                                    ctx.getSource().getPlayerOrException().getUUID(), player.getUUID()));
-                                            sendThread.start();
+                                            // resolve both players server-side (uses the server player list),
+                                            // then ask the sender's client to read its cache and send the data
+                                            ServerPlayer sender = ctx.getSource().getPlayerOrException();
+                                            ServerPlayer receiver = EntityArgument.getPlayer(ctx, "player");
+                                            GTNetwork.sendToPlayer(sender,
+                                                    new SPacketStartProspectionShare(receiver.getUUID()));
                                             return 1;
                                         }))));
     }
@@ -345,34 +345,5 @@ public class GTCommands {
         }
 
         return 1;
-    }
-
-    private static class ProspectingShareTask implements Runnable {
-
-        private final List<ClientCacheManager.ProspectionInfo> prospectionData;
-        private final UUID sender;
-        private final UUID receiver;
-
-        public ProspectingShareTask(UUID sender, UUID receiver) {
-            prospectionData = ClientCacheManager.getProspectionShareData();
-            this.sender = sender;
-            this.receiver = receiver;
-        }
-
-        @Override
-        public void run() {
-            boolean first = true;
-            for (ClientCacheManager.ProspectionInfo info : prospectionData) {
-                GTNetwork.sendToServer(new SCPacketShareProspection(sender, receiver, info.cacheName, info.key,
-                        info.isDimCache, info.dim, info.data, first));
-                first = false;
-
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/network/GTNetwork.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/GTNetwork.java
@@ -119,5 +119,7 @@ public class GTNetwork {
         register(SPacketSendWorldID.class, SPacketSendWorldID::new, NetworkDirection.PLAY_TO_CLIENT);
         register(SPacketNotifyCapeChange.class, SPacketNotifyCapeChange::new, NetworkDirection.PLAY_TO_CLIENT);
         register(SCPacketShareProspection.class, SCPacketShareProspection::new, null);
+        register(SPacketStartProspectionShare.class, SPacketStartProspectionShare::new,
+                NetworkDirection.PLAY_TO_CLIENT);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketStartProspectionShare.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/network/packets/SPacketStartProspectionShare.java
@@ -1,0 +1,74 @@
+package com.gregtechceu.gtceu.common.network.packets;
+
+import com.gregtechceu.gtceu.common.network.GTNetwork;
+import com.gregtechceu.gtceu.integration.map.ClientCacheManager;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Sent from the server to the sender's client to kick off sharing their local prospection cache.
+ *
+ * The {@code /gtceu share_prospection_data} command is a server command. The prospection cache
+ * only exists on the client, so the server delegates the actual read + send back to the sender's
+ * client via this packet.
+ */
+@AllArgsConstructor
+public class SPacketStartProspectionShare implements GTNetwork.INetPacket {
+
+    private UUID receiver;
+
+    @SuppressWarnings("unused")
+    public SPacketStartProspectionShare() {}
+
+    public SPacketStartProspectionShare(FriendlyByteBuf buf) {
+        receiver = buf.readUUID();
+    }
+
+    @Override
+    public void encode(FriendlyByteBuf buf) {
+        buf.writeUUID(receiver);
+    }
+
+    @Override
+    public void execute(NetworkEvent.Context context) {
+        UUID sender = Minecraft.getInstance().player.getUUID();
+        Thread sendThread = new Thread(new ProspectingShareTask(sender, receiver));
+        sendThread.start();
+    }
+
+    private static class ProspectingShareTask implements Runnable {
+
+        private final List<ClientCacheManager.ProspectionInfo> prospectionData;
+        private final UUID sender;
+        private final UUID receiver;
+
+        public ProspectingShareTask(UUID sender, UUID receiver) {
+            prospectionData = ClientCacheManager.getProspectionShareData();
+            this.sender = sender;
+            this.receiver = receiver;
+        }
+
+        @Override
+        public void run() {
+            boolean first = true;
+            for (ClientCacheManager.ProspectionInfo info : prospectionData) {
+                GTNetwork.sendToServer(new SCPacketShareProspection(sender, receiver, info.cacheName, info.key,
+                        info.isDimCache, info.dim, info.data, first));
+                first = false;
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
#4919 made it so that the cache was called on the server. This doesn't work since the cache lives on the client. This adds a task to "Fetch" the data from the client and send it back to the server.


### AI Usage
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

_If you answered yes, please fill out the following information_
#### Agent Used
Opus 4.8 high
#### Agent Usage Description
Asked it to fix the problem, I reviewed
  
## Outcome
We can share the data

## How Was This Tested
GTMCP dev run


## Potential Compatibility Issues
This keeps the issue of "anyone can send any prospection data to anyone" but idt we have a way around that

