### PR TITLE
Fix broken pipenets causing DuctPipeBlockEntity to return illegal LazyOptionals

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/GTCapabilityHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/GTCapabilityHelper.java
@@ -16,16 +16,17 @@ import net.minecraftforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@SuppressWarnings("DataFlowIssue")
 public class GTCapabilityHelper {
 
     @Nullable
     public static IElectricItem getElectricItem(ItemStack itemStack) {
-        return itemStack.getCapability(GTCapability.CAPABILITY_ELECTRIC_ITEM).resolve().orElse(null);
+        return itemStack.getCapability(GTCapability.CAPABILITY_ELECTRIC_ITEM).orElse(null);
     }
 
     @Nullable
     public static IEnergyStorage getForgeEnergyItem(ItemStack itemStack) {
-        return itemStack.getCapability(ForgeCapabilities.ENERGY).resolve().orElse(null);
+        return itemStack.getCapability(ForgeCapabilities.ENERGY).orElse(null);
     }
 
     @Nullable
@@ -65,13 +66,7 @@ public class GTCapabilityHelper {
 
     @Nullable
     public static IEnergyStorage getForgeEnergy(Level level, BlockPos pos, @Nullable Direction side) {
-        if (level.getBlockState(pos).hasBlockEntity()) {
-            var blockEntity = level.getBlockEntity(pos);
-            if (blockEntity != null) {
-                return blockEntity.getCapability(ForgeCapabilities.ENERGY, side).resolve().orElse(null);
-            }
-        }
-        return null;
+        return getBlockEntityCapability(ForgeCapabilities.ENERGY, level, pos, side);
     }
 
     @Nullable
@@ -106,7 +101,7 @@ public class GTCapabilityHelper {
         if (level.getBlockState(pos).hasBlockEntity()) {
             var blockEntity = level.getBlockEntity(pos);
             if (blockEntity != null) {
-                return blockEntity.getCapability(capability, side).resolve().orElse(null);
+                return blockEntity.getCapability(capability, side).orElse(null);
             }
         }
         return null;
@@ -114,6 +109,6 @@ public class GTCapabilityHelper {
 
     @Nullable
     public static MedicalConditionTracker getMedicalConditionTracker(@NotNull Entity entity) {
-        return entity.getCapability(GTCapability.CAPABILITY_MEDICAL_CONDITION_TRACKER, null).resolve().orElse(null);
+        return entity.getCapability(GTCapability.CAPABILITY_MEDICAL_CONDITION_TRACKER, null).orElse(null);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/DuctPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/DuctPipeBlockEntity.java
@@ -52,6 +52,11 @@ public class DuctPipeBlockEntity extends PipeBlockEntity<DuctPipeType, DuctPipeP
                 initHandlers();
             }
             checkNetwork();
+
+            if (defaultHandler == null) {
+                // if the default handler is null, return LazyOptional.empty because that means the pipenet is invalid
+                return LazyOptional.empty();
+            }
             return GTCapability.CAPABILITY_HAZARD_CONTAINER.orEmpty(cap,
                     LazyOptional.of(() -> handlers.getOrDefault(side, defaultHandler)));
         } else if (cap == GTCapability.CAPABILITY_COVERABLE) {


### PR DESCRIPTION
## What
Thats it

## Implementation Details
Added an `if (defaultHandler == null) return LazyOptional.empty()` to `DuctPipeBlockEntity#getCapability`. That field is always non-null if the pipenet is valid (and it's used as the default value in the 'normal' path) so I deemed it a good way to check the state.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
no more crash

## How Was This Tested
Opened a world with an invalid duct pipenet that locked me out of that world previously. It doesn't do that anymore.

## Additional Information
this PR should not be cherrypicked to 1.21 because NeoForge doesn't have LazyOptional (and thus the original return value is fine).