### PR TITLE
Fix misuse of IO.BOTH by using .storage when needed

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -91,11 +91,11 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
         this.cleanroomReceiver = attachTrait(new CleanroomReceiverTrait());
         this.recipeLogic = attachTrait(recipeLogic);
         this.recipeLogic.setKeepSubscribing(false);
-        this.importItems = attachTrait(new NotifiableItemStackHandler(importSlots, IO.IN, IO.BOTH));
+        this.importItems = attachTrait(new NotifiableItemStackHandler(importSlots, IO.IN));
         this.exportItems = attachTrait(new NotifiableItemStackHandler(exportSlots, IO.OUT));
         this.importFluids = attachTrait(
                 new NotifiableFluidTank(fluidImportSlots, tankScalingFunction.applyAsInt(getTier()),
-                        IO.IN, IO.BOTH));
+                        IO.IN));
         this.exportFluids = attachTrait(
                 new NotifiableFluidTank(fluidExportSlots, tankScalingFunction.applyAsInt(getTier()),
                         IO.OUT));
@@ -126,7 +126,7 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
         this.recipeLogic.setKeepSubscribing(false);
         this.importItems = attachTrait(
                 new NotifiableItemStackHandler(getDefinition().getInputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
-                        IO.IN, IO.BOTH));
+                        IO.IN));
         this.exportItems = attachTrait(
                 new NotifiableItemStackHandler(
                         getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()),

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SimpleSteamMachine.java
@@ -49,7 +49,7 @@ public class SimpleSteamMachine extends SteamWorkableMachine {
     public SimpleSteamMachine(BlockEntityCreationInfo info, RecipeLogic recipeLogic, boolean isHighPressure,
                               int importSlots, int exportSlots) {
         super(info, isHighPressure, recipeLogic);
-        this.importItems = attachTrait(new NotifiableItemStackHandler(importSlots, IO.IN, IO.BOTH));
+        this.importItems = attachTrait(new NotifiableItemStackHandler(importSlots, IO.IN));
         this.exportItems = attachTrait(new NotifiableItemStackHandler(exportSlots, IO.OUT));
         this.exhaustVentTrait = attachTrait(new ExhaustVentMachineTrait());
     }
@@ -58,7 +58,7 @@ public class SimpleSteamMachine extends SteamWorkableMachine {
         super(info, isHighPressure);
         this.importItems = attachTrait(
                 new NotifiableItemStackHandler(getDefinition().getInputSize(ItemRecipeCapability.CAP, getRecipeTypes()),
-                        IO.IN, IO.BOTH));
+                        IO.IN));
         this.exportItems = attachTrait(
                 new NotifiableItemStackHandler(
                         getDefinition().getOutputSize(ItemRecipeCapability.CAP, getRecipeTypes()),

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/MachineCapabilityLayoutBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/MachineCapabilityLayoutBuilder.java
@@ -49,7 +49,7 @@ public interface MachineCapabilityLayoutBuilder {
 
         if (layout.getRecipeType().getMaxSlots(ItemRecipeCapability.CAP, io) == 1) {
             var slot = new ItemSlot()
-                    .slot(new ModularSlot(itemHandler, 0)
+                    .slot(new ModularSlot(itemHandler.storage, 0)
                             .slotGroup(slotGroup)
                             .accessibility(itemHandler.getCapabilityIO().support(IO.IN), true))
                     .backgroundOverlay(layout.capabilityInfo(ItemRecipeCapability.CAP).getOverlay(io, 0));
@@ -62,7 +62,7 @@ public interface MachineCapabilityLayoutBuilder {
                 .builder()
                 .matrix(layout.capabilityInfo(ItemRecipeCapability.CAP).getMachineGrid(io, machine))
                 .key('s', i -> new ItemSlot()
-                        .slot(new ModularSlot(itemHandler, i)
+                        .slot(new ModularSlot(itemHandler.storage, i)
                                 .slotGroup(slotGroup)
                                 .accessibility(itemHandler.getCapabilityIO().support(IO.IN), true))
                         .backgroundOverlay(layout.capabilityInfo(ItemRecipeCapability.CAP).getOverlay(io, i)))

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BlockBreakerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/BlockBreakerMachine.java
@@ -238,8 +238,11 @@ public class BlockBreakerMachine extends TieredEnergyMachine
                         .center()
                         .coverChildren()
                         .margin(2, 3)
-                        .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache,
-                                "output_item_inv", cache.getSize(), 'i',
+                        .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache.storage,
+                                "output_item_inv", cache.getSize(), 'i', slot -> {
+                                    slot.getSlot().accessibility(false, true);
+                                    return slot;
+                                },
                                 syncManager, outputItemGrid))
                         .padding(4, 0));
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -287,7 +287,7 @@ public class FisherMachine extends TieredEnergyMachine
                         .margin(2, 3)
                         .childPadding(4)
                         .child(new ItemSlot()
-                                .slot(new ModularSlot(baitHandler, 0).singletonSlotGroup(0).accessibility(true, true))
+                                .slot(new ModularSlot(baitHandler.storage, 0).singletonSlotGroup(0).accessibility(true, true))
                                 .background(GTGuiTextures.SLOT, GTGuiTextures.STRING_SLOT_OVERLAY))
                         .child(new ProgressWidget()
                                 .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -287,7 +287,8 @@ public class FisherMachine extends TieredEnergyMachine
                         .margin(2, 3)
                         .childPadding(4)
                         .child(new ItemSlot()
-                                .slot(new ModularSlot(baitHandler.storage, 0).singletonSlotGroup(0).accessibility(true, true))
+                                .slot(new ModularSlot(baitHandler.storage, 0).singletonSlotGroup(0).accessibility(true,
+                                        true))
                                 .background(GTGuiTextures.SLOT, GTGuiTextures.STRING_SLOT_OVERLAY))
                         .child(new ProgressWidget()
                                 .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/FisherMachine.java
@@ -293,8 +293,11 @@ public class FisherMachine extends TieredEnergyMachine
                         .child(new ProgressWidget()
                                 .texture(GTGuiTextures.PROGRESS_ARROW.main(), ProgressDrawable.Direction.RIGHT)
                                 .value(progressPercent))
-                        .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache,
-                                "output_item_inv", cache.getSize(), 'i',
+                        .child(GTMuiMachineUtil.createSlotGroupFromInventory(cache.storage,
+                                "output_item_inv", cache.getSize(), 'i', slot -> {
+                                    slot.getSlot().accessibility(false, true);
+                                    return slot;
+                                },
                                 syncManager, outputItemGrid))
                         .padding(4, 0));
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/ItemCollectorMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/ItemCollectorMachine.java
@@ -289,8 +289,11 @@ public class ItemCollectorMachine extends TieredEnergyMachine
                                 .child(new ItemSlot()
                                         .slot(filterInventory, 0)
                                         .background(GTGuiTextures.SLOT, GTGuiTextures.FILTER_SLOT_OVERLAY))
-                                .child(GTMuiMachineUtil.createSlotGroupFromInventory(output,
-                                        "output_item_inv", output.getSize(), 'i',
+                                .child(GTMuiMachineUtil.createSlotGroupFromInventory(output.storage,
+                                        "output_item_inv", output.getSize(), 'i', slot -> {
+                                            slot.getSlot().accessibility(false, true);
+                                            return slot;
+                                        },
                                         syncManager, outputItemGrid))
                                 .padding(4, 0)));
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DataAccessHatchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/DataAccessHatchMachine.java
@@ -88,7 +88,8 @@ public class DataAccessHatchMachine extends TieredPartMachine
     @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
-        var grid = GTMuiMachineUtil.createSlotGroupFromInventory(importItems, "data_inventory", getInventorySize(), 'I',
+        var grid = GTMuiMachineUtil.createSlotGroupFromInventory(importItems.storage, "data_inventory",
+                getInventorySize(), 'I',
                 i -> i.background(GTGuiTextures.SLOT, GTGuiTextures.DATA_ORB_OVERLAY), syncManager,
                 GTMuiMachineUtil.createSquareMatrix(importItems.getSlots(), 'I'));
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -70,7 +70,7 @@ public class ItemBusPartMachine extends TieredIOPartMachine
      */
     public ItemBusPartMachine(BlockEntityCreationInfo info, int tier, IO io) {
         this(info, tier, io,
-                new NotifiableItemStackHandler(getInventorySize(tier), io, io.support(IO.IN) ? IO.BOTH : io));
+                new NotifiableItemStackHandler(getInventorySize(tier), io));
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ObjectHolderMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ObjectHolderMachine.java
@@ -90,7 +90,7 @@ public class ObjectHolderMachine extends MultiblockPartMachine implements IMuiMa
                 .center()
                 .coverChildren()
                 .child(new ItemSlot()
-                        .slot(new ModularSlot(heldItems, 1).slotGroup(orbGroup))
+                        .slot(new ModularSlot(heldItems.storage, 1).slotGroup(orbGroup))
                         .background(GTGuiTextures.SLOT, GTGuiTextures.DATA_ORB_OVERLAY)
                         .marginLeft(30)
                         .marginRight(30)
@@ -101,7 +101,7 @@ public class ObjectHolderMachine extends MultiblockPartMachine implements IMuiMa
                         .pos(75, 0))
 
                 .child(new ItemSlot()
-                        .slot(new ModularSlot(heldItems, 0).slotGroup(objectGroup))
+                        .slot(new ModularSlot(heldItems.storage, 0).slotGroup(objectGroup).accessibility(false, true))
                         .background(GTGuiTextures.SLOT, GTGuiTextures.RESEARCH_STATION_OVERLAY)
                         .marginLeft(30)
                         .marginRight(30)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/PrimitiveWorkableMachine.java
@@ -52,9 +52,9 @@ public class PrimitiveWorkableMachine extends WorkableMultiblockMachine {
                                     int fluidImportSlots, int fluidExportSlots,
                                     int tankCapacity) {
         super(info, recipeLogic);
-        this.importItems = attachTrait(new NotifiableItemStackHandler(importSlots, IO.IN, IO.BOTH));
+        this.importItems = attachTrait(new NotifiableItemStackHandler(importSlots, IO.IN));
         this.exportItems = attachTrait(new NotifiableItemStackHandler(exportSlots, IO.OUT));
-        this.importFluids = attachTrait(new NotifiableFluidTank(fluidImportSlots, tankCapacity, IO.IN, IO.BOTH));
+        this.importFluids = attachTrait(new NotifiableFluidTank(fluidImportSlots, tankCapacity, IO.IN));
         this.exportFluids = attachTrait(new NotifiableFluidTank(fluidExportSlots, tankCapacity, IO.OUT));
         this.hazardEmitter = attachTrait(
                 new EnvironmentalHazardEmitterTrait(GTMedicalConditions.CARBON_MONOXIDE_POISONING,

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamSolidBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamSolidBoilerMachine.java
@@ -137,12 +137,12 @@ public class SteamSolidBoilerMachine extends SteamBoilerMachine {
                 .childPadding(4)
                 .reverseLayout(true)
                 .child(new ItemSlot()
-                        .slot(new ModularSlot(this.fuelHandler, 0)))
+                        .slot(new ModularSlot(this.fuelHandler.storage, 0).accessibility(true, true)))
                 .child(new ProgressWidget()
                         .size(18)
                         .texture(progressTexture, ProgressDrawable.Direction.UP)
                         .value(progressPercent))
                 .child(new ItemSlot()
-                        .slot(new ModularSlot(this.ashHandler, 0))));
+                        .slot(new ModularSlot(this.ashHandler.storage, 0).accessibility(false, true))));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
@@ -15,9 +15,13 @@ import brachy.modularui.widgets.slot.ItemSlot;
 import brachy.modularui.widgets.slot.ModularSlot;
 import brachy.modularui.widgets.slot.SlotGroup;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 
 public class GTMuiMachineUtil {
+
+    private static final int MAX_LOG_SPAM_FOR_ITEMSTACKHANDLER_ABUSE = 3; // 3 seems reasonable
+    private static AtomicInteger currentLogSpam = new AtomicInteger(0);
 
     public static SlotGroupWidget createSlotGroupFromInventory(IItemHandler itemHandler, String slotGroupName,
                                                                int maxSlots, char key, PanelSyncManager syncManager,
@@ -31,8 +35,15 @@ public class GTMuiMachineUtil {
                                                                PanelSyncManager syncManager,
                                                                String... matrix) {
         SlotGroup slotGroup = new SlotGroup(slotGroupName, maxSlots);
-        if (itemHandler instanceof NotifiableItemStackHandler handler) {
-            GTCEu.LOGGER.warn("NotifiableItemStackHandler passed");
+        var currentLogSpamHere = currentLogSpam.get();
+        if (currentLogSpamHere < MAX_LOG_SPAM_FOR_ITEMSTACKHANDLER_ABUSE &&
+                itemHandler instanceof NotifiableItemStackHandler handler) {
+            GTCEu.LOGGER.warn(String.format(
+                    "Logging warning here, %d left until this warning is silenced to avoid log spam, IO=%s",
+                    MAX_LOG_SPAM_FOR_ITEMSTACKHANDLER_ABUSE - currentLogSpamHere, handler.getHandlerIO().name()),
+                    new Exception(
+                            "NotifiableItemStackHandler passed instead of its internal storage; this may NOT be a bug"));
+            currentLogSpam.getAndIncrement();
         }
 
         return SlotGroupWidget.builder()

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
@@ -15,13 +15,12 @@ import brachy.modularui.widgets.slot.ItemSlot;
 import brachy.modularui.widgets.slot.ModularSlot;
 import brachy.modularui.widgets.slot.SlotGroup;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 
 public class GTMuiMachineUtil {
-
-    private static final int MAX_LOG_SPAM_FOR_ITEMSTACKHANDLER_ABUSE = 3; // 3 seems reasonable
-    private static AtomicInteger currentLogSpam = new AtomicInteger(0);
+    private static AtomicBoolean currentLogSpam = new AtomicBoolean(false);
 
     public static SlotGroupWidget createSlotGroupFromInventory(IItemHandler itemHandler, String slotGroupName,
                                                                int maxSlots, char key, PanelSyncManager syncManager,
@@ -35,15 +34,12 @@ public class GTMuiMachineUtil {
                                                                PanelSyncManager syncManager,
                                                                String... matrix) {
         SlotGroup slotGroup = new SlotGroup(slotGroupName, maxSlots);
-        var currentLogSpamHere = currentLogSpam.get();
-        if (currentLogSpamHere < MAX_LOG_SPAM_FOR_ITEMSTACKHANDLER_ABUSE &&
+        if (!currentLogSpam.getAndSet(true) &&
                 itemHandler instanceof NotifiableItemStackHandler handler) {
-            GTCEu.LOGGER.warn(String.format(
-                    "Logging warning here, %d left until this warning is silenced to avoid log spam, IO=%s",
-                    MAX_LOG_SPAM_FOR_ITEMSTACKHANDLER_ABUSE - currentLogSpamHere, handler.getHandlerIO().name()),
+            GTCEu.LOGGER.warn(
+                    "NotifiableItemStackHandler passed instead of its internal storage. IO={}", handler.getHandlerIO().name(),
                     new Exception(
-                            "NotifiableItemStackHandler passed instead of its internal storage; this may NOT be a bug"));
-            currentLogSpam.getAndIncrement();
+                            "NotifiableItemStackHandler passed instead of its internal storage."));
         }
 
         return SlotGroupWidget.builder()

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
@@ -38,8 +38,7 @@ public class GTMuiMachineUtil {
                 itemHandler instanceof NotifiableItemStackHandler handler) {
             GTCEu.LOGGER.warn(
                     "NotifiableItemStackHandler passed instead of its internal storage. IO={}", handler.getHandlerIO().name(),
-                    new Exception(
-                            "NotifiableItemStackHandler passed instead of its internal storage."));
+                    new Throwable());
         }
 
         return SlotGroupWidget.builder()

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
@@ -1,6 +1,8 @@
 package com.gregtechceu.gtceu.common.mui;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableFluidTank;
+import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableItemStackHandler;
 
 import net.minecraftforge.items.IItemHandler;
 
@@ -29,6 +31,9 @@ public class GTMuiMachineUtil {
                                                                PanelSyncManager syncManager,
                                                                String... matrix) {
         SlotGroup slotGroup = new SlotGroup(slotGroupName, maxSlots);
+        if (itemHandler instanceof NotifiableItemStackHandler handler) {
+            GTCEu.LOGGER.warn("NotifiableItemStackHandler passed");
+        }
 
         return SlotGroupWidget.builder()
                 .matrix(matrix)

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
@@ -16,10 +16,10 @@ import brachy.modularui.widgets.slot.ModularSlot;
 import brachy.modularui.widgets.slot.SlotGroup;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
 
 public class GTMuiMachineUtil {
+
     private static AtomicBoolean currentLogSpam = new AtomicBoolean(false);
 
     public static SlotGroupWidget createSlotGroupFromInventory(IItemHandler itemHandler, String slotGroupName,
@@ -33,13 +33,12 @@ public class GTMuiMachineUtil {
                                                                UnaryOperator<ItemSlot> slotModifier,
                                                                PanelSyncManager syncManager,
                                                                String... matrix) {
-        SlotGroup slotGroup = new SlotGroup(slotGroupName, maxSlots);
-        if (!currentLogSpam.getAndSet(true) &&
-                itemHandler instanceof NotifiableItemStackHandler handler) {
-            GTCEu.LOGGER.warn(
-                    "NotifiableItemStackHandler passed instead of its internal storage. IO={}", handler.getHandlerIO().name(),
+        // Error ONCE upon NotifiableItemStackHandler occurrence
+        if (itemHandler instanceof NotifiableItemStackHandler && !currentLogSpam.getAndSet(true))
+            GTCEu.LOGGER.error("createSlotGroupFromInventory called with a NotifiableItemStackHandler directly",
                     new Throwable());
-        }
+
+        SlotGroup slotGroup = new SlotGroup(slotGroupName, maxSlots);
 
         return SlotGroupWidget.builder()
                 .matrix(matrix)


### PR DESCRIPTION
## What

Fixes item stuffs pulling stuff out of input slots outside of the UI

## Implementation Details

I replaced every usage of `new ItemSlot`/`new ModularSlot` to point at storage and set accessibility, then I set the slots to not be `IO.BOTH` but instead the proper `IO.IN`

### AI Usage

Good old CTRL+F and manual edits did the trick here

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome

Item input buses now no longer pull from input slots :D

## How Was This Tested

I went in game, grabbed a bunch of multi-blocks and single-blocks and it worked fine, third-party testing appreciated.

## Potential Compatibility Issues

Potentially this will break some designs that rely upon input items being taken out, but that is something you should not be doing anyways

## Potential Other Issues

I have not validated fluid slots yet