### PR TITLE
Fix flickering of items in filters

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -119,9 +119,7 @@ public class SimpleItemFilter implements ItemFilter {
                 .gridOfSizeWidth(9, 3, (x, y, i) -> new PhantomItemSlot()
                         .size(16)
                         .syncHandler(new PhantomItemSlotSyncHandler(new ModularSlot(handler, i)
-                                .changeListener((stack, amount, client, init) -> {
-                                    handler.setStackInSlot(i, stack);
-                                }).ignoreMaxStackSize(true).accessibility(true, false))));
+                                .ignoreMaxStackSize(true).accessibility(true, false))));
 
         BooleanSyncValue blacklist = new BooleanSyncValue(this::isBlackList, this::setBlackList).allowC2S();
         syncManager.syncValue("blacklist", blacklist);

--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/ItemMagnetBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/ItemMagnetBehavior.java
@@ -147,7 +147,6 @@ public class ItemMagnetBehavior implements IInteractionItem, IItemLifeCycle, IAd
                 .gridOfSizeWidth(9, 3, (x, y, i) -> new PhantomItemSlot()
                         .size(16)
                         .syncHandler(new PhantomItemSlotSyncHandler(new ModularSlot(handler, i)
-                                .changeListener((stack, amount, client, init) -> handler.setStackInSlot(i, stack))
                                 .ignoreMaxStackSize(true).accessibility(true, false))));
 
         BooleanSyncValue blacklist = new BooleanSyncValue(filter::isBlackList, filter::setBlackList).allowC2S();


### PR DESCRIPTION
## What
Fixes filter flickering (the changelistener is redundant, MUI already takes care of that)

### AI Usage 
Yes, opus 4.8 found the problem (as well as the item change problem which was fixed in MUI's latest snapshot)
  
## Outcome
Filter covers now have the correct items

## How Was This Tested
In game

