### PR TITLE
Fix recipe duration related exploit

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
@@ -524,7 +524,7 @@ public final class MaterialRecipeHandler {
                             .notConsumable(GTItems.SHAPE_MOLD_NUGGET)
                             .inputFluids(stack)
                             .outputItems(nugget, material, 9)
-                            .duration((int) material.getMass())
+                            .duration(20)
                             .EUt(VA[ULV])
                             .save(provider);
                 }
@@ -583,7 +583,7 @@ public final class MaterialRecipeHandler {
                         .notConsumable(GTItems.SHAPE_MOLD_BLOCK)
                         .inputFluids(stack)
                         .outputItems(blockStack)
-                        .duration((int) material.getMass()).EUt(VA[ULV])
+                        .duration(180).EUt(VA[ULV])
                         .save(provider);
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PartsRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PartsRecipeHandler.java
@@ -621,7 +621,7 @@ public final class PartsRecipeHandler {
         }
 
         LATHE_RECIPES.recipeBuilder("lathe_" + material.getName() + "_nugget_to_round")
-                .EUt(VA[ULV]).duration(100)
+                .EUt(VA[ULV]).duration((int) material.getMass() + 80)
                 .inputItems(nugget, material)
                 .outputItems(round, outputMaterial)
                 .save(provider);


### PR DESCRIPTION
## What
The liquid -> ingot solidification recipe duration is a static 1s, however, the liquid -> block and liquid -> nugget aren't, they're scaled with material mass

This means that in certain situations (manual compression disabled, low mass item), it becomes more effective to solidify your molten material into blocks, and decrafting them. CEu has historically tried to get rid of these kinds of "exploits"

This PR aims to fix this inconsistency, aswell as maintain balance of existing recipes

## Implementation Details
- Ingot solidifying duration remains the same (1s)
- Block solidifying duration is changed to a static duration of 9s <sup>[0]</sup>
- Nugget solidifying duration is changed to a static duration of 1s <sup>[1]</sup>
  -  Round lathing duration is changed from a static duration (5s) to scaling with mass + 4s static <sup>[2]</sup>

### AI Usage 
- [x] No AI driven tools were used for this pull request.

## Outcome
You no longer have to consider if it's more efficient to solidify directly into blocks, or solidify into ingots and then extrude the ingots into a block

This restores some intended balance
This does also nerf/buff some block -> plate cutting recipes, worth considering, but i personally find it to be worth the consistency

## Additional Information

[0] - This might seem like a big buff for materials like neutronium, but in actuality it makes no difference; since the ingot -> block extruder recipe is a static 0.5s, meaning the old effective duration was 9.5s
[1] - The only place I found where this could have potential balance implications is wrought iron, however by the time you can do this recipe, the arc furnace is available too, meaning you don't gain too much from it
[2] - The static 4 seconds are there to keep total duration of making rounds consistent with the previous values

## Potential Compatibility Issues
None that I can see, unless pack makers change autogen recipe duration