### PR TITLE
Misc mui fixes

### DIFF
--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -144,3 +144,4 @@ As a recipe-matching optimization, input handlers whose `getTotalContentAmount()
 - `GTUtil.getMoltenFluid(Material)` has been moved to `Material.getHotFluid()`.
 - `ICopyable::copyConfig`'s `CompoundTag` argument should now be mutated by reference instead of a new one returned (and thus, the return type has been changed to `void`).
 - Tiered Chance Boosting has been formally removed from the API (as it was deprecated in v7.0.) `ChancedInput` and `ChancedOutput` kubeJS calls will throw errors if they still had chance boost values as arguments.
+- Any custom `IDistinctPart`'s will have to implement `supportsDistinct` if they don't extend `ItemBusPartMachine`.

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IDistinctPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/feature/multiblock/IDistinctPart.java
@@ -5,4 +5,6 @@ public interface IDistinctPart {
     boolean isDistinct();
 
     void setDistinct(boolean isDistinct);
+
+    boolean supportsDistinct();
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -83,7 +83,7 @@ public class MachineUIPanelBuilder {
                 attachRight.child(GTMuiWidgets.createVoidingButton(voidable));
             }
             if (machine instanceof IDistinctPart distinctPart) {
-                attachRight.child(GTMuiWidgets.createDistinctnessButton(distinctPart));
+                attachRight.childIf(distinctPart.supportsDistinct(), () -> GTMuiWidgets.createDistinctnessButton(distinctPart));
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/mui/MachineUIPanelBuilder.java
@@ -83,7 +83,8 @@ public class MachineUIPanelBuilder {
                 attachRight.child(GTMuiWidgets.createVoidingButton(voidable));
             }
             if (machine instanceof IDistinctPart distinctPart) {
-                attachRight.childIf(distinctPart.supportsDistinct(), () -> GTMuiWidgets.createDistinctnessButton(distinctPart));
+                attachRight.childIf(distinctPart.supportsDistinct(),
+                        () -> GTMuiWidgets.createDistinctnessButton(distinctPart));
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.common.machine.electric;
 
-import brachy.modularui.screen.RichTooltip;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
@@ -21,7 +20,6 @@ import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiMachineUtil;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
-import com.gregtechceu.gtceu.utils.GTStringUtils;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.core.Direction;
@@ -32,9 +30,9 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraftforge.energy.IEnergyStorage;
 
 import brachy.modularui.api.drawable.IDrawable;
-import brachy.modularui.api.drawable.Text;
 import brachy.modularui.drawable.progress.ProgressDrawable;
 import brachy.modularui.factory.PosGuiData;
+import brachy.modularui.screen.RichTooltip;
 import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.DoubleSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
@@ -170,8 +168,8 @@ public class BatteryBufferMachine extends TieredEnergyMachine
     private void getRichTooltip(RichTooltip r) {
         if (GTUtil.isShiftDown()) {
             r.addLine(Component.literal(
-                "%s/%s EU".formatted(
-                        energyContainer.getEnergyStored(), energyContainer.getEnergyCapacity())));
+                    "%s/%s EU".formatted(
+                            energyContainer.getEnergyStored(), energyContainer.getEnergyCapacity())));
         } else {
             r.addLine(Component.literal(
                     "%s/%s EU".formatted(

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BatteryBufferMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.common.machine.electric;
 
+import brachy.modularui.screen.RichTooltip;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
@@ -19,6 +20,7 @@ import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.GTMuiMachineUtil;
 import com.gregtechceu.gtceu.config.ConfigHolder;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTStringUtils;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
@@ -152,10 +154,8 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                 .value(energyPercentage)
                 .marginLeft(5)
                 .size(18, 60)
-                .addTooltipLine(Text.dynamic(() -> Component.literal(
-                        "%s/%s EU".formatted(
-                                GTStringUtils.formatInt(energyContainer.getEnergyStored()),
-                                GTStringUtils.formatInt(energyContainer.getEnergyCapacity()))))))
+                .tooltipDynamic(this::getRichTooltip))
+                .tooltipAutoUpdate(true)
                 .child(GTMuiMachineUtil.createSlotGroupFromInventory(
                         batteryInventory, "batteries",
                         inventorySize, 'B',
@@ -165,6 +165,19 @@ public class BatteryBufferMachine extends TieredEnergyMachine
                         .center());
 
         mainWidget.child(flow);
+    }
+
+    private void getRichTooltip(RichTooltip r) {
+        if (GTUtil.isShiftDown()) {
+            r.addLine(Component.literal(
+                "%s/%s EU".formatted(
+                        energyContainer.getEnergyStored(), energyContainer.getEnergyCapacity())));
+        } else {
+            r.addLine(Component.literal(
+                    "%s/%s EU".formatted(
+                            FormattingUtil.formatNumberReadable(energyContainer.getEnergyStored()),
+                            FormattingUtil.formatNumberReadable(energyContainer.getEnergyCapacity()))));
+        }
     }
 
     private double getEnergyPercentage() {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -138,7 +138,7 @@ public class ItemBusPartMachine extends TieredIOPartMachine
 
     @Override
     public boolean supportsDistinct() {
-        return io != IO.OUT;
+        return !io.support(IO.OUT);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -137,6 +137,11 @@ public class ItemBusPartMachine extends TieredIOPartMachine
     }
 
     @Override
+    public boolean supportsDistinct() {
+        return io != IO.OUT;
+    }
+
+    @Override
     public int tintColor(int index) {
         if (index == 9) return getRealColor();
         return -1;


### PR DESCRIPTION
## What
Only add the distinct button in hatches if they are input hatches.
Fixes the battery buffer tooltip and it now shows the exact value when you hold shift.

## Implementation Details
added `supportsDistinct` to `IDistinctPart`

### AI Usage 
- [ x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
less jank UI

## How Was This Tested
ingame

## Potential Compatibility Issues
addon devs that impl their own `IDistinctPart` will have to implement `supportsDistinct`
