### PR TITLE
Fix tooltips and allow tank locking

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
@@ -63,6 +63,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
             this.storages[i] = new CustomFluidTank(capacity);
             this.storages[i].setOnContentsChanged(this::onContentsChanged);
         }
+        this.lockedFluid.setOnContentsChanged(this::onLockedFluidChanged);
     }
 
     public NotifiableFluidTank(List<CustomFluidTank> storages, IO io, IO capabilityIO) {
@@ -76,6 +77,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         if (io == IO.IN) {
             this.allowSameFluids = true;
         }
+        this.lockedFluid.setOnContentsChanged(this::onLockedFluidChanged);
     }
 
     public NotifiableFluidTank(int slots, int capacity, IO io) {
@@ -90,6 +92,26 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         isEmpty = null;
         syncDataHolder.markClientSyncFieldDirty("storages");
         notifyListeners();
+    }
+
+    protected void onLockedFluidChanged() {
+        syncDataHolder.markClientSyncFieldDirty("lockedFluid");
+        var newFluid = this.lockedFluid.getFluid();
+        if (newFluid.isEmpty()) {
+            this.setFilter(stack -> true);
+            this.onContentsChanged();
+            return;
+        }
+        for (int i = 0; i < this.getTanks(); i++) {
+            if (this.getFluidInTank(i).isEmpty()) continue;
+            if (!this.getFluidInTank(i).isFluidEqual(newFluid)) {
+                // Fluid in a tank that doesn't equal the new locked fluid
+                this.lockedFluid.setFluid(FluidStack.EMPTY);
+                return;
+            }
+        }
+        this.setFilter(stack -> stack.isFluidEqual(newFluid));
+        this.onContentsChanged();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java
@@ -255,7 +255,7 @@ public class FluidHatchPartMachine extends TieredIOPartMachine implements IMuiMa
     }
 
     protected Flow createSingleSlotUI(PanelSyncManager syncManager) {
-        BooleanSyncValue locked = new BooleanSyncValue(this.tank::isLocked, this.tank::setLocked);
+        BooleanSyncValue locked = new BooleanSyncValue(this.tank::isLocked, this.tank::setLocked).allowC2S();
         syncManager.syncValue("locked", locked);
         return Flow.col()
                 .width(MachineUIPanel.DEFAULT_CONTENT_WIDTH)
@@ -271,12 +271,13 @@ public class FluidHatchPartMachine extends TieredIOPartMachine implements IMuiMa
                         .coverChildren()
                         .childIf(io.support(IO.OUT), () -> new FluidSlot()
                                 .name("lockedFluid")
-                                .syncHandler(new FluidSlotSyncHandler(tank.getLockedFluid()))
+                                .syncHandler(new FluidSlotSyncHandler(tank.getLockedFluid()).phantom(true))
                                 .alwaysShowFull(true)
                                 .tooltip(t -> t.addLine("Locked Fluid")))
                         .childIf(io.support(IO.OUT), () -> new ToggleButton()
                                 .syncHandler("locked")
-                                .tooltip(t -> t.addLine("gtceu.gui.fluid_lock.tooltip"))
+                                .tooltipDynamic(t -> t.addLine(Component.translatable("gtceu.gui.fluid_lock.tooltip." +
+                                        (locked.getBoolValue() ? "enabled" : "disabled"))))
                                 .overlay(false, GTGuiTextures.BUTTON_LOCK)
                                 .overlay(true, GTGuiTextures.BUTTON_LOCK)
                                 .background(GuiTextures.MC_BUTTON)


### PR DESCRIPTION
## What
We lost locking functionality during the MUI refactor (https://github.com/GregTechCEu/GregTech-Modern/blob/91a79b8a7a2b62ec6277423e6c0ded4af89a831e/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/FluidHatchPartMachine.java#L308-L319 wasn't copied). We re-implement it from scratch on NotifiableFluidTank in a way that doesn't allow tank.lockedFluid to drift from tank.filter

## Implementation Details
LDlib implemented this in the UI code, we implement it in the underlying notifiable handler code

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Opus 4.8
#### Agent Usage Description
Helped debugging but didn't write any code
  
## Outcome
Fluid hatch locking work again 

## How Was This Tested
In game, in call with html


