### PR TITLE
MINEABLE_WITH_SHEARS Tag Regression in 1.21.1 Specifically

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -76,7 +76,7 @@ public class BlockTagLoader {
                 .addTag(BlockTags.LEAVES)
                 .addTag(BlockTags.WOOL)
                 .add(Blocks.COBWEB, Blocks.DEAD_BUSH, Blocks.FERN, Blocks.GLOW_LICHEN, Blocks.HANGING_ROOTS,
-                        Blocks.LARGE_FERN, Blocks.NETHER_SPROUTS, Blocks.SEAGRASS, Blocks.GRASS,
+                        Blocks.LARGE_FERN, Blocks.NETHER_SPROUTS, Blocks.SEAGRASS, Blocks.SHORT_GRASS,
                         Blocks.SMALL_DRIPLEAF, Blocks.TALL_GRASS, Blocks.TALL_SEAGRASS, Blocks.TRIPWIRE,
                         Blocks.TWISTING_VINES, Blocks.VINE, Blocks.WEEPING_VINES);
 

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -76,7 +76,7 @@ public class BlockTagLoader {
                 .addTag(BlockTags.LEAVES)
                 .addTag(BlockTags.WOOL)
                 .add(Blocks.COBWEB, Blocks.DEAD_BUSH, Blocks.FERN, Blocks.GLOW_LICHEN, Blocks.HANGING_ROOTS,
-                        Blocks.LARGE_FERN, Blocks.NETHER_SPROUTS, Blocks.SEAGRASS, Blocks.GRASS_BLOCK,
+                        Blocks.LARGE_FERN, Blocks.NETHER_SPROUTS, Blocks.SEAGRASS, Blocks.GRASS,
                         Blocks.SMALL_DRIPLEAF, Blocks.TALL_GRASS, Blocks.TALL_SEAGRASS, Blocks.TRIPWIRE,
                         Blocks.TWISTING_VINES, Blocks.VINE, Blocks.WEEPING_VINES);
 


### PR DESCRIPTION
## What
So I was making a new tool with aoe, and I used the `MINEABLE_WITH_SHEARS` tag, and it would break grass BLOCKS in an AOE, but not short grass. So I dug in the code and noticed that for some reason `Blocks.GRASS_BLOCK` was being used instead of `Blocks.GRASS`. I checked to see if this was in 1.20, and it wasn't, it was correct. I then went through the 1.21 branch and yes that was incorrect there and then looked at the commit history... and Gus changed it in a random commit for some reason lol.

[Git Blame Without Squashed Commits](https://github.com/GregTechCEu/GregTech-Modern/blame/842b2052e54e96cdd0550ce130ee8969be2ce12c/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java#L79)

## Implementation Details
Changed it back

### AI Usage 

- [X] No AI driven tools were used for this pull request.
  
## Outcome
Should make Short Grass be properly mined by shears with aoe, and not grass blocks.

## Potential Compatibility Issues
none? I hope not.
