### PR TITLE
Fix dedicated-server crashes and missing boiler fuel recipes (MC 1.21.1)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/GTCEu.java
+++ b/src/main/java/com/gregtechceu/gtceu/GTCEu.java
@@ -13,6 +13,7 @@ import net.minecraft.server.MinecraftServer;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.fml.javafmlmod.FMLModContainer;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLLoader;
@@ -44,6 +45,80 @@ public class GTCEu {
     @ApiStatus.Internal
     public static IEventBus gtModBus;
 
+    // Classes observed to deterministically trip RuntimeDistCleaner's ClientLevel/Particle/GameRenderer
+    // false-positive on first load in some modpacks (ASM's stack-frame merge computation loads these
+    // client-only classes just to inspect their hierarchy, never actually using them - see
+    // https://github.com/GregTechCEu/GregTech-Modern/issues/3584). Warmed up here with the dist check
+    // reflectively and temporarily disabled for just this call, so the false positive can't poison the
+    // class for the rest of the session. This MUST run from FMLCommonSetupEvent#enqueueWork, not from the
+    // mod constructor or the raw event handler - both of those run on FML's parallel dispatch executor
+    // alongside every other mod's construction/setup, and briefly disabling the dist check while other
+    // mods are concurrently loading their own client-only classes on other threads lets THEIR classes
+    // skip the check too, corrupting them instead (confirmed by testing: crashed mod loading for
+    // createbigcannons/aeronautics/railways). enqueueWork callbacks run one at a time, strictly after
+    // every mod's parallel setup work has finished, so no other mod is loading classes concurrently here.
+    private static final String[] DIST_CLEANER_WARMUP_CLASSES = {
+            "com.gregtechceu.gtceu.common.machine.multiblock.part.CokeOvenHatch",
+    };
+
+    private static java.lang.reflect.Field runtimeDistCleanerDistField;
+    private static Object runtimeDistCleanerInstance;
+
+    private static void initRuntimeDistCleanerHook() {
+        try {
+            var launcherClass = Class.forName("cpw.mods.modlauncher.Launcher");
+            var instanceField = launcherClass.getDeclaredField("INSTANCE");
+            instanceField.setAccessible(true);
+            Object launcherInstance = instanceField.get(null);
+
+            var launchPluginsField = launcherClass.getDeclaredField("launchPlugins");
+            launchPluginsField.setAccessible(true);
+            Object launchPluginHandler = launchPluginsField.get(launcherInstance);
+
+            var getMethod = launchPluginHandler.getClass().getMethod("get", String.class);
+            var pluginOpt = (java.util.Optional<?>) getMethod.invoke(launchPluginHandler, "runtimedistcleaner");
+            if (pluginOpt.isPresent()) {
+                runtimeDistCleanerInstance = pluginOpt.get();
+                runtimeDistCleanerDistField = runtimeDistCleanerInstance.getClass().getDeclaredField("dist");
+                runtimeDistCleanerDistField.setAccessible(true);
+            }
+        } catch (Throwable t) {
+            LOGGER.warn("Could not hook RuntimeDistCleaner for targeted class warmup", t);
+        }
+    }
+
+    private static void warmupClassBypassingDistCleaner(String className) {
+        if (runtimeDistCleanerDistField == null) {
+            try {
+                Class.forName(className, true, GTCEu.class.getClassLoader());
+            } catch (Throwable e) {
+                LOGGER.warn("Warmup failed for {} (no RuntimeDistCleaner hook available)", className, e);
+            }
+            return;
+        }
+        Object originalDist;
+        try {
+            originalDist = runtimeDistCleanerDistField.get(runtimeDistCleanerInstance);
+        } catch (Throwable e) {
+            LOGGER.warn("Could not read RuntimeDistCleaner.dist, skipping targeted warmup for {}", className, e);
+            return;
+        }
+        try {
+            runtimeDistCleanerDistField.set(runtimeDistCleanerInstance, null);
+            Class.forName(className, true, GTCEu.class.getClassLoader());
+        } catch (Throwable e) {
+            LOGGER.warn("Targeted warmup still failed for {}", className, e);
+        } finally {
+            try {
+                runtimeDistCleanerDistField.set(runtimeDistCleanerInstance, originalDist);
+            } catch (Throwable e) {
+                LOGGER.error(
+                        "Failed to restore RuntimeDistCleaner.dist after warmup - the dist check may stay disabled for the rest of this session!",
+                        e);
+            }
+        }
+    }
+
     public GTCEu(IEventBus modBus, FMLModContainer container) {
         GTCEuAPI.instance = this;
         GTCEu.gtModBus = modBus;
@@ -59,6 +134,15 @@ public class GTCEu {
         CommonProxy.init(modBus);
 
         modBus.addListener(GTNetwork::registerPayloads);
+
+        if (FMLEnvironment.dist.isDedicatedServer()) {
+            modBus.addListener((FMLCommonSetupEvent event) -> event.enqueueWork(() -> {
+                initRuntimeDistCleanerHook();
+                for (String className : DIST_CLEANER_WARMUP_CLASSES) {
+                    warmupClassBypassingDistCleaner(className);
+                }
+            }));
+        }
     }
 
     public static ResourceLocation id(String path) {

--- a/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/MetaMachineBlock.java
@@ -43,6 +43,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.Rotation;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -64,6 +65,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -74,6 +77,12 @@ public class MetaMachineBlock extends Block implements ManagedSyncEntityBlock {
 
     @Getter
     public final MachineDefinition definition;
+
+    // Machines whose block entity class failed to load once this JVM run; the failure is not transient (the same
+    // class fails identically on every retry), so we stop trying rather than re-triggering the expensive ASM
+    // transform (and its RuntimeDistCleaner false-positive, see
+    // https://github.com/GregTechCEu/GregTech-Modern/issues/3584) on every single access.
+    private static final Set<ResourceLocation> BROKEN_MACHINE_BLOCK_ENTITIES = ConcurrentHashMap.newKeySet();
 
     public MetaMachineBlock(Properties properties, MachineDefinition definition) {
         super(properties);
@@ -582,6 +591,19 @@ public class MetaMachineBlock extends Block implements ManagedSyncEntityBlock {
     @Nullable
     @Override
     public final BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-        return getDefinition().getBlockEntityType().create(pos, state);
+        var id = getDefinition().getId();
+        if (BROKEN_MACHINE_BLOCK_ENTITIES.contains(id)) return null;
+        try {
+            return getDefinition().getBlockEntityType().create(pos, state);
+        } catch (Throwable e) {
+            // Once the underlying machine class fails to load once (RuntimeException from RuntimeDistCleaner),
+            // the JVM marks it permanently erroneous; every subsequent attempt throws NoClassDefFoundError
+            // (an Error, not a RuntimeException) instead, so we must catch Throwable here, not just
+            // RuntimeException, or that second failure propagates uncaught and crashes the calling command/tick.
+            BROKEN_MACHINE_BLOCK_ENTITIES.add(id);
+            GTCEu.LOGGER.error(
+                    "Machine {} failed to create its block entity and will not be retried this session", id, e);
+            return null;
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/worldgen/generator/indicators/SurfaceIndicatorGenerator.java
@@ -184,9 +184,18 @@ public class SurfaceIndicatorGenerator extends IndicatorGenerator {
     public enum IndicatorPlacement implements StringRepresentable {
 
         SURFACE(
-                (level, access, pos) -> pos.atY(Math.max(
-                        level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, pos.getX(), pos.getZ()),
-                        pos.getY())),
+                (level, access, pos) -> {
+                    try {
+                        return pos.atY(Math.max(
+                                level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, pos.getX(), pos.getZ()),
+                                pos.getY()));
+                    } catch (IllegalStateException e) {
+                        // WorldGenRegion throws this when the queried chunk hasn't reached the required
+                        // generation status yet (e.g. just outside the current feature placement radius).
+                        // Skip height resolution for this position rather than crashing chunk generation.
+                        return pos;
+                    }
+                },
                 block -> getBlockState(block, Direction.DOWN)),
 
         ABOVE(

--- a/src/main/java/com/gregtechceu/gtceu/common/block/SurfaceRockBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/block/SurfaceRockBlock.java
@@ -116,7 +116,14 @@ public class SurfaceRockBlock extends Block {
         var facing = state.getValue(FACING);
         var attachedBlock = pos.relative(facing);
 
-        return level.getBlockState(attachedBlock).isFaceSturdy(level, attachedBlock, facing.getOpposite());
+        try {
+            return level.getBlockState(attachedBlock).isFaceSturdy(level, attachedBlock, facing.getOpposite());
+        } catch (IllegalStateException e) {
+            // During world generation, WorldGenRegion throws this when the attached block's chunk hasn't
+            // reached the required generation status yet (e.g. querying just outside the current feature
+            // placement radius). Assume the attachment is valid rather than crashing chunk generation.
+            return true;
+        }
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/misc/FuelRecipes.java
@@ -27,6 +27,22 @@ public class FuelRecipes {
                 .duration(350) // 150s -> 17.5s
                 .save(provider);
 
+        // solid fuels; duration scaled off each material's vanilla burn value (Coal/Charcoal 1600, Coke 3200)
+        STEAM_BOILER_RECIPES.recipeBuilder("charcoal")
+                .inputItems(gem, Charcoal)
+                .duration(1600 * 3)
+                .save(provider);
+
+        STEAM_BOILER_RECIPES.recipeBuilder("coal")
+                .inputItems(gem, Coal)
+                .duration(1600 * 3)
+                .save(provider);
+
+        STEAM_BOILER_RECIPES.recipeBuilder("coke")
+                .inputItems(gem, Coke)
+                .duration(3200 * 3)
+                .save(provider);
+
         // semi-fluid fuels, like creosote - these are awful and need to be scrutinized heavily...
         LARGE_BOILER_RECIPES.recipeBuilder("gtceu_creosote")
                 .inputFluids(Creosote.getFluid(250))


### PR DESCRIPTION
## What
This PR fixes two categories of dedicated-server-only crashes/breakage found while running a heavily modded (~145 mods) NeoForge 1.21.1 server, plus one missing recipe found along the way:

1. **RuntimeDistCleaner false positives crash the server / permanently break machines.** NeoForge's RuntimeDistCleaner has a false-positive bug: when ASM recomputes stack-map frames for a transformed class, its `getCommonSuperClass()` implementation loads both merge-candidate types just to inspect their class hierarchy - it never actually uses them at runtime. If one of those types happens to be client-only (e.g. `ClientLevel`, `Particle`, `GameRenderer`), RuntimeDistCleaner misreads this internal ASM lookup as real client-code execution on a dedicated server and throws, permanently poisoning the class for the rest of the JVM session (the JVM marks a class erroneous forever once its definition fails once - the first failure throws `RuntimeException`, every later access throws `NoClassDefFoundError` instead).

   This was previously reported in #3584 and closed with the comment "Close as invalid" - but that close was based on the original reporter's case being harmless log spam ("the server is thankfully able to launch"). It is not always harmless. Confirmed live on a dedicated server, this exact mechanism:
   - Crashes chunk generation outright when it hits `SurfaceRockBlock`/`SurfaceIndicatorGenerator`.
   - Permanently breaks `CokeOvenHatch`'s block entity for the entire session when it hits `MetaMachineBlock#newBlockEntity` (confirmed via RCON: the block placed fine but had no working capabilities - no item/fluid transfer at all - until a full server restart, and it reproduced on every single restart with this exact mod list).

2. **World-gen chunk-boundary crash unrelated to RuntimeDistCleaner.** `SurfaceRockBlock#canSurvive` and `SurfaceIndicatorGenerator`'s `SURFACE` indicator placement both query `WorldGenRegion` for a neighboring chunk that may not have reached the required generation status yet (just outside the current feature placement radius), throwing `IllegalStateException` and crashing chunk generation entirely. Found this independently while investigating the crashes above - it's a separate, genuine bug.

3. **Missing solid-fuel recipes.** `STEAM_BOILER_RECIPES` had zero recipes for coal/charcoal/coke, despite `SteamSolidBoilerMachine`'s fuel filter accepting any item with a vanilla furnace burn time. Steam boilers could never actually burn solid fuel as a result.

## Implementation Details

- `MetaMachineBlock#newBlockEntity` now catches `Throwable` (not just `RuntimeException`) around block entity creation, caches the failed machine's `ResourceLocation`, and logs + degrades gracefully (returns `null`) instead of crashing. This is necessary because the *second* and later failures throw `NoClassDefFoundError` (a `LinkageError`), which a `RuntimeException`-only catch does not cover.
- `SurfaceRockBlock#canSurvive` and `SurfaceIndicatorGenerator`'s `SURFACE` resolver both now catch `IllegalStateException` from the chunk-boundary query and degrade gracefully instead of crashing chunk generation.
- `STEAM_BOILER_RECIPES` gained coal/charcoal/coke recipes, duration scaled off each material's vanilla furnace burn value (Coal/Charcoal 1600 ticks, Coke 3200 ticks), matching the existing `x3` multiplier convention already used for lava/creosote in the same file.
- `GTCEu`'s constructor now warms up `CokeOvenHatch`'s class specifically - the one machine class confirmed (via repeated live dedicated-server restarts) to deterministically trip the RuntimeDistCleaner false positive on this project's exact class layout - with the dist check reflectively and temporarily disabled for just that one call, **from `FMLCommonSetupEvent#enqueueWork`**. This location matters and is worth reviewers double-checking: both the mod constructor and the raw (non-enqueued) event handler run on FML's parallel per-mod dispatch executor alongside every other mod's construction/setup, and briefly disabling the check there corrupts whichever other mods happen to be loading their own client-only classes on other threads at that exact moment - confirmed live, this crashed mod loading entirely for `createbigcannons`/`aeronautics`/`railways` when tried at those earlier points in the lifecycle. `enqueueWork` callbacks run strictly sequentially, after every mod's parallel setup work has already finished, so no other mod is loading classes concurrently by the time this runs.

This last change is the one most worth alternate-solution discussion: it's a targeted workaround for one specific class rather than a general fix for the underlying RuntimeDistCleaner false positive, since a general fix would require changes to FancyModLoader itself (out of scope for this repo). Happy to discuss whether maintaining a small allowlist like this is acceptable, or whether this should instead be reported/fixed upstream in FancyModLoader.

### AI Usage
- [ ] No AI driven tools were used for this pull request.
- [x] Yes AI driven tools were used for this pull request.

#### Agent Used
Claude Code (Sonnet 5)

#### Agent Usage Description
Used to diagnose all three issues via live RCON testing and log analysis on a private dedicated server (reproducing the RuntimeDistCleaner-triggered crashes and the CokeOvenHatch breakage across multiple clean restarts, confirming the boiler never consumed coal despite accepting it, and confirming the world-gen `IllegalStateException` crash from a live crash report), and to write and test all four fixes, including two earlier attempted approaches for the CokeOvenHatch workaround that were tried, found to cause worse collateral damage (a global RuntimeDistCleaner disable broke AE2/CreativeCore/ParCool; a bulk class-warmup at boot time increased failure rates and added lag), and reverted before arriving at the `enqueueWork`-based approach in this PR. All changes were reviewed and tested live before this PR was opened.

## Outcome
Fixes: #3584 (for the CokeOvenHatch/world-gen crash cases specifically - the original report's harmless-log-spam case may still occur for other classes, since this PR targets the one class confirmed to cause real breakage, not the underlying false positive itself)

- Dedicated servers no longer crash when RuntimeDistCleaner's false positive hits `SurfaceRockBlock` or `SurfaceIndicatorGenerator` during world generation.
- `CokeOvenHatch` no longer gets permanently disabled for the session on this mod list - confirmed via 4 consecutive clean dedicated-server restarts (previously: failed on every single restart) plus a live RCON check confirming the block entity holds real NBT state.
- Steam boilers (bronze and steel/high-pressure) can now actually burn coal, charcoal, and coke as fuel.

## How Was This Tested
All four fixes were verified live on a private dedicated server, not just compiled/inspected:
- 4 consecutive clean dedicated-server boots with zero `ModLoadingException` and zero `CokeOvenHatch` failures (previously: failed on every boot with this mod list).
- Live RCON test: placed `gtceu:coke_oven_hatch` via `/setblock`, confirmed via `/data get block` that it holds real NBT state (`cover: {}`, `paintingColor: -1`, etc.) rather than a dead/capability-less block entity.
- A formed Coke Oven multiblock actually processing its recipe in live gameplay - "Structure Formed", consuming coal, producing coke + creosote on schedule (see screenshot below).
- Chunk generation no longer crashes with the `SurfaceRockBlock`/`SurfaceIndicatorGenerator` `IllegalStateException` (confirmed via crash report before the fix, clean world generation after).
- Steam boiler consuming exactly 1 coal per full boil cycle and producing steam as expected, confirmed via RCON (`consecutiveRecipes: 1`, temperature rising 0 → 246).

## Additional Information
Reproduced on a ~145-mod NeoForge 1.21.1 dedicated server. Full mod list for reference (in case the CokeOvenHatch classload-order issue is mod-list-dependent and other maintainers want to try reproducing it):

<details>
<summary>Mod list (145 mods)</summary>

```
777-2.0.0d.jar
AdvancedPeripherals-1.21.1-0.7.62b.jar
Almanac-1.21.1-2-neoforge-1.5.2.jar
Chunky-NeoForge-1.4.23.jar
CreateFastSchematicCannon-1.4.1-neoforge-1.21.1.jar
CreativeCore_NEOFORGE_v2.13.41_mc1.21.1.jar
ExclusionsLib-1.1.0-NEO.jar
GnKinetics-1.21.1-1.0m.jar
Iceberg-1.21.1-neoforge-1.3.2.jar
Jade-1.21.1-NeoForge-15.10.5.jar
ParCool-1.21.1-3.4.3.3-NF.jar
Pastel-1.1.5.5.jar
Patchouli-1.21.1-93-NEOFORGE.jar
Prism-1.21.1-neoforge-1.0.11.jar
PuzzlesLib-v21.1.52-1.21.1-NeoForge.jar
Searchables-neoforge-1.21.1-1.0.2.jar
Spelled-1.21.1-0.8.1.jar
Stellarity-3.0.6.1.jar
VistaAeronauricsFix-1.0.1.jar
aero_addition-1.0.2.jar
aerocables-0.4.0.jar
aerocopycats-1.1.1.jar
aeroportals-1.21.1-1.2.0.jar
aeroshipsaver-1.1.0.jar
alltheleaks-1.1.10+1.21.1-neoforge.jar
appleskin-neoforge-mc1.21-3.0.9.jar
appliedenergistics2-19.2.17.jar
architectury-13.0.11-neoforge.jar
balm-neoforge-1.21.1-21.0.63.jar
buildaspell-1.0.0-mc1.21.1.jar
caelus-neoforge-7.0.1+1.21.1.jar
cbc_compact_mount-1.2.2.jar
cbc_fuze_sable_fix-1.0.1.jar
cbc_going_ballistic-0.3.0.jar
cc-cbc-v1.1.1-1.21.1-neoforge.jar
cc-tweaked-1.21.1-forge-1.120.0.jar
cc_cbc_compact_mount-1.21.1-1.0.0.jar
cc_deepseas-1.1.1.jar
cc_sable-neoforge-1.3.4.jar
cccbridge-mc1.21.1-v1.7.3-neoforge.jar
ccredstonelinkbridge-neoforge-1.0.3.jar
chloride-NEOFORGE-mc1.21.1-v1.8.1.jar
cloth-config-15.0.140-neoforge.jar
configuration-neoforge-1.21.1-3.1.1.jar
copycats-3.0.4+mc.1.21.1-neoforge.jar
cosmonautics-26.07.289.jar
cosmonauticsdeepair-1.0.2.jar
craft_config-1.1.12+1.21.1-neoforge.jar
create-1.21.1-6.0.10.jar
create-aeronautics-bundled-1.21.1-1.3.0.jar
create_aero_radar-0.1.1-1.21.1.jar
create_aeronautics_throwable_rope_connector-0.4.1.jar
create_aeronautics_transmission_linkage-0.2.5.jar
create_avionics-neoforge-1.21.1-0.5.1.jar
create_connected-1.3.2-mc1.21.1.jar
create_enhanced_schematicannon-1.0.4.jar
create_flight_control-neoforge-0.5.1.jar
create_radar-0.4.9.4-1.21.1.jar
create_submarine-2.2.4.jar
create_things_and_misc-4.1.1-neoforge-1.21.1.jar
createaerophysicsgantry-1.0.3.jar
createbigcannons-5.11.7+mc.1.21.1.jar
createcontraptionterminals-1.21-1.3.0.jar
createpropulsion-1.1.4.jar
createschematicchecker-1.21.27-6.0-neoforge-1.21.1.jar
cristellib-neoforge-1.21.1-3.1.7.jar
curios-neoforge-9.5.1+1.21.1.jar
databank-1.3.1.jar
dimdoors-neoforge-1.21.1-6.2.2.jar
extra_copycats-1.0.2.jar
extraspecialcore-1.2.2+1.21.1-neoforge.jar
fdbosses-3.1.0.3-1.21.1.jar
fdlib-1.0.8-1.21.1.jar
ferritecore-7.0.3-neoforge.jar
fzzy_config-0.7.6+1.21+neoforge.jar
geckolib-neoforge-1.21.1-4.9.2.jar
gravestone-neoforge-1.21.1-1.0.37.jar
gtceu-1.21.1-7.0.2.jar
guideme-21.1.17.jar
hammers-2.1.5-1.21.1-neoforge.jar
harddisks-1.0.1+mc1.21.1.jar
hudglassescc-0.1.3-beta.jar
jei-1.21.1-neoforge-19.39.0.370.jar
kotlinforforge-5.11.0-all.jar
krypton_fnp-neoforge-1.21.1-0.2.28.1-1.21.1.jar
letmedespawn-1.21.x-neoforge-1.5.0.jar
libIPN-neoforge-1.21.1-6.6.3.jar
linked-copycats-1.21.1-1.0.0.jar
lithium-neoforge-0.15.4+mc1.21.1.jar
lomka-0.3.1-neoforge+1.21.jar
ly-clumps-v1.0.2.jar
memguard-1.0.4.jar
midnightlib-neoforge-1.9.3+1.21.1.jar
modernfix-neoforge-5.27.20+mc1.21.1.jar
modonomicon-1.21.1-neoforge-1.120.3.jar
moonlight-neoforge-1.21.1-3.1.2.jar
morepropulsion-1.2.1.jar
neoorigins-2.2.20+1.21.1.jar
nodupefix-2.0.0.jar
polymorph-neoforge-1.1.0+1.21.1.jar
portable_engine_overdrive-1.0.1-neoforge-1.21.1.jar
potentials-neoforge-1.21-0.7.1.jar
railways-0.3.0-beta+neoforge-mc1.21.1.jar
resourcefulconfig-neoforge-1.21-3.0.11.jar
ritchiesprojectilelib-2.1.2-mc.1.21.1-neoforge.jar
s_a_b-1.4.3-neoforge-1.21.1.jar
sab_tfmg_compat-1.0.0.jar
sable-autonomous-chunk-loader-1.3.4.jar
sable-neoforge-1.21.1-2.0.3.jar
sablejade-1.2.1.jar
sablemassview-1.0.0.jar
sablephysicscompat-1.3.0.jar
saturn-mc1.21.1-0.1.5.jar
schematicenergistics-1.21.1-1.5.4a.jar
servercore-neoforge-1.5.10+1.21.1.jar
sg_tracks-1.2.0.jar
sim_copycats-1.3.1.jar
sophisticatedbackpacks-1.21.1-3.25.72.2012.jar
sophisticatedcore-1.21.1-1.4.79.2182.jar
spark-1.10.124-neoforge.jar
spore_1.21.1_2.2.0j_neo.jar
stellaris-1.21-neoforge-1.4.25.jar
stickywheels-1.21.1-0.0.3.jar
structure_layout_optimizer-neoforge-1.0.12.jar
submarinefix-1.0.1.jar
supermartijn642configlib-1.1.8-neoforge-mc1.21.jar
supermartijn642corelib-1.1.21-neoforge-mc1.21.jar
tfmg-1.2.2.jar
tinygates-1.21.1-5.0.2.jar
tinypipes-1.21.1-5.3.1.jar
tinyredstone-1.21.1-6.1.5.jar
toms-peripherals-1.21-1.3.1.jar
toms_storage-1.21-2.4.0.jar
txnilib-neoforge-1.0.24-1.21.1.jar
vista-1.21-3.1.1-neoforge.jar
void_power-1.0.7.jar
waystones-neoforge-1.21.1-21.1.38.jar
```
</details>

## Potential Compatibility Issues
None expected for the crash fixes (`MetaMachineBlock#newBlockEntity`, `SurfaceRockBlock`, `SurfaceIndicatorGenerator`) - all are additive error handling around existing calls; behavior on the success path is unchanged.

The `STEAM_BOILER_RECIPES` additions are new recipes only and do not modify or remove any existing recipe.

The `GTCEu` constructor change reflectively touches FancyModLoader's `RuntimeDistCleaner` internals via `Class.forName`/reflection - this is inherently a bit fragile against loader-internal refactors (field/class renames in a future FancyModLoader version would make the hook silently no-op, logged as a warning, with no other side effects). It only runs on dedicated servers (`FMLEnvironment.dist.isDedicatedServer()`), never on the client.