### PR TITLE
Enable bloom safe mode by default

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/config/GTEarlyConfig.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/config/GTEarlyConfig.java
@@ -29,10 +29,10 @@ public class GTEarlyConfig {
         // Defines the default rules which can be configured by the user or other mods.
         // You must manually add a rule for any new mixins not covered by an existing package rule.
 
-        Option option = addMixinRule(SAFE_MODE, false);
+        Option option = addMixinRule(SAFE_MODE, true);
         option.addComment(
                 "Whether to use a 'safe mode' for bloom rendering",
-                "NOTE: considerably slower than the normal logic, but likely fixes compatibility issues with other mods.",
+                "NOTE: may be slower than 'normal' logic, but is considerably more stable and less prone to compatibility issues with other mods.",
                 "Requires restarting the client to take effect.");
 
         addDelegateRule("client.bloom.safemode", SAFE_MODE, false);


### PR DESCRIPTION
## What
Having thought about the matter a bit more, the features it adds (ex. specifying a whole model as having bloom with the JSON) don't outweigh the negatives (lots of possible incompatibility issues). Thus I believe that safe mode should be the default choice.

## Implementation Details
changed a "false" to a "true" and modified the comment a bit to reflect the new default

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes, AI driven tools were used for this pull request.

## Outcome
Bloom safe mode is enabled by default

## How Was This Tested
Launched game with empty GT early config, checked the default value it wrote