### PR TITLE
Clean up drum fluid and screwdriver interactions

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/DrumMachine.java
@@ -16,6 +16,7 @@ import com.gregtechceu.gtceu.utils.ISubscription;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionResult;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidUtil;
@@ -112,18 +113,25 @@ public class DrumMachine extends MetaMachine {
 
     @Override
     public InteractionResult onUseWithItem(ExtendedUseOnContext context) {
-        if (!isRemote()) {
-            if (FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), cache)) {
-                return InteractionResult.CONSUME;
-            }
-            return InteractionResult.PASS;
+        if (FluidUtil.getFluidHandler(context.getItemInHand()).isEmpty()) {
+            return super.onUseWithItem(context);
         }
-        return getLevel().isClientSide() ? InteractionResult.SUCCESS : InteractionResult.PASS;
+        if (isRemote()) return InteractionResult.SUCCESS;
+        FluidUtil.interactWithFluidHandler(context.getPlayer(), context.getHand(), cache);
+        return InteractionResult.CONSUME;
     }
 
     @Override
     protected InteractionResult onScrewdriverClick(ExtendedUseOnContext context) {
-        autoOutput.setAllowAutoOutputFluids(!autoOutput.isAutoOutputFluids());
-        return InteractionResult.SUCCESS;
+        if (autoOutput.getFluidOutputDirection() != context.getGridSide()) {
+            return InteractionResult.PASS;
+        }
+        boolean enabled = !autoOutput.isAutoOutputFluids();
+        autoOutput.setAllowAutoOutputFluids(enabled);
+        if (!isRemote()) {
+            context.getPlayer().displayClientMessage(Component.translatable(
+                    enabled ? "gtceu.gui.fluid_auto_output.enabled" : "gtceu.gui.fluid_auto_output.disabled"), true);
+        }
+        return InteractionResult.sidedSuccess(isRemote());
     }
 }


### PR DESCRIPTION
## What
Apparently drums had a fiasco of different changes applied to them that made their behaviors unstable. Looked into it and tried to ammend it the best I could with the help of tools as well for debugging.

Also took the time to make drums respect output face and display action-bar messages, so this PR will be marked for reverification on the parity tracker for all fronts, which is why I was fine with keeping the two changes in the same PR.

### AI Usage
Yes AI
Used Codex-5.6-Sol to migrate these patches out of CosmicCore and into GTM.
Codex also referenced #5089 which merged a 1.20 pr, #5067, and found issues with behavior. Notably fluid still attempting to be placed on the faces of machines. I verified this myself before continuing with the suggested fixes.
Codex was also granted the ability to do a quick verification test before Human Testing/Code Review was handled by myself (See the normal testing tab)

Agent Tested By:
- Successfully ran `spotlessApply build -x test`.
- Verified compiled bytecode delegates ordinary held items to normal machine interaction.
- Verified valid fluid-container interactions are claimed on both logical sides, including failed server-side transfers.
- Verified screwdriver interaction only toggles on the configured fluid-output face and sends translated state feedback.

## Outcome
Fluid Container Interactions play kindly with drums again.

Closes GregTechCEu/modern-planning#63 and kills the bucket

## Human Testing & Review
- Was patched directly as a mixin for CosmicFrontiers and was tested against live player tests.
- Was tested in game from the dev client to double verify it still works as intended
- Tested it with all fluid containers I could have found in the creative inventory, be it ours, minecrafts, or others mods
- Tested that the screwdriver face check worked and that the action bar shows properly ingame