### PR TITLE
Add instanceof check to miner logic getCachedItemHandler

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -433,6 +433,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         if (cachedItemHandler == null) {
             cachedItemHandler = new NotifiableAccountedInvWrapper(getRLMachine()
                     .getCapabilitiesFlat(IO.OUT, ItemRecipeCapability.CAP).stream()
+                    .filter(cap -> cap instanceof IItemHandlerModifiable)
                     .map(IItemHandlerModifiable.class::cast)
                     .toArray(IItemHandlerModifiable[]::new));
         }


### PR DESCRIPTION
## What
Title

## Implementation Details
streams moment

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
(Large ?) Miners no longer crash the game

## How Was This Tested
ingame

## Potential Compatibility Issues
none