### PR TITLE
Fix registry crash for KubeJS materials registered under non-mod namespaces

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -253,7 +253,21 @@ public class CommonProxy {
             if (GTCEu.Mods.isKubeJSLoaded()) {
                 KJSEventWrapper.materialModification();
             }
-            // --spacer--
+            // Eagerly create the per-namespace registrates for all material namespaces now, while the
+            // material registry event is being fired (before any vanilla registry event, see GameDataMixin).
+            // If they are instead created lazily during e.g. the BLOCK registry event (by
+            // GTMaterialBlocks#generateMaterialBlocks), their Registrate registration listener is subscribed
+            // to the mod bus *while that same event is being dispatched* and never runs for it, so every
+            // entry queued in that registrate for the in-flight registry is silently never registered.
+            // Dependent entries (e.g. a material block's BlockItem) then crash with
+            // "Trying to access unbound value" and/or leave unregistered intrusive holders that blow up
+            // MappedRegistry#freeze. This happens for any KubeJS material whose namespace is not a loaded
+            // mod (e.g. materials registered under a pack-specific namespace).
+            GTRegistries.MATERIALS.getUsedNamespaces().forEach(namespace -> GTRegistrate
+                    .create(namespace, false)
+                    .registerEventListeners(ModList.get().getModContainerById(namespace)
+                            .map(ModContainer::getEventBus)
+                            .orElse(modBus)));
         } else if (event.getRegistryKey() == Registries.BLOCK) {
             // Material Blocks
             REGISTRATE.creativeModeTab(GTCreativeModeTabs.MATERIAL_BLOCK);

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -263,11 +263,7 @@ public class CommonProxy {
             // "Trying to access unbound value" and/or leave unregistered intrusive holders that blow up
             // MappedRegistry#freeze. This happens for any KubeJS material whose namespace is not a loaded
             // mod (e.g. materials registered under a pack-specific namespace).
-            GTRegistries.MATERIALS.getUsedNamespaces().forEach(namespace -> GTRegistrate
-                    .create(namespace, false)
-                    .registerEventListeners(ModList.get().getModContainerById(namespace)
-                            .map(ModContainer::getEventBus)
-                            .orElse(modBus)));
+            GTRegistries.MATERIALS.getUsedNamespaces().forEach(GTRegistrate::createIgnoringListenerErrors);
         } else if (event.getRegistryKey() == Registries.BLOCK) {
             // Material Blocks
             REGISTRATE.creativeModeTab(GTCreativeModeTabs.MATERIAL_BLOCK);

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -253,16 +253,6 @@ public class CommonProxy {
             if (GTCEu.Mods.isKubeJSLoaded()) {
                 KJSEventWrapper.materialModification();
             }
-            // Eagerly create the per-namespace registrates for all material namespaces now, while the
-            // material registry event is being fired (before any vanilla registry event, see GameDataMixin).
-            // If they are instead created lazily during e.g. the BLOCK registry event (by
-            // GTMaterialBlocks#generateMaterialBlocks), their Registrate registration listener is subscribed
-            // to the mod bus *while that same event is being dispatched* and never runs for it, so every
-            // entry queued in that registrate for the in-flight registry is silently never registered.
-            // Dependent entries (e.g. a material block's BlockItem) then crash with
-            // "Trying to access unbound value" and/or leave unregistered intrusive holders that blow up
-            // MappedRegistry#freeze. This happens for any KubeJS material whose namespace is not a loaded
-            // mod (e.g. materials registered under a pack-specific namespace).
             GTRegistries.MATERIALS.getUsedNamespaces().forEach(GTRegistrate::createIgnoringListenerErrors);
         } else if (event.getRegistryKey() == Registries.BLOCK) {
             // Material Blocks


### PR DESCRIPTION
## What
Eagerly creates the per-namespace `GTRegistrate` instances for every material namespace while the `gtceu:material` `RegisterEvent` is still being fired (which `GameDataMixin` guarantees happens before all vanilla registry events), instead of letting them be created lazily in the middle of the `BLOCK`/`FLUID`/`ITEM` registry events.

## Why
A KubeJS material registered under a namespace that is **not a loaded mod** (e.g. `event.create('mypack:my_material')` in a startup script) currently breaks registration:

1. `GTMaterialBlocks#generateMaterialBlocks` runs during the `minecraft:block` `RegisterEvent` and calls `GTRegistrate.createIgnoringListenerErrors(namespace)` for the material's namespace — creating the registrate **while the BLOCK event is already being dispatched** on the mod bus.
2. A listener subscribed to a NeoForge event bus during dispatch of an event never runs for that in-flight event, so the registrate's `onRegister` flush is skipped for `minecraft:block` and every material block queued in it is silently never registered.
3. During the `minecraft:item` event the same registrate's listener *does* run and tries to build the material blocks' `BlockItem`s, which fails with `NullPointerException: Trying to access unbound value: ResourceKey[minecraft:block / <namespace>:<material>_block]`.
4. Depending on the pack, the partially-aborted flushes additionally leave objects behind as unregistered intrusive holders, which crashes registry freeze with `IllegalStateException: Some intrusive holders were not registered` (the crash reported in #5104, where counts scale with the material set and are ordering-sensitive).

## Repro (before this PR)
```js
// startup_scripts/test.js — GTCEu + KubeJS only, dedicated server or client
StartupEvents.registry('gtceu:material', event => {
    event.create('tfg:my_test').dust().ingot().color(0xdddddd)
})
```
crashes mod loading with
`Unexpected error while registering entry tfg:my_test_block to registry minecraft:item` / `Trying to access unbound value: ResourceKey[minecraft:block / tfg:my_test_block]`.

With this PR the same script loads fine and `tfg:my_test_dust`, `tfg:my_test_ingot`, `tfg:my_test_block` etc. all exist (verified on a 1.21.1 NeoForge 21.1.235 dedicated server).

Materials in the `gtceu` namespace (or any loaded mod's namespace) were unaffected because their registrate already exists with listeners subscribed before the vanilla registry events.

For namespaces that do belong to loaded mods the behavior is unchanged: the listeners are registered on that mod's event bus (same as `CommonProxy#postInitMaterials` does), and `GTRegistrate`'s internal `registered` flag prevents double subscription.

Fixes #5104

🤖 Generated with [Claude Code](https://claude.com/claude-code)