### PR TITLE
RotorHolderPartMachine shouldn't allow IO on its inventory

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/RotorHolderPartMachine.java
@@ -66,7 +66,7 @@ public class RotorHolderPartMachine extends TieredPartMachine implements IMuiMac
 
     public RotorHolderPartMachine(BlockEntityCreationInfo info, int tier) {
         super(info, tier);
-        this.inventory = attachTrait(new NotifiableItemStackHandler(1, IO.NONE, IO.BOTH));
+        this.inventory = attachTrait(new NotifiableItemStackHandler(1, IO.NONE, IO.NONE));
         this.maxRotorHolderSpeed = 2000 + 1000 * tier;
     }
 
@@ -238,7 +238,7 @@ public class RotorHolderPartMachine extends TieredPartMachine implements IMuiMac
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
         var slot = new ItemSlot()
-                .slot(new ModularSlot(inventory, 0).slotGroup(new SlotGroup("rotor", 1)))
+                .slot(new ModularSlot(inventory.storage, 0).slotGroup(new SlotGroup("rotor", 1)))
                 .background(GTGuiTextures.SLOT, GTGuiTextures.TURBINE_OVERLAY).center();
 
         var rotorSync = new IntSyncValue(this::getRotorSpeed);


### PR DESCRIPTION
## What

It is unintended for the inventory of `RotorHolderPartMachine` to be able to be interacted with by covers and other item extracting/inserting things, so this patch disables that.


## Implementation Details

This is a 2-line change, I am unsure

### AI Usage 

No AI tools were used, because its literally a 2-line change I figured out in about 5 minutes

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome

The `RotorPartHolderMachine` class no longer allows inventory access, because I set its IO to `IO.None`.

## How Was This Tested

I confirmed that conveyor covers, ender item covers, and AE2 all refuse to insert/extract the rotor from the rotor holder now

## Additional Information

This was discussed internally.

## Potential Compatibility Issues

I don't see any possibility of that.
