### PR TITLE
The item bus now actually works

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -260,7 +260,7 @@ public class ItemBusPartMachine extends TieredIOPartMachine
                 .center()
                 .margin(7, 5)
                 .gridOfSizeHeight(rowSize * rowSize, rowSize, (x, y, index) -> new ItemSlot()
-                        .slot(SyncHandlers.itemSlot(inventory, index)
+                        .slot(SyncHandlers.itemSlot(inventory.storage, index)
                                 .slotGroup(group)
                                 .changeListener((oldStack, newStack, client, init) -> {
                                     if (ItemStack.isSameItem(oldStack, newStack)) {


### PR DESCRIPTION
## What

The item input bus used the incorrect pattern, causing item extraction to not work

### AI Usage 

- [x] No AI driven tools were used for this pull request.
  
## Outcome

The input item bus now allows item extraction

## How Was This Tested

I went in-game via `gradlew runClient`