### PR TITLE
Add missing super call to item bus on destroy

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -128,6 +128,7 @@ public class ItemBusPartMachine extends TieredIOPartMachine
     public void onMachineDestroyed() {
         if (filterHandler.isFilterPresent())
             Block.popResource(getLevel(), getBlockPos(), filterHandler.getFilterItem());
+        super.onMachineDestroyed();
     }
 
     @Override


### PR DESCRIPTION
## What
Title

## Implementation Details
_Any implementations in this PR that should be carefully looked over, or that could/should have alternate solutions proposed._

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
Item buses now drop their contents again

## How Was This Tested
ingame

## Additional Information
we wont void hss-e again (hopefully)
