### PR TITLE
Initialize Embeddium bloom chunk layer & material lazily

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/BlockRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/BlockRendererMixin.java
@@ -53,11 +53,11 @@ public abstract class BlockRendererMixin {
         ChunkBuildContext chunkContext = GlobalChunkBuildContext.get();
         if (BloomShaderManager.isBloomActive() && chunkContext != null &&
                 TextureMetadataHelper.hasBloom((BakedQuad) quad, lightData.lm)) {
-            var bloomBuilder = chunkContext.buffers.get(GTEmbeddiumCompat.BLOOM_RENDER_PASS);
+            var bloomBuilder = chunkContext.buffers.get(GTEmbeddiumCompat.getBloomRenderPass());
             bloomBuilderRef.set(bloomBuilder);
 
             // call the same method again, this time with the bloom chunk model builder
-            this.writeGeometry(ctx, bloomBuilder, offset, GTEmbeddiumCompat.BLOOM_MATERIAL, quad, vertexColors,
+            this.writeGeometry(ctx, bloomBuilder, offset, GTEmbeddiumCompat.getBloomMaterial(), quad, vertexColors,
                     lightData);
         } else {
             bloomBuilderRef.set(null);

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/DefaultMaterialsMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/DefaultMaterialsMixin.java
@@ -17,12 +17,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class DefaultMaterialsMixin {
 
     @Inject(method = "forRenderLayer", at = @At(value = "HEAD"), cancellable = true)
-    private static void gtceu$fixBloomLayerError(RenderType renderType,
+    private static void gtceu$fixBloomLayerError(RenderType layer,
                                                  CallbackInfoReturnable<Material> cir) {
         if (!BloomShaderManager.isBloomAvailable()) return;
 
-        if (renderType == GTRenderTypes.bloom()) {
-            cir.setReturnValue(GTEmbeddiumCompat.BLOOM_MATERIAL);
+        if (layer == GTRenderTypes.bloom()) {
+            cir.setReturnValue(GTEmbeddiumCompat.getBloomMaterial());
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/DefaultTerrainRenderPassesMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/DefaultTerrainRenderPassesMixin.java
@@ -22,6 +22,6 @@ public class DefaultTerrainRenderPassesMixin {
         // don't bother checking if bloom can be loaded here; Embeddium won't load with OptiFine installed and shaders
         // aren't loaded when this class is loaded.
         // This mixin is also only applied if bloom safe mode is disabled.
-        ALL = ArrayUtils.add(ALL, GTEmbeddiumCompat.BLOOM_RENDER_PASS);
+        ALL = ArrayUtils.add(ALL, GTEmbeddiumCompat.getBloomRenderPass());
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/SodiumWorldRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/normal/embeddium/SodiumWorldRendererMixin.java
@@ -30,7 +30,7 @@ public class SodiumWorldRendererMixin {
         if (!BloomShaderManager.isBloomActive()) return;
 
         if (renderLayer == GTRenderTypes.bloom()) {
-            this.renderSectionManager.renderLayer(matrices, GTEmbeddiumCompat.BLOOM_RENDER_PASS, x, y, z);
+            this.renderSectionManager.renderLayer(matrices, GTEmbeddiumCompat.getBloomRenderPass(), x, y, z);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/embeddium/GTEmbeddiumCompat.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/embeddium/GTEmbeddiumCompat.java
@@ -11,6 +11,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
+import lombok.Getter;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.TerrainRenderPass;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.parameters.AlphaCutoffParameter;
@@ -21,9 +22,10 @@ import java.util.Collection;
 
 public class GTEmbeddiumCompat {
 
-    public static final TerrainRenderPass BLOOM_RENDER_PASS = new TerrainRenderPass(GTRenderTypes.bloom(), false, true);
-    public static final Material BLOOM_MATERIAL = new Material(BLOOM_RENDER_PASS,
-            AlphaCutoffParameter.ONE_TENTH, true);
+    @Getter(lazy = true)
+    private static final TerrainRenderPass bloomRenderPass = new TerrainRenderPass(GTRenderTypes.bloom(), false, true);
+    @Getter(lazy = true)
+    private static final Material bloomMaterial = new Material(getBloomRenderPass(), AlphaCutoffParameter.ZERO, true);
 
     public static void init() {
         MinecraftForge.EVENT_BUS.register(GTEmbeddiumCompat.class);


### PR DESCRIPTION
## What
fix #5045

## Implementation Details
### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes, AI driven tools were used for this pull request.
  
## Outcome
Game launches (though it launched for me before as well, but this should remove any possibility of the crash described in #5045)

## How Was This Tested
Launched game, game launched

## Potential Compatibility Issues
None; pre-alpha snapshots don't count.