### PR TITLE
Add getComponentPos for monitor

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/IMonitorComponent.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/IMonitorComponent.java
@@ -1,6 +1,7 @@
 package com.gregtechceu.gtceu.api.capability;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.items.IItemHandler;
 
 import brachy.modularui.api.drawable.IDrawable;
@@ -14,7 +15,13 @@ public interface IMonitorComponent {
 
     IDrawable getIcon();
 
-    BlockPos getBlockPos();
+    default BlockPos getComponentPos() {
+        if (this instanceof BlockEntity be) {
+            return be.getBlockPos();
+        }
+        throw new UnsupportedOperationException(
+                "IMonitorComponent implementations that are not BlockEntities must override getComponentPos()");
+    }
 
     default @Nullable IItemHandler getDataItems() {
         return null;

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/CentralMonitorRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/CentralMonitorRender.java
@@ -86,7 +86,7 @@ public class CentralMonitorRender extends DynamicRender<CentralMonitorMachine, C
                 IMonitorComponent component = machine.getComponent(row, col);
                 if (component != null && component.isMonitor()) {
                     // noinspection deprecation
-                    bounds.encapsulate(component.getBlockPos());
+                    bounds.encapsulate(component.getComponentPos());
                 }
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
@@ -213,9 +213,9 @@ public class CentralMonitorUIFactory implements PanelFactory {
                                         }).draggable(true).size(160, 80));
                 IntSupplier colorSupplier = () -> {
                     if (component == null) return 0;
-                    boolean inGroup = group.contains(component.getBlockPos());
+                    boolean inGroup = group.contains(component.getComponentPos());
                     BlockPos target = group.getTargetRaw();
-                    boolean isTarget = target != null && target.asLong() == component.getBlockPos().asLong();
+                    boolean isTarget = target != null && target.asLong() == component.getComponentPos().asLong();
                     if (inGroup && isTarget) return 0xFFFF00FF;
                     else if (inGroup) return 0xFFFF0000;
                     else if (isTarget) return 0xFF0000FF;
@@ -226,7 +226,7 @@ public class CentralMonitorUIFactory implements PanelFactory {
                         .background(texture, new BorderDrawable(colorSupplier, 1), Text.dynamic(() -> {
                             if (component == null || component.getDataItems() == null) return Component.empty();
                             BlockPos target = group.getTargetRaw();
-                            boolean isTarget = target != null && target.asLong() == component.getBlockPos().asLong();
+                            boolean isTarget = target != null && target.asLong() == component.getComponentPos().asLong();
                             if (isTarget) return Component.literal(String.valueOf(group.getDataSlot() + 1));
                             else return Component.empty();
                         }))
@@ -237,13 +237,13 @@ public class CentralMonitorUIFactory implements PanelFactory {
                                     int button = mouseData.mouseButton();
                                     if (button == InputConstants.MOUSE_BUTTON_LEFT) {
                                         if (!component.isMonitor()) return;
-                                        if (group.contains(component.getBlockPos())) {
-                                            group.remove(component.getBlockPos());
+                                        if (group.contains(component.getComponentPos())) {
+                                            group.remove(component.getComponentPos());
                                         } else {
-                                            group.add(component.getBlockPos());
+                                            group.add(component.getComponentPos());
                                         }
                                     } else if (button == InputConstants.MOUSE_BUTTON_RIGHT) {
-                                        group.setTarget(component.getBlockPos());
+                                        group.setTarget(component.getComponentPos());
                                         groupSync.setValue(groups, true, false);
                                         if (slotDialogHandler != null) {
                                             slotDialogHandler.openPanel();

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/factory/CentralMonitorUIFactory.java
@@ -226,7 +226,8 @@ public class CentralMonitorUIFactory implements PanelFactory {
                         .background(texture, new BorderDrawable(colorSupplier, 1), Text.dynamic(() -> {
                             if (component == null || component.getDataItems() == null) return Component.empty();
                             BlockPos target = group.getTargetRaw();
-                            boolean isTarget = target != null && target.asLong() == component.getComponentPos().asLong();
+                            boolean isTarget = target != null &&
+                                    target.asLong() == component.getComponentPos().asLong();
                             if (isTarget) return Component.literal(String.valueOf(group.getDataSlot() + 1));
                             else return Component.empty();
                         }))


### PR DESCRIPTION
## What
Fixes this error:
<img width="1646" height="394" alt="image" src="https://github.com/user-attachments/assets/e1d817a9-87cf-4c15-9092-37cb5f11f00e" />

The CM was using getBlockPos which was shadowed by BlockEntity.getBlockPos. When remapping, that method gets renamed, but this interface one doesn't.

### AI Usage 
Yes, opus 4.8, used to find the problem and also fix it, I iterated on its solutionmitting a pull request._
  
## Outcome
World loads with placed CM

## How Was This Tested
in game

