### PR TITLE
FIX BLOOM SAFE MODE

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/bloom/BloomRenderer.java
@@ -277,7 +277,7 @@ public class BloomRenderer {
 
             BLOOM_RENDER_LOCK.writeLock().lock();
             try {
-                BLOOM_BUFFER_BUILDERS.remove(sectionPos, builder);
+                BLOOM_BUFFER_BUILDERS.remove(sectionPos);
                 BLOOM_BUFFER_SORT_STATES.put(sectionPos, builder.getSortState());
 
                 RenderCall upload = () -> {
@@ -304,12 +304,17 @@ public class BloomRenderer {
         }
 
         public static BufferBuilder getOrStartBloomBuffer(SectionPos sectionPos) {
-            BufferBuilder builder = BLOOM_BUFFER_BUILDERS.computeIfAbsent(sectionPos,
-                    $ -> new BufferBuilder(GTRenderTypes.bloom().bufferSize()));
-            if (!builder.building()) {
-                builder.begin(GTRenderTypes.bloom().mode(), GTRenderTypes.bloom().format());
+            BLOOM_RENDER_LOCK.writeLock().lock();
+            try {
+                BufferBuilder builder = BLOOM_BUFFER_BUILDERS.computeIfAbsent(sectionPos,
+                        $ -> new BufferBuilder(GTRenderTypes.bloom().bufferSize()));
+                if (!builder.building()) {
+                    builder.begin(GTRenderTypes.bloom().mode(), GTRenderTypes.bloom().format());
+                }
+                return builder;
+            } finally {
+                BLOOM_RENDER_LOCK.writeLock().unlock();
             }
-            return builder;
         }
 
         public static void bakeBloomChunkBuffers(SectionPos sectionPos, float camX, float camY, float camZ) {

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/safemode/embeddium/BlockRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/safemode/embeddium/BlockRendererMixin.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.client.bloom.BloomRenderer;
 import com.gregtechceu.gtceu.client.bloom.BloomShaderManager;
 import com.gregtechceu.gtceu.client.util.TextureMetadataHelper;
 
-import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.caffeinemc.mods.sodium.api.util.NormI8;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.core.SectionPos;
@@ -69,7 +68,7 @@ public class BlockRendererMixin {
         if (normal == 0) normal = quad.getComputedFaceNormal();
 
         bloomBuffer.vertex(v.x, v.y, v.z)
-                .color(ColorARGB.toABGR(v.color))
+                .color(v.color)
                 .uv(v.u, v.v)
                 .uv2(v.light)
                 .normal(NormI8.unpackX(normal), NormI8.unpackY(normal), NormI8.unpackZ(normal))

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/safemode/embeddium/BlockRendererMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/client/bloom/safemode/embeddium/BlockRendererMixin.java
@@ -72,6 +72,7 @@ public class BlockRendererMixin {
                 .color(ColorARGB.toABGR(v.color))
                 .uv(v.u, v.v)
                 .uv2(v.light)
-                .normal(NormI8.unpackX(normal), NormI8.unpackY(normal), NormI8.unpackZ(normal));
+                .normal(NormI8.unpackX(normal), NormI8.unpackY(normal), NormI8.unpackZ(normal))
+                .endVertex();
     }
 }


### PR DESCRIPTION
###### Well, this is awkward.

## What
...not ending vertices, causing buffer overflows.
Also removed an erroneous color conversion in the same mixin and added a missing write lock check.

## Implementation Details
It's quite simple, really.

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
bloom appears and game doesn't crash after 30s

## How Was This Tested
Ran game, looked, waited

## Additional Information
Don't cherrypick this to 1.21, I'll PR a separate fix that includes these as well as a bunch of other stuff with bloom shortly.