### PR TITLE
Fix off by one error in `getDisplayGeneratorPower`

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/WorkableElectricMultiblockMachine.java
@@ -242,7 +242,7 @@ public class WorkableElectricMultiblockMachine extends WorkableMultiblockMachine
     @Override
     public long getDisplayGeneratorPower() {
         if (this.isGenerator()) {
-            long power = -1;
+            long power = 0;
             var handlers = getCapabilitiesFlat(IO.OUT, EURecipeCapability.CAP);
             for (IRecipeHandler<?> handler : handlers) {
                 if (handler instanceof IEnergyContainer container) {


### PR DESCRIPTION
## What
title


## Implementation Details
### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
the jade provider for generator is no longer incorrect

## How Was This Tested
Ingame

## Potential Compatibility Issues
none
