### PR TITLE
drop filter when item bus broken

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -125,6 +125,12 @@ public class ItemBusPartMachine extends TieredIOPartMachine
     }
 
     @Override
+    public void onMachineDestroyed() {
+        if (filterHandler.isFilterPresent())
+            Block.popResource(getLevel(), getBlockPos(), filterHandler.getFilterItem());
+    }
+
+    @Override
     public void onPaintingColorChanged(int color) {
         getHandlerList().setColor(color, true);
     }


### PR DESCRIPTION
## What
Drops the inserted filter when an item bus is broken, fixes #5062
- [X] No AI driven tools were used for this pull request.
