### PR TITLE
fix fluids not displaying, mouse clicks not being recognized and auto…

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/AEConfigWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gui/AEConfigWidget.java
@@ -241,8 +241,8 @@ public class AEConfigWidget extends Widget<AEConfigWidget>
 
     @Override
     public Result onMousePressed(int button) {
-        double localX = getContext().getMouseX() - getArea().x;
-        double localY = getContext().getMouseY() - getArea().y;
+        double localX = getContext().getMouseX();
+        double localY = getContext().getMouseY();
 
         int slotIndex = getSlotAtLocal(localX, localY);
         if (slotIndex < 0) return Result.IGNORE;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
@@ -136,7 +136,7 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
                 Component.translatable("gtceu.gui.me_network.online") :
                 Component.translatable("gtceu.gui.me_network.offline"))
                 .asWidget().marginTop(2).marginBottom(4));
-        flow.child(new AEConfigWidget(aeFluidHandler, CONFIG_SIZE, false)
+        flow.child(new AEConfigWidget(aeFluidHandler, CONFIG_SIZE, true)
                 .syncManager(syncManager)
                 .size(8 * 18, 2 * (18 * 2 + 2)));
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
@@ -15,7 +15,7 @@ import brachy.modularui.drawable.ItemDrawable;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.RichTooltip;
 import brachy.modularui.screen.UISettings;
-import brachy.modularui.value.BoolValue;
+import brachy.modularui.value.sync.BooleanSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.SyncHandlers;
 import brachy.modularui.widgets.ButtonWidget;
@@ -94,10 +94,13 @@ public interface IMEStockingPart extends IAutoPullPart, IMuiMachine {
                                         .setNumbers(1, 200))
                                 .margin(5)));
 
+        BooleanSyncValue autoPullValue = new BooleanSyncValue(this::isAutoPull, this::setAutoPull).allowC2S();
+        syncManager.syncValue("stocking_auto_pull", autoPullValue);
+
         return MachineUIPanelBuilder.panelBuilder(this.self())
                 .rightConfigurators(f -> {
                     f.child(new ToggleButton()
-                            .value(new BoolValue.Dynamic(this::isAutoPull, this::setAutoPull))
+                            .syncHandler("stocking_auto_pull")
                             .stateOverlay(GTGuiTextures.BUTTON_AUTO_PULL)
                             .tooltipAutoUpdate(true)
                             .tooltipBuilder(r -> r

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
@@ -94,13 +94,10 @@ public interface IMEStockingPart extends IAutoPullPart, IMuiMachine {
                                         .setNumbers(1, 200))
                                 .margin(5)));
 
-        BooleanSyncValue autoPullValue = new BooleanSyncValue(this::isAutoPull, this::setAutoPull).allowC2S();
-        syncManager.syncValue("stocking_auto_pull", autoPullValue);
-
         return MachineUIPanelBuilder.panelBuilder(this.self())
                 .rightConfigurators(f -> {
                     f.child(new ToggleButton()
-                            .syncHandler("stocking_auto_pull")
+                            .value(new BooleanSyncValue(this::isAutoPull, this::setAutoPull).allowC2S())
                             .stateOverlay(GTGuiTextures.BUTTON_AUTO_PULL)
                             .tooltipAutoUpdate(true)
                             .tooltipBuilder(r -> r


### PR DESCRIPTION
## What
Fixes fluids not rendering in ME hatches, mouse clicks not working and auto pull button not working.

## Implementation Details
Mouse clicks were normalized but they are already normalized so they were reporting that they hit at negative coordinates. The fluid was not rendering because the config widget had isFluid false. The autopull was not working because it was not synced to the server.

### AI Usage 

- [x] No AI driven tools were used for this pull request.

## Outcome
Things mentioned above work.

## How Was This Tested
I tested this on dev instance.