### PR TITLE
Fix fluid handler interactions

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
@@ -295,10 +295,14 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
 
     @Override
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
-        if (!isRemote()) {
-            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), waterTank)) {
+        if (FluidUtil.getFluidHandler(context.getItemInHand()).isPresent()) {
+            if (isRemote()) {
                 return InteractionResult.SUCCESS;
             }
+            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), waterTank)) {
+                return InteractionResult.CONSUME;
+            }
+            return InteractionResult.PASS;
         }
         return super.onUseWithItem(context);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CokeOvenMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/primitive/CokeOvenMachine.java
@@ -134,15 +134,18 @@ public class CokeOvenMachine extends PrimitiveWorkableMachine implements IMuiMac
 
     @Override
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
-        if (!isRemote()) {
-            if (super.onUseWithItem(context) == InteractionResult.SUCCESS) {
+        var toolResult = super.onUseWithItem(context);
+        if (toolResult != InteractionResult.PASS) {
+            return toolResult;
+        }
+        if (FluidUtil.getFluidHandler(context.getItemInHand()).isPresent()) {
+            if (isRemote()) {
                 return InteractionResult.SUCCESS;
             }
             if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), exportFluids)) {
-                return InteractionResult.SUCCESS;
+                return InteractionResult.CONSUME;
             }
-            return InteractionResult.PASS;
         }
-        return super.onUseWithItem(context);
+        return InteractionResult.PASS;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamLiquidBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamLiquidBoilerMachine.java
@@ -116,10 +116,14 @@ public class SteamLiquidBoilerMachine extends SteamBoilerMachine {
 
     @Override
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
-        if (!isRemote()) {
-            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), fuelTank)) {
+        if (FluidUtil.getFluidHandler(context.getItemInHand()).isPresent()) {
+            if (isRemote()) {
                 return InteractionResult.SUCCESS;
             }
+            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), fuelTank)) {
+                return InteractionResult.CONSUME;
+            }
+            return InteractionResult.PASS;
         }
         return super.onUseWithItem(context);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeTankMachine.java
@@ -89,7 +89,10 @@ public class CreativeTankMachine extends QuantumTankMachine {
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
         var heldItem = context.getItemInHand();
         var player = context.getPlayer();
-        if (context.getClickedFace() == getFrontFacing() && !isRemote()) {
+        if (context.getClickedFace() == getFrontFacing() && FluidUtil.getFluidHandler(heldItem).isPresent()) {
+            if (isRemote()) {
+                return InteractionResult.SUCCESS;
+            }
             // If no fluid set and held-item has fluid, set fluid
             if (stored.isEmpty()) {
                 return FluidUtil.getFluidContained(heldItem)

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
@@ -118,7 +118,7 @@ public class DrumMachine extends MetaMachine {
                 return InteractionResult.CONSUME;
             }
         }
-        return getLevel().isClientSide() ? InteractionResult.SUCCESS : InteractionResult.PASS;
+        return super.onUseWithItem(context);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
@@ -113,10 +113,14 @@ public class DrumMachine extends MetaMachine {
 
     @Override
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
-        if (!isRemote()) {
+        if (FluidUtil.getFluidHandler(context.getItemInHand()).isPresent()) {
+            if (isRemote()) {
+                return InteractionResult.SUCCESS;
+            }
             if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), cache)) {
                 return InteractionResult.CONSUME;
             }
+            return InteractionResult.PASS;
         }
         return super.onUseWithItem(context);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/QuantumTankMachine.java
@@ -143,10 +143,15 @@ public class QuantumTankMachine extends TieredMachine implements IControllable,
 
     @Override
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
-        if (context.getClickedFace() == getFrontFacing() && !isRemote()) {
-            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), cache)) {
+        if (context.getClickedFace() == getFrontFacing() &&
+                FluidUtil.getFluidHandler(context.getItemInHand()).isPresent()) {
+            if (isRemote()) {
                 return InteractionResult.SUCCESS;
             }
+            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), cache)) {
+                return InteractionResult.CONSUME;
+            }
+            return InteractionResult.PASS;
         }
         return super.onUseWithItem(context);
     }


### PR DESCRIPTION
## What
Before, on client we just passed the "check the fluid interaction" codeblock for a bunch of stuff, leading to desyncs and ghost fluid blocks
Now we check the



### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Opus 4.8
#### Agent Usage Description
Agent used for debugging and code help
  
## Outcome
Fluid bucket on hatch/bus/etc now work instead of putting ghost block on client

## How Was This Tested
Not yet, I got distracted. Will do later

