### PR TITLE
Change `Element#halfLifeSeconds` from long to double

### DIFF
--- a/docs/content/Modpacks/Materials-and-Elements/02-Element-Creation.md
+++ b/docs/content/Modpacks/Materials-and-Elements/02-Element-Creation.md
@@ -24,7 +24,7 @@ GTCEuStartupEvents.registry('gtceu:element', event => {
 1.  `.create(String name)` ->  The element name.
 2.  `.protons(int protons)` -> Proton Count. Use `-1` if it is an element that will not get a material.
 3.  `.neutrons(int neutrons)` -> Neutron Count. Use `-1` if it is an element that will not get a material
-4.  `.halfLifeSeconds(int seconds)` -> Half Life Decay in Seconds. After N seconds, half of the material will have decayed. Use `-1` if your element doesn't decay.
+4.  `.halfLifeSeconds(double seconds)` -> Half Life Decay in Seconds. After N seconds, half of the material will have decayed. Use `-1` if your element doesn't decay.
 5.  `.decayTo(Material material)` -> Material to decay to. Use `null` if your element doesn't decay.
 6.  `.symbol(String symbol)` -> Atomic Symbol, which will be displayed as in chemical formulas.
 7.  `.isIsotope(boolean isotope)` -> Whether the element is an isotope, e.g. Uranium 235 and Uranium 238.

--- a/src/main/java/com/gregtechceu/gtceu/api/data/chemical/Element.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/chemical/Element.java
@@ -27,7 +27,7 @@ public class Element {
      */
     @Getter
     @Setter
-    private long halfLifeSeconds;
+    private double halfLifeSeconds;
     /**
      * String representing the Elements this element decays to. Separated by an '&' Character
      */
@@ -57,7 +57,7 @@ public class Element {
         return protons + neutrons;
     }
 
-    public Element(long protons, long neutrons, long halfLifeSeconds, String decayTo, String name, String symbol,
+    public Element(long protons, long neutrons, double halfLifeSeconds, String decayTo, String name, String symbol,
                    boolean isIsotope) {
         this.protons = protons;
         this.neutrons = neutrons;

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
@@ -214,15 +214,15 @@ public class GTElements {
 
     /**
      * @deprecated Use
-     *             {@link GTElements#createAndRegister(ResourceLocation, long, long, long, String, String, String, boolean)}
+     *             {@link GTElements#createAndRegister(ResourceLocation, long, long, double, String, String, String, boolean)}
      */
     @Deprecated
-    public static Element createAndRegister(long protons, long neutrons, long halfLifeSeconds, String decayTo,
+    public static Element createAndRegister(long protons, long neutrons, double halfLifeSeconds, String decayTo,
                                             String name, String symbol, boolean isIsotope) {
         return createAndRegister(GTCEu.id(name), protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);
     }
 
-    public static Element createAndRegister(ResourceLocation id, long protons, long neutrons, long halfLifeSeconds,
+    public static Element createAndRegister(ResourceLocation id, long protons, long neutrons, double halfLifeSeconds,
                                             String decayTo,
                                             String name, String symbol, boolean isIsotope) {
         Element element = new Element(protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/ElementBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/ElementBuilder.java
@@ -20,7 +20,9 @@ public class ElementBuilder extends BuilderBase<Element> {
     @Setter
     public transient Component translatableName;
     @Setter
-    public transient long protons, neutrons, halfLifeSeconds = -1;
+    public transient long protons, neutrons;
+    @Setter
+    public transient double halfLifeSeconds = -1D;
     @Setter
     public transient String decayTo, symbol;
     @Setter


### PR DESCRIPTION
## What
As the titles says, changes all references to `halfLiveSeconds` from `long` to `double`.

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.