### PR TITLE
Update v8 machine migration docs

### DIFF
--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -15,7 +15,8 @@ Many aspects of the machine classes have been refactored and changed in order to
 
 - The `MetaMachineBlockEntity`(MMBE) class has been removed, and `MetaMachine`(MM) is now a BlockEntity.
 - Most methods and properties of MMBE have been moved onto MM.
-- The `IMachineBlockEntity` interface has been removed. Use `MetaMachineBlock` directly instead.
+- The `IMachineBlock` interface has been removed. Use `MetaMachineBlock` directly instead.
+- The `IMachineBlockEntity` interface has been removed. Use `MetaMachine` directly instead.
 - Many methods common to all block entities have been moved to the `IGregtechBlockEntity` interface.
 - Machine instance creation functions have signature `(BlockEntityCreationInfo) -> MetaMachine` instead of `(IMachineBlockEntity) -> MetaMachine` 
 


### PR DESCRIPTION
2 line change to machine migration docs, removing mistake in migration instructions for `IMachineBlockEntity`