### PR TITLE
Fix UI incorrect amounts for Chanced Outputs + serialize parallels

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -8,7 +8,6 @@ import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.multiblock.pattern.PatternState;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
-import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
 import com.gregtechceu.gtceu.config.ConfigHolder;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockDisplayText.java
@@ -428,8 +428,6 @@ public class MultiblockDisplayText {
             if (!isStructureFormed || !isActive)
                 return this;
             if (recipe != null) {
-                int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-                int chanceTier = recipeTier + recipe.ocLevel;
                 double maxDurationSec = (double) recipe.duration / 20.0;
                 var itemOutputs = recipe.getOutputContents(ItemRecipeCapability.CAP);
                 var fluidOutputs = recipe.getOutputContents(FluidRecipeCapability.CAP);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.recipe.chance.logic.ChanceLogic;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
+import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.RegistryAccess;
@@ -83,6 +84,10 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 recipeCategory, groupColor);
     }
 
+    /**
+     * Accepts Parallels, Batches, and BatchParallels as a single List
+     * Necessary for {@link GTRecipeSerializer}
+     */
     public GTRecipe(GTRecipeType recipeType,
                     Map<RecipeCapability<?>, List<Content>> inputs,
                     Map<RecipeCapability<?>, List<Content>> outputs,
@@ -105,6 +110,9 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 allParallels.get(2), recipeCategory, groupColor);
     }
 
+    /**
+     * Main constructor, used by {@link GTRecipeBuilder#buildRawRecipe()}
+     */
     public GTRecipe(GTRecipeType recipeType,
                     @Nullable ResourceLocation id,
                     Map<RecipeCapability<?>, List<Content>> inputs,

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -7,6 +7,7 @@ import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
 
+import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
@@ -50,9 +51,9 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     @NotNull
     public CompoundTag data;
     public int duration;
-    public int parallels = 1;
-    public int subtickParallels = 1;
-    public int batchParallels = 1;
+    public int parallels;
+    public int subtickParallels;
+    public int batchParallels;
     public int ocLevel = 0;
     public final GTRecipeCategory recipeCategory;
     // Lazy fields, since we need the recipe EUt very often
@@ -60,7 +61,27 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     private final @NotNull EnergyStack inputEUt = calculateEUt(tickInputs);
     @Getter(lazy = true)
     private final @NotNull EnergyStack outputEUt = calculateEUt(tickOutputs);
-    public int groupColor = -1;
+    public int groupColor;
+
+    public GTRecipe(GTRecipeType recipeType,
+                    Map<RecipeCapability<?>, List<Content>> inputs,
+                    Map<RecipeCapability<?>, List<Content>> outputs,
+                    Map<RecipeCapability<?>, List<Content>> tickInputs,
+                    Map<RecipeCapability<?>, List<Content>> tickOutputs,
+                    Map<RecipeCapability<?>, ChanceLogic> inputChanceLogics,
+                    Map<RecipeCapability<?>, ChanceLogic> outputChanceLogics,
+                    Map<RecipeCapability<?>, ChanceLogic> tickInputChanceLogics,
+                    Map<RecipeCapability<?>, ChanceLogic> tickOutputChanceLogics,
+                    List<RecipeCondition<?>> conditions,
+                    List<?> ingredientActions,
+                    @NotNull CompoundTag data,
+                    int duration, int parallels,  int subtickParallels, int batchParallels,
+                    @NotNull GTRecipeCategory recipeCategory,
+                    int groupColor) {
+        this(recipeType, null, inputs, outputs, tickInputs, tickOutputs,
+                inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
+                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, recipeCategory, groupColor);
+    }
 
     public GTRecipe(GTRecipeType recipeType,
                     Map<RecipeCapability<?>, List<Content>> inputs,
@@ -75,11 +96,13 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     List<?> ingredientActions,
                     @NotNull CompoundTag data,
                     int duration,
+                    List<Integer> allParallels,
                     @NotNull GTRecipeCategory recipeCategory,
                     int groupColor) {
         this(recipeType, null, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, recipeCategory, groupColor);
+                conditions, ingredientActions, data, duration, allParallels.get(0), allParallels.get(1),
+                allParallels.get(2), recipeCategory, groupColor);
     }
 
     public GTRecipe(GTRecipeType recipeType,
@@ -96,6 +119,27 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     List<?> ingredientActions,
                     @NotNull CompoundTag data,
                     int duration,
+                    @NotNull GTRecipeCategory recipeCategory,
+                    int groupColor) {
+        this(recipeType, id, inputs, outputs, tickInputs, tickOutputs,
+                inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
+                conditions, ingredientActions, data, duration, 1,1,1, recipeCategory, groupColor);
+    }
+
+    public GTRecipe(GTRecipeType recipeType,
+                    @Nullable ResourceLocation id,
+                    Map<RecipeCapability<?>, List<Content>> inputs,
+                    Map<RecipeCapability<?>, List<Content>> outputs,
+                    Map<RecipeCapability<?>, List<Content>> tickInputs,
+                    Map<RecipeCapability<?>, List<Content>> tickOutputs,
+                    Map<RecipeCapability<?>, ChanceLogic> inputChanceLogics,
+                    Map<RecipeCapability<?>, ChanceLogic> outputChanceLogics,
+                    Map<RecipeCapability<?>, ChanceLogic> tickInputChanceLogics,
+                    Map<RecipeCapability<?>, ChanceLogic> tickOutputChanceLogics,
+                    List<RecipeCondition<?>> conditions,
+                    List<?> ingredientActions,
+                    @NotNull CompoundTag data,
+                    int duration, int parallels, int subtickParallels, int batchParallels,
                     @NotNull GTRecipeCategory recipeCategory, int groupColor) {
         this.recipeType = recipeType;
         this.id = id;
@@ -114,6 +158,9 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
         this.ingredientActions = ingredientActions;
         this.data = data;
         this.duration = duration;
+        this.parallels = parallels;
+        this.subtickParallels = subtickParallels;
+        this.batchParallels = batchParallels;
         this.recipeCategory = (recipeCategory != GTRecipeCategory.DEFAULT) ? recipeCategory : recipeType.getCategory();
         this.groupColor = groupColor;
     }
@@ -133,14 +180,11 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 new HashMap<>(inputChanceLogics), new HashMap<>(outputChanceLogics),
                 new HashMap<>(tickInputChanceLogics), new HashMap<>(tickOutputChanceLogics),
                 new ArrayList<>(conditions),
-                new ArrayList<>(ingredientActions), data, duration, recipeCategory, groupColor);
+                new ArrayList<>(ingredientActions), data, duration, parallels, subtickParallels, batchParallels, recipeCategory, groupColor);
         if (modifyDuration) {
             copied.duration = modifier.apply(this.duration);
         }
         copied.ocLevel = ocLevel;
-        copied.parallels = parallels;
-        copied.batchParallels = batchParallels;
-        copied.subtickParallels = subtickParallels;
         return copied;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -7,7 +7,6 @@ import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.ingredient.EnergyStack;
 
-import dev.latvian.mods.kubejs.recipe.ingredientaction.IngredientAction;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.nbt.CompoundTag;
@@ -75,12 +74,13 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     List<RecipeCondition<?>> conditions,
                     List<?> ingredientActions,
                     @NotNull CompoundTag data,
-                    int duration, int parallels,  int subtickParallels, int batchParallels,
+                    int duration, int parallels, int subtickParallels, int batchParallels,
                     @NotNull GTRecipeCategory recipeCategory,
                     int groupColor) {
         this(recipeType, null, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, recipeCategory, groupColor);
+                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels,
+                recipeCategory, groupColor);
     }
 
     public GTRecipe(GTRecipeType recipeType,
@@ -123,7 +123,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     int groupColor) {
         this(recipeType, id, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, 1,1,1, recipeCategory, groupColor);
+                conditions, ingredientActions, data, duration, 1, 1, 1, recipeCategory, groupColor);
     }
 
     public GTRecipe(GTRecipeType recipeType,
@@ -180,7 +180,8 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 new HashMap<>(inputChanceLogics), new HashMap<>(outputChanceLogics),
                 new HashMap<>(tickInputChanceLogics), new HashMap<>(tickOutputChanceLogics),
                 new ArrayList<>(conditions),
-                new ArrayList<>(ingredientActions), data, duration, parallels, subtickParallels, batchParallels, recipeCategory, groupColor);
+                new ArrayList<>(ingredientActions), data, duration, parallels, subtickParallels, batchParallels,
+                recipeCategory, groupColor);
         if (modifyDuration) {
             copied.duration = modifier.apply(this.duration);
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -145,7 +145,8 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         GTRecipe recipe = new GTRecipe(type, id,
                 inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, category, groupColor);
+                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, category,
+                groupColor);
 
         recipe.recipeCategory.addRecipe(recipe);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -99,7 +99,6 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
     @NotNull
     public GTRecipe fromNetwork(@NotNull ResourceLocation id, @NotNull FriendlyByteBuf buf) {
         ResourceLocation recipeType = buf.readResourceLocation();
-        int duration = buf.readVarInt();
         Map<RecipeCapability<?>, List<Content>> inputs = tuplesToMap(
                 buf.readCollection(c -> new ArrayList<>(), GTRecipeSerializer::entryReader));
         Map<RecipeCapability<?>, List<Content>> tickInputs = tuplesToMap(
@@ -132,6 +131,11 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         if (data == null) {
             data = new CompoundTag();
         }
+        int duration = buf.readVarInt();
+        int parallels = buf.readVarInt();
+        int subtickParallels = buf.readVarInt();
+        int batchParallels = buf.readVarInt();
+
         int groupColor = buf.readInt();
         ResourceLocation categoryLoc = buf.readResourceLocation();
 
@@ -141,7 +145,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         GTRecipe recipe = new GTRecipe(type, id,
                 inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, category, groupColor);
+                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, category, groupColor);
 
         recipe.recipeCategory.addRecipe(recipe);
 
@@ -160,7 +164,6 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
     @Override
     public void toNetwork(FriendlyByteBuf buf, GTRecipe recipe) {
         buf.writeResourceLocation(recipe.recipeType.registryName);
-        buf.writeVarInt(recipe.duration);
         buf.writeCollection(recipe.inputs.entrySet(), GTRecipeSerializer::entryWriter);
         buf.writeCollection(recipe.tickInputs.entrySet(), GTRecipeSerializer::entryWriter);
         buf.writeCollection(recipe.outputs.entrySet(), GTRecipeSerializer::entryWriter);
@@ -184,6 +187,10 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
             KJSCallWrapper.writeIngredientActions(recipe.ingredientActions, buf);
         }
         buf.writeNbt(recipe.data);
+        buf.writeVarInt(recipe.duration);
+        buf.writeVarInt(recipe.parallels);
+        buf.writeVarInt(recipe.subtickParallels);
+        buf.writeVarInt(recipe.batchParallels);
         buf.writeInt(recipe.groupColor);
         buf.writeResourceLocation(recipe.recipeCategory.registryKey);
     }
@@ -208,15 +215,16 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             RecipeCondition.CODEC.listOf().optionalFieldOf("recipeConditions", List.of()).forGetter(val -> val.conditions),
                             CompoundTag.CODEC.optionalFieldOf("data", new CompoundTag()).forGetter(val -> val.data),
                             ExtraCodecs.NON_NEGATIVE_INT.fieldOf("duration").forGetter(val -> val.duration),
+                            Codec.INT.listOf().fieldOf("all_parallels").forGetter(val -> Arrays.asList(val.parallels, val.subtickParallels, val.batchParallels)),
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
                             Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor))
                     .apply(instance, (type,
                                       inputs, outputs, tickInputs, tickOutputs,
                                       inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                                      conditions, data, duration, recipeCategory, groupColor) ->
+                                      conditions, data, duration, all_parallels, recipeCategory, groupColor) ->
                             new GTRecipe(type, inputs, outputs, tickInputs, tickOutputs,
                                     inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                                    conditions, List.of(), data, duration, recipeCategory, groupColor)));
+                                    conditions, List.of(), data, duration, all_parallels, recipeCategory, groupColor)));
         } else {
             return RecordCodecBuilder.create(instance -> instance.group(
                             GTRegistries.RECIPE_TYPES.codec().fieldOf("type").forGetter(val -> val.recipeType),
@@ -236,6 +244,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             KJSCallWrapper.INGREDIENT_ACTION_CODEC.optionalFieldOf("kubejs:actions", List.of()).forGetter(val -> (List<IngredientAction>) val.ingredientActions),
                             CompoundTag.CODEC.optionalFieldOf("data", new CompoundTag()).forGetter(val -> val.data),
                             ExtraCodecs.NON_NEGATIVE_INT.fieldOf("duration").forGetter(val -> val.duration),
+                            Codec.INT.listOf().fieldOf("all_parallels").forGetter(val -> Arrays.asList(val.parallels, val.subtickParallels, val.batchParallels)),
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
                             Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor))
                     .apply(instance, GTRecipe::new));

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -196,6 +196,10 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         buf.writeResourceLocation(recipe.recipeCategory.registryKey);
     }
 
+    /**
+     * Codecs can only have up to 16 inputs. This is at 15 now, so the three recipe Parallel/Batch values are
+     * condensed to a List.
+     */
     private static Codec<GTRecipe> makeCodec(boolean isKubeLoaded) {
         // spotless:off
         if (!isKubeLoaded) {

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -9,7 +9,6 @@ import com.gregtechceu.gtceu.api.machine.multiblock.WorkableMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.steam.SteamEnergyRecipeHandler;
 import com.gregtechceu.gtceu.api.multiblock.error.PatternError;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
-import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -594,6 +594,7 @@ public class GTMultiblockTextUtil {
                 amountD = amountD * runs * fluidOutput.chance() / fluidOutput.maxChance();
             }
             amount = Math.max(1, (int) Math.round(amountD));
+            stack.setAmount(amount);
             displaycount = Component.literal(String.valueOf(amount));
         }
         if (amountD < maxDurationSec) {

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -527,6 +527,7 @@ public class GTMultiblockTextUtil {
                 countD = countD * runs * itemOutput.chance() / itemOutput.maxChance();
             }
             count = Math.max(1, (int) Math.round(countD));
+            stack.setCount(count);
             displaycount = Component.literal(String.valueOf(count));
         }
         if (countD < maxDurationSec) {

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -496,9 +496,6 @@ public class GTMultiblockTextUtil {
 
     public static Optional<Widget<?>> createItemLineForOutput(Content itemOutput, GTRecipe recipe) {
         int runs = recipe.getTotalRuns();
-
-        int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-        int chanceTier = recipeTier + recipe.ocLevel;
         double maxDurationSec = (double) recipe.duration / 20.0;
 
         boolean rounded = false;
@@ -566,8 +563,6 @@ public class GTMultiblockTextUtil {
     public static Optional<Widget<?>> createFluidLineForOutput(Content fluidOutput, GTRecipe recipe) {
         int runs = recipe.getTotalRuns();
 
-        int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-        int chanceTier = recipeTier + recipe.ocLevel;
         double maxDurationSec = (double) recipe.duration / 20.0;
 
         boolean rounded = false;

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
@@ -56,8 +56,7 @@ public class RecipeOutputProvider extends MachineTraitProvider<RecipeLogic, Comp
             data.putBoolean("Working", recipeLogic.isWorking());
             var recipe = recipeLogic.getLastRecipe();
             if (recipe != null) {
-                int recipeTier = RecipeHelper.getPreOCRecipeEuTier(recipe);
-                int chanceTier = recipeTier + recipe.ocLevel;
+
                 var itemContents = recipe.getOutputContents(ItemRecipeCapability.CAP);
                 var fluidContents = recipe.getOutputContents(FluidRecipeCapability.CAP);
                 int runs = recipe.getTotalRuns();

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/RecipeOutputProvider.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
-import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;


### PR DESCRIPTION
## What
The Jade and MUI2 displays for recipes with Chanced Outputs run in high Parallel or Batch counts displayed different values for the chanced outputs. Jade showed values correctly. MUI2 did not, only showing the recipe base output unmodified by parallels.

So this fixes that.

## Implementation Details
Modifies GTRecipeSerializer to also serialize the Parallel, Batch, and Subtick Parallel values. This was necessary because the MUI2 sync handler relies on the client having a correctly sync'd copy of the recipe being run; because Chanced Ingredients in Parallel Recipes are rolled at completion not in advance, the UI has to calculate the average and to do that it needs the BatchParallel counts.
Adds two additional constructor overloads to GTRecipe to take in the extra params. New recipe creation still uses the original constructors and is thus unchanged.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
<img width="372" height="273" alt="image" src="https://github.com/user-attachments/assets/3155ac9e-a625-48a9-9b2c-df598b396264" />

### Additional Notes
Also cleans up a few stray references to Recipe Chance Tiers that were previously used for Chance Boosting and got missed in the removal

## Potential Compatibility Issues
I hope none of our addons try to mixin GTRecipeSerializer 