### PR TITLE
Cover opening from machine GUI

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -14,7 +14,6 @@ import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.network.chat.Component;
 
-import brachy.modularui.drawable.ItemDrawable;
 import brachy.modularui.drawable.UITexture;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.utils.Color;
@@ -22,7 +21,6 @@ import brachy.modularui.value.sync.DoubleSyncValue;
 import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widget.ParentWidget;
-import brachy.modularui.widgets.ButtonWidget;
 import brachy.modularui.widgets.layout.Flow;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -137,11 +135,7 @@ public class MachineUIPanelBuilder {
         }
 
         for (var cover : machine.getCoverContainer().getCovers()) {
-            attachLeft.child(new ButtonWidget<>()
-                    .overlay(new ItemDrawable(cover.getAttachItem()))
-                    .onMousePressed((context, button) -> {
-                        return true;
-                    }));
+            GTMuiWidgets.createCoverWidget(attachLeft, cover, null, syncManager, settings);
         }
 
         return panel;

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -3,6 +3,8 @@ package com.gregtechceu.gtceu.common.mui;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.IControllable;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.cover.CoverBehavior;
+import com.gregtechceu.gtceu.api.cover.IMuiCover;
 import com.gregtechceu.gtceu.api.cover.filter.Filter;
 import com.gregtechceu.gtceu.api.cover.filter.FilterHandler;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
@@ -363,6 +365,28 @@ public class GTMuiWidgets {
         }
 
         return cycleButton;
+    }
+
+    public static ParentWidget<?> createCoverWidget(Flow flow, CoverBehavior cover, SidedPosGuiData data,
+                                                    PanelSyncManager syncManager, UISettings settings) {
+        IMuiCover muiCover;
+        if (cover instanceof IMuiCover) {
+            muiCover = (IMuiCover) cover;
+        } else {
+            muiCover = null;
+            return null;
+        }
+        IPanelHandler panelHandler = syncManager.syncedPanel(
+                cover.getAttachItem().getDisplayName() + cover.attachedSide.name(), true,
+                (sm, sh) -> muiCover.buildUI(data, sm, settings).disablePanelsBelow(true)
+                        .closeOnOutOfBoundsClick(true));
+        return flow.child(new ButtonWidget<>()
+                .overlay(new ItemDrawable(cover.getAttachItem()))
+                .tooltip(r -> r.addFromItem(cover.getAttachItem()))
+                .onMousePressed((context, button) -> {
+                    panelHandler.togglePanel();
+                    return true;
+                }));
     }
 
     public static <T, S extends Filter<T, S>> ParentWidget<?> createFilterRow(Flow existingRow,


### PR DESCRIPTION
## What
allow the user to open cover settings from inside any machine's main gui


## Implementation Details
work similar to how filters work in coveyors

### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
more qol

## How Was This Tested
ingame, currently the panel swapping is a bit broken
