### PR TITLE
Sussy! (fix the 'sus record' music disc)

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -4838,7 +4838,7 @@
   "item.gtceu.storage_cover": "ɹǝʌoƆ ǝbɐɹoʇS",
   "item.gtceu.sugar_gem": "ǝqnƆ ɹɐbnS",
   "item.gtceu.sus_record": "ɔsıᗡ ɔısnW",
-  "item.gtceu.sus_record.desc": "¡ʎssnsㄥ§",
+  "item.gtceu.sus_record.desc": "¡ʎssns",
   "item.gtceu.sword_extruder_mold.tooltip": "spɹoʍS buıʞɐɯ ɹoɟ ǝdɐɥS ɹǝpnɹʇxƎㄥ§",
   "item.gtceu.tag_filter.tooltip.0": "˙ㄥ§ɹǝʌoƆɟ§ sɐ ㄥ§bɐ⟘ɟ§ ɥʇıʍ O/I ㄥ§ɯǝʇIɟ§ sɹǝʇןıℲㄥ§",
   "item.gtceu.tag_filter.tooltip.1": "˙ǝpɐɹbdn ㄥ§ɯɹⱯ ɔıʇoqoᴚɟ§ puɐ ㄥ§ǝןnpoW ɹoʎǝʌuoƆɟ§ ɐ sɐ pǝsn ǝq uɐƆ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -4838,7 +4838,7 @@
   "item.gtceu.storage_cover": "Storage Cover",
   "item.gtceu.sugar_gem": "Sugar Cube",
   "item.gtceu.sus_record": "Music Disc",
-  "item.gtceu.sus_record.desc": "§7sussy!",
+  "item.gtceu.sus_record.desc": "sussy!",
   "item.gtceu.sword_extruder_mold.tooltip": "§7Extruder Shape for making Swords",
   "item.gtceu.tag_filter.tooltip.0": "§7Filters §fItem§7 I/O with §fTag§7 as §fCover§7.",
   "item.gtceu.tag_filter.tooltip.1": "Can be used as a §fConveyor Module§7 and §fRobotic Arm§7 upgrade.",

--- a/src/generated/resources/data/minecraft/tags/items/music_discs.json
+++ b/src/generated/resources/data/minecraft/tags/items/music_discs.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "gtceu:sus_record"
+  ]
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTItems.java
@@ -2516,6 +2516,8 @@ public class GTItems {
     public static ItemEntry<RecordItem> SUS_RECORD = REGISTRATE
             .item("sus_record", p -> new RecordItem(15, GTSoundEntries.SUS_RECORD::getMainEvent, p, 820))
             .lang("Music Disc")
+            .properties(p -> p.stacksTo(1).rarity(Rarity.RARE))
+            .tag(ItemTags.MUSIC_DISCS)
             .register();
     public static ItemEntry<Item> NAN_CERTIFICATE = REGISTRATE.item("nan_certificate", Item::new)
             .lang("Certificate of Not Being a Noob Anymore").properties(p -> p.rarity(Rarity.EPIC))

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/ItemLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/ItemLang.java
@@ -352,6 +352,6 @@ public class ItemLang {
         provider.add("item.gtceu.terminal.tooltip",
                 "Shift + R-Click on a controller to automatically build a multiblock with items from your inventory");
 
-        provider.add("item.gtceu.sus_record.desc", "§7sussy!");
+        provider.add("item.gtceu.sus_record.desc", "sussy!");
     }
 }


### PR DESCRIPTION
## What
Turns out it was just missing an item tag.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes, AI driven tools were used for this pull request.
  
## Outcome
sus record doesn't void itself when put in a jukebox

## How Was This Tested
~~Boil em, mash em, stick em in a stew~~ I put it in a jukebox. Like this:
<img width="2560" height="1377" alt="sussy!" src="https://github.com/user-attachments/assets/787edbe3-e3cc-4c75-b57d-affadc063ddf" />

## Additional Information
I also removed a `§7` (gray color code) from the item's 'description' translation, as vanilla applies the same color to it automatically. That means having the color code there did nothing except slow down text processing.

Note that the item tag **does not exist on 1.21**, so that change should be skipped. The other changes still apply, though.