### PR TITLE
Make covers' redstone work slightly better

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/CoverBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/CoverBehavior.java
@@ -129,6 +129,11 @@ public abstract class CoverBehavior implements ISyncManaged, IToolGridHighlight,
         if (this.redstoneSignalOutput == redstoneSignalOutput) return;
         this.redstoneSignalOutput = redstoneSignalOutput;
         coverHolder.notifyBlockUpdate();
+        var level = coverHolder.getLevel();
+        if (level != null) {
+            BlockPos poweredPos = coverHolder.getBlockPos().relative(attachedSide);
+            level.updateNeighborsAt(poweredPos, level.getBlockState(poweredPos).getBlock());
+        }
     }
 
     public boolean canConnectRedstone() {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -943,7 +943,6 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
         if (cover != null) return cover.getRedstoneSignalOutput();
 
         var signal = 0;
-
         for (var trait : getTraitHolder().getTraitsByInterface(IRedstoneSignalTrait.class)) {
             signal = Math.max(signal, trait.getOutputSignal(side));
         }
@@ -958,6 +957,13 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
      * @return Direct output signal
      */
     public int getOutputDirectSignal(@Nullable Direction side) {
+        if (side == null) return 0;
+
+        // For some reason, Minecraft requests the output signal from the opposite side...
+        CoverBehavior cover = getCoverContainer().getCoverAtSide(side.getOpposite());
+
+        if (cover != null) return cover.getRedstoneSignalOutput();
+
         var signal = 0;
         for (var trait : getTraitHolder().getTraitsByInterface(IRedstoneSignalTrait.class)) {
             signal = Math.max(signal, trait.getOutputDirectSignal(side));

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -943,6 +943,7 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
         if (cover != null) return cover.getRedstoneSignalOutput();
 
         var signal = 0;
+
         for (var trait : getTraitHolder().getTraitsByInterface(IRedstoneSignalTrait.class)) {
             signal = Math.max(signal, trait.getOutputSignal(side));
         }
@@ -965,6 +966,7 @@ public class MetaMachine extends ManagedSyncBlockEntity implements IGregtechBloc
         if (cover != null) return cover.getRedstoneSignalOutput();
 
         var signal = 0;
+
         for (var trait : getTraitHolder().getTraitsByInterface(IRedstoneSignalTrait.class)) {
             signal = Math.max(signal, trait.getOutputDirectSignal(side));
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
@@ -141,7 +141,7 @@ public class AdvancedEnergyDetectorCover extends EnergyDetectorCover implements 
                         .child(GTMuiWidgets.createLongInputWithButtons(maxValueSync, () -> 0,
                                 () -> usePercent ? 100 : getEnergyCapacity()).width(142)))
                 .child(coverUIRow()
-                        .child(new ToggleButton().value(new BooleanSyncValue(this::isInverted, this::setInverted))
+                        .child(new ToggleButton().value(new BooleanSyncValue(this::isInverted, this::setInverted).allowC2S())
                                 .overlay(false, GTGuiTextures.OVERLAY_REDSTONE_OFF)
                                 .overlay(true, GTGuiTextures.OVERLAY_REDSTONE_ON)
                                 .tooltip(false, t -> t.add("cover.advanced_energy_detector.invert.disabled"))

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedEnergyDetectorCover.java
@@ -141,7 +141,8 @@ public class AdvancedEnergyDetectorCover extends EnergyDetectorCover implements 
                         .child(GTMuiWidgets.createLongInputWithButtons(maxValueSync, () -> 0,
                                 () -> usePercent ? 100 : getEnergyCapacity()).width(142)))
                 .child(coverUIRow()
-                        .child(new ToggleButton().value(new BooleanSyncValue(this::isInverted, this::setInverted).allowC2S())
+                        .child(new ToggleButton()
+                                .value(new BooleanSyncValue(this::isInverted, this::setInverted).allowC2S())
                                 .overlay(false, GTGuiTextures.OVERLAY_REDSTONE_OFF)
                                 .overlay(true, GTGuiTextures.OVERLAY_REDSTONE_ON)
                                 .tooltip(false, t -> t.add("cover.advanced_energy_detector.invert.disabled"))


### PR DESCRIPTION
## What
Before, covers into blocks didn't work. Now they work slightly better, but still not great. They now emit both weak and strong redstone.

## Implementation Details
it seems the redstone code (e.g. the getOutputDirectSignal) is being called both server and clientside,but the client side doesn't have the data so ti returns 0. I am under the impression that redstone is server only so that shouldn't affect things? and regardless if I put e.g. a redstone lamp after the repeater it also doesn't update/work


### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.
 Opus 4.8 did most of the impl, I reviewed it.

## Outcome
Before:
<img width="1364" height="756" alt="image" src="https://github.com/user-attachments/assets/c8c7ac83-1eda-4233-8f3a-992b38992f84" />

After:
<img width="1324" height="792" alt="image" src="https://github.com/user-attachments/assets/788f9a6f-68fb-4970-9197-1bb37bc57c79" />

