### PR TITLE
Fix AOE ui

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/AOEConfigUIBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/behavior/AOEConfigUIBehavior.java
@@ -162,7 +162,7 @@ public class AOEConfigUIBehavior implements IToolUIBehavior {
                                                         GuiTextures.REMOVE.asIcon().size(10))
                                                 .syncHandler(minusLayers))
                                         .child(new TextWidget<>(Text.dynamic(() -> Component.literal(Integer.toString(
-                                                2 * AoESymmetrical.getLayer(tag, defaultDefinition) + 1)))))
+                                                AoESymmetrical.getLayer(tag, defaultDefinition) + 1)))))
                                         .child(new ButtonWidget<>()
                                                 .size(12)
                                                 .background(GuiTextures.MC_BUTTON,


### PR DESCRIPTION
Made the layers actually increment by 1 properly which follows the actual inworld behaviour instead of following the 1, 3, 5... sequence that the rows and cols use

## Implementation Details
removed a `2 *`

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
Tools with AOE now have UI's that match with the inworld behaviour

## How Was This Tested
ingame
