### PR TITLE
Fix Jade recipe output item display

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
@@ -206,20 +206,13 @@ public class RecipeOutputProvider extends MachineTraitProvider<RecipeLogic, Comp
             if (itemOutput == null || itemOutput.ingredient().hasNoItems()) {
                 continue;
             }
-            ItemStack item = itemOutput.getItems()[0];
-            int count = item.getCount();
-            item.setCount(1);
-
-            iTooltip.add(helper.smallItem(item));
-            MutableComponent text = CommonComponents.space();
-            item = itemOutput.getItems()[0];
-            text.append(String.valueOf(item.getCount()));
-            item.setCount(1);
+            ItemStack icon = itemOutput.getItems()[0].copyWithCount(1);
+            MutableComponent text = CommonComponents.space().append(String.valueOf(itemOutput.count()));
             text.append(Component.translatable("gtceu.gui.content.times_item",
-                    getItemName(item))
+                    getItemName(icon))
                     .withStyle(ChatFormatting.WHITE));
 
-            iTooltip.add(helper.smallItem(item));
+            iTooltip.add(helper.smallItem(icon));
             iTooltip.append(text);
         }
     }


### PR DESCRIPTION
## What
Fix Jade recipe output tooltips emitting duplicate item icons, displaying incorrect quantities, and mutating  Itemstacks.

### AI Usage
Yes AI
Used Codex-5.6-Sol to migrate this patch out of CosmicCore and into GTM, audit it against 1.20 parity, and trace the regression in 1.21.
Codex was also granted the ability to do a quick verification test before Human Testing/Code Review was handled by myself (See the normal testing tab)

Agent Tested By:
- Verified the full GTM 1.21 build completes successfully.
- Verified compiled bytecode copies the display stack at count one and reads the quantity from `SizedIngredient.count()`.
- Verified compiled bytecode emits exactly one Jade item element per recipe output.

## Outcome
Jade now displays one icon per recipe item output with the correct quantity, without modifying the ingredient-owned stack.

## Human Testing, Verification, and Review
- Was patched directly as a mixin for CosmicFrontiers and was tested against live player tests.
- Was tested in game from the dev client to double verify it still works as intended.