### PR TITLE
Fix HPCA not setting a reason for its RecipeLogic being placed in WAITING

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -228,11 +228,15 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
                 return true;
             } else {
                 this.hasNotEnoughEnergy = true;
-                getRecipeLogic().setStatus(RecipeLogic.Status.WAITING);
+                getRecipeLogic()
+                        .setWaiting(Component.translatable("gtceu.recipe_logic.insufficient_in")
+                                .append(": ").append(EURecipeCapability.CAP.getName()));
             }
         } else {
             this.hasNotEnoughEnergy = true;
-            getRecipeLogic().setStatus(RecipeLogic.Status.WAITING);
+            getRecipeLogic()
+                    .setWaiting(Component.translatable("gtceu.recipe_logic.insufficient_in")
+                            .append(": ").append(EURecipeCapability.CAP.getName()));
         }
         return false;
     }


### PR DESCRIPTION
## What
When the HPCA drops into WAITING due to low power it doesn't actually set the RL error status as "insufficient energy". So now it does.


## Implementation Details
code stolen from the Data Bank because it does do this.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.