### PR TITLE
Fix machine drops saving everything to NBT

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -245,6 +245,10 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
      */
     public void modifyDrops(List<ItemStack> drops) {}
 
+    public void saveToItem(ItemStack stack, HolderLookup.Provider registries) {
+        stack.applyComponents(this.collectComponents());
+    }
+
     /**
      * Applies item stack component data when this machine is placed.
      *


### PR DESCRIPTION
## What
title, everything got saved to nbt regardless of the trait behavior before.


## Implementation Details
dont call save additional/saveToItem anymore when breaking a machine

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
machines can stack again and lost contents

## How Was This Tested
in game