### PR TITLE
Readd multiamp draw when low power

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/WorkableTieredMachine.java
@@ -4,9 +4,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.machine.feature.*;
-import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableComputationContainer;
-import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableFluidTank;
-import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableItemStackHandler;
+import com.gregtechceu.gtceu.api.machine.trait.notifiable.*;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.IRecipeHandlerTrait;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
@@ -81,7 +79,9 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
                                  int exportSlots,
                                  int fluidImportSlots, int fluidExportSlots, boolean energyEmitter,
                                  Int2IntFunction tankScalingFunction) {
-        super(info, tier, energyEmitter);
+        super(info, tier, (energyEmitter ?
+                RecipeAmperageEnergyContainer.emitterContainer(GTValues.V[tier] * 64L, GTValues.V[tier], 1) :
+                RecipeAmperageEnergyContainer.receiverContainer(GTValues.V[tier] * 64L, GTValues.V[tier], 1)));
         this.overclockTier = getMaxOverclockTier();
         this.recipeTypes = getDefinition().getRecipeTypes();
         this.activeRecipeType = 0;
@@ -114,7 +114,9 @@ public abstract class WorkableTieredMachine extends TieredEnergyMachine implemen
      */
     public WorkableTieredMachine(BlockEntityCreationInfo info, int tier, boolean energyEmitter,
                                  Int2IntFunction tankScalingFunction) {
-        super(info, tier, energyEmitter);
+        super(info, tier, (energyEmitter ?
+                RecipeAmperageEnergyContainer.emitterContainer(GTValues.V[tier] * 64L, GTValues.V[tier], 1) :
+                RecipeAmperageEnergyContainer.receiverContainer(GTValues.V[tier] * 64L, GTValues.V[tier], 1)));
         this.overclockTier = getMaxOverclockTier();
         this.recipeTypes = getDefinition().getRecipeTypes();
         this.activeRecipeType = 0;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/RecipeAmperageEnergyContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/RecipeAmperageEnergyContainer.java
@@ -1,0 +1,51 @@
+package com.gregtechceu.gtceu.api.machine.trait.notifiable;
+
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
+
+public class RecipeAmperageEnergyContainer extends NotifiableEnergyContainer {
+
+    public RecipeAmperageEnergyContainer(long maxCapacity, long maxInputVoltage, long maxInputAmperage,
+                                         long maxOutputVoltage, long maxOutputAmperage) {
+        super(maxCapacity, maxInputVoltage, maxInputAmperage, maxOutputVoltage, maxOutputAmperage);
+    }
+
+    public static RecipeAmperageEnergyContainer emitterContainer(long maxCapacity,
+                                                                 long maxOutputVoltage, long maxOutputAmperage) {
+        return new RecipeAmperageEnergyContainer(maxCapacity, 0L, 0L, maxOutputVoltage, maxOutputAmperage);
+    }
+
+    public static RecipeAmperageEnergyContainer receiverContainer(long maxCapacity,
+                                                                  long maxInputVoltage, long maxInputAmperage) {
+        return new RecipeAmperageEnergyContainer(maxCapacity, maxInputVoltage, maxInputAmperage, 0L, 0L);
+    }
+
+    @Override
+    public long getInputAmperage() {
+        var recipeLogic = getMachine().getTrait(RecipeLogic.TYPE);
+        if (recipeLogic == null) return 1L;
+        var lastRecipe = recipeLogic.getLastRecipe();
+        long amperage;
+        if (lastRecipe != null) {
+            amperage = lastRecipe.getInputEUt().amperage();
+        } else {
+            amperage = super.getInputAmperage();
+        }
+        if (getEnergyCapacity() / 2 > getEnergyStored() && recipeLogic.isActive()) {
+            return amperage + 1;
+        } else {
+            return amperage;
+        }
+    }
+
+    @Override
+    public long getOutputAmperage() {
+        var recipeLogic = getMachine().getTrait(RecipeLogic.TYPE);
+        if (recipeLogic == null) return 1L;
+        var lastRecipe = recipeLogic.getLastRecipe();
+        if (lastRecipe != null) {
+            return lastRecipe.getOutputEUt().amperage();
+        } else {
+            return super.getOutputAmperage();
+        }
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/MachineCapabilityLayoutBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/MachineCapabilityLayoutBuilder.java
@@ -43,7 +43,9 @@ public interface MachineCapabilityLayoutBuilder {
         var handlers = ItemRecipeCapability.CAP.getCapabilityHandlers(machine, io);
         if (handlers.isEmpty()) return;
         NotifiableItemStackHandler itemHandler = handlers.get(0);
-        if (itemHandler == null || layout.getRecipeType().getMaxSlots(ItemRecipeCapability.CAP, io) == 0) return;
+        if (itemHandler == null || itemHandler.getSlots() < 1 ||
+                layout.getRecipeType().getMaxSlots(ItemRecipeCapability.CAP, io) == 0)
+            return;
 
         var slotGroup = new SlotGroup(ItemRecipeCapability.CAP.id + "_" + io.name(), 3);
 
@@ -82,14 +84,16 @@ public interface MachineCapabilityLayoutBuilder {
         var handlers = FluidRecipeCapability.CAP.getCapabilityHandlers(machine, io);
         if (handlers.isEmpty()) return;
         NotifiableFluidTank fluidTank = handlers.get(0);
-        if (fluidTank == null || layout.getRecipeType().getMaxSlots(FluidRecipeCapability.CAP, io) == 0) return;
+        if (fluidTank == null || fluidTank.getStorages().length < 1 ||
+                layout.getRecipeType().getMaxSlots(FluidRecipeCapability.CAP, io) == 0)
+            return;
 
         if (layout.getRecipeType().getMaxSlots(FluidRecipeCapability.CAP, io) == 1) {
             var slot = new FluidSlot()
                     .syncHandler(new FluidSlotSyncHandler(fluidTank.getStorages()[0])
                             .canFillSlot(fluidTank.getCapabilityIO().support(IO.IN))
                             .canDrainSlot(true)
-                            .controlsAmount(false))
+                            .controlsAmount(true))
                     .backgroundOverlay(layout.capabilityInfo(FluidRecipeCapability.CAP).getOverlay(io, 0));
             if (io == IO.IN) widget.inputColumn.child(slot);
             else widget.outputColumn.child(slot);


### PR DESCRIPTION
## What
allows machines to multiple amps when low on power
also fixes a aioobe for machines that have a mismatch of slots vs the recipe map

## Implementation Details
readd the energy container

### AI Usage 

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
early game is less pain

## How Was This Tested
ingame
