### PR TITLE
Fix Data Bank and Network Switch failing to turn off.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/DataBankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/DataBankMachine.java
@@ -143,31 +143,33 @@ public class DataBankMachine extends WorkableElectricMultiblockMachine
     }
 
     public void tick() {
-        int energyToConsume = this.getEnergyUsage();
-        boolean hasMaintenance = ConfigHolder.INSTANCE.machines.enableMaintenance && this.maintenance != null;
-        if (hasMaintenance) {
-            // 10% more energy per maintenance problem
-            energyToConsume += maintenance.getNumMaintenanceProblems() * energyToConsume / 10;
-        }
-
-        if (getRecipeLogic().isWaiting() && energyContainer.getInputPerSec() > 19L * energyToConsume) {
-            getRecipeLogic().setStatus(RecipeLogic.Status.IDLE);
-        }
-
-        if (this.energyContainer.getEnergyStored() >= energyToConsume) {
-            if (!getRecipeLogic().isWaiting()) {
-                long consumed = this.energyContainer.removeEnergy(energyToConsume);
-                if (consumed == energyToConsume) {
-                    getRecipeLogic().setStatus(RecipeLogic.Status.WORKING);
-                } else {
-                    getRecipeLogic()
-                            .setWaiting(Component.translatable("gtceu.recipe_logic.insufficient_in")
-                                    .append(": ").append(EURecipeCapability.CAP.getName()));
-                }
+        if (isWorkingEnabled()) {
+            int energyToConsume = this.getEnergyUsage();
+            boolean hasMaintenance = ConfigHolder.INSTANCE.machines.enableMaintenance && this.maintenance != null;
+            if (hasMaintenance) {
+                // 10% more energy per maintenance problem
+                energyToConsume += maintenance.getNumMaintenanceProblems() * energyToConsume / 10;
             }
-        } else {
-            getRecipeLogic().setWaiting(Component.translatable("gtceu.recipe_logic.insufficient_in").append(": ")
-                    .append(EURecipeCapability.CAP.getName()));
+
+            if (getRecipeLogic().isWaiting() && energyContainer.getEnergyStored() > 19L * energyToConsume) {
+                getRecipeLogic().setStatus(RecipeLogic.Status.IDLE);
+            }
+
+            if (this.energyContainer.getEnergyStored() >= energyToConsume) {
+                if (!getRecipeLogic().isWaiting()) {
+                    long consumed = this.energyContainer.removeEnergy(energyToConsume);
+                    if (consumed == energyToConsume) {
+                        getRecipeLogic().setStatus(RecipeLogic.Status.WORKING);
+                    } else {
+                        getRecipeLogic()
+                                .setWaiting(Component.translatable("gtceu.recipe_logic.insufficient_in")
+                                        .append(": ").append(EURecipeCapability.CAP.getName()));
+                    }
+                }
+            } else {
+                getRecipeLogic().setWaiting(Component.translatable("gtceu.recipe_logic.insufficient_in").append(": ")
+                        .append(EURecipeCapability.CAP.getName()));
+            }
         }
         updateTickSubscription();
     }


### PR DESCRIPTION
## What
The Data Bank and Network Switch didn't actually turn off or stop consuming energy when it was toggled off. So now they do. (Network Switch extends Data Bank so the fix is in DB.)

 Also fix databank getting stuck on IDLE if the energy hatch is full. (Same bug the HPCA had.)

## Implementation Details
Github is obfuscating the list of changes, all I actually did was wrap `tick()` in an `isWorkingEnabled()` check and then swap 19L * inputPerSecond to 19L * energyStored.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## How Was This Tested
Ingame creative world

## Additional Information
There's also two more UI issues I found while working on this but they'll get their own PRs.
