### PR TITLE
 Wiki information on .handleNonMaterialFluids() in Java

### DIFF
--- a/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
+++ b/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
@@ -82,9 +82,9 @@ material is custom, this is done using `GTCEuStartupEvents.registry()`, as depic
 
 Fluids are treated differently to items, their inclusion in a material is a property rather than a TagPrefix or MaterialFlag. 
 This makes replacing the fluid of a material with a fluid that you or another mod have created require a different approach than setIgnored. 
-This is done using `handleNonMaterialFluids()` which can be found in the [``GTFluids`` class](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/common/data/GTFluids.java)
+The way to do this is using `GTFluids.handleNonMaterialFluids()` which can be found in the [``GTFluids`` class](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/common/data/GTFluids.java)
 
-`.handleNonMaterialFluids()` takes in a `Material` and a `Fluid` or `Supplier<Fluid>` to replace the liquid of the material with the provided fluid.
+`GTFluids.handleNonMaterialFluids()` takes in a `Material` and a `Fluid` or `Supplier<Fluid>` to replace the liquid of the material with the provided fluid.
 Assure that the material is registered with a liquid before attempting to replace it with your new fluid. An example is below.
 
 !!! note "This may differ!"
@@ -95,6 +95,6 @@ public static void register() {
     GLUGG_BRINE = new Material.Builder(MyMod.id("glugg_brine"))
         .liquid(new FluidBuilder()).buildAndRegister();
 
-    GTFluids.handleNonMaterialFluids(GLUGG_BRINE, PVFluidRegistry.BRINE_FLUID_SOURCE::get);
+    GTFluids.handleNonMaterialFluids(GLUGG_BRINE, () -> PVFluidRegistry.BRINE_FLUID_SOURCE.get());
 }
 ```

--- a/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
+++ b/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
@@ -91,12 +91,10 @@ Assure that the material is registered with a liquid before attempting to replac
     Depending on the way your fluid is registered you may need to change how you pass the `Fluid` argument, check how it is registered in the mod you are working with.
 
 ```java title="ExampleMaterials.java"
-import static com.gregtechceu.gtceu.common.data.GTFluids.handleNonMaterialFluids;
-
 public static void register() {
-    EXAMPLE_MATERIAL =  = new Material.Builder(your_mod_id.id("EXAMPLE_MATERIAL"))
-        .liquid().buildAndRegister();
+    GLUGG_BRINE = new Material.Builder(MyMod.id("glugg_brine"))
+        .liquid(new FluidBuilder()).buildAndRegister();
 
-    handleNonMaterialFluids(EXAMPLE_MATERIAL, ExampleFluidRegistry.EXAMPLE_FLUID_SOURCE::get);
+    GTFluids.handleNonMaterialFluids(GLUGG_BRINE, PVFluidRegistry.BRINE_FLUID_SOURCE::get);
 }
 ```

--- a/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
+++ b/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
@@ -77,6 +77,7 @@ GTCEuStartupEvents.materialModification(event => { // (1)
 The `Material` for which you are adjusting the TagPrefix must be registered in GTCEu Modern's material registry; if this
 material is custom, this is done using `GTCEuStartupEvents.registry()`, as depicted in these docs.
 
+
 ## What about fluids?
 
 Fluids are treated differently to items, their inclusion in a material is a property rather than a TagPrefix or MaterialFlag. 
@@ -97,6 +98,5 @@ public static void register() {
         .liquid().buildAndRegister();
 
     handleNonMaterialFluids(EXAMPLE_MATERIAL, ExampleFluidRegistry.EXAMPLE_FLUID_SOURCE::get);
-
 }
 ```

--- a/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
+++ b/docs/content/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored().md
@@ -76,3 +76,27 @@ GTCEuStartupEvents.materialModification(event => { // (1)
 
 The `Material` for which you are adjusting the TagPrefix must be registered in GTCEu Modern's material registry; if this
 material is custom, this is done using `GTCEuStartupEvents.registry()`, as depicted in these docs.
+
+## What about fluids?
+
+Fluids are treated differently to items, their inclusion in a material is a property rather than a TagPrefix or MaterialFlag. 
+This makes replacing the fluid of a material with a fluid that you or another mod have created require a different approach than setIgnored. 
+This is done using `handleNonMaterialFluids()` which can be found in the [``GTFluids`` class](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/common/data/GTFluids.java)
+
+`.handleNonMaterialFluids()` takes in a `Material` and a `Fluid` or `Supplier<Fluid>` to replace the liquid of the material with the provided fluid.
+Assure that the material is registered with a liquid before attempting to replace it with your new fluid. An example is below.
+
+!!! note "This may differ!"
+    Depending on the way your fluid is registered you may need to change how you pass the `Fluid` argument, check how it is registered in the mod you are working with.
+
+```java title="ExampleMaterials.java"
+import static com.gregtechceu.gtceu.common.data.GTFluids.handleNonMaterialFluids;
+
+public static void register() {
+    EXAMPLE_MATERIAL =  = new Material.Builder(your_mod_id.id("EXAMPLE_MATERIAL"))
+        .liquid().buildAndRegister();
+
+    handleNonMaterialFluids(EXAMPLE_MATERIAL, ExampleFluidRegistry.EXAMPLE_FLUID_SOURCE::get);
+
+}
+```


### PR DESCRIPTION
## What
Adds information to the wiki page https://gregtechceu.github.io/GregTech-Modern/1.20.1/Modpacks/Materials-and-Elements/TagPrefixes-and-the-power-of-.setIgnored%28%29/ about .handleNonMaterialFluids().

## Implementation Details
It is possible that this would better fit on its own page (as it is not strictly a TagPrefix or setIgnored topic) but it shares a theme of material integration with other mods' registry objects. Potentially rename the page to suit this.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
Added details to setIgnored page on .handleNonMaterialFluids() for integrating fluids from other sources with a material.

## How Was This Tested
Tested by mkdocs serve from a Codespace, which shows a correctly formatted page with all intended information appended to the end of the current page. 

<img width="789" height="731" alt="image" src="https://github.com/user-attachments/assets/deb2a928-ba97-4559-8bd8-302ac166cbc0" />