### PR TITLE
Fix Jade not displaying GT Tools valid for breaking blocks

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/GTJadePlugin.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.common.blockentity.FluidPipeBlockEntity;
 import com.gregtechceu.gtceu.common.data.GTMaterialItems;
 import com.gregtechceu.gtceu.integration.jade.provider.*;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -116,7 +117,9 @@ public class GTJadePlugin implements IWailaPlugin {
 
     static {
         GTMaterialItems.TOOL_ITEMS.columnMap().forEach((type, map) -> {
-            if (type.toolDefinition.getTool().rules().isEmpty() || map.isEmpty()) return;
+            boolean hasCustomHarvestTag = type.harvestTags.stream()
+                    .anyMatch(tag -> !tag.location().getNamespace().equals(ResourceLocation.DEFAULT_NAMESPACE));
+            if ((type.toolDefinition.getTool().rules().isEmpty() && !hasCustomHarvestTag) || map.isEmpty()) return;
 
             List<Item> tools = map
                     .values()


### PR DESCRIPTION
## What
Register GT material tool families with Jade when they use custom harvest tags, while preserving existing rule-based registration.

### AI Usage
Yes AI
Used Codex-5.6-Sol to migrate this patch out of CosmicCore and into GTM.
Codex was also granted the ability to do a quick verification test before Human Testing/Code Review was handled by myself (See the normal testing tab)

Agent Tested By:
- Successfully ran `spotlessApply build -x test`.
- Verified compiled bytecode accepts either existing tool rules or a non-vanilla harvest tag and reaches a single handler registration path.
- Confirmed the predicate restores registration for 13 custom-tagged tool families without double-registering rule-backed families.

## Outcome
Jade can correctly recognize GT tools and their electric variants as valid harvest tools.

## Human Testing, Verification, and Review
- Was patched directly as a mixin for CosmicFrontiers and was tested against live player tests.
- Was tested in game from the dev client to double verify it still works as intended