### PR TITLE
Fishers actually open

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiMachineUtil.java
@@ -46,8 +46,7 @@ public class GTMuiMachineUtil {
                     ModularSlot slot = new ModularSlot(itemHandler, i);
                     ItemSlotSyncHandler syncHandler = new ItemSlotSyncHandler(slot.slotGroup(slotGroup));
                     syncManager.syncValue(slotGroupName, i, syncHandler);
-                    return slotModifier.apply(new ItemSlot()
-                            .syncHandler(slotGroupName, i));
+                    return slotModifier.apply(new ItemSlot().syncHandler(syncHandler));
                 })
                 .build();
     }


### PR DESCRIPTION
Fishers didn't open, now they do

this sets the synchandler during the widget build, which is needed because the added accessability call calls syncHandler.getSlot() which NPE's if there's only a key and no actual handler, like in the util function before this.

Opus 4.8 was used to find the bug and fix it