### PR TITLE
Stocking optimization

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTAEMachines.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/machines/GTAEMachines.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.data.RotationState;
 import com.gregtechceu.gtceu.api.machine.MachineDefinition;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
+import com.gregtechceu.gtceu.integration.ae2.gridservice.StockingGridService;
 import com.gregtechceu.gtceu.integration.ae2.machine.*;
 
 import net.minecraft.network.chat.Component;
@@ -132,5 +133,7 @@ public class GTAEMachines {
                     Component.translatable("gtceu.part_sharing.enabled"))
             .register();
 
-    public static void init() {}
+    public static void init() {
+        StockingGridService.register();
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gridservice/IStockingService.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gridservice/IStockingService.java
@@ -1,0 +1,12 @@
+package com.gregtechceu.gtceu.integration.ae2.gridservice;
+
+import com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock.IMEStockingPart;
+
+import appeng.api.networking.IGridService;
+
+public interface IStockingService extends IGridService {
+
+    void markForRefresh(IMEStockingPart part);
+
+    void markForAutoPull(IMEStockingPart part);
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/gridservice/StockingGridService.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/gridservice/StockingGridService.java
@@ -1,0 +1,318 @@
+package com.gregtechceu.gtceu.integration.ae2.gridservice;
+
+import com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock.IMEStockingPart;
+
+import net.minecraft.nbt.CompoundTag;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.GridServices;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNode;
+import appeng.api.networking.IGridServiceProvider;
+import appeng.api.stacks.AEKey;
+import appeng.api.stacks.GenericStack;
+import appeng.api.stacks.KeyCounter;
+import appeng.api.storage.MEStorage;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class StockingGridService implements IStockingService, IGridServiceProvider {
+
+    public static void register() {
+        GridServices.register(IStockingService.class, StockingGridService.class);
+    }
+
+    private final IGrid grid;
+    private final Set<IMEStockingPart> parts = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Map<AEKey, Set<IMEStockingPart>> keyToParts = new HashMap<>();
+    private final Map<IMEStockingPart, Set<AEKey>> partKeys = new IdentityHashMap<>();
+    private final Object2LongMap<AEKey> lastAmounts = new Object2LongOpenHashMap<>();
+    private final Set<IMEStockingPart> pendingRefresh = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Set<IMEStockingPart> pendingAutoPull = Collections.newSetFromMap(new IdentityHashMap<>());
+    private final Map<IMEStockingPart, Set<AEKey>> pendingStockUpdates = new IdentityHashMap<>();
+    private final Set<IMEStockingPart> pendingImmediate = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    public StockingGridService(IGrid grid) {
+        this.grid = grid;
+    }
+
+    @Override
+    public void addNode(IGridNode node, @Nullable CompoundTag savedData) {
+        if (node.getOwner() instanceof IMEStockingPart part) {
+            parts.add(part);
+            pendingRefresh.add(part);
+            if (part.isAutoPull()) {
+                pendingAutoPull.add(part);
+            }
+        }
+    }
+
+    @Override
+    public void removeNode(IGridNode node) {
+        if (node.getOwner() instanceof IMEStockingPart part) {
+            unregister(part);
+        }
+    }
+
+    @Override
+    public void markForRefresh(IMEStockingPart part) {
+        if (parts.contains(part)) {
+            pendingRefresh.add(part);
+        }
+    }
+
+    @Override
+    public void markForAutoPull(IMEStockingPart part) {
+        if (parts.contains(part)) {
+            pendingAutoPull.add(part);
+        }
+    }
+
+    private void unregister(IMEStockingPart part) {
+        parts.remove(part);
+        pendingRefresh.remove(part);
+        pendingAutoPull.remove(part);
+        pendingStockUpdates.remove(part);
+        pendingImmediate.remove(part);
+
+        Set<AEKey> keys = partKeys.remove(part);
+        if (keys != null) {
+            for (AEKey key : keys) {
+                removeInterest(key, part);
+            }
+        }
+    }
+
+    private void removeInterest(AEKey key, IMEStockingPart part) {
+        Set<IMEStockingPart> interested = keyToParts.get(key);
+        if (interested != null) {
+            interested.remove(part);
+            if (interested.isEmpty()) {
+                keyToParts.remove(key);
+                lastAmounts.removeLong(key);
+            }
+        }
+    }
+
+    @Override
+    public void onServerStartTick() {
+        if (parts.isEmpty()) {
+            return;
+        }
+
+        KeyCounter cached = grid.getStorageService().getCachedInventory();
+
+        processAutoPull(cached);
+        processPendingRegistrations(cached);
+        detectStockChanges(cached);
+        applyStockUpdates(cached);
+    }
+
+    private void processAutoPull(KeyCounter cached) {
+        List<IMEStockingPart> duePulls = new ArrayList<>();
+
+        for (IMEStockingPart part : parts) {
+            if (part.isAutoPull() && part.isOnline() &&
+                    (part.isCycleDue() || pendingAutoPull.contains(part))) {
+                duePulls.add(part);
+            }
+        }
+
+        pendingAutoPull.clear();
+
+        MEStorage storage = grid.getStorageService().getInventory();
+        var ranked = rankByAmountDescending(cached);
+        Object2LongMap<AEKey> extractableCache = new Object2LongOpenHashMap<>();
+
+        for (IMEStockingPart part : duePulls) {
+            refreshAutoPull(part, ranked, storage, extractableCache);
+        }
+    }
+
+    private void processPendingRegistrations(KeyCounter cached) {
+        if (pendingRefresh.isEmpty()) {
+            return;
+        }
+
+        List<IMEStockingPart> refreshing = new ArrayList<>(pendingRefresh);
+        pendingRefresh.clear();
+
+        for (IMEStockingPart part : refreshing) {
+            if (!parts.contains(part)) {
+                continue;
+            }
+
+            refreshRegistration(part, cached);
+        }
+    }
+
+    private void detectStockChanges(KeyCounter cached) {
+        for (var entry : keyToParts.entrySet()) {
+            AEKey key = entry.getKey();
+            long amount = cached.get(key);
+
+            if (lastAmounts.containsKey(key) && lastAmounts.getLong(key) == amount) {
+                continue;
+            }
+
+            lastAmounts.put(key, amount);
+
+            for (IMEStockingPart part : entry.getValue()) {
+                pendingStockUpdates.computeIfAbsent(part, ignored -> new HashSet<>()).add(key);
+            }
+        }
+    }
+
+    private void applyStockUpdates(KeyCounter cached) {
+        if (pendingStockUpdates.isEmpty()) {
+            return;
+        }
+
+        MEStorage storage = null;
+        var realAmounts = new Object2LongOpenHashMap<>();
+
+        var iterator = pendingStockUpdates.entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            IMEStockingPart part = entry.getKey();
+
+            if (!parts.contains(part)) {
+                iterator.remove();
+                pendingImmediate.remove(part);
+                continue;
+            }
+
+            if (part.isOnline() && !part.isCycleDue() && !pendingImmediate.contains(part)) {
+                continue;
+            }
+
+            Set<AEKey> keys = entry.getValue();
+            iterator.remove();
+            pendingImmediate.remove(part);
+
+            if (keys.isEmpty()) {
+                continue;
+            }
+
+            if (storage == null) {
+                storage = grid.getStorageService().getInventory();
+            }
+
+            Object2LongMap<AEKey> changes = new Object2LongOpenHashMap<>(keys.size());
+            for (AEKey key : keys) {
+                long realAmount;
+
+                if (realAmounts.containsKey(key)) {
+                    realAmount = realAmounts.getLong(key);
+                } else {
+                    realAmount = storage.extract(key, cached.get(key), Actionable.SIMULATE, part.getActionSource());
+                    realAmounts.put(key, realAmount);
+                }
+
+                changes.put(key, realAmount);
+            }
+
+            if (part.applyStockSilent(changes)) {
+                part.notifyStockChanged();
+            }
+        }
+    }
+
+    private void refreshRegistration(IMEStockingPart part, KeyCounter cached) {
+        Set<AEKey> newKeys = new HashSet<>(part.getStockingKeys());
+        Set<AEKey> oldKeys = partKeys.getOrDefault(part, Collections.emptySet());
+        Set<AEKey> queuedKeys = pendingStockUpdates.get(part);
+
+        for (AEKey key : oldKeys) {
+            if (!newKeys.contains(key)) {
+                removeInterest(key, part);
+                if (queuedKeys != null) {
+                    queuedKeys.remove(key);
+                }
+            }
+        }
+
+        if (queuedKeys != null && queuedKeys.isEmpty()) {
+            pendingStockUpdates.remove(part);
+        }
+
+        for (AEKey key : newKeys) {
+            keyToParts.computeIfAbsent(key, ignored -> Collections.newSetFromMap(new IdentityHashMap<>())).add(part);
+
+            if (!lastAmounts.containsKey(key)) {
+                lastAmounts.put(key, cached.get(key));
+            }
+
+            pendingStockUpdates.computeIfAbsent(part, ignored -> new HashSet<>()).add(key);
+        }
+
+        if (newKeys.isEmpty()) {
+            partKeys.remove(part);
+        } else {
+            partKeys.put(part, newKeys);
+            pendingImmediate.add(part);
+        }
+    }
+
+    private List<Object2LongMap.Entry<AEKey>> rankByAmountDescending(KeyCounter cached) {
+        List<Object2LongMap.Entry<AEKey>> ranked = new ArrayList<>();
+
+        for (Object2LongMap.Entry<AEKey> entry : cached) {
+            if (entry.getLongValue() > 0) {
+                ranked.add(entry);
+            }
+        }
+
+        ranked.sort((a, b) -> Long.compare(b.getLongValue(), a.getLongValue()));
+        return ranked;
+    }
+
+    private void refreshAutoPull(IMEStockingPart part, List<Object2LongMap.Entry<AEKey>> ranked, MEStorage storage,
+                                 Object2LongMap<AEKey> extractableCache) {
+        int configSize = part.getSlotList().getConfigurableSlots();
+        int minStackSize = part.getMinStackSize();
+        List<GenericStack> selection = new ArrayList<>(configSize);
+
+        for (var entry : ranked) {
+            if (selection.size() >= configSize) {
+                break;
+            }
+
+            long amount = entry.getLongValue();
+            if (amount < minStackSize) {
+                break;
+            }
+
+            AEKey what = entry.getKey();
+            if (!part.isAutoPullValid(what, amount)) {
+                continue;
+            }
+
+            long extractable;
+            if (extractableCache.containsKey(what)) {
+                extractable = extractableCache.getLong(what);
+            } else {
+                extractable = storage.extract(what, amount, Actionable.SIMULATE, part.getActionSource());
+                extractableCache.put(what, extractable);
+            }
+
+            if (extractable < minStackSize) {
+                continue;
+            }
+
+            selection.add(new GenericStack(what, extractable));
+        }
+
+        part.applyAutoPull(selection);
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputBusPartMachine.java
@@ -148,7 +148,11 @@ public class MEInputBusPartMachine extends MEBusPartMachine
             var player = syncManager.getPlayer();
             ItemStack held = player.containerMenu.getCarried();
             if (!held.isEmpty()) {
-                slot.setConfig(GenericStack.fromItemStack(held));
+                GenericStack newStack = GenericStack.fromItemStack(held);
+                if (!aeItemHandler.isConfigStackAllowed(newStack)) {
+                    return;
+                }
+                slot.setConfig(newStack);
             }
         });
 
@@ -192,7 +196,11 @@ public class MEInputBusPartMachine extends MEBusPartMachine
             if (!isFluid) {
                 ItemStack item = packet.readItem();
                 if (!item.isEmpty()) {
-                    aeItemHandler.getInventory()[index].setConfig(GenericStack.fromItemStack(item));
+                    GenericStack newStack = GenericStack.fromItemStack(item);
+                    if (!aeItemHandler.isConfigStackAllowed(newStack)) {
+                        return;
+                    }
+                    aeItemHandler.getInventory()[index].setConfig(newStack);
                 }
             }
         });

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
@@ -136,7 +136,7 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
                 Component.translatable("gtceu.gui.me_network.online") :
                 Component.translatable("gtceu.gui.me_network.offline"))
                 .asWidget().marginTop(2).marginBottom(4));
-        flow.child(new AEConfigWidget(aeFluidHandler, CONFIG_SIZE, false)
+        flow.child(new AEConfigWidget(aeFluidHandler, CONFIG_SIZE, true)
                 .syncManager(syncManager)
                 .size(8 * 18, 2 * (18 * 2 + 2)));
 
@@ -151,7 +151,11 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
             var player = syncManager.getPlayer();
             ItemStack held = player.containerMenu.getCarried();
             FluidUtil.getFluidContained(held).ifPresent(fluid -> {
-                slot.setConfig(AEUtil.fromFluidStack(fluid));
+                GenericStack newStack = AEUtil.fromFluidStack(fluid);
+                if (!aeFluidHandler.isConfigStackAllowed(newStack)) {
+                    return;
+                }
+                slot.setConfig(newStack);
             });
         });
 
@@ -178,7 +182,11 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
             if (isFluidGhost) {
                 FluidStack fluid = FluidStack.readFromPacket(packet);
                 if (!fluid.isEmpty()) {
-                    aeFluidHandler.getInventory()[index].setConfig(AEUtil.fromFluidStack(fluid));
+                    GenericStack newStack = AEUtil.fromFluidStack(fluid);
+                    if (!aeFluidHandler.isConfigStackAllowed(newStack)) {
+                        return;
+                    }
+                    aeFluidHandler.getInventory()[index].setConfig(newStack);
                 }
             }
         });

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEInputHatchPartMachine.java
@@ -136,7 +136,7 @@ public class MEInputHatchPartMachine extends MEHatchPartMachine
                 Component.translatable("gtceu.gui.me_network.online") :
                 Component.translatable("gtceu.gui.me_network.offline"))
                 .asWidget().marginTop(2).marginBottom(4));
-        flow.child(new AEConfigWidget(aeFluidHandler, CONFIG_SIZE, true)
+        flow.child(new AEConfigWidget(aeFluidHandler, CONFIG_SIZE, false)
                 .syncManager(syncManager)
                 .size(8 * 18, 2 * (18 * 2 + 2)));
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingBusPartMachine.java
@@ -7,10 +7,7 @@ import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock.IMEStockingPart;
-import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEItemList;
-import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEItemSlot;
-import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAESlot;
-import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlotList;
+import com.gregtechceu.gtceu.integration.ae2.slot.*;
 import com.gregtechceu.gtceu.utils.ExtendedUseOnContext;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -20,19 +17,17 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.ItemStack;
 
 import appeng.api.config.Actionable;
-import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNodeListener;
+import appeng.api.networking.security.IActionSource;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.storage.MEStorage;
-import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Comparator;
 import java.util.Objects;
-import java.util.PriorityQueue;
 import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -87,34 +82,44 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
 
     @Override
     public void autoIO() {
-        super.autoIO();
-        if (ticksPerCycle == 0) ticksPerCycle = ConfigHolder.INSTANCE.compat.ae2.updateIntervals; // Emergency Check to
-                                                                                                  // Avoid Crash loops.
-        if (getOffsetTimer() % ticksPerCycle == 0) {
-            if (autoPull) {
-                refreshList();
-            }
-            syncME();
+        if (!isWorkingEnabled()) {
+            return;
+        }
+        if (!shouldSyncME()) {
+            return;
+        }
+        if (ticksPerCycle == 0) {
+            ticksPerCycle = ConfigHolder.INSTANCE.compat.ae2.updateIntervals;
+        }
+        if (updateMEStatus()) {
+            updateInventorySubscription();
         }
     }
 
     @Override
-    protected void syncME() {
-        // Update the visual display for the fake items. This also is important for the item handler's
-        // getStackInSlot() method, as it uses the cached items set here.
-        MEStorage networkInv = this.getMainNode().getGrid().getStorageService().getInventory();
-        for (ExportOnlyAEItemSlot slot : this.aeItemHandler.getInventory()) {
-            var config = slot.getConfig();
-            if (config != null) {
-                // Try to fill the slot
-                var key = config.what();
-                long extracted = networkInv.extract(key, Long.MAX_VALUE, Actionable.SIMULATE, actionSource);
-                if (extracted >= minStackSize) {
-                    slot.setStock(new GenericStack(key, extracted));
-                    continue;
+    public void onMainNodeStateChanged(IGridNodeListener.State reason) {
+        boolean wasOnline = isOnline();
+        super.onMainNodeStateChanged(reason);
+        if (isOnline() == wasOnline) {
+            return;
+        }
+        if (isOnline()) {
+            if (isAutoPull()) {
+                markForAutoPull();
+            }
+            markForRefresh();
+        } else {
+            if (isAutoPull()) {
+                getSlotList().clearInventory(0);
+            } else {
+                for (int i = 0; i < getSlotList().getConfigurableSlots(); i++) {
+                    IConfigurableSlot slot = getSlotList().getConfigurableSlot(i);
+                    if (slot == null) {
+                        continue;
+                    }
+                    slot.setStock(null);
                 }
             }
-            slot.setStock(null);
         }
     }
 
@@ -141,8 +146,21 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
     }
 
     @Override
+    public void onPaintingColorChanged(int color) {
+        super.onPaintingColorChanged(color);
+        if (!isRemote()) {
+            validateConfig();
+        }
+    }
+
+    @Override
     public IConfigurableSlotList getSlotList() {
         return aeItemHandler;
+    }
+
+    @Override
+    public IActionSource getActionSource() {
+        return actionSource;
     }
 
     @Override
@@ -156,8 +174,9 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
         for (MultiblockControllerMachine controller : getControllers()) {
             for (MultiblockPartMachine part : controller.getParts()) {
                 if (part instanceof MEStockingBusPartMachine bus) {
-                    // We don't need to check for ourselves, as this case is handled elsewhere.
-                    if (bus == this || bus.isDistinct()) continue;
+                    if (bus == this || bus.isDistinct() || bus.getPaintingColor() != this.getPaintingColor()) {
+                        continue;
+                    }
                     if (bus.aeItemHandler.hasStackInConfig(config, false)) {
                         return true;
                     }
@@ -175,7 +194,7 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
             if (!this.autoPull) {
                 this.aeItemHandler.clearInventory(0);
             } else if (updateMEStatus()) {
-                this.refreshList();
+                markForAutoPull();
                 updateInventorySubscription();
             }
         }
@@ -186,68 +205,9 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
         setOffsetBound(ticksPerCycle);
     }
 
-    /**
-     * Refresh the configuration list in auto-pull mode.
-     * Sets the config to the CONFIG_SIZE items with the highest amount in the ME system.
-     */
-    private void refreshList() {
-        IGrid grid = this.getMainNode().getGrid();
-        if (grid == null) {
-            aeItemHandler.clearInventory(0);
-            return;
-        }
-
-        MEStorage networkStorage = grid.getStorageService().getInventory();
-        var counter = networkStorage.getAvailableStacks();
-
-        // Use a PriorityQueue to sort the stacks on size, take the first CONFIG_SIZE
-        // biggest stacks.
-        PriorityQueue<Object2LongMap.Entry<AEKey>> topItems = new PriorityQueue<>(
-                Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
-
-        for (Object2LongMap.Entry<AEKey> entry : counter) {
-            long amount = entry.getLongValue();
-            AEKey what = entry.getKey();
-
-            if (amount <= 0) continue;
-            if (!(what instanceof AEItemKey itemKey)) continue;
-
-            long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
-            if (request == 0) continue;
-
-            // Ensure that it is valid to configure with this stack
-            if (autoPullTest != null && !autoPullTest.test(new GenericStack(itemKey, amount))) continue;
-            if (amount >= minStackSize) {
-                if (topItems.size() < CONFIG_SIZE) {
-                    topItems.offer(entry);
-                } else if (amount > topItems.peek().getLongValue()) {
-                    topItems.poll();
-                    topItems.offer(entry);
-                }
-            }
-        }
-
-        // Now, topItems is a PQ with CONFIG_SIZE highest amount items in the system.
-        int index;
-        int itemAmount = topItems.size();
-        for (index = 0; index < CONFIG_SIZE; index++) {
-            if (topItems.isEmpty()) break;
-            Object2LongMap.Entry<AEKey> entry = topItems.poll();
-
-            AEKey what = entry.getKey();
-            long amount = entry.getLongValue();
-
-            // If we get here, the item has already been checked by the PQ.
-            long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
-
-            // Since we want our items to be displayed from highest to lowest, but poll() returns
-            // the lowest first, we fill in the slots starting at itemAmount-1
-            var slot = this.aeItemHandler.getInventory()[itemAmount - index - 1];
-            slot.setConfig(new GenericStack(what, 1));
-            slot.setStock(new GenericStack(what, request));
-        }
-
-        aeItemHandler.clearInventory(index);
+    @Override
+    public boolean isAutoPullValid(AEKey what, long amount) {
+        return what instanceof AEItemKey && autoPullTest.test(new GenericStack(what, amount));
     }
 
     @Override
@@ -348,6 +308,16 @@ public class MEStockingBusPartMachine extends MEInputBusPartMachine implements I
 
         public ExportOnlyAEStockingItemSlot(@Nullable GenericStack config, @Nullable GenericStack stock) {
             super(config, stock);
+        }
+
+        @Override
+        public void setConfig(@Nullable GenericStack val) {
+            GenericStack oldConfig = getConfig();
+            boolean changed = !Objects.equals(oldConfig, val);
+            super.setConfig(val);
+            if (changed && stockingBusPartMachine != null) {
+                stockingBusPartMachine.markForRefresh();
+            }
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
+import appeng.api.stacks.AEItemKey;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
@@ -9,10 +10,7 @@ import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock.IMEStockingPart;
-import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEFluidList;
-import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAEFluidSlot;
-import com.gregtechceu.gtceu.integration.ae2.slot.ExportOnlyAESlot;
-import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlotList;
+import com.gregtechceu.gtceu.integration.ae2.slot.*;
 import com.gregtechceu.gtceu.integration.ae2.utils.AEUtil;
 import com.gregtechceu.gtceu.utils.ExtendedUseOnContext;
 
@@ -20,21 +18,21 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import appeng.api.config.Actionable;
-import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNodeListener;
+import appeng.api.networking.security.IActionSource;
 import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.api.storage.MEStorage;
-import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import lombok.Getter;
 import lombok.Setter;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Comparator;
-import java.util.PriorityQueue;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -96,32 +94,52 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
 
     @Override
     public void autoIO() {
-        super.autoIO();
-        if (ticksPerCycle == 0) ticksPerCycle = ConfigHolder.INSTANCE.compat.ae2.updateIntervals; // Emergency Check to
-                                                                                                  // Avoid Crash loops.
-        if (getOffsetTimer() % ticksPerCycle == 0) {
-            if (autoPull) {
-                refreshList();
-            }
-            syncME();
+        if (!isWorkingEnabled()) {
+            return;
+        }
+        if (!shouldSyncME()) {
+            return;
+        }
+        if (ticksPerCycle == 0) {
+            ticksPerCycle = ConfigHolder.INSTANCE.compat.ae2.updateIntervals;
+        }
+        if (updateMEStatus()) {
+            updateTankSubscription();
         }
     }
 
     @Override
-    protected void syncME() {
-        MEStorage networkInv = this.getMainNode().getGrid().getStorageService().getInventory();
-        for (ExportOnlyAEFluidSlot slot : aeFluidHandler.getInventory()) {
-            var config = slot.getConfig();
-            if (config != null) {
-                // Try to fill the slot
-                var key = config.what();
-                long extracted = networkInv.extract(key, Long.MAX_VALUE, Actionable.SIMULATE, actionSource);
-                if (extracted >= minStackSize) {
-                    slot.setStock(new GenericStack(key, extracted));
-                    continue;
+    public void onMainNodeStateChanged(IGridNodeListener.State reason) {
+        boolean wasOnline = isOnline();
+        super.onMainNodeStateChanged(reason);
+        if (isOnline() == wasOnline) {
+            return;
+        }
+        if (isOnline()) {
+            if (isAutoPull()) {
+                markForAutoPull();
+            }
+            markForRefresh();
+        } else {
+            if (isAutoPull()) {
+                getSlotList().clearInventory(0);
+            } else {
+                for (int i = 0; i < getSlotList().getConfigurableSlots(); i++) {
+                    IConfigurableSlot slot = getSlotList().getConfigurableSlot(i);
+                    if (slot == null) {
+                        continue;
+                    }
+                    slot.setStock(null);
                 }
             }
-            slot.setStock(null);
+        }
+    }
+
+    @Override
+    public void onPaintingColorChanged(int color) {
+        super.onPaintingColorChanged(color);
+        if (!isRemote()) {
+            validateConfig();
         }
     }
 
@@ -143,6 +161,11 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
     }
 
     @Override
+    public IActionSource getActionSource() {
+        return actionSource;
+    }
+
+    @Override
     public boolean testConfiguredInOtherPart(@Nullable GenericStack config) {
         if (config == null) return false;
         if (!isFormed()) return false;
@@ -150,7 +173,9 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
         for (MultiblockControllerMachine controller : getControllers()) {
             for (MultiblockPartMachine part : controller.getParts()) {
                 if (part instanceof MEStockingHatchPartMachine hatch) {
-                    if (hatch == this) continue;
+                    if (hatch == this || hatch.getPaintingColor() != this.getPaintingColor()) {
+                        continue;
+                    }
                     if (hatch.aeFluidHandler.hasStackInConfig(config, false)) {
                         return true;
                     }
@@ -168,7 +193,7 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
             if (!this.autoPull) {
                 this.aeFluidHandler.clearInventory(0);
             } else if (updateMEStatus()) {
-                this.refreshList();
+                markForAutoPull();
                 updateTankSubscription();
             }
         }
@@ -179,63 +204,9 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
         setOffsetBound(ticksPerCycle);
     }
 
-    private void refreshList() {
-        IGrid grid = this.getMainNode().getGrid();
-        if (grid == null) {
-            aeFluidHandler.clearInventory(0);
-            return;
-        }
-
-        MEStorage networkStorage = grid.getStorageService().getInventory();
-        var counter = networkStorage.getAvailableStacks();
-
-        // Use a PriorityQueue to sort the stacks on size, take the first CONFIG_SIZE
-        // biggest stacks.
-        PriorityQueue<Object2LongMap.Entry<AEKey>> topFluids = new PriorityQueue<>(
-                Comparator.comparingLong(Object2LongMap.Entry<AEKey>::getLongValue));
-
-        for (Object2LongMap.Entry<AEKey> entry : counter) {
-            long amount = entry.getLongValue();
-            AEKey what = entry.getKey();
-
-            if (amount <= 0) continue;
-            if (!(what instanceof AEFluidKey fluidKey)) continue;
-
-            long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
-            if (request == 0) continue;
-
-            // Ensure that it is valid to configure with this stack
-            if (autoPullTest != null && !autoPullTest.test(new GenericStack(fluidKey, amount))) continue;
-            if (amount >= minStackSize) {
-                if (topFluids.size() < CONFIG_SIZE) {
-                    topFluids.offer(entry);
-                } else if (amount > topFluids.peek().getLongValue()) {
-                    topFluids.poll();
-                    topFluids.offer(entry);
-                }
-            }
-        }
-
-        // Now, topFluids is a PQ with CONFIG_SIZE highest amount fluids in the system.
-        int index;
-        int fluidAmount = topFluids.size();
-        for (index = 0; index < CONFIG_SIZE; index++) {
-            if (topFluids.isEmpty()) break;
-            Object2LongMap.Entry<AEKey> entry = topFluids.poll();
-            AEKey what = entry.getKey();
-            long amount = entry.getLongValue();
-
-            // If we get here, the fluid has already been checked by the PQ.
-            long request = networkStorage.extract(what, amount, Actionable.SIMULATE, actionSource);
-
-            // Since we want our fluids to be displayed from highest to lowest, but poll() returns
-            // the lowest first, we fill in the slots starting at fluidAmount-1
-            var slot = this.aeFluidHandler.getInventory()[fluidAmount - index - 1];
-            slot.setConfig(new GenericStack(what, 1));
-            slot.setStock(new GenericStack(what, request));
-        }
-
-        aeFluidHandler.clearInventory(index);
+    @Override
+    public boolean isAutoPullValid(AEKey what, long amount) {
+        return what instanceof AEFluidKey && autoPullTest.test(new GenericStack(what, amount));
     }
 
     ////////////////////////////////
@@ -324,6 +295,16 @@ public class MEStockingHatchPartMachine extends MEInputHatchPartMachine implemen
 
         public ExportOnlyAEStockingFluidSlot(@Nullable GenericStack config, @Nullable GenericStack stock) {
             super(config, stock);
+        }
+
+        @Override
+        public void setConfig(@Nullable GenericStack val) {
+            GenericStack oldConfig = getConfig();
+            boolean changed = !Objects.equals(oldConfig, val);
+            super.setConfig(val);
+            if (changed) {
+                markForRefresh();
+            }
         }
 
         @Override

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEStockingHatchPartMachine.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.integration.ae2.machine;
 
-import appeng.api.stacks.AEItemKey;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
@@ -18,7 +17,6 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import appeng.api.config.Actionable;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
@@ -94,9 +94,11 @@ public interface IMEStockingPart extends IAutoPullPart, IMuiMachine {
             GenericStack newStock;
             if (amount >= min) {
                 newStock = new GenericStack(key, amount);
-                if (slot.setStockSilent(newStock)) {
-                    anyChanged = true;
-                }
+            } else {
+                newStock = null;
+            }
+            if (slot.setStockSilent(newStock)) {
+                anyChanged = true;
             }
         }
         return anyChanged;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
@@ -1,6 +1,5 @@
 package com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock;
 
-import brachy.modularui.value.BoolValue;
 import com.gregtechceu.gtceu.api.machine.feature.IMuiMachine;
 import com.gregtechceu.gtceu.api.machine.mui.MachineUIPanelBuilder;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
@@ -22,7 +21,7 @@ import brachy.modularui.drawable.ItemDrawable;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.RichTooltip;
 import brachy.modularui.screen.UISettings;
-import brachy.modularui.value.sync.BooleanSyncValue;
+import brachy.modularui.value.BoolValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.SyncHandlers;
 import brachy.modularui.widgets.ButtonWidget;

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.widgets.PopupPanel;
+import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.integration.ae2.gridservice.IStockingService;
 import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlot;
 import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlotList;
@@ -111,7 +112,7 @@ public interface IMEStockingPart extends IAutoPullPart, IMuiMachine {
     default boolean isCycleDue() {
         int interval = getTicksPerCycle();
         if (interval <= 0) {
-            interval = 40;
+            interval = ConfigHolder.INSTANCE.compat.ae2.updateIntervals;
         }
         return self().getOffsetTimer() % interval == 0;
     }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/feature/multiblock/IMEStockingPart.java
@@ -1,13 +1,20 @@
 package com.gregtechceu.gtceu.integration.ae2.machine.feature.multiblock;
 
+import brachy.modularui.value.BoolValue;
 import com.gregtechceu.gtceu.api.machine.feature.IMuiMachine;
 import com.gregtechceu.gtceu.api.machine.mui.MachineUIPanelBuilder;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 import com.gregtechceu.gtceu.common.mui.widgets.PopupPanel;
+import com.gregtechceu.gtceu.integration.ae2.gridservice.IStockingService;
+import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlot;
 import com.gregtechceu.gtceu.integration.ae2.slot.IConfigurableSlotList;
 
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IManagedGridNode;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import brachy.modularui.api.IPanelHandler;
 import brachy.modularui.api.drawable.Text;
@@ -15,14 +22,19 @@ import brachy.modularui.drawable.ItemDrawable;
 import brachy.modularui.factory.PosGuiData;
 import brachy.modularui.screen.RichTooltip;
 import brachy.modularui.screen.UISettings;
-import brachy.modularui.value.BoolValue;
+import brachy.modularui.value.sync.BooleanSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.SyncHandlers;
 import brachy.modularui.widgets.ButtonWidget;
 import brachy.modularui.widgets.ToggleButton;
 import brachy.modularui.widgets.layout.Flow;
 import brachy.modularui.widgets.textfield.TextFieldWidget;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public interface IMEStockingPart extends IAutoPullPart, IMuiMachine {
 
@@ -44,6 +56,111 @@ public interface IMEStockingPart extends IAutoPullPart, IMuiMachine {
     }
 
     IConfigurableSlotList getSlotList();
+
+    IManagedGridNode getMainNode();
+
+    IActionSource getActionSource();
+
+    boolean isOnline();
+
+    default Set<AEKey> getStockingKeys() {
+        Set<AEKey> keys = new HashSet<>();
+        IConfigurableSlotList slots = getSlotList();
+        for (int i = 0; i < slots.getConfigurableSlots(); i++) {
+            GenericStack config = slots.getConfigurableSlot(i).getConfig();
+            // Don't trust IntelliJ here, it surely CAN be null
+            if (config != null) {
+                keys.add(config.what());
+            }
+        }
+        return keys;
+    }
+
+    default boolean applyStockSilent(Object2LongMap<AEKey> changed) {
+        IConfigurableSlotList slots = getSlotList();
+        int min = getMinStackSize();
+        boolean anyChanged = false;
+        for (int i = 0; i < slots.getConfigurableSlots(); i++) {
+            IConfigurableSlot slot = slots.getConfigurableSlot(i);
+            GenericStack config = slot.getConfig();
+            // Don't trust IntelliJ here, it surely CAN be null
+            if (config == null) {
+                continue;
+            }
+            AEKey key = config.what();
+            if (!changed.containsKey(key)) {
+                continue;
+            }
+            long amount = changed.getLong(key);
+            GenericStack newStock;
+            if (amount >= min) {
+                newStock = new GenericStack(key, amount);
+                if (slot.setStockSilent(newStock)) {
+                    anyChanged = true;
+                }
+            }
+        }
+        return anyChanged;
+    }
+
+    default void notifyStockChanged() {
+        getSlotList().onContentsChanged();
+    }
+
+    default boolean isCycleDue() {
+        int interval = getTicksPerCycle();
+        if (interval <= 0) {
+            interval = 40;
+        }
+        return self().getOffsetTimer() % interval == 0;
+    }
+
+    boolean isAutoPullValid(AEKey what, long amount);
+
+    default void applyAutoPull(List<GenericStack> selection) {
+        IConfigurableSlotList slots = getSlotList();
+        int slotCount = slots.getConfigurableSlots();
+        int filled = 0;
+        boolean changed = false;
+        for (GenericStack stack : selection) {
+            if (filled >= slotCount) {
+                break;
+            }
+            IConfigurableSlot slot = slots.getConfigurableSlot(filled++);
+            GenericStack newConfig = new GenericStack(stack.what(), 1);
+            if (!newConfig.equals(slot.getConfig())) {
+                changed = true;
+            }
+            slot.setConfig(newConfig);
+            if (slot.setStockSilent(stack)) {
+                changed = true;
+            }
+        }
+        slots.clearInventory(filled);
+        if (changed) {
+            slots.onContentsChanged();
+        }
+    }
+
+    default void markForRefresh() {
+        if (self().isRemote()) {
+            return;
+        }
+        IGrid grid = getMainNode().getGrid();
+        if (grid != null) {
+            grid.getService(IStockingService.class).markForRefresh(this);
+        }
+    }
+
+    default void markForAutoPull() {
+        if (self().isRemote()) {
+            return;
+        }
+        IGrid grid = getMainNode().getGrid();
+        if (grid != null) {
+            grid.getService(IStockingService.class).markForAutoPull(this);
+        }
+    }
 
     /**
      * @return True if the passed stack is found as a configuration in any other stocking buses on the multiblock.

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/ExportOnlyAESlot.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/ExportOnlyAESlot.java
@@ -38,6 +38,22 @@ public abstract class ExportOnlyAESlot implements IConfigurableSlot, INBTSeriali
         this(null, null);
     }
 
+    @Override
+    public boolean setStockSilent(@Nullable GenericStack stack) {
+        if (this.stock == null && stack == null) {
+            return false;
+        }
+        if (stack == null) {
+            this.stock = null;
+            return true;
+        }
+        if (stack.equals(this.stock)) {
+            return false;
+        }
+        this.stock = stack;
+        return true;
+    }
+
     @Nullable
     public GenericStack requestStack() {
         if (this.stock != null && this.stock.amount() <= 0) {

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/IConfigurableSlot.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/IConfigurableSlot.java
@@ -15,5 +15,7 @@ public interface IConfigurableSlot {
 
     void setStock(GenericStack val);
 
+    boolean setStockSilent(GenericStack val);
+
     IConfigurableSlot copy();
 }

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/IConfigurableSlotList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/IConfigurableSlotList.java
@@ -1,12 +1,29 @@
 package com.gregtechceu.gtceu.integration.ae2.slot;
 
 import appeng.api.stacks.GenericStack;
+import org.jetbrains.annotations.Nullable;
 
 public interface IConfigurableSlotList {
 
     IConfigurableSlot getConfigurableSlot(int index);
 
     int getConfigurableSlots();
+
+    void onContentsChanged();
+
+    default boolean isStocking() {
+        return false;
+    }
+
+    default boolean isConfigStackAllowed(@Nullable GenericStack stack) {
+        if (stack == null || stack.amount() <= 0) {
+            return true;
+        }
+        if (!isStocking()) {
+            return true;
+        }
+        return !hasStackInConfig(stack, true);
+    }
 
     default boolean hasStackInConfig(GenericStack stack, boolean checkExternal) {
         if (stack == null || stack.amount() <= 0) return false;


### PR DESCRIPTION
## What
Rework to stocking input buses and hatches

## Implementation Details
This makes stocking buses and hatches managed by a grid service from AE2, so instead of each bus polling for all its items each 40 ticks, AE2 keeps track of all stocking parts in the grid and updates them accordingly. AE2 keeps a cached inventory updated each tick anyway, so based on that cache if any item that is observed by any bus (or fluid by hatch) changed in quantity, AE2 remembers and when the bus's tick is due, it checks the real extractable amount from the network (at most once per key per tick) and then updates all parts tracking that key. It also updates them silently and after its done then notifies their listeners, so 5 changes in the same bus will notify its RHL only once. Autopull is now also managed from the grid service, it does check for the top X keys in the network cache, then tries to fill the bus with those keys checking extractable amounts while doing so for valid candidates. It does also checks if a key is valid for the bus, if it does not exist in any other bus in the same group (painting or just not distinct).

### AI Usage 

- [x] Yes AI driven tools were used for this pull request.

#### Agent Used
ClaudeCode Opus 4.8
Usage Description
I used it for basic sanity checking my work if i didn't miss anything important, and to help me get a wider view of the repo and the thing i wanted to do. I also used it to make a tool to measure the performance but it was not commited to the repo as it was only a tool.

## Outcome
It improves performance a lot on a bases that rely heavily on stocking buses/hatches

## How Was This Tested
My friend tested this both with #5165 on 7.5.3 then I moved all stocking bus/hatch changes to this branch and on weaker CPU in endgame monifactory base the results were good, stocking parts no longer were top1 in observable and stopped taking 26% instead they took 0,8%. 
<img width="848" height="150" alt="image" src="https://github.com/user-attachments/assets/6139e3d9-346a-458e-8178-49fcca8e45af" />
before: 
<img width="1055" height="671" alt="image" src="https://github.com/user-attachments/assets/92fdfa6f-c16c-4f89-b62c-0eb5f1d8273f" />
after:
<img width="1086" height="670" alt="image" src="https://github.com/user-attachments/assets/fb779110-429f-4a9d-85d2-696033624045" />

## Additional Information
it wont work without #5168 because it fixes me hatches/buses UI so it works at all. Didn't want to make it in 1 PR in case you don't want this one.

## Additional information 2
My friend profiled #5165 change and a this one with spark and the results are bellow (screenshots + links because links expire):
<img width="383" height="200" alt="image" src="https://github.com/user-attachments/assets/3f247147-1b01-4fd7-877d-111c5c829918" />
<img width="417" height="197" alt="image" src="https://github.com/user-attachments/assets/97eb60f5-06a0-4528-bc9f-8aaff08f6adb" />
OLD: https://spark.lucko.me/MjRH6gc91y
NEW: https://spark.lucko.me/JmBrjCa5tZ
I also profiled this a bit earlier when not all the current changes were implemented and I did it on a weaker laptop, results bellow:
<img width="425" height="201" alt="image" src="https://github.com/user-attachments/assets/abab9552-546f-446f-8f9b-4473f05092ab" />
<img width="446" height="196" alt="image" src="https://github.com/user-attachments/assets/e36c5ea6-7a36-466e-8aeb-dfdc3128386c" />
OLD: https://spark.lucko.me/MfsQrUmAzH
NEW: https://spark.lucko.me/XWbaUwQIkc