### PR TITLE
Fix machine type limits not being applied

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
@@ -221,6 +221,17 @@ public class MachineDefinition implements Supplier<MetaMachineBlock> {
     }
 
     /**
+     * Gets the input size for a machine for the capability with the machine having the specified recipe types
+     */
+    public int getInputSize(RecipeCapability<?> cap, GTRecipeType... recipeTypes) {
+        int recipeTypeInputSize = 0;
+        for (var recipeType : recipeTypes) {
+            recipeTypeInputSize = Math.max(recipeType.getMaxInputs(cap), recipeTypeInputSize);
+        }
+        return recipeTypeInputSize;
+    }
+
+    /**
      * Gets the output size for a machine for the capability with the machine having the specified recipe types
      */
     public int getOutputSize(RecipeCapability<?> cap, GTRecipeType... recipeTypes) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MachineDefinition.java
@@ -219,4 +219,16 @@ public class MachineDefinition implements Supplier<MetaMachineBlock> {
     public static void clearBuilt() {
         STATE.remove();
     }
+
+    /**
+     * Gets the output size for a machine for the capability with the machine having the specified recipe types
+     */
+    public int getOutputSize(RecipeCapability<?> cap, GTRecipeType... recipeTypes) {
+        int recipeTypeOutputSize = 0;
+        for (var recipeType : recipeTypes) {
+            recipeTypeOutputSize = Math.max(recipeType.getMaxOutputs(cap), recipeTypeOutputSize);
+        }
+        int machineTypeOutputLimit = this.getRecipeOutputLimits().getOrDefault(cap, recipeTypeOutputSize);
+        return Math.min(recipeTypeOutputSize, machineTypeOutputLimit);
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -128,12 +128,11 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
                 new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP),
                         IO.IN, IO.BOTH));
         this.exportItems = attachTrait(
-                new NotifiableItemStackHandler(getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP),
-                        IO.OUT));
+                new NotifiableItemStackHandler(getMaxOutputSize(ItemRecipeCapability.CAP), IO.OUT));
         this.importFluids = attachTrait(new NotifiableFluidTank(getRecipeType().getMaxInputs(FluidRecipeCapability.CAP),
                 tankScalingFunction.applyAsInt(getTier()), IO.IN));
         this.exportFluids = attachTrait(
-                new NotifiableFluidTank(getRecipeType().getMaxOutputs(FluidRecipeCapability.CAP),
+                new NotifiableFluidTank(getMaxOutputSize(FluidRecipeCapability.CAP),
                         tankScalingFunction.applyAsInt(getTier()), IO.OUT));
         this.importComputation = attachTrait(new NotifiableComputationContainer(IO.IN, true));
         this.exportComputation = attachTrait(new NotifiableComputationContainer(IO.OUT, false));
@@ -176,6 +175,13 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
     public void setMuffled(boolean muffled) {
         isMuffled = muffled;
         syncDataHolder.markClientSyncFieldDirty("isMuffled");
+    }
+
+    private int getMaxOutputSize(RecipeCapability<?> cap) {
+        int recipeTypeOutputSize = getRecipeType().getMaxOutputs(cap);
+        int machineTypeOutputLimit = this.getDefinition().getRecipeOutputLimits().getOrDefault(cap,
+                recipeTypeOutputSize);
+        return Math.min(recipeTypeOutputSize, machineTypeOutputLimit);
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -128,11 +128,12 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
                 new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP),
                         IO.IN, IO.BOTH));
         this.exportItems = attachTrait(
-                new NotifiableItemStackHandler(getMaxOutputSize(ItemRecipeCapability.CAP), IO.OUT));
+                new NotifiableItemStackHandler(
+                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()), IO.OUT));
         this.importFluids = attachTrait(new NotifiableFluidTank(getRecipeType().getMaxInputs(FluidRecipeCapability.CAP),
                 tankScalingFunction.applyAsInt(getTier()), IO.IN));
         this.exportFluids = attachTrait(
-                new NotifiableFluidTank(getMaxOutputSize(FluidRecipeCapability.CAP),
+                new NotifiableFluidTank(getDefinition().getOutputSize(FluidRecipeCapability.CAP, getRecipeTypes()),
                         tankScalingFunction.applyAsInt(getTier()), IO.OUT));
         this.importComputation = attachTrait(new NotifiableComputationContainer(IO.IN, true));
         this.exportComputation = attachTrait(new NotifiableComputationContainer(IO.OUT, false));
@@ -175,13 +176,6 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
     public void setMuffled(boolean muffled) {
         isMuffled = muffled;
         syncDataHolder.markClientSyncFieldDirty("isMuffled");
-    }
-
-    private int getMaxOutputSize(RecipeCapability<?> cap) {
-        int recipeTypeOutputSize = getRecipeType().getMaxOutputs(cap);
-        int machineTypeOutputLimit = this.getDefinition().getRecipeOutputLimits().getOrDefault(cap,
-                recipeTypeOutputSize);
-        return Math.min(recipeTypeOutputSize, machineTypeOutputLimit);
     }
 
     //////////////////////////////////////

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -125,13 +125,15 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
         this.recipeLogic = attachTrait(new RecipeLogic());
         this.recipeLogic.setKeepSubscribing(false);
         this.importItems = attachTrait(
-                new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP),
+                new NotifiableItemStackHandler(getDefinition().getInputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
                         IO.IN, IO.BOTH));
         this.exportItems = attachTrait(
                 new NotifiableItemStackHandler(
-                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()), IO.OUT));
-        this.importFluids = attachTrait(new NotifiableFluidTank(getRecipeType().getMaxInputs(FluidRecipeCapability.CAP),
-                tankScalingFunction.applyAsInt(getTier()), IO.IN));
+                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
+                        IO.OUT));
+        this.importFluids = attachTrait(
+                new NotifiableFluidTank(getDefinition().getInputSize(FluidRecipeCapability.CAP, getRecipeTypes()),
+                        tankScalingFunction.applyAsInt(getTier()), IO.IN));
         this.exportFluids = attachTrait(
                 new NotifiableFluidTank(getDefinition().getOutputSize(FluidRecipeCapability.CAP, getRecipeTypes()),
                         tankScalingFunction.applyAsInt(getTier()), IO.OUT));

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
@@ -57,10 +57,12 @@ public class SimpleSteamMachine extends SteamWorkableMachine {
     public SimpleSteamMachine(BlockEntityCreationInfo info, boolean isHighPressure) {
         super(info, isHighPressure);
         this.importItems = attachTrait(
-                new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN, IO.BOTH));
+                new NotifiableItemStackHandler(getDefinition().getInputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
+                        IO.IN, IO.BOTH));
         this.exportItems = attachTrait(
                 new NotifiableItemStackHandler(
-                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()), IO.OUT));
+                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
+                        IO.OUT));
 
         this.exhaustVentTrait = attachTrait(new ExhaustVentMachineTrait());
         exhaustVentTrait.setVentingDamageAmount(isHighPressure() ? 12F : 6F);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
@@ -58,11 +58,9 @@ public class SimpleSteamMachine extends SteamWorkableMachine {
         super(info, isHighPressure);
         this.importItems = attachTrait(
                 new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN, IO.BOTH));
-        int recipeTypeOutputSize = getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP);
-        int machineTypeOutputLimit = this.getDefinition().getRecipeOutputLimits().getOrDefault(ItemRecipeCapability.CAP,
-                recipeTypeOutputSize);
         this.exportItems = attachTrait(
-                new NotifiableItemStackHandler(Math.min(recipeTypeOutputSize, machineTypeOutputLimit), IO.OUT));
+                new NotifiableItemStackHandler(
+                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()), IO.OUT));
 
         this.exhaustVentTrait = attachTrait(new ExhaustVentMachineTrait());
         exhaustVentTrait.setVentingDamageAmount(isHighPressure() ? 12F : 6F);

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
@@ -58,8 +58,11 @@ public class SimpleSteamMachine extends SteamWorkableMachine {
         super(info, isHighPressure);
         this.importItems = attachTrait(
                 new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN, IO.BOTH));
+        int recipeTypeOutputSize = getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP);
+        int machineTypeOutputLimit = this.getDefinition().getRecipeOutputLimits().getOrDefault(ItemRecipeCapability.CAP,
+                recipeTypeOutputSize);
         this.exportItems = attachTrait(
-                new NotifiableItemStackHandler(getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP), IO.OUT));
+                new NotifiableItemStackHandler(Math.min(recipeTypeOutputSize, machineTypeOutputLimit), IO.OUT));
 
         this.exhaustVentTrait = attachTrait(new ExhaustVentMachineTrait());
         exhaustVentTrait.setVentingDamageAmount(isHighPressure() ? 12F : 6F);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
@@ -70,12 +70,15 @@ public class PrimitiveWorkableMachine extends WorkableMultiblockMachine {
     public PrimitiveWorkableMachine(BlockEntityCreationInfo info) {
         super(info);
         this.importItems = attachTrait(
-                new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN));
+                new NotifiableItemStackHandler(getDefinition().getInputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
+                        IO.IN));
         this.exportItems = attachTrait(
                 new NotifiableItemStackHandler(
-                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()), IO.OUT));
-        this.importFluids = attachTrait(new NotifiableFluidTank(getRecipeType().getMaxInputs(FluidRecipeCapability.CAP),
-                32 * FluidType.BUCKET_VOLUME, IO.IN));
+                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
+                        IO.OUT));
+        this.importFluids = attachTrait(
+                new NotifiableFluidTank(getDefinition().getInputSize(FluidRecipeCapability.CAP, getRecipeTypes()),
+                        32 * FluidType.BUCKET_VOLUME, IO.IN));
         this.exportFluids = attachTrait(
                 new NotifiableFluidTank(getDefinition().getOutputSize(FluidRecipeCapability.CAP, getRecipeTypes()),
                         32 * FluidType.BUCKET_VOLUME, IO.OUT));

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
@@ -72,11 +72,12 @@ public class PrimitiveWorkableMachine extends WorkableMultiblockMachine {
         this.importItems = attachTrait(
                 new NotifiableItemStackHandler(getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), IO.IN));
         this.exportItems = attachTrait(
-                new NotifiableItemStackHandler(getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP), IO.OUT));
+                new NotifiableItemStackHandler(
+                        getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()), IO.OUT));
         this.importFluids = attachTrait(new NotifiableFluidTank(getRecipeType().getMaxInputs(FluidRecipeCapability.CAP),
                 32 * FluidType.BUCKET_VOLUME, IO.IN));
         this.exportFluids = attachTrait(
-                new NotifiableFluidTank(getRecipeType().getMaxOutputs(FluidRecipeCapability.CAP),
+                new NotifiableFluidTank(getDefinition().getOutputSize(FluidRecipeCapability.CAP, getRecipeTypes()),
                         32 * FluidType.BUCKET_VOLUME, IO.OUT));
         this.hazardEmitter = attachTrait(
                 new EnvironmentalHazardEmitterTrait(GTMedicalConditions.CARBON_MONOXIDE_POISONING,


### PR DESCRIPTION
## What
machined now make the correct amount of output slot handlers

## Implementation Details
no nice place to tuck `getMaxOutputSize` to make it more general.

### AI Usage 
- [x ] No AI driven tools were used for this pull request.

## Outcome
macerators don’t fill up with inaccessible stuff

## How Was This Tested
ingame

## Potential Compatibility Issues
stuff will be voided if people have them in the phantom slots
this should only be snapshot players though
