### PR TITLE
Fix dedicated-server crash from RuntimeDistCleaner false positive (#3584)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -43,6 +43,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.Rotation;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -64,6 +65,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -74,6 +77,12 @@ public class MetaMachineBlock extends Block implements ManagedSyncEntityBlock {
 
     @Getter
     public final MachineDefinition definition;
+
+    // Machines whose block entity class failed to load once this JVM run; the failure is not transient (the same
+    // class fails identically on every retry), so we stop trying rather than re-triggering the expensive ASM
+    // transform (and its RuntimeDistCleaner false-positive, see
+    // https://github.com/GregTechCEu/GregTech-Modern/issues/3584) on every single access.
+    private static final Set<ResourceLocation> BROKEN_MACHINE_BLOCK_ENTITIES = ConcurrentHashMap.newKeySet();
 
     public MetaMachineBlock(Properties properties, MachineDefinition definition) {
         super(properties);
@@ -582,6 +591,19 @@ public class MetaMachineBlock extends Block implements ManagedSyncEntityBlock {
     @Nullable
     @Override
     public final BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        return getDefinition().getBlockEntityType().create(pos, state);
+        var id = getDefinition().getId();
+        if (BROKEN_MACHINE_BLOCK_ENTITIES.contains(id)) return null;
+        try {
+            return getDefinition().getBlockEntityType().create(pos, state);
+        } catch (Throwable e) {
+            // Once the underlying machine class fails to load once (RuntimeException from RuntimeDistCleaner),
+            // the JVM marks it permanently erroneous; every subsequent attempt throws NoClassDefFoundError
+            // (an Error, not a RuntimeException) instead, so we must catch Throwable here, not just
+            // RuntimeException, or that second failure propagates uncaught and crashes the calling command/tick.
+            BROKEN_MACHINE_BLOCK_ENTITIES.add(id);
+            GTCEu.LOGGER.error(
+                    "Machine {} failed to create its block entity and will not be retried this session", id, e);
+            return null;
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -27,6 +27,22 @@ public class FuelRecipes {
                 .duration(350) // 150s -> 17.5s
                 .save(provider);
 
+        // solid fuels; duration scaled off each material's vanilla burn value (Coal/Charcoal 1600, Coke 3200)
+        STEAM_BOILER_RECIPES.recipeBuilder("charcoal")
+                .inputItems(gem, Charcoal)
+                .duration(1600 * 3)
+                .save(provider);
+
+        STEAM_BOILER_RECIPES.recipeBuilder("coal")
+                .inputItems(gem, Coal)
+                .duration(1600 * 3)
+                .save(provider);
+
+        STEAM_BOILER_RECIPES.recipeBuilder("coke")
+                .inputItems(gem, Coke)
+                .duration(3200 * 3)
+                .save(provider);
+
         // semi-fluid fuels, like creosote - these are awful and need to be scrutinized heavily...
         LARGE_BOILER_RECIPES.recipeBuilder("gtceu_creosote")
                 .inputFluids(Creosote.getFluid(250))


### PR DESCRIPTION
Prevent dedicated-server crash from RuntimeDistCleaner false positives; add missing solid fuel recipes for steam boilers

RuntimeDistCleaner can spuriously block loading of machine block entity classes on dedicated servers with no real client-only references, crashing the whole server (see #3584). The first failed load throws a RuntimeException, but the JVM permanently poisons the class afterward, so every subsequent access throws NoClassDefFoundError instead - newBlockEntity now catches Throwable, caches the failed id, and logs+degrades gracefully instead of propagating the crash.

Also adds coal/charcoal/coke recipes to STEAM_BOILER_RECIPES - solid fuel items were accepted by SteamSolidBoilerMachine's fuel filter but had no matching recipe to actually consume them, so boilers never burned them.

## What
Two independent fixes found while running a 1.21.1 dedicated server:

1. `MetaMachineBlock#newBlockEntity` had no error handling around block entity creation. When `RuntimeDistCleaner` spuriously flags a machine's block entity class as client-only on a dedicated server (a known false positive with no real client-only references, see #3584), the first access throws a `RuntimeException` that crashes the calling command/tick. Worse, once the JVM marks that class permanently erroneous, every subsequent access throws `NoClassDefFoundError` (a `LinkageError`, not a `RuntimeException`) instead, so a plain `catch (RuntimeException)` only protects the first failure.
2. `STEAM_BOILER_RECIPES` had zero solid-fuel recipes despite `SteamSolidBoilerMachine`'s fuel filter accepting any item with a vanilla furnace burn time (coal, charcoal, coke). Boilers would accept these items into the fuel slot but never actually consume/burn them since no matching recipe existed.

## Implementation Details
`newBlockEntity` now catches `Throwable` (not just `RuntimeException`) so it also covers the `NoClassDefFoundError` case on repeat access, caches the failed block's `ResourceLocation` in a `ConcurrentHashMap`-backed `Set` so it's not retried every access, and logs the failure instead of propagating it. This does not swallow or hide real bugs — it only prevents one machine's classload failure from crashing the whole server/command; the error is still logged with its full stack trace.

The new boiler recipes duration is scaled off each material's vanilla furnace burn time (Coal/Charcoal 1600 ticks, Coke 3200 ticks), multiplied by 3 to match the existing multiplier convention already used by the lava/creosote recipes in this file.

### AI Usage
- [ ] No AI driven tools were used for this pull request.
- [x] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Code (Sonnet 5)

#### Agent Usage Description
Used to diagnose the root cause (via live RCON testing on a private dedicated server: reproducing the RuntimeDistCleaner false-positive crash, confirming the NoClassDefFoundError-on-retry behavior, and confirming the boiler never consumed coal despite accepting it), and to write and port both fixes. All changes were reviewed and tested live before this PR was opened.

## Outcome
Fixes: #3584

Machines whose block entity class is spuriously flagged by RuntimeDistCleaner on a dedicated server no longer crash the server; the affected machine simply fails to place/function and logs an error, instead of taking down the whole tick/command. Steam boilers (bronze and steel/high-pressure) can now actually burn coal, charcoal, and coke as fuel.

## How Was This Tested
Tested live on a private dedicated server via RCON:
- Confirmed clean server boot with zero `ModLoadingException` after the fix.
- Reproduced a machine block entity failing to load (RuntimeDistCleaner false positive); confirmed the first failure is caught and logged instead of crashing, and confirmed repeat `/setblock` attempts on the same machine type continue to fail gracefully (`NoClassDefFoundError` case) instead of crashing.
- Confirmed unaffected machine types (e.g. compressor, extractor) continue to place and function normally.
- Placed a bronze steam boiler, fed it coal via RCON, and confirmed it consumed exactly 1 coal per full boil cycle (`consecutiveRecipes: 1`) and steam temperature rose as expected (0 → 246).

## Potential Compatibility Issues
None expected. The `newBlockEntity` change is additive error handling around an existing call (behavior on the success path is unchanged); the boiler recipe additions are new recipes only and do not modify or remove any existing recipe.