### PR TITLE
Circuit Set correct value on sync read amount for 1.21.1

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/IntCircuitBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/IntCircuitBehaviour.java
@@ -30,7 +30,11 @@ public class IntCircuitBehaviour implements IAddInformation, IItemUIHolder {
     public static final int CIRCUIT_MAX = 32;
 
     public static ItemStack stack(int configuration) {
-        var stack = GTItems.PROGRAMMED_CIRCUIT.asStack();
+        return stack(configuration, 1);
+    }
+
+    public static ItemStack stack(int configuration, int count) {
+        var stack = GTItems.PROGRAMMED_CIRCUIT.asStack(count);
         setCircuitConfiguration(stack, configuration);
         return stack;
     }
@@ -58,13 +62,7 @@ public class IntCircuitBehaviour implements IAddInformation, IItemUIHolder {
 
     @Override
     public ModularPanel<?> buildUI(PlayerInventoryGuiData<?> data, PanelSyncManager syncManager, UISettings settings) {
-        return GTMuiWidgets.createCircuitSlotPanel(configured -> {
-            ItemStack current = data.getUsedItemStack();
-            if (!current.isEmpty() && !configured.isEmpty()) {
-                configured.setCount(current.getCount());
-            }
-            data.setUsedItemStack(configured);
-        }, data::getUsedItemStack, syncManager);
+        return GTMuiWidgets.createCircuitSlotPanel(data::setUsedItemStack, data::getUsedItemStack, syncManager);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/IntCircuitBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/IntCircuitBehaviour.java
@@ -58,7 +58,13 @@ public class IntCircuitBehaviour implements IAddInformation, IItemUIHolder {
 
     @Override
     public ModularPanel<?> buildUI(PlayerInventoryGuiData<?> data, PanelSyncManager syncManager, UISettings settings) {
-        return GTMuiWidgets.createCircuitSlotPanel(data::setUsedItemStack, data::getUsedItemStack, syncManager);
+        return GTMuiWidgets.createCircuitSlotPanel(configured -> {
+            ItemStack current = data.getUsedItemStack();
+            if (!current.isEmpty() && !configured.isEmpty()) {
+                configured.setCount(current.getCount());
+            }
+            data.setUsedItemStack(configured);
+        }, data::getUsedItemStack, syncManager);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -215,7 +215,7 @@ public class GTMuiWidgets {
             return IntCircuitBehaviour.getCircuitConfiguration(circuitGetter.get());
         },
                 (v) -> circuitSetter.accept(v < 0 ? ItemStack.EMPTY :
-                        IntCircuitBehaviour.stack(v)))
+                        IntCircuitBehaviour.stack(v, circuitGetter.get().getCount())))
                 .allowC2S();
     }
 


### PR DESCRIPTION
## What
Preserve programmed circuit stack counts when selecting a configuration.

Initially referenced 4480 as per jurre's request, and adopted it for 1.21.1

### AI Usage
Yes AI
Used Codex-5.6-Sol to verify behaviors i migrated from 1.20.1 to 1.21.1 still worked the same

## Human Testing, Verification, and Review
- Was patched directly as a mixin for CosmicFrontiers and was tested against live player tests.
- Was tested in game from the dev client to double verify it still works as intended.

Circuits don't delete themselves now yippie