### PR TITLE
Move makeRegistryKey into Keys

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/registry/GTRegistries.java
@@ -96,6 +96,10 @@ public final class GTRegistries {
         public static final ResourceKey<Registry<IWorldGenLayer>> WORLD_GEN_LAYER = makeRegistryKey(GTCEu.id("world_gen_layer"));
         public static final ResourceKey<Registry<PatternError.PatternErrorType>> PATTERN_ERROR_TYPE = makeRegistryKey(GTCEu.id("pattern_error_type"));
         public static final ResourceKey<Registry<Placeholder>> PLACEHOLDER = makeRegistryKey(GTCEu.id("placeholder"));
+
+        private static <T> ResourceKey<Registry<T>> makeRegistryKey(ResourceLocation registryId) {
+            return ResourceKey.createRegistryKey(registryId);
+        }
     }
 
     // GT Registries
@@ -132,10 +136,6 @@ public final class GTRegistries {
     public static final Registry<IWorldGenLayer> WORLD_GEN_LAYERS = makeRegistry(Keys.WORLD_GEN_LAYER);
 
     // spotless:on
-
-    private static <T> ResourceKey<Registry<T>> makeRegistryKey(ResourceLocation registryId) {
-        return ResourceKey.createRegistryKey(registryId);
-    }
 
     public static <T> MappedRegistry<T> makeRegistry(ResourceKey<Registry<T>> key) {
         return makeRegistry(key, true);


### PR DESCRIPTION
#### Description
Move makeRegistryKey into Keys inside GTRegistries
#### Agent Used
- GPT-5.6-Luna and Claude Opus 5 with a collaborative workflow
#### Usage Desc
- Used to audit the entire registration pipeline to double check this wouldn't cause any edgecase failures
### Outcome
Game doesn't crash if you register KJS or GTAddon Mats. and they register properly