### PR TITLE
remove gtregistrate default when creating machines

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/predicates/BasePredicate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/predicates/BasePredicate.java
@@ -62,10 +62,10 @@ public class BasePredicate {
      *                       Terminal Auto-Builder},
      *                       {@link PatternPreviewRenderer#draw(PoseStack, MultiBufferSource.BufferSource, Camera, RenderLevelStageEvent.Stage, float)
      *                       In-world Preview} or
-     *                       {@link MultiblockPreviewWidget#MultiblockPreviewWidget(MultiblockMachineDefinition, MultiblockSchemaInfo)
+     *                       {@link MultiblockPreviewWidget#MultiblockPreviewWidget(MultiblockMachineDefinition, MultiblockSchemaInfo, int, int)
      *                       XEI Preview}
      */
-    public BasePredicate(Function<CurrentBlockInfo, PatternError> errorPredicate,
+    public BasePredicate(Function<CurrentBlockInfo, @Nullable PatternError> errorPredicate,
                          @Nullable List<BlockInfo> candidates) {
         this("Unknown", errorPredicate, candidates);
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/registrate/GTRegistrate.java
@@ -253,7 +253,7 @@ public class GTRegistrate extends AbstractRegistrate<GTRegistrate> {
         return this.currentTab;
     }
 
-    public void creativeModeTab(Supplier<RegistryEntry<CreativeModeTab>> currentTab) {
+    public void creativeModeTab(Supplier<@Nullable RegistryEntry<CreativeModeTab>> currentTab) {
         this.currentTab = currentTab.get();
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMachines.java
@@ -66,6 +66,7 @@ import static com.gregtechceu.gtceu.common.data.machines.GTMachineUtils.ALL_TIER
 import static com.gregtechceu.gtceu.common.data.models.GTMachineModels.*;
 import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
 
+@SuppressWarnings("unused")
 public class GTMachines {
 
     static {
@@ -77,6 +78,7 @@ public class GTMachines {
     // ****** Steam Machine ******//
     //////////////////////////////////////
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_SOLID_BOILER = registerSteamMachines(
+            REGISTRATE,
             "steam_solid_boiler",
             SteamSolidBoilerMachine::new,
             (pressure, builder) -> builder.rotationState(RotationState.ALL)
@@ -91,6 +93,7 @@ public class GTMachines {
                     .register());
 
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_LIQUID_BOILER = registerSteamMachines(
+            REGISTRATE,
             "steam_liquid_boiler",
             SteamLiquidBoilerMachine::new,
             (pressure, builder) -> builder.rotationState(RotationState.ALL)
@@ -105,6 +108,7 @@ public class GTMachines {
                     .register());
 
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_SOLAR_BOILER = registerSteamMachines(
+            REGISTRATE,
             "steam_solar_boiler",
             SteamSolarBoiler::new,
             (pressure, builder) -> builder.rotationState(RotationState.NON_Y_AXIS)
@@ -119,9 +123,10 @@ public class GTMachines {
                     .register());
 
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_EXTRACTOR = registerSimpleSteamMachines(
+            REGISTRATE,
             "extractor", GTRecipeTypes.EXTRACTOR_RECIPES);
 
-    public static final Pair<MachineDefinition, MachineDefinition> STEAM_MACERATOR = registerSteamMachines(
+    public static final Pair<MachineDefinition, MachineDefinition> STEAM_MACERATOR = registerSteamMachines(REGISTRATE,
             "steam_macerator", SimpleSteamMachine::new, (pressure, builder) -> builder
                     .rotationState(RotationState.NON_Y_AXIS)
                     .recipeType(GTRecipeTypes.MACERATOR_RECIPES)
@@ -134,16 +139,21 @@ public class GTMachines {
                     .register());
 
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_COMPRESSOR = registerSimpleSteamMachines(
+            REGISTRATE,
             "compressor", GTRecipeTypes.COMPRESSOR_RECIPES);
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_HAMMER = registerSimpleSteamMachines(
+            REGISTRATE,
             "forge_hammer", GTRecipeTypes.FORGE_HAMMER_RECIPES);
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_FURNACE = registerSimpleSteamMachines(
+            REGISTRATE,
             "furnace", GTRecipeTypes.FURNACE_RECIPES);
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_ALLOY_SMELTER = registerSimpleSteamMachines(
+            REGISTRATE,
             "alloy_smelter", GTRecipeTypes.ALLOY_SMELTER_RECIPES);
     public static final Pair<MachineDefinition, MachineDefinition> STEAM_ROCK_CRUSHER = registerSimpleSteamMachines(
+            REGISTRATE,
             "rock_crusher", GTRecipeTypes.ROCK_BREAKER_RECIPES);
-    public static final Pair<MachineDefinition, MachineDefinition> STEAM_MINER = registerSteamMachines(
+    public static final Pair<MachineDefinition, MachineDefinition> STEAM_MINER = registerSteamMachines(REGISTRATE,
             "steam_miner",
             (holder, isHP) -> isHP ? new SteamMinerMachine(holder, true, 240, 6, 0, 32) :
                     new SteamMinerMachine(holder, false, 320, 4, 0, 16),
@@ -168,7 +178,7 @@ public class GTMachines {
     //////////////////////////////////////
     // *** SimpleTieredMachine ***//
     //////////////////////////////////////
-    public static final MachineDefinition[] HULL = GTMachineUtils.registerTieredMachines("machine_hull",
+    public static final MachineDefinition[] HULL = GTMachineUtils.registerTieredMachines(REGISTRATE, "machine_hull",
             HullMachine::new,
             (tier, builder) -> builder
                     .rotationState(RotationState.ALL)
@@ -185,7 +195,7 @@ public class GTMachines {
     public static final MachineDefinition[] ALLOY_SMELTER = new SimpleMachineBuilder(REGISTRATE, "alloy_smelter",
             GTRecipeTypes.ALLOY_SMELTER_RECIPES).register();
 
-    public static final MachineDefinition[] ARC_FURNACE = registerTieredMachines("arc_furnace",
+    public static final MachineDefinition[] ARC_FURNACE = registerTieredMachines(REGISTRATE, "arc_furnace",
             SimpleTieredMachine::new, (tier, builder) -> builder
                     .langValue("%s Arc Furnace %s".formatted(VLVH[tier], VLVT[tier]))
                     .rotationState(RotationState.NON_Y_AXIS)
@@ -296,7 +306,7 @@ public class GTMachines {
             .tankScalingFunction(hvCappedTankSizeFunction)
             .hasPollutionDebuff(true)
             .register();
-    public static final MachineDefinition[] MACERATOR = registerTieredMachines("macerator",
+    public static final MachineDefinition[] MACERATOR = registerTieredMachines(REGISTRATE, "macerator",
             SimpleTieredMachine::new, (tier, builder) -> builder
                     .langValue("%s Macerator %s".formatted(VLVH[tier], VLVT[tier]))
                     .rotationState(RotationState.NON_Y_AXIS)
@@ -319,7 +329,7 @@ public class GTMachines {
             .hasPollutionDebuff(true)
             .register();
 
-    public static final MachineDefinition[] ROCK_CRUSHER = registerTieredMachines("rock_crusher",
+    public static final MachineDefinition[] ROCK_CRUSHER = registerTieredMachines(REGISTRATE, "rock_crusher",
             GTMachineInstanceFactories.ROCK_CRUSHER, (tier, builder) -> builder
                     .langValue("%s Rock Crusher %s".formatted(VLVH[tier], VLVT[tier]))
                     .ui(GTSingleblockMachinePanels.GENERAL_MACHINE)
@@ -332,7 +342,7 @@ public class GTMachines {
                     .tooltips(explosion())
                     .register(),
             ELECTRIC_TIERS);
-    public static final MachineDefinition[] AIR_SCRUBBER = registerTieredMachines("air_scrubber",
+    public static final MachineDefinition[] AIR_SCRUBBER = registerTieredMachines(REGISTRATE, "air_scrubber",
             AirScrubberMachine::new, (tier, builder) -> builder
                     .langValue("%s Air Scrubber %s".formatted(VLVH[tier], VLVT[tier]))
                     .ui(GTSingleblockMachinePanels.GENERAL_MACHINE)
@@ -349,28 +359,30 @@ public class GTMachines {
     //////////////////////////////////////
     // **** Simple Generator ****//
     //////////////////////////////////////
-    public static final MachineDefinition[] COMBUSTION = registerSimpleGenerator("combustion",
+    public static final MachineDefinition[] COMBUSTION = registerSimpleGenerator(REGISTRATE, "combustion",
             GTRecipeTypes.COMBUSTION_GENERATOR_FUELS, genericGeneratorTankSizeFunction, 0.1f, GTValues.LV, GTValues.MV,
             GTValues.HV);
-    public static final MachineDefinition[] STEAM_TURBINE = registerSimpleGenerator("steam_turbine",
+    public static final MachineDefinition[] STEAM_TURBINE = registerSimpleGenerator(REGISTRATE, "steam_turbine",
             GTRecipeTypes.STEAM_TURBINE_FUELS, steamGeneratorTankSizeFunction, 0.0f, GTValues.LV, GTValues.MV,
             GTValues.HV);
-    public static final MachineDefinition[] GAS_TURBINE = registerSimpleGenerator("gas_turbine",
+    public static final MachineDefinition[] GAS_TURBINE = registerSimpleGenerator(REGISTRATE, "gas_turbine",
             GTRecipeTypes.GAS_TURBINE_FUELS, genericGeneratorTankSizeFunction, 0.1f, GTValues.LV, GTValues.MV,
             GTValues.HV);
 
     //////////////////////////////////////
     // ******** Electric ********//
     //////////////////////////////////////
-    public static final MachineDefinition[] TRANSFORMER = registerTransformerMachines("", 1);
-    public static final MachineDefinition[] HI_AMP_TRANSFORMER_2A = registerTransformerMachines("Hi-Amp (2x)", 2);
-    public static final MachineDefinition[] HI_AMP_TRANSFORMER_4A = registerTransformerMachines("Hi-Amp (4x)", 4);
-    public static final MachineDefinition[] POWER_TRANSFORMER = registerTransformerMachines("Power", 16);
+    public static final MachineDefinition[] TRANSFORMER = registerTransformerMachines(REGISTRATE, "", 1);
+    public static final MachineDefinition[] HI_AMP_TRANSFORMER_2A = registerTransformerMachines(REGISTRATE,
+            "Hi-Amp (2x)", 2);
+    public static final MachineDefinition[] HI_AMP_TRANSFORMER_4A = registerTransformerMachines(REGISTRATE,
+            "Hi-Amp (4x)", 4);
+    public static final MachineDefinition[] POWER_TRANSFORMER = registerTransformerMachines(REGISTRATE, "Power", 16);
 
-    public static final MachineDefinition[] ENERGY_CONVERTER_1A = registerConverter(1);
-    public static final MachineDefinition[] ENERGY_CONVERTER_4A = registerConverter(4);
-    public static final MachineDefinition[] ENERGY_CONVERTER_8A = registerConverter(8);
-    public static final MachineDefinition[] ENERGY_CONVERTER_16A = registerConverter(16);
+    public static final MachineDefinition[] ENERGY_CONVERTER_1A = registerConverter(REGISTRATE, 1);
+    public static final MachineDefinition[] ENERGY_CONVERTER_4A = registerConverter(REGISTRATE, 4);
+    public static final MachineDefinition[] ENERGY_CONVERTER_8A = registerConverter(REGISTRATE, 8);
+    public static final MachineDefinition[] ENERGY_CONVERTER_16A = registerConverter(REGISTRATE, 16);
 
     public static final MachineDefinition LONG_DIST_ITEM_ENDPOINT = REGISTRATE
             .machine("long_distance_item_pipeline_endpoint", LDItemEndpointMachine::new)
@@ -406,15 +418,15 @@ public class GTMachines {
             })
             .register();
 
-    public static final MachineDefinition[] BATTERY_BUFFER_4 = registerBatteryBuffer(4);
+    public static final MachineDefinition[] BATTERY_BUFFER_4 = registerBatteryBuffer(REGISTRATE, 4);
 
-    public static final MachineDefinition[] BATTERY_BUFFER_8 = registerBatteryBuffer(8);
+    public static final MachineDefinition[] BATTERY_BUFFER_8 = registerBatteryBuffer(REGISTRATE, 8);
 
-    public static final MachineDefinition[] BATTERY_BUFFER_16 = registerBatteryBuffer(16);
+    public static final MachineDefinition[] BATTERY_BUFFER_16 = registerBatteryBuffer(REGISTRATE, 16);
 
-    public static final MachineDefinition[] CHARGER_4 = registerCharger(4);
+    public static final MachineDefinition[] CHARGER_4 = registerCharger(REGISTRATE, 4);
 
-    public static final MachineDefinition[] PUMP = registerTieredMachines("pump", PumpMachine::new,
+    public static final MachineDefinition[] PUMP = registerTieredMachines(REGISTRATE, "pump", PumpMachine::new,
             (tier, builder) -> builder
                     .rotationState(RotationState.ALL)
                     .tieredHullModel(GTCEu.id("block/machine/template/pump_machine"))
@@ -433,7 +445,7 @@ public class GTMachines {
                     .register(),
             LV, MV, HV, EV);
 
-    public static final MachineDefinition[] FISHER = registerTieredMachines("fisher", FisherMachine::new,
+    public static final MachineDefinition[] FISHER = registerTieredMachines(REGISTRATE, "fisher", FisherMachine::new,
             (tier, builder) -> builder
                     .rotationState(RotationState.ALL)
                     // .editableUI(FisherMachine.EDITABLE_UI_CREATOR.apply(GTCEu.id("fisher"), (tier + 1) * (tier + 1)))
@@ -451,7 +463,7 @@ public class GTMachines {
                     .register(),
             LV, MV, HV, EV, IV, LuV);
 
-    public static final MachineDefinition[] BLOCK_BREAKER = registerTieredMachines("block_breaker",
+    public static final MachineDefinition[] BLOCK_BREAKER = registerTieredMachines(REGISTRATE, "block_breaker",
             BlockBreakerMachine::new,
             (tier, builder) -> builder
                     .rotationState(RotationState.NON_Y_AXIS)
@@ -468,7 +480,7 @@ public class GTMachines {
                     .register(),
             LV, MV, HV, EV);
 
-    public static final MachineDefinition[] MINER = registerTieredMachines("miner",
+    public static final MachineDefinition[] MINER = registerTieredMachines(REGISTRATE, "miner",
             (holder, tier) -> new MinerMachine(holder, tier, ConfigHolder.INSTANCE.machines.minerSpeed / (tier * 2),
                     tier * 8, tier),
             (tier, builder) -> builder
@@ -496,7 +508,7 @@ public class GTMachines {
                     .register(),
             LV, MV, HV);
 
-    public static final MachineDefinition[] WORLD_ACCELERATOR = registerTieredMachines("world_accelerator",
+    public static final MachineDefinition[] WORLD_ACCELERATOR = registerTieredMachines(REGISTRATE, "world_accelerator",
             WorldAcceleratorMachine::new,
             (tier, builder) -> builder
                     .rotationState(RotationState.NONE)
@@ -525,7 +537,7 @@ public class GTMachines {
                     .register(),
             LV, MV, HV, EV, IV, LuV, ZPM, UV);
 
-    public static final MachineDefinition[] ITEM_COLLECTOR = registerTieredMachines("item_collector",
+    public static final MachineDefinition[] ITEM_COLLECTOR = registerTieredMachines(REGISTRATE, "item_collector",
             ItemCollectorMachine::new,
             (tier, builder) -> builder
                     .rotationState(RotationState.NONE)
@@ -550,7 +562,7 @@ public class GTMachines {
     // ********* Storage *********//
     //////////////////////////////////////
 
-    public static final MachineDefinition[] BUFFER = registerTieredMachines("buffer",
+    public static final MachineDefinition[] BUFFER = registerTieredMachines(REGISTRATE, "buffer",
             BufferMachine::new,
             (tier, builder) -> builder
                     .langValue("%s Buffer %s".formatted(VLVH[tier], VLVT[tier]))
@@ -629,43 +641,51 @@ public class GTMachines {
             .hasBER(true)
             .register();
 
-    public static final MachineDefinition[] SUPER_CHEST = registerQuantumChests("super_chest", LOW_TIERS);
-    public static final MachineDefinition[] QUANTUM_CHEST = registerQuantumChests("quantum_chest", HIGH_TIERS);
+    public static final MachineDefinition[] SUPER_CHEST = registerQuantumChests(REGISTRATE, "super_chest", LOW_TIERS);
+    public static final MachineDefinition[] QUANTUM_CHEST = registerQuantumChests(REGISTRATE, "quantum_chest",
+            HIGH_TIERS);
 
-    public static final MachineDefinition[] SUPER_TANK = registerQuantumTanks("super_tank", LOW_TIERS);
-    public static final MachineDefinition[] QUANTUM_TANK = registerQuantumTanks("quantum_tank", HIGH_TIERS);
+    public static final MachineDefinition[] SUPER_TANK = registerQuantumTanks(REGISTRATE, "super_tank", LOW_TIERS);
+    public static final MachineDefinition[] QUANTUM_TANK = registerQuantumTanks(REGISTRATE, "quantum_tank", HIGH_TIERS);
 
-    public static MachineDefinition WOODEN_CRATE = registerCrate(GTMaterials.Wood, 27, 9, "Wooden Crate");
-    public static MachineDefinition BRONZE_CRATE = registerCrate(GTMaterials.Bronze, 54, 9, "Bronze Crate");
-    public static MachineDefinition STEEL_CRATE = registerCrate(GTMaterials.Steel, 72, 9, "Steel Crate");
-    public static MachineDefinition ALUMINIUM_CRATE = registerCrate(GTMaterials.Aluminium, 90, 10, "Aluminium Crate");
-    public static MachineDefinition STAINLESS_STEEL_CRATE = registerCrate(GTMaterials.StainlessSteel, 108, 12,
+    public static MachineDefinition WOODEN_CRATE = registerCrate(REGISTRATE, GTMaterials.Wood, 27, 9, "Wooden Crate");
+    public static MachineDefinition BRONZE_CRATE = registerCrate(REGISTRATE, GTMaterials.Bronze, 54, 9, "Bronze Crate");
+    public static MachineDefinition STEEL_CRATE = registerCrate(REGISTRATE, GTMaterials.Steel, 72, 9, "Steel Crate");
+    public static MachineDefinition ALUMINIUM_CRATE = registerCrate(REGISTRATE, GTMaterials.Aluminium, 90, 10,
+            "Aluminium Crate");
+    public static MachineDefinition STAINLESS_STEEL_CRATE = registerCrate(REGISTRATE, GTMaterials.StainlessSteel, 108,
+            12,
             "Stainless Steel Crate");
-    public static MachineDefinition TITANIUM_CRATE = registerCrate(GTMaterials.Titanium, 126, 14, "Titanium Crate");
-    public static MachineDefinition TUNGSTENSTEEL_CRATE = registerCrate(GTMaterials.TungstenSteel, 144, 16,
+    public static MachineDefinition TITANIUM_CRATE = registerCrate(REGISTRATE, GTMaterials.Titanium, 126, 14,
+            "Titanium Crate");
+    public static MachineDefinition TUNGSTENSTEEL_CRATE = registerCrate(REGISTRATE, GTMaterials.TungstenSteel, 144, 16,
             "Tungstensteel Crate");
 
-    public static MachineDefinition WOODEN_DRUM = registerDrum(GTMaterials.Wood, (16 * FluidType.BUCKET_VOLUME),
+    public static MachineDefinition WOODEN_DRUM = registerDrum(REGISTRATE, GTMaterials.Wood,
+            (16 * FluidType.BUCKET_VOLUME),
             "Wooden Barrel");
-    public static MachineDefinition BRONZE_DRUM = registerDrum(GTMaterials.Bronze, (32 * FluidType.BUCKET_VOLUME),
+    public static MachineDefinition BRONZE_DRUM = registerDrum(REGISTRATE, GTMaterials.Bronze,
+            (32 * FluidType.BUCKET_VOLUME),
             "Bronze Drum");
-    public static MachineDefinition STEEL_DRUM = registerDrum(GTMaterials.Steel, (64 * FluidType.BUCKET_VOLUME),
+    public static MachineDefinition STEEL_DRUM = registerDrum(REGISTRATE, GTMaterials.Steel,
+            (64 * FluidType.BUCKET_VOLUME),
             "Steel Drum");
-    public static MachineDefinition ALUMINIUM_DRUM = registerDrum(GTMaterials.Aluminium,
+    public static MachineDefinition ALUMINIUM_DRUM = registerDrum(REGISTRATE, GTMaterials.Aluminium,
             (128 * FluidType.BUCKET_VOLUME), "Aluminium Drum");
-    public static MachineDefinition STAINLESS_STEEL_DRUM = registerDrum(GTMaterials.StainlessSteel,
+    public static MachineDefinition STAINLESS_STEEL_DRUM = registerDrum(REGISTRATE, GTMaterials.StainlessSteel,
             (256 * FluidType.BUCKET_VOLUME), "Stainless Steel Drum");
-    public static MachineDefinition GOLD_DRUM = registerDrum(GTMaterials.Gold, (32 * FluidType.BUCKET_VOLUME),
+    public static MachineDefinition GOLD_DRUM = registerDrum(REGISTRATE, GTMaterials.Gold,
+            (32 * FluidType.BUCKET_VOLUME),
             "Gold Drum");
-    public static MachineDefinition TITANIUM_DRUM = registerDrum(GTMaterials.Titanium,
+    public static MachineDefinition TITANIUM_DRUM = registerDrum(REGISTRATE, GTMaterials.Titanium,
             (512 * FluidType.BUCKET_VOLUME), "Titanium Drum");
-    public static MachineDefinition TUNGSTENSTEEL_DRUM = registerDrum(GTMaterials.TungstenSteel,
+    public static MachineDefinition TUNGSTENSTEEL_DRUM = registerDrum(REGISTRATE, GTMaterials.TungstenSteel,
             (1024 * FluidType.BUCKET_VOLUME), "Tungstensteel Drum");
 
     //////////////////////////////////////
     // ********** Part **********//
     //////////////////////////////////////
-    public static final MachineDefinition[] ITEM_IMPORT_BUS = registerTieredMachines("input_bus",
+    public static final MachineDefinition[] ITEM_IMPORT_BUS = registerTieredMachines(REGISTRATE, "input_bus",
             (holder, tier) -> new ItemBusPartMachine(holder, tier, IN),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " Input Bus")
@@ -680,7 +700,7 @@ public class GTMachines {
                     .register(),
             ALL_TIERS);
 
-    public static final MachineDefinition[] ITEM_EXPORT_BUS = registerTieredMachines("output_bus",
+    public static final MachineDefinition[] ITEM_EXPORT_BUS = registerTieredMachines(REGISTRATE, "output_bus",
             (holder, tier) -> new ItemBusPartMachine(holder, tier, OUT),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " Output Bus")
@@ -695,43 +715,44 @@ public class GTMachines {
                     .register(),
             ALL_TIERS);
 
-    public final static MachineDefinition[] FLUID_IMPORT_HATCH = registerFluidHatches(
+    public final static MachineDefinition[] FLUID_IMPORT_HATCH = registerFluidHatches(REGISTRATE,
             "input_hatch", "Input Hatch", "fluid_hatch.import",
             IN, FluidHatchPartMachine.INITIAL_TANK_CAPACITY_1X, 1,
             ALL_TIERS, PartAbility.IMPORT_FLUIDS,
             PartAbility.IMPORT_FLUIDS_1X);
 
-    public final static MachineDefinition[] FLUID_IMPORT_HATCH_4X = registerFluidHatches(
+    public final static MachineDefinition[] FLUID_IMPORT_HATCH_4X = registerFluidHatches(REGISTRATE,
             "input_hatch_4x", "Quadruple Input Hatch", "fluid_hatch.import",
             IN, FluidHatchPartMachine.INITIAL_TANK_CAPACITY_4X, 4,
             MULTI_HATCH_TIERS, PartAbility.IMPORT_FLUIDS,
             PartAbility.IMPORT_FLUIDS_4X);
 
-    public final static MachineDefinition[] FLUID_IMPORT_HATCH_9X = registerFluidHatches(
+    public final static MachineDefinition[] FLUID_IMPORT_HATCH_9X = registerFluidHatches(REGISTRATE,
             "input_hatch_9x", "Nonuple Input Hatch", "fluid_hatch.import",
             IN, FluidHatchPartMachine.INITIAL_TANK_CAPACITY_9X, 9,
             MULTI_HATCH_TIERS, PartAbility.IMPORT_FLUIDS,
             PartAbility.IMPORT_FLUIDS_9X);
 
-    public final static MachineDefinition[] FLUID_EXPORT_HATCH = registerFluidHatches(
+    public final static MachineDefinition[] FLUID_EXPORT_HATCH = registerFluidHatches(REGISTRATE,
             "output_hatch", "Output Hatch", "fluid_hatch.export",
             OUT, FluidHatchPartMachine.INITIAL_TANK_CAPACITY_1X, 1,
             ALL_TIERS, PartAbility.EXPORT_FLUIDS,
             PartAbility.EXPORT_FLUIDS_1X);
 
-    public final static MachineDefinition[] FLUID_EXPORT_HATCH_4X = registerFluidHatches(
+    public final static MachineDefinition[] FLUID_EXPORT_HATCH_4X = registerFluidHatches(REGISTRATE,
             "output_hatch_4x", "Quadruple Output Hatch", "fluid_hatch.export",
             OUT, FluidHatchPartMachine.INITIAL_TANK_CAPACITY_4X, 4,
             MULTI_HATCH_TIERS, PartAbility.EXPORT_FLUIDS,
             PartAbility.EXPORT_FLUIDS_4X);
 
-    public final static MachineDefinition[] FLUID_EXPORT_HATCH_9X = registerFluidHatches(
+    public final static MachineDefinition[] FLUID_EXPORT_HATCH_9X = registerFluidHatches(REGISTRATE,
             "output_hatch_9x", "Nonuple Output Hatch", "fluid_hatch.export",
             OUT, FluidHatchPartMachine.INITIAL_TANK_CAPACITY_9X, 9,
             MULTI_HATCH_TIERS, PartAbility.EXPORT_FLUIDS,
             PartAbility.EXPORT_FLUIDS_9X);
 
-    public static final MachineDefinition[] ENERGY_INPUT_HATCH = registerTieredMachines("energy_input_hatch",
+    public static final MachineDefinition[] ENERGY_INPUT_HATCH = registerTieredMachines(REGISTRATE,
+            "energy_input_hatch",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, IN, 2),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " Energy Hatch")
@@ -749,7 +770,8 @@ public class GTMachines {
                     .register(),
             ALL_TIERS);
 
-    public static final MachineDefinition[] ENERGY_OUTPUT_HATCH = registerTieredMachines("energy_output_hatch",
+    public static final MachineDefinition[] ENERGY_OUTPUT_HATCH = registerTieredMachines(REGISTRATE,
+            "energy_output_hatch",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, OUT, 2),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " Dynamo Hatch")
@@ -767,7 +789,8 @@ public class GTMachines {
                     .register(),
             ALL_TIERS);
 
-    public static final MachineDefinition[] ENERGY_INPUT_HATCH_4A = registerTieredMachines("energy_input_hatch_4a",
+    public static final MachineDefinition[] ENERGY_INPUT_HATCH_4A = registerTieredMachines(REGISTRATE,
+            "energy_input_hatch_4a",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, IN, 4),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " 4A Energy Hatch")
@@ -785,7 +808,8 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(EV, GTCEuAPI.isHighTier() ? MAX : UHV));
 
-    public static final MachineDefinition[] ENERGY_OUTPUT_HATCH_4A = registerTieredMachines("energy_output_hatch_4a",
+    public static final MachineDefinition[] ENERGY_OUTPUT_HATCH_4A = registerTieredMachines(REGISTRATE,
+            "energy_output_hatch_4a",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, OUT, 4),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " 4A Dynamo Hatch")
@@ -803,7 +827,8 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(EV, GTCEuAPI.isHighTier() ? MAX : UHV));
 
-    public static final MachineDefinition[] ENERGY_INPUT_HATCH_16A = registerTieredMachines("energy_input_hatch_16a",
+    public static final MachineDefinition[] ENERGY_INPUT_HATCH_16A = registerTieredMachines(REGISTRATE,
+            "energy_input_hatch_16a",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, IN, 16),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " 16A Energy Hatch")
@@ -821,7 +846,8 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(EV, GTCEuAPI.isHighTier() ? MAX : UHV));
 
-    public static final MachineDefinition[] ENERGY_OUTPUT_HATCH_16A = registerTieredMachines("energy_output_hatch_16a",
+    public static final MachineDefinition[] ENERGY_OUTPUT_HATCH_16A = registerTieredMachines(REGISTRATE,
+            "energy_output_hatch_16a",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, OUT, 16),
             (tier, builder) -> builder
                     .langValue(VNF[tier] + " 16A Dynamo Hatch")
@@ -839,7 +865,7 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(EV, GTCEuAPI.isHighTier() ? MAX : UHV));
 
-    public static final MachineDefinition[] SUBSTATION_ENERGY_INPUT_HATCH = registerTieredMachines(
+    public static final MachineDefinition[] SUBSTATION_ENERGY_INPUT_HATCH = registerTieredMachines(REGISTRATE,
             "substation_input_hatch_64a",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, IN, 64),
             (tier, builder) -> builder
@@ -858,7 +884,7 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(EV, GTCEuAPI.isHighTier() ? MAX : UHV));
 
-    public static final MachineDefinition[] SUBSTATION_ENERGY_OUTPUT_HATCH = registerTieredMachines(
+    public static final MachineDefinition[] SUBSTATION_ENERGY_OUTPUT_HATCH = registerTieredMachines(REGISTRATE,
             "substation_output_hatch_64a",
             (holder, tier) -> new EnergyHatchPartMachine(holder, tier, OUT, 64),
             (tier, builder) -> builder
@@ -877,7 +903,7 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(EV, GTCEuAPI.isHighTier() ? MAX : UHV));
 
-    public static final MachineDefinition[] MUFFLER_HATCH = registerTieredMachines("muffler_hatch",
+    public static final MachineDefinition[] MUFFLER_HATCH = registerTieredMachines(REGISTRATE, "muffler_hatch",
             MufflerPartMachine::new,
             (tier, builder) -> builder
                     .langValue("Muffler Hatch " + VNF[tier])
@@ -1011,7 +1037,8 @@ public class GTMachines {
             .tier(HV)
             .register();
 
-    public static final MachineDefinition[] ITEM_PASSTHROUGH_HATCH = registerTieredMachines("item_passthrough_hatch",
+    public static final MachineDefinition[] ITEM_PASSTHROUGH_HATCH = registerTieredMachines(REGISTRATE,
+            "item_passthrough_hatch",
             (holder, tier) -> new ItemBusPartMachine(holder, tier, IO.BOTH),
             (tier, builder) -> builder
                     .langValue("%s Item Passthrough Hatch".formatted(VNF[tier]))
@@ -1026,7 +1053,8 @@ public class GTMachines {
                     .register(),
             ELECTRIC_TIERS);
 
-    public static final MachineDefinition[] FLUID_PASSTHROUGH_HATCH = registerTieredMachines("fluid_passthrough_hatch",
+    public static final MachineDefinition[] FLUID_PASSTHROUGH_HATCH = registerTieredMachines(REGISTRATE,
+            "fluid_passthrough_hatch",
             (holder, tier) -> new FluidHatchPartMachine(holder, tier, IO.BOTH,
                     FluidHatchPartMachine.INITIAL_TANK_CAPACITY_1X, 1),
             (tier, builder) -> builder
@@ -1056,7 +1084,7 @@ public class GTMachines {
             .overlayTieredHullModel("reservoir_hatch")
             .register();
 
-    public static final MachineDefinition[] DUAL_IMPORT_HATCH = registerTieredMachines(
+    public static final MachineDefinition[] DUAL_IMPORT_HATCH = registerTieredMachines(REGISTRATE,
             "dual_input_hatch",
             (holder, tier) -> new DualHatchPartMachine(holder, tier, IN),
             (tier, builder) -> builder
@@ -1079,7 +1107,7 @@ public class GTMachines {
                     .register(),
             DUAL_HATCH_TIERS);
 
-    public static final MachineDefinition[] DUAL_EXPORT_HATCH = registerTieredMachines(
+    public static final MachineDefinition[] DUAL_EXPORT_HATCH = registerTieredMachines(REGISTRATE,
             "dual_output_hatch",
             (holder, tier) -> new DualHatchPartMachine(holder, tier, OUT),
             (tier, builder) -> builder
@@ -1102,7 +1130,7 @@ public class GTMachines {
                     .register(),
             DUAL_HATCH_TIERS);
 
-    public static final MachineDefinition[] DIODE = registerTieredMachines("diode",
+    public static final MachineDefinition[] DIODE = registerTieredMachines(REGISTRATE, "diode",
             DiodePartMachine::new,
             (tier, builder) -> builder
                     .langValue("%s Diode".formatted(VNF[tier]))
@@ -1121,7 +1149,7 @@ public class GTMachines {
                     .register(),
             ELECTRIC_TIERS);
 
-    public static final MachineDefinition[] ROTOR_HOLDER = registerTieredMachines("rotor_holder",
+    public static final MachineDefinition[] ROTOR_HOLDER = registerTieredMachines(REGISTRATE, "rotor_holder",
             RotorHolderPartMachine::new,
             (tier, builder) -> builder
                     .langValue("%s Rotor Holder".formatted(VNF[tier]))
@@ -1137,17 +1165,17 @@ public class GTMachines {
                     .register(),
             GTValues.tiersBetween(HV, GTCEuAPI.isHighTier() ? OpV : UV));
 
-    public static final MachineDefinition[] LASER_INPUT_HATCH_256 = registerLaserHatch(IN, 256,
+    public static final MachineDefinition[] LASER_INPUT_HATCH_256 = registerLaserHatch(REGISTRATE, IN, 256,
             PartAbility.INPUT_LASER);
-    public static final MachineDefinition[] LASER_OUTPUT_HATCH_256 = registerLaserHatch(OUT, 256,
+    public static final MachineDefinition[] LASER_OUTPUT_HATCH_256 = registerLaserHatch(REGISTRATE, OUT, 256,
             PartAbility.OUTPUT_LASER);
-    public static final MachineDefinition[] LASER_INPUT_HATCH_1024 = registerLaserHatch(IN, 1024,
+    public static final MachineDefinition[] LASER_INPUT_HATCH_1024 = registerLaserHatch(REGISTRATE, IN, 1024,
             PartAbility.INPUT_LASER);
-    public static final MachineDefinition[] LASER_OUTPUT_HATCH_1024 = registerLaserHatch(OUT, 1024,
+    public static final MachineDefinition[] LASER_OUTPUT_HATCH_1024 = registerLaserHatch(REGISTRATE, OUT, 1024,
             PartAbility.OUTPUT_LASER);
-    public static final MachineDefinition[] LASER_INPUT_HATCH_4096 = registerLaserHatch(IN, 4096,
+    public static final MachineDefinition[] LASER_INPUT_HATCH_4096 = registerLaserHatch(REGISTRATE, IN, 4096,
             PartAbility.INPUT_LASER);
-    public static final MachineDefinition[] LASER_OUTPUT_HATCH_4096 = registerLaserHatch(OUT, 4096,
+    public static final MachineDefinition[] LASER_OUTPUT_HATCH_4096 = registerLaserHatch(REGISTRATE, OUT, 4096,
             PartAbility.OUTPUT_LASER);
     public static final MachineDefinition MONITOR = REGISTRATE.machine("monitor", MonitorPartMachine::new)
             .rotationState(RotationState.ALL)

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCYMMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GCYMMachines.java
@@ -49,7 +49,7 @@ public class GCYMMachines {
 
     public static void init() {}
 
-    public static final MachineDefinition[] PARALLEL_HATCH = registerTieredMachines("parallel_hatch",
+    public static final MachineDefinition[] PARALLEL_HATCH = registerTieredMachines(REGISTRATE, "parallel_hatch",
             ParallelHatchPartMachine::new,
             (tier, builder) -> builder
                     .langValue(switch (tier) {

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMachineUtils.java
@@ -92,7 +92,6 @@ import static com.gregtechceu.gtceu.common.data.GTRecipeTypes.*;
 import static com.gregtechceu.gtceu.common.data.models.GTMachineModels.*;
 import static com.gregtechceu.gtceu.common.machine.electric.BatteryBufferMachine.AMPS_PER_BATTERY_NORMAL;
 import static com.gregtechceu.gtceu.common.machine.storage.QuantumTankMachine.TANK_CAPACITY;
-import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
 import static com.gregtechceu.gtceu.utils.FormattingUtil.*;
 
 public class GTMachineUtils {
@@ -130,20 +129,6 @@ public class GTMachineUtils {
      * @deprecated Use {@link SimpleMachineBuilder}
      */
     @Deprecated(since = "8.0.0")
-    public static MachineDefinition[] registerSimpleMachines(String name, GTRecipeType recipeType,
-                                                             Int2IntFunction tankScalingFunction,
-                                                             boolean hasPollutionDebuff, PanelFactory panelFactory) {
-        return new SimpleMachineBuilder(REGISTRATE, name, recipeType)
-                .tankScalingFunction(tankScalingFunction)
-                .hasPollutionDebuff(hasPollutionDebuff)
-                .panelFactory(panelFactory)
-                .register();
-    }
-
-    /**
-     * @deprecated Use {@link SimpleMachineBuilder}
-     */
-    @Deprecated(since = "8.0.0")
     public static MachineDefinition[] registerSimpleMachines(GTRegistrate registrate, String name,
                                                              GTRecipeType recipeType,
                                                              Int2IntFunction tankScalingFunction,
@@ -159,19 +144,6 @@ public class GTMachineUtils {
      * @deprecated Use {@link SimpleMachineBuilder}
      */
     @Deprecated(since = "8.0.0")
-    public static MachineDefinition[] registerSimpleMachines(String name, GTRecipeType recipeType,
-                                                             Int2IntFunction tankScalingFunction,
-                                                             PanelFactory panelFactory) {
-        return new SimpleMachineBuilder(REGISTRATE, name, recipeType)
-                .panelFactory(panelFactory)
-                .tankScalingFunction(tankScalingFunction)
-                .register();
-    }
-
-    /**
-     * @deprecated Use {@link SimpleMachineBuilder}
-     */
-    @Deprecated(since = "8.0.0")
     public static MachineDefinition[] registerSimpleMachines(GTRegistrate registrate, String name,
                                                              GTRecipeType recipeType,
                                                              Int2IntFunction tankScalingFunction,
@@ -179,17 +151,6 @@ public class GTMachineUtils {
         return new SimpleMachineBuilder(registrate, name, recipeType)
                 .panelFactory(panelFactory)
                 .tankScalingFunction(tankScalingFunction)
-                .register();
-    }
-
-    /**
-     * @deprecated Use {@link SimpleMachineBuilder}
-     */
-    @Deprecated(since = "8.0.0")
-    public static MachineDefinition[] registerSimpleMachines(String name, GTRecipeType recipeType,
-                                                             PanelFactory panelFactory) {
-        return new SimpleMachineBuilder(REGISTRATE, name, recipeType)
-                .panelFactory(panelFactory)
                 .register();
     }
 
@@ -219,13 +180,6 @@ public class GTMachineUtils {
                 .register();
     }
 
-    public static <MACHINE extends MetaMachine> MachineDefinition[] registerTieredMachines(String name,
-                                                                                           MachineInstanceFactory.Tiered<MACHINE> factory,
-                                                                                           BiFunction<Integer, MachineBuilder<MachineDefinition, MACHINE, ?>, MachineDefinition> builder,
-                                                                                           int... tiers) {
-        return registerTieredMachines(REGISTRATE, name, factory, builder, tiers);
-    }
-
     public static <MACHINE extends MetaMachine> MachineDefinition[] registerTieredMachines(GTRegistrate registrate,
                                                                                            String name,
                                                                                            MachineInstanceFactory.Tiered<MACHINE> factory,
@@ -243,13 +197,6 @@ public class GTMachineUtils {
     }
 
     public static <
-            MACHINE extends MetaMachine> Pair<MachineDefinition, MachineDefinition> registerSteamMachines(String name,
-                                                                                                          MachineInstanceFactory.Steam<MACHINE> factory,
-                                                                                                          BiFunction<Boolean, MachineBuilder<MachineDefinition, MACHINE, ?>, MachineDefinition> builder) {
-        return registerSteamMachines(REGISTRATE, name, factory, builder);
-    }
-
-    public static <
             MACHINE extends MetaMachine> Pair<MachineDefinition, MachineDefinition> registerSteamMachines(GTRegistrate registrate,
                                                                                                           String name,
                                                                                                           MachineInstanceFactory.Steam<MACHINE> factory,
@@ -263,13 +210,6 @@ public class GTMachineUtils {
                         .langValue("High Pressure " + FormattingUtil.toEnglishName(name))
                         .tier(1));
         return Pair.of(lowTier, highTier);
-    }
-
-    public static MachineDefinition[] registerFluidHatches(String name, String displayName, String tooltip,
-                                                           IO io, int initialCapacity, int slots,
-                                                           int[] tiers, PartAbility... abilities) {
-        return registerFluidHatches(REGISTRATE, name, displayName, tooltip, io, initialCapacity, slots, tiers,
-                abilities);
     }
 
     public static MachineDefinition[] registerFluidHatches(GTRegistrate registrate, String name, String displayName,
@@ -311,10 +251,6 @@ public class GTMachineUtils {
                 tiers);
     }
 
-    public static MachineDefinition[] registerTransformerMachines(String langName, int baseAmp) {
-        return registerTransformerMachines(REGISTRATE, langName, baseAmp);
-    }
-
     public static MachineDefinition[] registerTransformerMachines(GTRegistrate registrate, String langName,
                                                                   int baseAmp) {
         return registerTieredMachines(registrate, "transformer_%da".formatted(baseAmp),
@@ -347,15 +283,6 @@ public class GTMachineUtils {
         // UHV not needed, as a UV transformer transforms up to UHV
     }
 
-    public static MachineDefinition[] registerSimpleGenerator(String name,
-                                                              GTRecipeType recipeType,
-                                                              Int2IntFunction tankScalingFunction,
-                                                              float hazardStrengthPerOperation,
-                                                              int... tiers) {
-        return registerSimpleGenerator(REGISTRATE, name, recipeType, tankScalingFunction, hazardStrengthPerOperation,
-                tiers);
-    }
-
     public static MachineDefinition[] registerSimpleGenerator(GTRegistrate registrate, String name,
                                                               GTRecipeType recipeType,
                                                               Int2IntFunction tankScalingFunction,
@@ -379,11 +306,6 @@ public class GTMachineUtils {
                 tiers);
     }
 
-    public static Pair<MachineDefinition, MachineDefinition> registerSimpleSteamMachines(String name,
-                                                                                         GTRecipeType recipeType) {
-        return registerSimpleSteamMachines(REGISTRATE, name, recipeType);
-    }
-
     public static Pair<MachineDefinition, MachineDefinition> registerSimpleSteamMachines(GTRegistrate registrate,
                                                                                          String name,
                                                                                          GTRecipeType recipeType) {
@@ -397,10 +319,6 @@ public class GTMachineUtils {
                         .modelProperty(GTMachineModelProperties.VENT_DIRECTION, RelativeDirection.BACK)
                         .workableSteamHullModel(pressure, GTCEu.id("block/machines/" + name))
                         .register());
-    }
-
-    public static MachineDefinition[] registerBatteryBuffer(int batterySlotSize) {
-        return registerBatteryBuffer(REGISTRATE, batterySlotSize);
     }
 
     public static MachineDefinition[] registerBatteryBuffer(GTRegistrate registrate, int batterySlotSize) {
@@ -426,10 +344,6 @@ public class GTMachineUtils {
                 ALL_TIERS);
     }
 
-    public static MachineDefinition[] registerCharger(int itemSlotSize) {
-        return registerCharger(REGISTRATE, itemSlotSize);
-    }
-
     public static MachineDefinition[] registerCharger(GTRegistrate registrate, int itemSlotSize) {
         return registerTieredMachines(registrate, "charger_" + itemSlotSize + "x",
                 (holder, tier) -> new BatteryBufferMachine(holder, tier, itemSlotSize,
@@ -449,10 +363,6 @@ public class GTMachineUtils {
                                         itemSlotSize * BatteryBufferMachine.AMPS_PER_BATTERY_CHARGER))
                         .register(),
                 ALL_TIERS);
-    }
-
-    public static MachineDefinition[] registerConverter(int amperage) {
-        return registerConverter(REGISTRATE, amperage);
     }
 
     public static MachineDefinition[] registerConverter(GTRegistrate registrate, int amperage) {
@@ -489,10 +399,6 @@ public class GTMachineUtils {
         return converters;
     }
 
-    public static MachineDefinition[] registerLaserHatch(IO io, int amperage, PartAbility ability) {
-        return registerLaserHatch(REGISTRATE, io, amperage, ability);
-    }
-
     public static MachineDefinition[] registerLaserHatch(GTRegistrate registrate, IO io, int amperage,
                                                          PartAbility ability) {
         String name = io == IN ? "target" : "source";
@@ -518,10 +424,6 @@ public class GTMachineUtils {
                 HIGH_TIERS);
     }
 
-    public static MachineDefinition registerCrate(Material material, int capacity, int rowLength, String lang) {
-        return registerCrate(REGISTRATE, material, capacity, rowLength, lang);
-    }
-
     public static MachineDefinition registerCrate(GTRegistrate registrate, Material material, int capacity,
                                                   int rowLength, String lang) {
         final boolean wooden = material.hasProperty(PropertyKey.WOOD);
@@ -537,10 +439,6 @@ public class GTMachineUtils {
                 .paintingColor(wooden ? 0xFFFFFF : material.getMaterialRGB())
                 .itemColor((s, t) -> wooden ? 0xFFFFFF : material.getMaterialRGB())
                 .register();
-    }
-
-    public static MachineDefinition registerDrum(Material material, int capacity, String lang) {
-        return registerDrum(REGISTRATE, material, capacity, lang);
     }
 
     public static MachineDefinition registerDrum(GTRegistrate registrate, Material material, int capacity,
@@ -571,10 +469,6 @@ public class GTMachineUtils {
         return definition;
     }
 
-    public static MachineDefinition[] registerQuantumTanks(String name, int... tiers) {
-        return registerQuantumTanks(REGISTRATE, name, tiers);
-    }
-
     public static MachineDefinition[] registerQuantumTanks(GTRegistrate registrate, String name, int... tiers) {
         MachineDefinition[] definitions = new MachineDefinition[GTValues.TIER_COUNT];
         for (int tier : tiers) {
@@ -603,10 +497,6 @@ public class GTMachineUtils {
         return definitions;
     }
 
-    public static MachineDefinition[] registerQuantumChests(String name, int... tiers) {
-        return registerQuantumChests(REGISTRATE, name, tiers);
-    }
-
     public static MachineDefinition[] registerQuantumChests(GTRegistrate registrate, String name, int... tiers) {
         return registerTieredMachines(registrate, name,
                 (holder, tier) -> new QuantumChestMachine(holder, tier,
@@ -632,14 +522,6 @@ public class GTMachineUtils {
     // ********** Misc **********//
     //////////////////////////////////////
     // multi register helpers
-
-    public static MultiblockMachineDefinition registerMultiblockTank(String name, String displayName, int capacity,
-                                                                     Supplier<? extends Block> casing,
-                                                                     Supplier<? extends Block> valve,
-                                                                     @Nullable PropertyFluidFilter filter,
-                                                                     BiConsumer<MultiblockMachineBuilder<?, ?, ?>, ResourceLocation> rendererSetup) {
-        return registerMultiblockTank(REGISTRATE, name, displayName, capacity, casing, valve, filter, rendererSetup);
-    }
 
     public static MultiblockMachineDefinition registerMultiblockTank(GTRegistrate registrate, String name,
                                                                      String displayName, int capacity,
@@ -671,11 +553,6 @@ public class GTMachineUtils {
         return builder.register();
     }
 
-    public static MachineDefinition registerTankValve(String name, String displayName, boolean isMetal,
-                                                      BiConsumer<MachineBuilder<?, ?, ?>, ResourceLocation> rendererSetup) {
-        return registerTankValve(REGISTRATE, name, displayName, isMetal, rendererSetup);
-    }
-
     public static MachineDefinition registerTankValve(GTRegistrate registrate, String name, String displayName,
                                                       boolean isMetal,
                                                       BiConsumer<MachineBuilder<?, ?, ?>, ResourceLocation> rendererSetup) {
@@ -687,14 +564,6 @@ public class GTMachineUtils {
                 .rotationState(RotationState.ALL);
         rendererSetup.accept(builder, GTCEu.id("block/multiblock/tank_valve"));
         return builder.register();
-    }
-
-    public static <
-            MACHINE extends MultiblockControllerMachine> MultiblockMachineDefinition[] registerTieredMultis(String name,
-                                                                                                            MachineInstanceFactory.Tiered<MACHINE> factory,
-                                                                                                            BiFunction<Integer, MultiblockMachineBuilder<?, MACHINE, ?>, MultiblockMachineDefinition> builder,
-                                                                                                            int... tiers) {
-        return registerTieredMultis(REGISTRATE, name, factory, builder, tiers);
     }
 
     public static <
@@ -712,15 +581,6 @@ public class GTMachineUtils {
             definitions[tier] = builder.apply(tier, register);
         }
         return definitions;
-    }
-
-    public static MultiblockMachineDefinition registerLargeBoiler(String name, Supplier<? extends Block> casing,
-                                                                  Supplier<? extends Block> pipe,
-                                                                  Supplier<? extends Block> fireBox,
-                                                                  ResourceLocation texture, BoilerFireboxType firebox,
-                                                                  int maxTemperature, int heatSpeed) {
-        return registerLargeBoiler(REGISTRATE, name, casing, pipe, fireBox, texture, firebox, maxTemperature,
-                heatSpeed);
     }
 
     public static MultiblockMachineDefinition registerLargeBoiler(GTRegistrate registrate, String name,
@@ -768,7 +628,7 @@ public class GTMachineUtils {
                 })
                 .recoveryItems(
                         () -> new ItemLike[] {
-                                GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get() })
+                                GTMaterialItems.MATERIAL_ITEMS.get(TagPrefix.dustTiny, GTMaterials.Ash).get()})
                 .modelProperty(GTMachineModelProperties.RECIPE_LOGIC_STATUS, RecipeLogic.Status.IDLE)
                 .model(createWorkableCasingMachineModel(texture,
                         GTCEu.id("block/multiblock/generator/large_%s_boiler".formatted(name)))
@@ -782,15 +642,6 @@ public class GTMachineUtils {
                                 .withStyle(ChatFormatting.DARK_RED))
                 .register();
         // spotless:on
-    }
-
-    public static MultiblockMachineDefinition registerLargeCombustionEngine(String name, int tier,
-                                                                            Supplier<? extends Block> casing,
-                                                                            Supplier<? extends Block> gear,
-                                                                            Supplier<? extends Block> intake,
-                                                                            ResourceLocation casingTexture,
-                                                                            ResourceLocation overlayModel) {
-        return registerLargeCombustionEngine(REGISTRATE, name, tier, casing, gear, intake, casingTexture, overlayModel);
     }
 
     public static MultiblockMachineDefinition registerLargeCombustionEngine(GTRegistrate registrate,
@@ -844,14 +695,6 @@ public class GTMachineUtils {
                 .register();
     }
 
-    public static MultiblockMachineDefinition registerLargeTurbine(String name, int tier, GTRecipeType recipeType,
-                                                                   Supplier<? extends Block> casing,
-                                                                   Supplier<? extends Block> gear,
-                                                                   ResourceLocation casingTexture,
-                                                                   ResourceLocation overlayModel) {
-        return registerLargeTurbine(REGISTRATE, name, tier, recipeType, casing, gear, casingTexture, overlayModel);
-    }
-
     public static MultiblockMachineDefinition registerLargeTurbine(GTRegistrate registrate,
                                                                    String name, int tier, GTRecipeType recipeType,
                                                                    Supplier<? extends Block> casing,
@@ -860,16 +703,6 @@ public class GTMachineUtils {
                                                                    ResourceLocation overlayModel) {
         return registerLargeTurbine(registrate, name, tier, recipeType, casing, gear, casingTexture, overlayModel,
                 true);
-    }
-
-    public static MultiblockMachineDefinition registerLargeTurbine(String name, int tier, GTRecipeType recipeType,
-                                                                   Supplier<? extends Block> casing,
-                                                                   Supplier<? extends Block> gear,
-                                                                   ResourceLocation casingTexture,
-                                                                   ResourceLocation overlayModel,
-                                                                   boolean needsMuffler) {
-        return registerLargeTurbine(REGISTRATE, name, tier, recipeType, casing, gear, casingTexture, overlayModel,
-                needsMuffler);
     }
 
     public static MultiblockMachineDefinition registerLargeTurbine(GTRegistrate registrate,

--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTMultiMachines.java
@@ -60,27 +60,29 @@ import static com.gregtechceu.gtceu.common.data.models.GTMachineModels.*;
 import static com.gregtechceu.gtceu.common.registry.GTRegistration.REGISTRATE;
 import static com.gregtechceu.gtceu.utils.FormattingUtil.toRomanNumeral;
 
+@SuppressWarnings("unused")
 public class GTMultiMachines {
 
     //////////////////////////////////////
     // ******* Multiblock *******//
     //////////////////////////////////////
-    public static final MultiblockMachineDefinition LARGE_BOILER_BRONZE = registerLargeBoiler("bronze",
+    public static final MultiblockMachineDefinition LARGE_BOILER_BRONZE = registerLargeBoiler(REGISTRATE, "bronze",
             CASING_BRONZE_BRICKS, CASING_BRONZE_PIPE, FIREBOX_BRONZE,
             GTCEu.id("block/casings/solid/machine_casing_bronze_plated_bricks"), BoilerFireboxType.BRONZE_FIREBOX,
             ConfigHolder.INSTANCE.machines.largeBoilers.bronzeBoilerMaxTemperature,
             ConfigHolder.INSTANCE.machines.largeBoilers.bronzeBoilerHeatSpeed);
-    public static final MultiblockMachineDefinition LARGE_BOILER_STEEL = registerLargeBoiler("steel",
+    public static final MultiblockMachineDefinition LARGE_BOILER_STEEL = registerLargeBoiler(REGISTRATE, "steel",
             CASING_STEEL_SOLID, CASING_STEEL_PIPE, FIREBOX_STEEL,
             GTCEu.id("block/casings/solid/machine_casing_solid_steel"), BoilerFireboxType.STEEL_FIREBOX,
             ConfigHolder.INSTANCE.machines.largeBoilers.steelBoilerMaxTemperature,
             ConfigHolder.INSTANCE.machines.largeBoilers.steelBoilerHeatSpeed);
-    public static final MultiblockMachineDefinition LARGE_BOILER_TITANIUM = registerLargeBoiler("titanium",
+    public static final MultiblockMachineDefinition LARGE_BOILER_TITANIUM = registerLargeBoiler(REGISTRATE, "titanium",
             CASING_TITANIUM_STABLE, CASING_TITANIUM_PIPE, FIREBOX_TITANIUM,
             GTCEu.id("block/casings/solid/machine_casing_stable_titanium"), BoilerFireboxType.TITANIUM_FIREBOX,
             ConfigHolder.INSTANCE.machines.largeBoilers.titaniumBoilerMaxTemperature,
             ConfigHolder.INSTANCE.machines.largeBoilers.titaniumBoilerHeatSpeed);
-    public static final MultiblockMachineDefinition LARGE_BOILER_TUNGSTENSTEEL = registerLargeBoiler("tungstensteel",
+    public static final MultiblockMachineDefinition LARGE_BOILER_TUNGSTENSTEEL = registerLargeBoiler(REGISTRATE,
+            "tungstensteel",
             CASING_TUNGSTENSTEEL_ROBUST, CASING_TUNGSTENSTEEL_PIPE, FIREBOX_TUNGSTENSTEEL,
             GTCEu.id("block/casings/solid/machine_casing_robust_tungstensteel"),
             BoilerFireboxType.TUNGSTENSTEEL_FIREBOX,
@@ -492,7 +494,8 @@ public class GTMultiMachines {
                                     BoilerFireboxType.BRONZE_FIREBOX, CASING_BRONZE_BRICKS))))
             .register();
 
-    public static final MultiblockMachineDefinition[] FUSION_REACTOR = registerTieredMultis("fusion_reactor",
+    public static final MultiblockMachineDefinition[] FUSION_REACTOR = registerTieredMultis(REGISTRATE,
+            "fusion_reactor",
             FusionReactorMachine::new, (tier, builder) -> builder
                     .rotationState(RotationState.ALL)
                     .langValue("Fusion Reactor Computer MK %s".formatted(toRomanNumeral(tier - 5)))
@@ -545,7 +548,7 @@ public class GTMultiMachines {
                     .register(),
             LuV, ZPM, UV);
 
-    public static final MultiblockMachineDefinition[] FLUID_DRILLING_RIG = registerTieredMultis(
+    public static final MultiblockMachineDefinition[] FLUID_DRILLING_RIG = registerTieredMultis(REGISTRATE,
             "fluid_drilling_rig", FluidDrillMachine::new, (tier, builder) -> builder
                     .rotationState(RotationState.ALL)
                     .langValue("%s Fluid Drilling Rig %s".formatted(VLVH[tier], VLVT[tier]))
@@ -578,7 +581,7 @@ public class GTMultiMachines {
                     .register(),
             MV, HV, EV);
 
-    public static final MultiblockMachineDefinition[] LARGE_MINER = registerTieredMultis("large_miner",
+    public static final MultiblockMachineDefinition[] LARGE_MINER = registerTieredMultis(REGISTRATE, "large_miner",
             (holder, tier) -> new LargeMinerMachine(holder, tier, 64 / tier, 2 * tier - 5, tier, 8 - (tier - 5)),
             (tier, builder) -> builder
                     .rotationState(RotationState.NON_Y_AXIS)
@@ -672,19 +675,21 @@ public class GTMultiMachines {
                     GTCEu.id("block/multiblock/cleanroom"))
             .register();
 
-    public static final MultiblockMachineDefinition LARGE_COMBUSTION_ENGINE = registerLargeCombustionEngine(
+    public static final MultiblockMachineDefinition LARGE_COMBUSTION_ENGINE = registerLargeCombustionEngine(REGISTRATE,
             "large_combustion_engine", EV,
             CASING_TITANIUM_STABLE, CASING_TITANIUM_GEARBOX, CASING_ENGINE_INTAKE,
             GTCEu.id("block/casings/solid/machine_casing_stable_titanium"),
             GTCEu.id("block/multiblock/generator/large_combustion_engine"));
 
     public static final MultiblockMachineDefinition EXTREME_COMBUSTION_ENGINE = registerLargeCombustionEngine(
+            REGISTRATE,
             "extreme_combustion_engine", IV,
             CASING_TUNGSTENSTEEL_ROBUST, CASING_TUNGSTENSTEEL_GEARBOX, CASING_EXTREME_ENGINE_INTAKE,
             GTCEu.id("block/casings/solid/machine_casing_robust_tungstensteel"),
             GTCEu.id("block/multiblock/generator/extreme_combustion_engine"));
 
-    public static final MultiblockMachineDefinition LARGE_STEAM_TURBINE = registerLargeTurbine("steam_large_turbine",
+    public static final MultiblockMachineDefinition LARGE_STEAM_TURBINE = registerLargeTurbine(REGISTRATE,
+            "steam_large_turbine",
             HV,
             GTRecipeTypes.STEAM_TURBINE_FUELS,
             CASING_STEEL_TURBINE, CASING_STEEL_GEARBOX,
@@ -692,14 +697,17 @@ public class GTMultiMachines {
             GTCEu.id("block/multiblock/generator/large_steam_turbine"),
             false);
 
-    public static final MultiblockMachineDefinition LARGE_GAS_TURBINE = registerLargeTurbine("gas_large_turbine", EV,
+    public static final MultiblockMachineDefinition LARGE_GAS_TURBINE = registerLargeTurbine(REGISTRATE,
+            "gas_large_turbine",
+            EV,
             GTRecipeTypes.GAS_TURBINE_FUELS,
             CASING_STAINLESS_TURBINE, CASING_STAINLESS_STEEL_GEARBOX,
             GTCEu.id("block/casings/mechanic/machine_casing_turbine_stainless_steel"),
             GTCEu.id("block/multiblock/generator/large_gas_turbine"),
             true);
 
-    public static final MultiblockMachineDefinition LARGE_PLASMA_TURBINE = registerLargeTurbine("plasma_large_turbine",
+    public static final MultiblockMachineDefinition LARGE_PLASMA_TURBINE = registerLargeTurbine(REGISTRATE,
+            "plasma_large_turbine",
             IV,
             GTRecipeTypes.PLASMA_GENERATOR_FUELS,
             CASING_TUNGSTENSTEEL_TURBINE, CASING_TUNGSTENSTEEL_GEARBOX,
@@ -788,7 +796,7 @@ public class GTMultiMachines {
                     GTCEu.id("block/multiblock/charcoal_pile_igniter"))
             .register();
 
-    public static MultiblockMachineDefinition[] BEDROCK_ORE_MINER = registerTieredMultis(
+    public static MultiblockMachineDefinition[] BEDROCK_ORE_MINER = registerTieredMultis(REGISTRATE,
             "bedrock_ore_miner", BedrockOreMinerMachine::new, (tier, builder) -> builder
                     .rotationState(RotationState.NON_Y_AXIS)
                     .langValue("%s Bedrock Ore Miner %s".formatted(VLVH[tier], VLVT[tier]))
@@ -825,31 +833,31 @@ public class GTMultiMachines {
             MV, HV, EV);
 
     // Multiblock Tanks
-    public static final MachineDefinition WOODEN_TANK_VALVE = GTMachineUtils.registerTankValve(
+    public static final MachineDefinition WOODEN_TANK_VALVE = GTMachineUtils.registerTankValve(REGISTRATE,
             "wooden_tank_valve", "Wooden Tank Valve", false,
             (builder, overlay) -> builder.sidedWorkableCasingModel(GTCEu.id("block/casings/wood_wall"), overlay));
-    public static final MultiblockMachineDefinition WOODEN_MULTIBLOCK_TANK = registerMultiblockTank(
+    public static final MultiblockMachineDefinition WOODEN_MULTIBLOCK_TANK = registerMultiblockTank(REGISTRATE,
             "wooden_multiblock_tank", "Wooden Multiblock Tank", 250 * 1000,
             CASING_WOOD_WALL, WOODEN_TANK_VALVE::getBlock,
             new PropertyFluidFilter(340, false, false, false, false),
             (builder, overlay) -> builder.sidedWorkableCasingModel(GTCEu.id("block/casings/wood_wall"), overlay));
 
-    public static final MachineDefinition BRONZE_TANK_VALVE = GTMachineUtils.registerTankValve(
+    public static final MachineDefinition BRONZE_TANK_VALVE = GTMachineUtils.registerTankValve(REGISTRATE,
             "bronze_tank_valve", "Bronze Tank Valve", true,
             (builder, overlay) -> builder
                     .workableCasingModel(GTCEu.id("block/casings/solid/machine_casing_bronze_plated_bricks"), overlay));
-    public static final MultiblockMachineDefinition BRONZE_MULTIBLOCK_TANK = registerMultiblockTank(
+    public static final MultiblockMachineDefinition BRONZE_MULTIBLOCK_TANK = registerMultiblockTank(REGISTRATE,
             "bronze_multiblock_tank", "Bronze Multiblock Tank", 500 * 1000,
             CASING_BRONZE_BRICKS, BRONZE_TANK_VALVE::getBlock,
             new PropertyFluidFilter(1696, true, false, false, false),
             (builder, overlay) -> builder
                     .workableCasingModel(GTCEu.id("block/casings/solid/machine_casing_bronze_plated_bricks"), overlay));
 
-    public static final MachineDefinition STEEL_TANK_VALVE = GTMachineUtils.registerTankValve(
+    public static final MachineDefinition STEEL_TANK_VALVE = GTMachineUtils.registerTankValve(REGISTRATE,
             "steel_tank_valve", "Steel Tank Valve", true,
             (builder, overlay) -> builder.workableCasingModel(
                     GTCEu.id("block/casings/solid/machine_casing_solid_steel"), overlay));
-    public static final MultiblockMachineDefinition STEEL_MULTIBLOCK_TANK = registerMultiblockTank(
+    public static final MultiblockMachineDefinition STEEL_MULTIBLOCK_TANK = registerMultiblockTank(REGISTRATE,
             "steel_multiblock_tank", "Steel Multiblock Tank", 1000 * 1000,
             CASING_STEEL_SOLID, STEEL_TANK_VALVE::getBlock,
             null,

--- a/src/main/java/com/gregtechceu/gtceu/common/registry/GTRegistration.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/registry/GTRegistration.java
@@ -6,9 +6,16 @@ import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
 
+import org.jetbrains.annotations.ApiStatus;
+
 public class GTRegistration {
 
+    /**
+     * Addon devs: You must use your own registrate instance.
+     */
+    @ApiStatus.Internal
     public static final GTRegistrate REGISTRATE = GTRegistrate.create(GTCEu.MOD_ID);
+
     static {
         GTRegistration.REGISTRATE.defaultCreativeTab((ResourceKey<CreativeModeTab>) null);
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSSteamMachineBuilder.java
@@ -8,8 +8,8 @@ import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
 import com.gregtechceu.gtceu.api.machine.steam.SimpleSteamMachine;
 import com.gregtechceu.gtceu.api.multiblock.util.RelativeDirection;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
+import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.api.registry.registrate.MachineBuilder;
-import com.gregtechceu.gtceu.common.registry.GTRegistration;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.resources.ResourceLocation;
@@ -31,7 +31,6 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
     public transient SteamDefinitionFunction definition = (isHP, def) -> def.tier(isHP ? 1 : 0);
 
     private transient MachineBuilder<?, ?, ?> lowPressureBuilder = null, highPressureBuilder = null;
-    private transient MachineDefinition hpValue = null;
 
     public KJSSteamMachineBuilder(ResourceLocation id) {
         super(id);
@@ -39,8 +38,10 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
 
     @Override
     public MachineDefinition register() {
+        var registrate = GTRegistrate.createIgnoringListenerErrors(this.id.getNamespace());
+
         if (hasLowPressure) {
-            this.lowPressureBuilder = GTRegistration.REGISTRATE.machine(
+            this.lowPressureBuilder = registrate.machine(
                     String.format("lp_%s", this.id.getPath()),
                     holder -> machine.create(holder, false));
             lowPressureBuilder.langValue("Low Pressure " + FormattingUtil.toEnglishName(this.id.getPath()))
@@ -53,7 +54,7 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
         }
 
         if (hasHighPressure) {
-            this.highPressureBuilder = GTRegistration.REGISTRATE.machine(
+            this.highPressureBuilder = registrate.machine(
                     String.format("hp_%s", this.id.getPath()),
                     holder -> machine.create(holder, true));
             highPressureBuilder.langValue("High Pressure " + FormattingUtil.toEnglishName(this.id.getPath()))
@@ -62,10 +63,10 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
                     .modelProperty(GTMachineModelProperties.VENT_DIRECTION, RelativeDirection.BACK)
                     .workableSteamHullModel(true, id.withPrefix("block/machines/"));
             definition.apply(true, highPressureBuilder);
-            hpValue = highPressureBuilder.register();
+            value = highPressureBuilder.register();
         }
 
-        return value != null ? value : hpValue;
+        return value;
     }
 
     @Override
@@ -82,17 +83,12 @@ public class KJSSteamMachineBuilder extends BuilderBase<MachineDefinition> {
     @Override
     public void generateLang(LangEventJS lang) {
         super.generateLang(lang);
-        if (value != null) {
-            lang.add(GTCEu.MOD_ID, value.getDescriptionId(), value.getLangValue());
-        }
-        if (hpValue != null) {
-            lang.add(GTCEu.MOD_ID, hpValue.getDescriptionId(), hpValue.getLangValue());
-        }
+        lang.add(GTCEu.MOD_ID, value.getDescriptionId(), value.getLangValue());
     }
 
     @Override
     public MachineDefinition get() {
-        return value != null ? value : hpValue;
+        return value;
     }
 
     @FunctionalInterface

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -6,9 +6,9 @@ import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
+import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.api.registry.registrate.MachineBuilder;
 import com.gregtechceu.gtceu.common.data.machines.GTMachineUtils;
-import com.gregtechceu.gtceu.common.registry.GTRegistration;
 
 import net.minecraft.resources.ResourceLocation;
 
@@ -92,7 +92,7 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
         MachineDefinition[] definitions = new MachineDefinition[TIER_COUNT];
         for (final int tier : tiers) {
             String tierName = VN[tier].toLowerCase(Locale.ROOT);
-            MachineBuilder<?, ?, ?> builder = GTRegistration.REGISTRATE.machine(
+            MachineBuilder<?, ?, ?> builder = GTRegistrate.createIgnoringListenerErrors(this.id.getNamespace()).machine(
                     String.format("%s_%s", tierName, this.id.getPath()),
                     holder -> machine.create(holder, tier, tankScalingFunction));
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMultiblockBuilder.java
@@ -4,10 +4,10 @@ import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
+import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.api.registry.registrate.MachineBuilder;
 import com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder;
 import com.gregtechceu.gtceu.common.data.machines.GTMachineUtils;
-import com.gregtechceu.gtceu.common.registry.GTRegistration;
 
 import net.minecraft.resources.ResourceLocation;
 
@@ -77,9 +77,10 @@ public class KJSTieredMultiblockBuilder extends BuilderBase<MultiblockMachineDef
         MultiblockMachineDefinition[] definitions = new MultiblockMachineDefinition[TIER_COUNT];
         for (final int tier : tiers) {
             String tierName = VN[tier].toLowerCase(Locale.ROOT);
-            MultiblockMachineBuilder<?, ?, ?> builder = GTRegistration.REGISTRATE.multiblock(
-                    String.format("%s_%s", tierName, this.id.getPath()),
-                    holder -> machine.create(holder, tier));
+            MultiblockMachineBuilder<?, ?, ?> builder = GTRegistrate
+                    .createIgnoringListenerErrors(this.id.getNamespace()).multiblock(
+                            String.format("%s_%s", tierName, this.id.getPath()),
+                            holder -> machine.create(holder, tier));
 
             builder.workableTieredHullModel(id.withPrefix("block/machines/"))
                     .tier(tier);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSWrappingMultiblockBuilder.java
@@ -6,8 +6,8 @@ import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
+import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.api.registry.registrate.MultiblockMachineBuilder;
-import com.gregtechceu.gtceu.common.registry.GTRegistration;
 
 import net.minecraft.resources.ResourceLocation;
 
@@ -75,7 +75,8 @@ public class KJSWrappingMultiblockBuilder extends BuilderBase<MultiblockMachineD
     }
 
     public static MultiblockMachineBuilder<?, WorkableElectricMultiblockMachine, ?> createKJSMulti(ResourceLocation id) {
-        return new MultiblockMachineBuilder<>(GTRegistration.REGISTRATE, id.getPath(),
+        return new MultiblockMachineBuilder<>(GTRegistrate.createIgnoringListenerErrors(id.getNamespace()),
+                id.getPath(),
                 MetaMachineBlock::new,
                 MetaMachineItem::new,
                 WorkableElectricMultiblockMachine::new);
@@ -83,7 +84,8 @@ public class KJSWrappingMultiblockBuilder extends BuilderBase<MultiblockMachineD
 
     public static MultiblockMachineBuilder<?, MultiblockControllerMachine, ?> createKJSMulti(ResourceLocation id,
                                                                                              KJSTieredMachineBuilder.CreationFunction<? extends MultiblockControllerMachine> machine) {
-        return new MultiblockMachineBuilder<>(GTRegistration.REGISTRATE, id.getPath(),
+        return new MultiblockMachineBuilder<>(GTRegistrate.createIgnoringListenerErrors(id.getNamespace()),
+                id.getPath(),
                 MetaMachineBlock::new,
                 MetaMachineItem::new,
                 machine::create);


### PR DESCRIPTION
## What

Removes the machine creation functions that implicitly use the GT registrate. Also fixes KJS machines that are registered in custom namespaces being registered in the GT registrate.

- [X] No AI driven tools were used for this pull request.