### PR TITLE
Fix AoE tools using stale interaction hand

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/CommonEventListener.java
@@ -184,7 +184,7 @@ public class CommonEventListener {
             return;
         }
 
-        ItemStack toolStack = event.getPlayer().getItemInHand(event.getPlayer().getUsedItemHand());
+        ItemStack toolStack = event.getPlayer().getMainHandItem();
         if (toolStack.getItem() instanceof IGTTool tool) {
             tool.definition$onBlockStartBreak(toolStack, event.getPos(), event.getPlayer());
         }


### PR DESCRIPTION
## What
Fix AOE using stale interaction hand
### AI Usage 
Yes AI: Used Opus 5 to migrate these patches out of my own coremod.
## Outcome
No more weird aoe breaking
## Testing
- Tested Against Multiple Pack Deployments of CosmicFrontiers with no further reports from testers.