### PR TITLE
Fix ambiguous KubeJS ore vein generator method

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilderJS.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/worldgen/OreVeinDefinitionBuilderJS.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import com.mojang.datafixers.util.Pair;
 import dev.latvian.mods.kubejs.registry.BuilderBase;
 import dev.latvian.mods.kubejs.util.RegistryAccessContainer;
+import dev.latvian.mods.rhino.util.RemapForJS;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.experimental.Tolerate;
@@ -183,6 +184,7 @@ public class OreVeinDefinitionBuilderJS extends BuilderBase<GTOreDefinition> {
 
     @Tolerate
     @Nullable
+    @RemapForJS("customVeinGenerator")
     public VeinGenerator veinGenerator(ResourceLocation id) {
         if (veinGenerator == null) {
             // noinspection DataFlowIssue


### PR DESCRIPTION
## What
Expose the custom ore vein generator lookup as `customVeinGenerator` in KubeJS, porting the established Rhino remapping fix from #4525.

### AI Usage
Yes AI
Used Codex-5.6-Sol to migrate this patch out of CosmicCore and into GTM.
Codex was also granted the ability to do a quick verification test before Human Testing/Code Review was handled by myself (See the normal testing tab)

Agent Tested By:
- Confirmed compiled bytecode carries `@RemapForJS("customVeinGenerator")` on `veinGenerator(ResourceLocation)`.
- Confirmed the Java method body and generated `veinGenerator(VeinGenerator)` setter remain unchanged, limiting the change to Rhino method resolution.
- Compared the implementation directly against the accepted approach from #4525.

## Outcome
KubeJS scripts can select a registered custom ore vein generator through `customVeinGenerator(...)` without Rhino confusing it with the fluent generator-object setter.

## Human Testing, Verification, and Review
- Was patched directly as a mixin for CosmicFrontiers and was tested against live player tests.
- Was tested in game from the dev client to double verify it still works as intended