### PR TITLE
Fix kjs material registration (1.20)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -160,24 +160,6 @@ public class CommonProxy {
         AddonFinder.getAddons().forEach(IGTAddon::initializeAddon);
 
         GregTechDatagen.initPost();
-        // Register all material manager registries, for materials with mod ids.
-        GTRegistries.MATERIALS.getUsedNamespaces().forEach(namespace -> {
-            // Force the material lang generator to be at index 0, so that addons' lang generators can override it.
-            var registrate = GTRegistrate.createIgnoringListenerErrors(namespace);
-            AbstractRegistrateAccessor accessor = (AbstractRegistrateAccessor) registrate;
-            if (accessor.getDoDatagen().get()) {
-                // noinspection UnstableApiUsage
-                List<NonNullConsumer<? extends RegistrateProvider>> providers = Multimaps.asMap(accessor.getDatagens())
-                        .get(ProviderType.LANG);
-                NonNullConsumer<? extends RegistrateProvider> generator = (provider) -> MaterialLangGenerator
-                        .generate((RegistrateLangProvider) provider, namespace);
-                if (providers == null) {
-                    accessor.getDatagens().put(ProviderType.LANG, generator);
-                } else {
-                    providers.add(0, generator);
-                }
-            }
-        });
 
         WorldGenLayers.init();
         VeinGenerators.registerAddonGenerators();
@@ -219,7 +201,25 @@ public class CommonProxy {
         if (GTCEu.Mods.isKubeJSLoaded()) {
             KJSEventWrapper.materialModification();
         }
-        GTRegistries.MATERIALS.getUsedNamespaces().forEach(GTRegistrate::createIgnoringListenerErrors);
+
+        // Register all material manager registries, for materials with mod ids.
+        GTRegistries.MATERIALS.getUsedNamespaces().forEach(namespace -> {
+            // Force the material lang generator to be at index 0, so that addons' lang generators can override it.
+            var registrate = GTRegistrate.createIgnoringListenerErrors(namespace);
+            AbstractRegistrateAccessor accessor = (AbstractRegistrateAccessor) registrate;
+            if (accessor.getDoDatagen().get()) {
+                // noinspection UnstableApiUsage
+                List<NonNullConsumer<? extends RegistrateProvider>> providers = Multimaps.asMap(accessor.getDatagens())
+                        .get(ProviderType.LANG);
+                NonNullConsumer<? extends RegistrateProvider> generator = (provider) -> MaterialLangGenerator
+                        .generate((RegistrateLangProvider) provider, namespace);
+                if (providers == null) {
+                    accessor.getDatagens().put(ProviderType.LANG, generator);
+                } else {
+                    providers.add(0, generator);
+                }
+            }
+        });
 
         // Freeze Material Registry before processing Items, Blocks, and Fluids
         GTRegistries.MATERIALS.freeze();

--- a/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonProxy.java
@@ -219,6 +219,7 @@ public class CommonProxy {
         if (GTCEu.Mods.isKubeJSLoaded()) {
             KJSEventWrapper.materialModification();
         }
+        GTRegistries.MATERIALS.getUsedNamespaces().forEach(GTRegistrate::createIgnoringListenerErrors);
 
         // Freeze Material Registry before processing Items, Blocks, and Fluids
         GTRegistries.MATERIALS.freeze();


### PR DESCRIPTION
## What
See #5141 & https://github.com/GregTechCEu/GregTech-Modern/issues/5104, where materials would not be registered if created for a namespace without an addon.
This doesn't cause an issue on 1.20 currently, but may in the future, so better to port the patch from 1.21 now IMO

- [X] No AI driven tools were used for this pull request.