### PR TITLE
Change battery buffer jade to show per tick instead of per second

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -2579,7 +2579,7 @@
   "gtceu.item_pipe.priority": "%dɟ§ :ʎʇıɹoıɹԀ6§",
   "gtceu.jade.amperage_use": "Ɐ %s",
   "gtceu.jade.at": " @ ",
-  "gtceu.jade.changes_eu_sec": "s/∩Ǝ %s",
+  "gtceu.jade.changes_eu_tick": "ʇ/∩Ǝ %s",
   "gtceu.jade.cleaned_this_second": "s/%s :pɹɐzɐɥ pǝuɐǝןƆ",
   "gtceu.jade.days": "sʎɐp %s",
   "gtceu.jade.energy_stored": "∩Ǝ %d / %d",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2579,7 +2579,7 @@
   "gtceu.item_pipe.priority": "§9Priority: §f%d",
   "gtceu.jade.amperage_use": "%s A",
   "gtceu.jade.at": " @ ",
-  "gtceu.jade.changes_eu_sec": "%s EU/s",
+  "gtceu.jade.changes_eu_tick": "%s EU/t",
   "gtceu.jade.cleaned_this_second": "Cleaned hazard: %s/s",
   "gtceu.jade.days": "%s days",
   "gtceu.jade.energy_stored": "%d / %d EU",

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/IntegrationLang.java
@@ -105,7 +105,7 @@ public class IntegrationLang {
         provider.add("gtceu.jade.at", " @ ");
         provider.add("gtceu.jade.remaining_charge_time", "Until charged: %s");
         provider.add("gtceu.jade.remaining_discharge_time", "Until empty: %s");
-        provider.add("gtceu.jade.changes_eu_sec", "%s EU/s");
+        provider.add("gtceu.jade.changes_eu_tick", "%s EU/t");
         provider.add("gtceu.jade.seconds", "%s seconds");
         provider.add("gtceu.jade.minutes", "%s minutes");
         provider.add("gtceu.jade.hours", "%s hours");

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/BatteryStorageInfoProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/BatteryStorageInfoProvider.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.capability.IElectricItem;
 import com.gregtechceu.gtceu.api.capability.IEnergyContainer;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.machine.electric.BatteryBufferMachine;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.nbt.CompoundTag;
@@ -51,7 +52,8 @@ public class BatteryStorageInfoProvider extends MachineInfoProvider<BatteryBuffe
         CompoundTag container = data.getCompound("energy");
         long changed = container.getLong("changed"), stored = container.getLong("stored"),
                 capacity = container.getLong("capacity");
-        tooltip.add(Component.translatable("gtceu.jade.changes_eu_sec", formatLongNumber(changed)));
+        double changedTick = ((double) changed) / 20.0;
+        tooltip.add(Component.translatable("gtceu.jade.changes_eu_tick", FormattingUtil.formatNumbers(changedTick)));
         if (changed > 0L) {
             tooltip.add(Component
                     .translatable("gtceu.jade.remaining_charge_time",

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/BatteryStorageInfoProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/BatteryStorageInfoProvider.java
@@ -52,8 +52,8 @@ public class BatteryStorageInfoProvider extends MachineInfoProvider<BatteryBuffe
         CompoundTag container = data.getCompound("energy");
         long changed = container.getLong("changed"), stored = container.getLong("stored"),
                 capacity = container.getLong("capacity");
-        double changedTick = ((double) changed) / 20.0;
-        tooltip.add(Component.translatable("gtceu.jade.changes_eu_tick", FormattingUtil.formatNumbers(changedTick)));
+        tooltip.add(Component.translatable("gtceu.jade.changes_eu_tick",
+                FormattingUtil.formatNumbers(((double) changed) / 20.0)));
         if (changed > 0L) {
             tooltip.add(Component
                     .translatable("gtceu.jade.remaining_charge_time",


### PR DESCRIPTION
## What
Title

## Implementation Details
did it the really simple way and divided the seconds value by 20.

### AI Usage 
- [x ] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
<img width="2050" height="1170" alt="image" src="https://github.com/user-attachments/assets/1fb30ffc-0594-475c-bb8a-2b2d373020d7" />
<img width="2050" height="1170" alt="image" src="https://github.com/user-attachments/assets/62a25c9f-facc-4ec0-acac-283133cb5569" />


## How Was This Tested
ingame

## Potential Compatibility Issues
the lang `gtceu.jade.changes_eu_sec` was removed and replaced by `gtceu.jade.changes_eu_tick`
