### PR TITLE
Fix NPE in applyResearchProperty when no recipe conditions exist

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/recipe/GTRecipeSchema.java
@@ -1059,6 +1059,7 @@ public interface GTRecipeSchema {
                         new IllegalStateException());
             }
 
+            if (getValue(CONDITIONS) == null) setValue(CONDITIONS, new ArrayList<>());
             ResearchCondition condition = this.getValue(CONDITIONS).stream()
                     .filter(ResearchCondition.class::isInstance).findAny().map(ResearchCondition.class::cast)
                     .orElse(null);


### PR DESCRIPTION
## What

Fixes an NPE when a KubeJS recipe calls `.stationResearch()` / `.scannerResearch()` / `.researchWithoutRecipe()` before any other recipe condition has been added: `applyResearchProperty` dereferences `getValue(CONDITIONS)`, which is `null` until something initializes it.

Fixes: #5106

## Implementation Details

One-line change: `applyResearchProperty` now applies the same lazy-init null-guard that `addCondition` already uses (`if (getValue(CONDITIONS) == null) setValue(CONDITIONS, new ArrayList<>());`).

An alternative would be routing the whole block through `addCondition` instead of mutating the found condition in place — happy to rework it that way if preferred.

### AI Usage

- [x] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Code (Claude Fable 5)

#### Agent Usage Description
The agent diagnosed the NPE from our modpack logs, located the missing null-guard by comparing `applyResearchProperty` with `addCondition`, and wrote this one-line fix and the PR text. The diff was reviewed by the submitter before opening.

## Outcome

KubeJS recipes can declare research (station/scanner/without-recipe) as the first builder condition without crashing the recipe event.

## How Was This Tested

- Reproduced the NPE in our 1.21.1 pack (GTCEu `8.0.0-SNAPSHOT b71dec5`, KubeJS `2101.7.2-build.368`) with an assembly-line recipe whose only condition was `.stationResearch(...)` — full stack trace in #5106.
- Verified the ordering workaround (calling `.cleanroom()` first, which goes through `addCondition` and initializes the list) makes the same recipe register fine — confirming the missing initialization is the only problem.
- The patched branch compiles; we are also running it inside our pack's dedicated test server setup.

## Potential Compatibility Issues

None expected — behavior is unchanged whenever any condition was already present; the guard only initializes an empty list where the code previously crashed.
