### PR TITLE
Make ScopedValue use thread local fields internally

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
@@ -55,8 +55,7 @@ public class BloomRenderer {
     @Accessors(fluent = true)
     @Getter
     @ApiStatus.Internal
-    static final ThreadLocal<ScopedValue.Object<Supplier<VertexConsumer>>> bloomChunkContext = ThreadLocal
-            .withInitial(ScopedValue.Object::new);
+    static final ScopedValue.Object<Supplier<VertexConsumer>> bloomChunkContext = new ScopedValue.Object<>();
 
     @ApiStatus.Internal
     static void renderBloom(Camera camera, PoseStack poseStack, Frustum frustum, Matrix4f projectionMatrix,
@@ -193,7 +192,8 @@ public class BloomRenderer {
         }
 
         if (TextureMetadataHelper.hasBloom(quad, packedLights)) {
-            Supplier<VertexConsumer> currentVertexConsumer = bloomChunkContext().get().getValue();
+            @SuppressWarnings("resource")
+            Supplier<VertexConsumer> currentVertexConsumer = bloomChunkContext().getValue();
             if (currentVertexConsumer == null) return;
 
             drawConsumer.accept(currentVertexConsumer.get());

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/ModelBlockRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/ModelBlockRendererMixin.java
@@ -26,8 +26,7 @@ import org.spongepowered.asm.mixin.injection.At;
 public class ModelBlockRendererMixin {
 
     @Unique
-    private static final ThreadLocal<ScopedValue.Object<RenderType>> gtceu$currentRenderType = ThreadLocal
-            .withInitial(ScopedValue.Object::new);
+    private static final ScopedValue.Object<RenderType> gtceu$currentRenderType = new ScopedValue.Object<>();
 
     @WrapMethod(method = {
             "tesselateWithAO(Lnet/minecraft/world/level/BlockAndTintGetter;Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/core/BlockPos;Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;ZLnet/minecraft/util/RandomSource;JILnet/minecraftforge/client/model/data/ModelData;Lnet/minecraft/client/renderer/RenderType;)V",
@@ -38,7 +37,7 @@ public class ModelBlockRendererMixin {
                                         RandomSource random, long seed, int packedOverlay,
                                         ModelData modelData, RenderType renderType,
                                         Operation<Void> original) {
-        try (var $ = gtceu$currentRenderType.get().with(renderType)) {
+        try (var $ = gtceu$currentRenderType.with(renderType)) {
             original.call(level, model, state, pos, poseStack, consumer, checkSides, random, seed, packedOverlay,
                     modelData, renderType);
         }
@@ -50,16 +49,15 @@ public class ModelBlockRendererMixin {
                             target = "Lcom/mojang/blaze3d/vertex/VertexConsumer;putBulkData(Lcom/mojang/blaze3d/vertex/PoseStack$Pose;Lnet/minecraft/client/renderer/block/model/BakedQuad;[FFFF[IIZ)V"))
     private void gtceu$copyBloomQuads(VertexConsumer consumer, PoseStack.Pose pose, BakedQuad quad,
                                       float[] colorMuls, float red, float green, float blue,
-                                      int[] combinedLights, int combinedOverlay, boolean mulColor,
+                                      int[] lightmap, int overlay, boolean mulColor,
                                       Operation<Void> original) {
-        original.call(consumer, pose, quad, colorMuls, red, green, blue, combinedLights, combinedOverlay, mulColor);
+        original.call(consumer, pose, quad, colorMuls, red, green, blue, lightmap, overlay, mulColor);
 
         if (!BloomShaderManager.isBloomActive()) return;
 
-        RenderType renderType = gtceu$currentRenderType.get().getValue();
-        BloomRenderer.copyBloomQuad(quad, combinedLights, renderType, bloomVertexConsumer -> {
-            original.call(bloomVertexConsumer, pose, quad, colorMuls, red, green, blue,
-                    combinedLights, combinedOverlay, mulColor);
+        RenderType renderType = gtceu$currentRenderType.getValue();
+        BloomRenderer.copyBloomQuad(quad, lightmap, renderType, bloomVertexConsumer -> {
+            original.call(bloomVertexConsumer, pose, quad, colorMuls, red, green, blue, lightmap, overlay, mulColor);
         });
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/RebuildTaskMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/RebuildTaskMixin.java
@@ -50,8 +50,9 @@ public abstract class RebuildTaskMixin {
                 return BloomRenderer.SafeMode.getOrStartBloomBuffer(SectionPos.of(sectionOrigin));
             }
         };
-        // intentionally no try-with-resource statement; closed in 'gtceu$clearBloomContextData'
-        BloomRenderer.bloomChunkContext().get().with(provider);
+        // intentionally no 'try'-with-resources statement; closed in 'gtceu$clearBloomContextData'
+        // noinspection resource
+        BloomRenderer.bloomChunkContext().with(provider);
     }
 
     @Inject(method = "compile",
@@ -65,6 +66,6 @@ public abstract class RebuildTaskMixin {
             BloomRenderer.SafeMode.bakeBloomChunkBuffers(SectionPos.of(sectionOrigin), camX, camY, camZ);
         }
 
-        BloomRenderer.bloomChunkContext().get().close();
+        BloomRenderer.bloomChunkContext().close();
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/utils/ScopedValue.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/ScopedValue.java
@@ -1,7 +1,5 @@
 package com.gregtechceu.gtceu.utils;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -14,19 +12,23 @@ public abstract class ScopedValue implements AutoCloseable {
      * 
      * @param <T> The type of the object.
      */
-    @RequiredArgsConstructor
     public static final class Object<T> extends ScopedValue {
 
-        private final @Nullable T initialValue;
-
-        /**
-         * Current value in this scope
-         */
-        @Getter
-        private @Nullable T value;
+        private final ThreadLocal<@Nullable T> value;
 
         public Object() {
             this(null);
+        }
+
+        public Object(@Nullable T initialValue) {
+            this.value = ThreadLocal.withInitial(() -> initialValue);
+        }
+
+        /**
+         * {@return Current value in this scope}
+         */
+        public @Nullable T getValue() {
+            return this.value.get();
         }
 
         /**
@@ -35,29 +37,40 @@ public abstract class ScopedValue implements AutoCloseable {
          * @return this
          */
         public Object<T> with(T value) {
-            this.value = value;
+            this.value.set(value);
             return this;
         }
 
         @Override
         public void close() {
-            this.value = this.initialValue;
+            this.value.remove();
         }
     }
 
     /**
      * Scoped boolean value. Resets to {@link #initialValue} when exiting scope.
      */
-    @RequiredArgsConstructor
     public static final class Boolean extends ScopedValue {
 
         private final boolean initialValue;
 
+        private final ThreadLocal<java.lang.Boolean> value;
+
+        public Boolean() {
+            this(false);
+        }
+
+        public Boolean(boolean initialValue) {
+            this.initialValue = initialValue;
+            this.value = ThreadLocal.withInitial(() -> this.initialValue);
+        }
+
         /**
-         * Current value in this scope
+         * {@return Current value in this scope}
          */
-        @Getter
-        private boolean active;
+        public boolean isActive() {
+            return this.value.get();
+        }
 
         /**
          * Set {@code current} to {@code value} within this scope.
@@ -65,7 +78,7 @@ public abstract class ScopedValue implements AutoCloseable {
          * @return this
          */
         public Boolean with(boolean value) {
-            this.active = value;
+            this.value.set(value);
             return this;
         }
 
@@ -74,13 +87,13 @@ public abstract class ScopedValue implements AutoCloseable {
          * 
          * @return this
          */
-        public Boolean active() {
+        public Boolean setActive() {
             return with(!this.initialValue);
         }
 
         @Override
         public void close() {
-            this.active = this.initialValue;
+            this.value.remove();
         }
     }
 }


### PR DESCRIPTION
...instead of the whole ScopedValue being thread local.

## What
Always wrap ScopedValue's value in a ThreadLocal. Non-thread-local scoped values should never exist because they cannot have a guarantee of being in scope of the source.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes, AI driven tools were used for this pull request.
  
## Outcome
ScopedValue's value is now inside a ThreadLocal.

## Additional Information
I was told to split this from #5021.

## Potential Compatibility Issues
None; this class isn't even in an alpha release yet.