### PR TITLE
Fix Multiblock UI reporting machines as "Working Perfectly" when powerstalled

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_ud.json
+++ b/src/generated/resources/assets/gtceu/lang/en_ud.json
@@ -3362,6 +3362,7 @@
   "gtceu.multiblock.cracker.description": "˙sʇuɐıɹɐʌ pǝʞɔɐɹƆ ɹıǝɥʇ oʇuı ןǝnℲ ʎʌɐǝH puɐ ʇɥbıꞀ buıuɹnʇ ɹoɟ pǝsn ǝɹnʇɔnɹʇs ʞɔoןqıʇןnɯ ɐ sı ʇıu∩ buıʞɔɐɹƆ ןıO ǝɥ⟘",
   "gtceu.multiblock.cracking_unit.energy": "%s%% :ǝbɐs∩ ʎbɹǝuƎ",
   "gtceu.multiblock.data_bank.description": "˙sǝןnpoW ɐʇɐᗡ uo ɐʇɐp ɥɔɹɐǝsǝɹ xǝןdɯoɔ ǝɹoɯ pɐǝɹ oʇ sǝuıꞀ ʎןqɯǝssⱯ sǝןqɐuǝ ʇı 'ʎןןɐuoıʇıppⱯ ˙sǝuıꞀ ʎןqɯǝssⱯ ǝןdıʇןnɯ uǝǝʍʇǝq ɐʇɐᗡ ɥɔɹɐǝsǝᴚ ǝuıꞀ ʎןqɯǝssⱯ buıɹɐɥs ɹoɟ pǝsn ǝɹnʇɔnɹʇs ʞɔoןqıʇןnɯ ɐ sı ʞuɐᗺ ɐʇɐᗡ ǝɥ⟘",
+  "gtceu.multiblock.data_bank.error_power": "¡pǝpıʌoɹd ɐʇɐp ou 'ʍoן ɹǝʍoԀ",
   "gtceu.multiblock.data_bank.providing": "˙ɐʇɐp buıpıʌoɹԀ",
   "gtceu.multiblock.dimension": "%sx%sx%sɹ§ :suoısuǝɯıᗡǝ§",
   "gtceu.multiblock.dimensions.0": " :suoısuǝɯıᗡ",

--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -3362,6 +3362,7 @@
   "gtceu.multiblock.cracker.description": "The Oil Cracking Unit is a multiblock structure used for turning Light and Heavy Fuel into their Cracked variants.",
   "gtceu.multiblock.cracking_unit.energy": "Energy Usage: %s%%",
   "gtceu.multiblock.data_bank.description": "The Data Bank is a multiblock structure used for sharing Assembly Line Research Data between multiple Assembly Lines. Additionally, it enables Assembly Lines to read more complex research data on Data Modules.",
+  "gtceu.multiblock.data_bank.error_power": "Power low, no data provided!",
   "gtceu.multiblock.data_bank.providing": "Providing data.",
   "gtceu.multiblock.dimension": "§eDimensions: §r%sx%sx%s",
   "gtceu.multiblock.dimensions.0": "Dimensions: ",

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/DataBankMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/DataBankMachine.java
@@ -184,7 +184,8 @@ public class DataBankMachine extends WorkableElectricMultiblockMachine
         widgets.add(GTMultiblockTextUtil.addUnformedWarning(this, syncManager));
         widgets.add(GTMultiblockTextUtil.addEnergyUsageExactLine(this, syncManager, energyStoredSyncValue));
         widgets.add(GTMultiblockTextUtil.addWorkingStatusLine(this, syncManager,
-                () -> Component.translatable("gtceu.multiblock.data_bank.providing").withStyle(ChatFormatting.GREEN)));
+                () -> Component.translatable("gtceu.multiblock.data_bank.providing").withStyle(ChatFormatting.GREEN),
+                () -> Component.translatable("gtceu.multiblock.data_bank.error_power").withStyle(ChatFormatting.RED)));
         widgets.addAll(GTMultiblockTextUtil.addRecipeFailReasonLines(this, syncManager));
 
         return widgets;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -263,7 +263,9 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
         syncManager.syncValue("text", text);
         List<IWidget> widgets = new ArrayList<>();
         widgets.add(GTMultiblockTextUtil.addUnformedWarning(this, syncManager));
-        widgets.add(GTMultiblockTextUtil.addWorkingStatusLine(this, syncManager));
+        widgets.add(GTMultiblockTextUtil.addWorkingStatusLine(this, syncManager,
+                () -> Component.translatable("gtceu.multiblock.running").withStyle(ChatFormatting.GREEN),
+                () -> Component.translatable("gtceu.multiblock.hpca.error_power").withStyle(ChatFormatting.RED)));
         widgets.add(GTMultiblockTextUtil.addEnergyUsageExactLine(this, syncManager));
         widgets.addAll(GTMultiblockTextUtil.addRecipeFailReasonLines(this, syncManager));
         widgets.add(new TextWidget<>(Text.dynamic(text::getValue)));
@@ -738,10 +740,6 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
             if (components.stream().anyMatch(HPCAComponentTrait::isDamaged)) {
                 textList.add(
                         Component.translatable("gtceu.multiblock.hpca.error_damaged").withStyle(ChatFormatting.RED));
-            }
-            if (this.controller != null && this.controller.hasNotEnoughEnergy) {
-                textList.add(
-                        Component.translatable("gtceu.multiblock.hpca.error_power").withStyle(ChatFormatting.RED));
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -354,7 +354,8 @@ public class GTMultiblockTextUtil {
         return addWorkingStatusLine(rlMachine, syncManager,
                 () -> Component.translatable("gtceu.multiblock.work_paused").withStyle(ChatFormatting.GOLD),
                 () -> Component.translatable("gtceu.multiblock.running").withStyle(ChatFormatting.GREEN),
-                () -> Component.translatable("gtceu.multiblock.idling").withStyle(ChatFormatting.GRAY));
+                () -> Component.translatable("gtceu.multiblock.idling").withStyle(ChatFormatting.GRAY),
+                () -> Component.translatable("gtceu.recipe_logic.recipe_waiting").withStyle(ChatFormatting.RED));
     }
 
     public static TextWidget<?> addWorkingStatusLine(WorkableMultiblockMachine rlMachine,
@@ -363,15 +364,30 @@ public class GTMultiblockTextUtil {
         return addWorkingStatusLine(rlMachine, syncManager,
                 () -> Component.translatable("gtceu.multiblock.work_paused").withStyle(ChatFormatting.GOLD),
                 runningPerfectly,
-                () -> Component.translatable("gtceu.multiblock.idling").withStyle(ChatFormatting.GRAY));
+                () -> Component.translatable("gtceu.multiblock.idling").withStyle(ChatFormatting.GRAY),
+                () -> Component.translatable("gtceu.recipe_logic.recipe_waiting").withStyle(ChatFormatting.RED));
+    }
+
+    public static TextWidget<?> addWorkingStatusLine(WorkableMultiblockMachine rlMachine,
+                                                     PanelSyncManager syncManager,
+                                                     Supplier<Component> runningPerfectly,
+                                                     Supplier<Component> waiting) {
+        return addWorkingStatusLine(rlMachine, syncManager,
+                () -> Component.translatable("gtceu.multiblock.work_paused").withStyle(ChatFormatting.GOLD),
+                runningPerfectly,
+                () -> Component.translatable("gtceu.multiblock.idling").withStyle(ChatFormatting.GRAY),
+                waiting);
     }
 
     public static TextWidget<?> addWorkingStatusLine(WorkableMultiblockMachine rlMachine, PanelSyncManager syncManager,
                                                      Supplier<Component> workPaused,
-                                                     Supplier<Component> runningPerfectly,
-                                                     Supplier<Component> idling) {
+                                                     Supplier<Component> runningPerfectly, Supplier<Component> idling,
+                                                     Supplier<Component> waiting) {
         BooleanSyncValue isFormed = syncManager.getOrCreateSyncHandler("isFormed", BooleanSyncValue.class,
                 () -> new BooleanSyncValue(rlMachine::isFormed));
+        BooleanSyncValue isWaiting = syncManager.getOrCreateSyncHandler("isWaiting",
+                BooleanSyncValue.class,
+                () -> new BooleanSyncValue(() -> rlMachine.getRecipeLogic().isWaiting()));
         BooleanSyncValue isActive = syncManager.getOrCreateSyncHandler("isActive", BooleanSyncValue.class,
                 () -> new BooleanSyncValue(() -> rlMachine.getRecipeLogic().isActive()));
         BooleanSyncValue isWorkingEnabled = syncManager.getOrCreateSyncHandler("isWorkingEnabled",
@@ -381,6 +397,9 @@ public class GTMultiblockTextUtil {
         return Text
                 .dynamic(() -> {
                     if (!isFormed.getBoolValue()) return Component.empty();
+                    if (isWaiting.getBoolValue()) {
+                        return waiting.get();
+                    }
                     if (!isWorkingEnabled.getBoolValue()) {
                         return workPaused.get();
                     }
@@ -401,6 +420,9 @@ public class GTMultiblockTextUtil {
 
         BooleanSyncValue isIdle = syncManager.getOrCreateSyncHandler("isIdle", BooleanSyncValue.class,
                 () -> new BooleanSyncValue(() -> rlMachine.getRecipeLogic().isIdle()));
+        BooleanSyncValue hasRunningRecipe = syncManager.getOrCreateSyncHandler("hasRunningRecipe",
+                BooleanSyncValue.class,
+                () -> new BooleanSyncValue(() -> rlMachine.getRecipeLogic().getLastRecipe() != null));
         BooleanSyncValue isWaiting = syncManager.getOrCreateSyncHandler("isWaiting", BooleanSyncValue.class,
                 () -> new BooleanSyncValue(() -> rlMachine.getRecipeLogic().isWaiting()));
         GenericSyncValue<Component> bestFailureReason = (GenericSyncValue<Component>) syncManager
@@ -413,12 +435,10 @@ public class GTMultiblockTextUtil {
         var lineList = new ArrayList<TextWidget<?>>();
 
         lineList.add(Text
-                .dynamic(() -> {
-                    return Component.translatable("gtceu.recipe_logic.setup_fail").withStyle(ChatFormatting.RED);
-                })
+                .dynamic(() -> Component.translatable("gtceu.recipe_logic.setup_fail").withStyle(ChatFormatting.RED))
                 .asWidget()
                 .setEnabledIf((w) -> isFormed.getBoolValue() && (isIdle.getBoolValue() || isWaiting.getBoolValue()) &&
-                        bestFailureReason.getValue() != null));
+                        !hasRunningRecipe.getBoolValue() && bestFailureReason.getValue() != null));
         lineList.add(Text
                 .dynamic(() -> {
                     var reason = bestFailureReason.getValue();

--- a/src/main/java/com/gregtechceu/gtceu/data/lang/MachineLang.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/lang/MachineLang.java
@@ -952,6 +952,7 @@ public class MachineLang {
         provider.add("gtceu.multiblock.active_transformer.max_output", "§cMax Output: §f%s EU/t");
         provider.add("gtceu.multiblock.active_transformer.danger_enabled", "§c§bDANGER: Explosive");
         provider.add("gtceu.multiblock.data_bank.providing", "Providing data.");
+        provider.add("gtceu.multiblock.data_bank.error_power", "Power low, no data provided!");
         provider.add("gtceu.multiblock.hpca.computation", "Providing: %s");
         provider.add("gtceu.multiblock.hpca.energy", "Using: %s / %s EU/t (%s)");
         provider.add("gtceu.multiblock.hpca.temperature", "Temperature: %s");


### PR DESCRIPTION
## What
Multiblock machines which had insufficient energy to run would previously report "Working Perfectly!" despite not in fact working at all.
Multiblocks will now actually report that they are stuck in Waiting; and if stuck in Waiting say Why.

## Implementation Details
Added an additional parameter to `GTMultiblockTextUtil.addWorkingStatusLine()` to also accept and display a text of "Recipe Waiting". Added an additional overload allowing defining both a Working and a Waiting message.
Removed the out-of-place "failed to set up recipe" warning if a machine drops to Waiting while having an active recipe.
Partial revert of #5183, moving the error from HPCA-specific to Multiblock-generalized.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
<img width="384" height="227" alt="image" src="https://github.com/user-attachments/assets/5aec529d-47df-4596-a5f8-de67393975a8" />

