### PR TITLE
Access shared storage of pattern buffers directly

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -662,7 +662,7 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
                                     .minColWidth(18).minRowHeight(18)
                                     .leftRel(0.5f)
                                     .gridOfSizeWidth(9, 3, (x, y, index) -> new ItemSlot()
-                                            .slot(SyncHandlers.itemSlot(shareInventory, index)
+                                            .slot(SyncHandlers.itemSlot(shareInventory.storage, index)
                                                     .slotGroup(sharedItemSlotGroup)
                                                     .accessibility(true, true))));
                 });


### PR DESCRIPTION
Pattern buffers work again, see other item bus PRs
no AI used
tested in singleplayer dev instance
