### PR TITLE
fix uppercase ids being used in reslocs

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagPrefix.java
@@ -149,7 +149,7 @@ public class TagPrefix {
                             .strength(0.5F).sound(SoundType.SAND),
                     ResourceLocation.withDefaultNamespace("block/sand"), false, true, false);
 
-    public static final TagPrefix oreRedSand = oreTagPrefix(GTCEu.id("redSand"), BlockTags.MINEABLE_WITH_SHOVEL)
+    public static final TagPrefix oreRedSand = oreTagPrefix(GTCEu.id("red_sand"), BlockTags.MINEABLE_WITH_SHOVEL)
             .langValue("Red Sand %s Ore")
             .registerOre(Blocks.RED_SAND::defaultBlockState, () -> GTMaterials.SiliconDioxide,
                     BlockBehaviour.Properties.of().mapColor(MapColor.COLOR_ORANGE).instrument(NoteBlockInstrument.SNARE)
@@ -203,7 +203,7 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix rawOreBlock = new TagPrefix(GTCEu.id("rawOreBlock"))
+    public static final TagPrefix rawOreBlock = new TagPrefix(GTCEu.id("raw_ore_block"))
             .idPattern("raw_%s_block")
             .defaultTagPath("storage_blocks/raw_%s")
             .unformattedTagPath("storage_blocks")
@@ -214,7 +214,7 @@ public class TagPrefix {
             .generateBlock(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix crushedRefined = new TagPrefix(GTCEu.id("refinedOre"))
+    public static final TagPrefix crushedRefined = new TagPrefix(GTCEu.id("refined_ore"))
             .idPattern("refined_%s_ore")
             .defaultTagPath("refined_ores/%s")
             .defaultTagPath("refined_ores")
@@ -224,7 +224,7 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix crushedPurified = new TagPrefix(GTCEu.id("purifiedOre"))
+    public static final TagPrefix crushedPurified = new TagPrefix(GTCEu.id("purified_ore"))
             .idPattern("purified_%s_ore")
             .defaultTagPath("purified_ores/%s")
             .defaultTagPath("purified_ores")
@@ -235,7 +235,7 @@ public class TagPrefix {
             .generateItem(true)
             .generationCondition(hasOreProperty);
 
-    public static final TagPrefix crushed = new TagPrefix(GTCEu.id("crushedOre"))
+    public static final TagPrefix crushed = new TagPrefix(GTCEu.id("crushed_ore"))
             .idPattern("crushed_%s_ore")
             .defaultTagPath("crushed_ores/%s")
             .unformattedTagPath("crushed_ores")
@@ -247,7 +247,7 @@ public class TagPrefix {
             .tooltip((mat, tooltips) -> tooltips.add(Component.translatable("metaitem.crushed.tooltip.purify")));
 
     // A hot Ingot, which has to be cooled down by a Vacuum Freezer.
-    public static final TagPrefix ingotHot = new TagPrefix(GTCEu.id("hotIngot"))
+    public static final TagPrefix ingotHot = new TagPrefix(GTCEu.id("hot_ingot"))
             .idPattern("hot_%s_ingot")
             .defaultTagPath("hot_ingots/%s")
             .unformattedTagPath("hot_ingots")
@@ -283,7 +283,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty);
 
     // A regular Gem worth one small Dust.
-    public static final TagPrefix gemChipped = new TagPrefix(GTCEu.id("chippedGem"))
+    public static final TagPrefix gemChipped = new TagPrefix(GTCEu.id("chipped_gem"))
             .idPattern("chipped_%s_gem")
             .defaultTagPath("chipped_gems/%s")
             .unformattedTagPath("chipped_gems")
@@ -296,7 +296,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty.and(unused -> ConfigHolder.INSTANCE.recipes.generateLowQualityGems));
 
     // A regular Gem worth two small Dusts.
-    public static final TagPrefix gemFlawed = new TagPrefix(GTCEu.id("flawedGem"))
+    public static final TagPrefix gemFlawed = new TagPrefix(GTCEu.id("flawed_gem"))
             .idPattern("flawed_%s_gem")
             .defaultTagPath("flawed_gems/%s")
             .unformattedTagPath("flawed_gems")
@@ -309,7 +309,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty.and(unused -> ConfigHolder.INSTANCE.recipes.generateLowQualityGems));
 
     // A regular Gem worth two Dusts.
-    public static final TagPrefix gemFlawless = new TagPrefix(GTCEu.id("flawlessGem"))
+    public static final TagPrefix gemFlawless = new TagPrefix(GTCEu.id("flawless_gem"))
             .idPattern("flawless_%s_gem")
             .defaultTagPath("flawless_gems/%s")
             .unformattedTagPath("flawless_gems")
@@ -323,7 +323,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty);
 
     // A regular Gem worth four Dusts.
-    public static final TagPrefix gemExquisite = new TagPrefix(GTCEu.id("exquisiteGem"))
+    public static final TagPrefix gemExquisite = new TagPrefix(GTCEu.id("exquisite_gem"))
             .idPattern("exquisite_%s_gem")
             .defaultTagPath("exquisite_gems/%s")
             .unformattedTagPath("exquisite_gems")
@@ -337,7 +337,7 @@ public class TagPrefix {
             .generationCondition(hasGemProperty);
 
     // 1/4th of a Dust.
-    public static final TagPrefix dustSmall = new TagPrefix(GTCEu.id("smallDust"))
+    public static final TagPrefix dustSmall = new TagPrefix(GTCEu.id("small_dust"))
             .idPattern("small_%s_dust")
             .defaultTagPath("small_dusts/%s")
             .unformattedTagPath("small_dusts")
@@ -349,7 +349,7 @@ public class TagPrefix {
             .generationCondition(hasDustProperty);
 
     // 1/9th of a Dust.
-    public static final TagPrefix dustTiny = new TagPrefix(GTCEu.id("tinyDust"))
+    public static final TagPrefix dustTiny = new TagPrefix(GTCEu.id("tiny_dust"))
             .idPattern("tiny_%s_dust")
             .defaultTagPath("tiny_dusts/%s")
             .unformattedTagPath("tiny_dusts")
@@ -361,7 +361,7 @@ public class TagPrefix {
             .generationCondition(hasDustProperty);
 
     // Dust with impurities. 1 Unit of Main Material and 1/9 - 1/4 Unit of secondary Material
-    public static final TagPrefix dustImpure = new TagPrefix(GTCEu.id("impureDust"))
+    public static final TagPrefix dustImpure = new TagPrefix(GTCEu.id("impure_dust"))
             .idPattern("impure_%s_dust")
             .defaultTagPath("impure_dusts/%s")
             .unformattedTagPath("impure_dusts")
@@ -374,7 +374,7 @@ public class TagPrefix {
             .tooltip((mat, tooltips) -> tooltips.add(Component.translatable("metaitem.dust.tooltip.purify")));
 
     // Pure Dust worth of one Ingot or Gem.
-    public static final TagPrefix dustPure = new TagPrefix(GTCEu.id("pureDust"))
+    public static final TagPrefix dustPure = new TagPrefix(GTCEu.id("pure_dust"))
             .idPattern("pure_%s_dust")
             .defaultTagPath("pure_dusts/%s")
             .unformattedTagPath("pure_dusts")
@@ -408,7 +408,7 @@ public class TagPrefix {
             .generationCondition(hasIngotProperty);
 
     // 9 Plates combined in one Item.
-    public static final TagPrefix plateDense = new TagPrefix(GTCEu.id("densePlate"))
+    public static final TagPrefix plateDense = new TagPrefix(GTCEu.id("dense_plate"))
             .idPattern("dense_%s_plate")
             .defaultTagPath("dense_plates/%s")
             .unformattedTagPath("dense_plates")
@@ -422,7 +422,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_DENSE));
 
     // 2 Plates combined in one Item
-    public static final TagPrefix plateDouble = new TagPrefix(GTCEu.id("doublePlate"))
+    public static final TagPrefix plateDouble = new TagPrefix(GTCEu.id("double_plate"))
             .idPattern("double_%s_plate")
             .defaultTagPath("double_plates/%s")
             .unformattedTagPath("double_plates")
@@ -470,7 +470,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_FOIL));
 
     // Stick made of an Ingot.
-    public static final TagPrefix rodLong = new TagPrefix(GTCEu.id("longRod"))
+    public static final TagPrefix rodLong = new TagPrefix(GTCEu.id("long_rod"))
             .idPattern("long_%s_rod")
             .defaultTagPath("rods/long/%s")
             .unformattedTagPath("rods/long")
@@ -528,7 +528,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_RING));
 
     // consisting out of 1 Fine Wire.
-    public static final TagPrefix springSmall = new TagPrefix(GTCEu.id("smallSpring"))
+    public static final TagPrefix springSmall = new TagPrefix(GTCEu.id("small_spring"))
             .idPattern("small_%s_spring")
             .defaultTagPath("small_springs/%s")
             .unformattedTagPath("small_springs")
@@ -554,7 +554,7 @@ public class TagPrefix {
                     mat -> mat.hasFlag(MaterialFlags.GENERATE_SPRING) && !mat.hasFlag(MaterialFlags.NO_SMASHING));
 
     // consisting out of 1/8 Ingot or 1/4 Wire.
-    public static final TagPrefix wireFine = new TagPrefix(GTCEu.id("fineWire"))
+    public static final TagPrefix wireFine = new TagPrefix(GTCEu.id("fine_wire"))
             .idPattern("fine_%s_wire")
             .defaultTagPath("fine_wires/%s")
             .unformattedTagPath("fine_wires")
@@ -579,7 +579,7 @@ public class TagPrefix {
             .generationCondition(mat -> mat.hasFlag(MaterialFlags.GENERATE_ROTOR));
 
     // Consisting of 1 Plate.
-    public static final TagPrefix gearSmall = new TagPrefix(GTCEu.id("smallGear"))
+    public static final TagPrefix gearSmall = new TagPrefix(GTCEu.id("small_gear"))
             .idPattern("small_%s_gear")
             .defaultTagPath("small_gears/%s")
             .unformattedTagPath("small_gears")
@@ -620,7 +620,7 @@ public class TagPrefix {
             .materialAmount(-1);
 
     // made of 4 Ingots.
-    public static final TagPrefix toolHeadBuzzSaw = new TagPrefix(GTCEu.id("buzzSawBlade"))
+    public static final TagPrefix toolHeadBuzzSaw = new TagPrefix(GTCEu.id("buzzsaw_blade"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Buzzsaw Blade")
             .materialAmount(GTValues.M * 4)
@@ -633,7 +633,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.BUZZSAW_LV)));
 
     // made of 1 Ingots.
-    public static final TagPrefix toolHeadScrewdriver = new TagPrefix(GTCEu.id("screwdriverTip"))
+    public static final TagPrefix toolHeadScrewdriver = new TagPrefix(GTCEu.id("screwdriver_tip"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Screwdriver Tip")
             .materialAmount(GTValues.M)
@@ -646,7 +646,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.SCREWDRIVER_LV)));
 
     // made of 4 Ingots.
-    public static final TagPrefix toolHeadDrill = new TagPrefix(GTCEu.id("drillHead"))
+    public static final TagPrefix toolHeadDrill = new TagPrefix(GTCEu.id("drill_head"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Drill Head")
             .materialAmount(GTValues.M * 4)
@@ -659,7 +659,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.DRILL_LV)));
 
     // made of 2 Ingots.
-    public static final TagPrefix toolHeadChainsaw = new TagPrefix(GTCEu.id("chainsawHead"))
+    public static final TagPrefix toolHeadChainsaw = new TagPrefix(GTCEu.id("chainsaw_head"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Chainsaw Head")
             .materialAmount(GTValues.M * 2)
@@ -672,7 +672,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.CHAINSAW_LV)));
 
     // made of 4 Ingots.
-    public static final TagPrefix toolHeadWrench = new TagPrefix(GTCEu.id("wrenchTip"))
+    public static final TagPrefix toolHeadWrench = new TagPrefix(GTCEu.id("wrench_tip"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Wrench Tip")
             .materialAmount(GTValues.M * 4)
@@ -684,7 +684,7 @@ public class TagPrefix {
             .generationCondition(hasNoCraftingToolProperty.and(mat -> mat.hasFlag(MaterialFlags.GENERATE_PLATE))
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.WRENCH_LV)));
 
-    public static final TagPrefix toolHeadWireCutter = new TagPrefix(GTCEu.id("wireCutterHead"))
+    public static final TagPrefix toolHeadWireCutter = new TagPrefix(GTCEu.id("wire_cutter_head"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Wire Cutter Head")
             .materialAmount(GTValues.M * 4)
@@ -697,7 +697,7 @@ public class TagPrefix {
                     .and(mat -> mat.getProperty(PropertyKey.TOOL).hasType(GTToolType.WIRE_CUTTER_LV)));
 
     // made of 5 Ingots.
-    public static final TagPrefix turbineBlade = new TagPrefix(GTCEu.id("turbineBlade"))
+    public static final TagPrefix turbineBlade = new TagPrefix(GTCEu.id("turbine_blade"))
             .itemTable(() -> GTMaterialItems.MATERIAL_ITEMS)
             .langValue("%s Turbine Blade")
             .materialAmount(GTValues.M * 10)
@@ -733,7 +733,7 @@ public class TagPrefix {
             .unformattedTagPath("stairs", true);
     public static final TagPrefix fence = new TagPrefix(GTCEu.id("fence"))
             .unformattedTagPath("fences");
-    public static final TagPrefix fenceGate = new TagPrefix(GTCEu.id("fenceGate"))
+    public static final TagPrefix fenceGate = new TagPrefix(GTCEu.id("fence_gate"))
             .unformattedTagPath("fence_gates");
     public static final TagPrefix door = new TagPrefix(GTCEu.id("door"))
             .unformattedTagPath("doors", true);
@@ -763,35 +763,35 @@ public class TagPrefix {
                     material.hasFlag(MaterialFlags.GENERATE_FRAME));
 
     // Pipes
-    public static final TagPrefix pipeTinyFluid = new TagPrefix(GTCEu.id("pipeTinyFluid"))
+    public static final TagPrefix pipeTinyFluid = new TagPrefix(GTCEu.id("pipe_tiny_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Tiny %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M / 2)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeSmallFluid = new TagPrefix(GTCEu.id("pipeSmallFluid"))
+    public static final TagPrefix pipeSmallFluid = new TagPrefix(GTCEu.id("pipe_small_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Small %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNormalFluid = new TagPrefix(GTCEu.id("pipeNormalFluid"))
+    public static final TagPrefix pipeNormalFluid = new TagPrefix(GTCEu.id("pipe_normal_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Normal %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 3)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeLargeFluid = new TagPrefix(GTCEu.id("pipeLargeFluid"))
+    public static final TagPrefix pipeLargeFluid = new TagPrefix(GTCEu.id("pipe_large_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Large %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 6)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeHugeFluid = new TagPrefix(GTCEu.id("pipeHugeFluid"))
+    public static final TagPrefix pipeHugeFluid = new TagPrefix(GTCEu.id("pipe_huge_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Huge %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
@@ -799,14 +799,14 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix pipeQuadrupleFluid = new TagPrefix(GTCEu.id("pipeQuadrupleFluid"))
+    public static final TagPrefix pipeQuadrupleFluid = new TagPrefix(GTCEu.id("pipe_quadruple_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Quadruple %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 4)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNonupleFluid = new TagPrefix(GTCEu.id("pipeNonupleFluid"))
+    public static final TagPrefix pipeNonupleFluid = new TagPrefix(GTCEu.id("pipe_nonuple_fluid"))
             .itemTable(() -> GTMaterialBlocks.FLUID_PIPE_BLOCKS)
             .langValue("Nonuple %s Fluid Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
@@ -814,28 +814,28 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix pipeSmallItem = new TagPrefix(GTCEu.id("pipeSmallItem"))
+    public static final TagPrefix pipeSmallItem = new TagPrefix(GTCEu.id("pipe_small_item"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Small %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNormalItem = new TagPrefix(GTCEu.id("pipeNormalItem"))
+    public static final TagPrefix pipeNormalItem = new TagPrefix(GTCEu.id("pipe_normal_item"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Normal %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 3)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeLargeItem = new TagPrefix(GTCEu.id("pipeLargeItem"))
+    public static final TagPrefix pipeLargeItem = new TagPrefix(GTCEu.id("pipe_large_item"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Large %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M * 6)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeHugeItem = new TagPrefix(GTCEu.id("pipeHugeItem"))
+    public static final TagPrefix pipeHugeItem = new TagPrefix(GTCEu.id("pipe_huge_item"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Huge %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
@@ -843,31 +843,31 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix pipeSmallRestrictive = new TagPrefix(GTCEu.id("pipeSmallRestrictive"))
+    public static final TagPrefix pipeSmallRestrictive = new TagPrefix(GTCEu.id("pipe_small_restrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS)
             .langValue("Small Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeNormalRestrictive = new TagPrefix(GTCEu.id("pipeNormalRestrictive"))
+    public static final TagPrefix pipeNormalRestrictive = new TagPrefix(GTCEu.id("pipe_normal_restrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Normal Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH).materialAmount(GTValues.M * 3)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeLargeRestrictive = new TagPrefix(GTCEu.id("pipeLargeRestrictive"))
+    public static final TagPrefix pipeLargeRestrictive = new TagPrefix(GTCEu.id("pipe_large_restrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Large Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH).materialAmount(GTValues.M * 6)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix pipeHugeRestrictive = new TagPrefix(GTCEu.id("pipeHugeRestrictive"))
+    public static final TagPrefix pipeHugeRestrictive = new TagPrefix(GTCEu.id("pipe_huge_restrictive"))
             .itemTable(() -> GTMaterialBlocks.ITEM_PIPE_BLOCKS).langValue("Huge Restrictive %s Item Pipe")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WRENCH).materialAmount(GTValues.M * 12)
             .unificationEnabled(true)
             .enableRecycling();
 
     // Wires and cables
-    public static final TagPrefix wireGtHex = new TagPrefix(GTCEu.id("wireGtHex"))
+    public static final TagPrefix wireGtHex = new TagPrefix(GTCEu.id("wire_gt_hex"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("16x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -875,7 +875,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtOctal = new TagPrefix(GTCEu.id("wireGtOctal"))
+    public static final TagPrefix wireGtOctal = new TagPrefix(GTCEu.id("wire_gt_octal"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("8x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -883,7 +883,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtQuadruple = new TagPrefix(GTCEu.id("wireGtQuadruple"))
+    public static final TagPrefix wireGtQuadruple = new TagPrefix(GTCEu.id("wire_gt_quadruple"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("4x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -891,7 +891,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtDouble = new TagPrefix(GTCEu.id("wireGtDouble"))
+    public static final TagPrefix wireGtDouble = new TagPrefix(GTCEu.id("wire_gt_double"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("2x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -899,7 +899,7 @@ public class TagPrefix {
             .materialIconType(MaterialIconType.wire)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix wireGtSingle = new TagPrefix(GTCEu.id("wireGtSingle"))
+    public static final TagPrefix wireGtSingle = new TagPrefix(GTCEu.id("wire_gt_single"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("1x %s Wire")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -908,34 +908,34 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix cableGtHex = new TagPrefix(GTCEu.id("cableGtHex"))
+    public static final TagPrefix cableGtHex = new TagPrefix(GTCEu.id("cable_gt_hex"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("16x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 8)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtOctal = new TagPrefix(GTCEu.id("cableGtOctal"))
+    public static final TagPrefix cableGtOctal = new TagPrefix(GTCEu.id("cable_gt_octal"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("8x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 4)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtQuadruple = new TagPrefix(GTCEu.id("cableGtQuadruple"))
+    public static final TagPrefix cableGtQuadruple = new TagPrefix(GTCEu.id("cable_gt_quadruple"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS).langValue("4x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M * 2)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtDouble = new TagPrefix(GTCEu.id("cableGtDouble"))
+    public static final TagPrefix cableGtDouble = new TagPrefix(GTCEu.id("cable_gt_double"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("2x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
             .materialAmount(GTValues.M)
             .unificationEnabled(true)
             .enableRecycling();
-    public static final TagPrefix cableGtSingle = new TagPrefix(GTCEu.id("cableGtSingle"))
+    public static final TagPrefix cableGtSingle = new TagPrefix(GTCEu.id("cable_gt_single"))
             .itemTable(() -> GTMaterialBlocks.CABLE_BLOCKS)
             .langValue("1x %s Cable")
             .miningToolTag(CustomTags.MINEABLE_WITH_CONFIG_VALID_PICKAXE_WIRE_CUTTER)
@@ -943,7 +943,7 @@ public class TagPrefix {
             .unificationEnabled(true)
             .enableRecycling();
 
-    public static final TagPrefix surfaceRock = new TagPrefix(GTCEu.id("surfaceRock"))
+    public static final TagPrefix surfaceRock = new TagPrefix(GTCEu.id("surface_rock"))
             .langValue("%s Surface Rock")
             .defaultTagPath("surface_rocks/%s")
             .unformattedTagPath("surface_rocks")
@@ -1066,9 +1066,9 @@ public class TagPrefix {
     public TagPrefix(ResourceLocation id, boolean invertedName) {
         this.id = id;
         this.name = id.getPath();
-        this.idPattern = "%s_" + getLowerCaseName();
+        this.idPattern = "%s_" + name;
         this.invertedName = invertedName;
-        this.langValue = "%s " + FormattingUtil.toEnglishName(getLowerCaseName());
+        this.langValue = "%s " + FormattingUtil.toEnglishName(name);
         GTRegistries.register(GTRegistries.TAG_PREFIXES, id, this);
     }
 
@@ -1279,12 +1279,8 @@ public class TagPrefix {
         return materialIconType;
     }
 
-    public String getLowerCaseName() {
-        return FormattingUtil.toLowerCaseUnderscore(this.name);
-    }
-
     public String getUnlocalizedName() {
-        return "tagprefix." + getLowerCaseName();
+        return "tagprefix." + name;
     }
 
     public MutableComponent getLocalizedName(Material material) {
@@ -1298,7 +1294,7 @@ public class TagPrefix {
             return matSpecificKey;
         }
         if (material.hasProperty(PropertyKey.POLYMER)) {
-            String localizationKey = String.format("tagprefix.polymer.%s", getLowerCaseName());
+            String localizationKey = String.format("tagprefix.polymer.%s", name);
             // Not every polymer tag prefix gets a special name
             if (Language.getInstance().has(localizationKey)) {
                 return localizationKey;

--- a/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/data/tag/TagType.java
@@ -47,7 +47,7 @@ public class TagType {
     public static TagType withPrefixFormatter(String tagPath) {
         TagType type = new TagType(tagPath);
         type.formatter = Util.memoize((prefix, mat) -> TagUtil.createItemTag(
-                type.tagPath.formatted(prefix.getLowerCaseName(), mat.getName())));
+                type.tagPath.formatted(prefix.name, mat.getName())));
         return type;
     }
 
@@ -58,7 +58,7 @@ public class TagType {
     public static TagType withPrefixOnlyFormatter(String tagPath) {
         TagType type = new TagType(tagPath);
         type.formatter = Util.memoize((prefix, mat) -> TagUtil
-                .createItemTag(type.tagPath.formatted(prefix.getLowerCaseName())));
+                .createItemTag(type.tagPath.formatted(prefix.name)));
         type.isParentTag = true;
         return type;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/Placeholder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/Placeholder.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.placeholder;
 import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.placeholder.exceptions.PlaceholderException;
 import com.gregtechceu.gtceu.common.capability.PlaceholderSavedData;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
@@ -24,8 +25,7 @@ public abstract class Placeholder {
                                              List<MultiLineComponent> args) throws PlaceholderException;
 
     public Placeholder(String str) {
-        this.id = GTCEu.id(str);
-        this.name = str;
+        this(GTCEu.id(FormattingUtil.toLowerCaseUnderscore(str)));
     }
 
     public Placeholder(ResourceLocation id) {

--- a/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/placeholder/PlaceholderHandler.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.registry.GTRegistries;
 import com.gregtechceu.gtceu.client.renderer.monitor.IMonitorRenderer;
 import com.gregtechceu.gtceu.common.mui.widgets.textfield.CodeEditorWidget;
 import com.gregtechceu.gtceu.data.lang.LangHandler;
+import com.gregtechceu.gtceu.utils.FormattingUtil;
 import com.gregtechceu.gtceu.utils.GTUtil;
 
 import net.minecraft.ChatFormatting;
@@ -93,7 +94,8 @@ public class PlaceholderHandler {
 
     public static @Nullable ResourceKey<Placeholder> toId(String placeholder) {
         try {
-            return ResourceKey.create(GTRegistries.Keys.PLACEHOLDER, GTCEu.id(placeholder));
+            return ResourceKey.create(GTRegistries.Keys.PLACEHOLDER,
+                    GTCEu.id(FormattingUtil.toLowerCaseUnderscore(placeholder)));
         } catch (ResourceLocationException e) {
             return null;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTElements.java
@@ -8,201 +8,142 @@ import net.minecraft.resources.ResourceLocation;
 
 public class GTElements {
 
-    public static final Element H = createAndRegister(GTCEu.id("Hydrogen"), 1, 0, -1, null, "Hydrogen", "H", false);
-    public static final Element D = createAndRegister(GTCEu.id("Deuterium"), 1, 1, -1, "H", "Deuterium", "D", true);
-    public static final Element T = createAndRegister(GTCEu.id("Tritium"), 1, 2, -1, "D", "Tritium", "T", true);
-    public static final Element He = createAndRegister(GTCEu.id("Helium"), 2, 2, -1, null, "Helium", "He", false);
-    public static final Element He3 = createAndRegister(GTCEu.id("Helium-3"), 2, 1, -1, "H&D", "Helium-3", "He-3",
-            true);
-    public static final Element Li = createAndRegister(GTCEu.id("Lithium"), 3, 4, -1, null, "Lithium", "Li", false);
-    public static final Element Be = createAndRegister(GTCEu.id("Beryllium"), 4, 5, -1, null, "Beryllium", "Be", false);
-    public static final Element B = createAndRegister(GTCEu.id("Boron"), 5, 5, -1, null, "Boron", "B", false);
-    public static final Element C = createAndRegister(GTCEu.id("Carbon"), 6, 6, -1, null, "Carbon", "C", false);
-    public static final Element N = createAndRegister(GTCEu.id("Nitrogen"), 7, 7, -1, null, "Nitrogen", "N", false);
-    public static final Element O = createAndRegister(GTCEu.id("Oxygen"), 8, 8, -1, null, "Oxygen", "O", false);
-    public static final Element F = createAndRegister(GTCEu.id("Fluorine"), 9, 9, -1, null, "Fluorine", "F", false);
-    public static final Element Ne = createAndRegister(GTCEu.id("Neon"), 10, 10, -1, null, "Neon", "Ne", false);
-    public static final Element Na = createAndRegister(GTCEu.id("Sodium"), 11, 11, -1, null, "Sodium", "Na", false);
-    public static final Element Mg = createAndRegister(GTCEu.id("Magnesium"), 12, 12, -1, null, "Magnesium", "Mg",
-            false);
-    public static final Element Al = createAndRegister(GTCEu.id("Aluminium"), 13, 13, -1, null, "Aluminium", "Al",
-            false);
-    public static final Element Si = createAndRegister(GTCEu.id("Silicon"), 14, 14, -1, null, "Silicon", "Si", false);
-    public static final Element P = createAndRegister(GTCEu.id("Phosphorus"), 15, 15, -1, null, "Phosphorus", "P",
-            false);
-    public static final Element S = createAndRegister(GTCEu.id("Sulfur"), 16, 16, -1, null, "Sulfur", "S", false);
-    public static final Element Cl = createAndRegister(GTCEu.id("Chlorine"), 17, 18, -1, null, "Chlorine", "Cl", false);
-    public static final Element Ar = createAndRegister(GTCEu.id("Argon"), 18, 22, -1, null, "Argon", "Ar", false);
-    public static final Element K = createAndRegister(GTCEu.id("Potassium"), 19, 20, -1, null, "Potassium", "K", false);
-    public static final Element Ca = createAndRegister(GTCEu.id("Calcium"), 20, 20, -1, null, "Calcium", "Ca", false);
-    public static final Element Sc = createAndRegister(GTCEu.id("Scandium"), 21, 24, -1, null, "Scandium", "Sc", false);
-    public static final Element Ti = createAndRegister(GTCEu.id("Titanium"), 22, 26, -1, null, "Titanium", "Ti", false);
-    public static final Element V = createAndRegister(GTCEu.id("Vanadium"), 23, 28, -1, null, "Vanadium", "V", false);
-    public static final Element Cr = createAndRegister(GTCEu.id("Chrome"), 24, 28, -1, null, "Chrome", "Cr", false);
-    public static final Element Mn = createAndRegister(GTCEu.id("Manganese"), 25, 30, -1, null, "Manganese", "Mn",
-            false);
-    public static final Element Fe = createAndRegister(GTCEu.id("Iron"), 26, 30, -1, null, "Iron", "Fe", false);
-    public static final Element Co = createAndRegister(GTCEu.id("Cobalt"), 27, 32, -1, null, "Cobalt", "Co", false);
-    public static final Element Ni = createAndRegister(GTCEu.id("Nickel"), 28, 30, -1, null, "Nickel", "Ni", false);
-    public static final Element Cu = createAndRegister(GTCEu.id("Copper"), 29, 34, -1, null, "Copper", "Cu", false);
-    public static final Element Zn = createAndRegister(GTCEu.id("Zinc"), 30, 35, -1, null, "Zinc", "Zn", false);
-    public static final Element Ga = createAndRegister(GTCEu.id("Gallium"), 31, 39, -1, null, "Gallium", "Ga", false);
-    public static final Element Ge = createAndRegister(GTCEu.id("Germanium"), 32, 40, -1, null, "Germanium", "Ge",
-            false);
-    public static final Element As = createAndRegister(GTCEu.id("Arsenic"), 33, 42, -1, null, "Arsenic", "As", false);
-    public static final Element Se = createAndRegister(GTCEu.id("Selenium"), 34, 45, -1, null, "Selenium", "Se", false);
-    public static final Element Br = createAndRegister(GTCEu.id("Bromine"), 35, 45, -1, null, "Bromine", "Br", false);
-    public static final Element Kr = createAndRegister(GTCEu.id("Krypton"), 36, 48, -1, null, "Krypton", "Kr", false);
-    public static final Element Rb = createAndRegister(GTCEu.id("Rubidium"), 37, 48, -1, null, "Rubidium", "Rb", false);
-    public static final Element Sr = createAndRegister(GTCEu.id("Strontium"), 38, 49, -1, null, "Strontium", "Sr",
-            false);
-    public static final Element Y = createAndRegister(GTCEu.id("Yttrium"), 39, 50, -1, null, "Yttrium", "Y", false);
-    public static final Element Zr = createAndRegister(GTCEu.id("Zirconium"), 40, 51, -1, null, "Zirconium", "Zr",
-            false);
-    public static final Element Nb = createAndRegister(GTCEu.id("Niobium"), 41, 53, -1, null, "Niobium", "Nb", false);
-    public static final Element Mo = createAndRegister(GTCEu.id("Molybdenum"), 42, 53, -1, null, "Molybdenum", "Mo",
-            false);
-    public static final Element Tc = createAndRegister(GTCEu.id("Technetium"), 43, 55, -1, null, "Technetium", "Tc",
-            false);
-    public static final Element Ru = createAndRegister(GTCEu.id("Ruthenium"), 44, 57, -1, null, "Ruthenium", "Ru",
-            false);
-    public static final Element Rh = createAndRegister(GTCEu.id("Rhodium"), 45, 58, -1, null, "Rhodium", "Rh", false);
-    public static final Element Pd = createAndRegister(GTCEu.id("Palladium"), 46, 60, -1, null, "Palladium", "Pd",
-            false);
-    public static final Element Ag = createAndRegister(GTCEu.id("Silver"), 47, 60, -1, null, "Silver", "Ag", false);
-    public static final Element Cd = createAndRegister(GTCEu.id("Cadmium"), 48, 64, -1, null, "Cadmium", "Cd", false);
-    public static final Element In = createAndRegister(GTCEu.id("Indium"), 49, 65, -1, null, "Indium", "In", false);
-    public static final Element Sn = createAndRegister(GTCEu.id("Tin"), 50, 68, -1, null, "Tin", "Sn", false);
-    public static final Element Sb = createAndRegister(GTCEu.id("Antimony"), 51, 70, -1, null, "Antimony", "Sb", false);
-    public static final Element Te = createAndRegister(GTCEu.id("Tellurium"), 52, 75, -1, null, "Tellurium", "Te",
-            false);
-    public static final Element I = createAndRegister(GTCEu.id("Iodine"), 53, 74, -1, null, "Iodine", "I", false);
-    public static final Element Xe = createAndRegister(GTCEu.id("Xenon"), 54, 77, -1, null, "Xenon", "Xe", false);
-    public static final Element Cs = createAndRegister(GTCEu.id("Caesium"), 55, 77, -1, null, "Caesium", "Cs", false);
-    public static final Element Ba = createAndRegister(GTCEu.id("Barium"), 56, 81, -1, null, "Barium", "Ba", false);
-    public static final Element La = createAndRegister(GTCEu.id("Lanthanum"), 57, 81, -1, null, "Lanthanum", "La",
-            false);
-    public static final Element Ce = createAndRegister(GTCEu.id("Cerium"), 58, 82, -1, null, "Cerium", "Ce", false);
-    public static final Element Pr = createAndRegister(GTCEu.id("Praseodymium"), 59, 81, -1, null, "Praseodymium", "Pr",
-            false);
-    public static final Element Nd = createAndRegister(GTCEu.id("Neodymium"), 60, 84, -1, null, "Neodymium", "Nd",
-            false);
-    public static final Element Pm = createAndRegister(GTCEu.id("Promethium"), 61, 83, -1, null, "Promethium", "Pm",
-            false);
-    public static final Element Sm = createAndRegister(GTCEu.id("Samarium"), 62, 88, -1, null, "Samarium", "Sm", false);
-    public static final Element Eu = createAndRegister(GTCEu.id("Europium"), 63, 88, -1, null, "Europium", "Eu", false);
-    public static final Element Gd = createAndRegister(GTCEu.id("Gadolinium"), 64, 93, -1, null, "Gadolinium", "Gd",
-            false);
-    public static final Element Tb = createAndRegister(GTCEu.id("Terbium"), 65, 93, -1, null, "Terbium", "Tb", false);
-    public static final Element Dy = createAndRegister(GTCEu.id("Dysprosium"), 66, 96, -1, null, "Dysprosium", "Dy",
-            false);
-    public static final Element Ho = createAndRegister(GTCEu.id("Holmium"), 67, 97, -1, null, "Holmium", "Ho", false);
-    public static final Element Er = createAndRegister(GTCEu.id("Erbium"), 68, 99, -1, null, "Erbium", "Er", false);
-    public static final Element Tm = createAndRegister(GTCEu.id("Thulium"), 69, 99, -1, null, "Thulium", "Tm", false);
-    public static final Element Yb = createAndRegister(GTCEu.id("Ytterbium"), 70, 103, -1, null, "Ytterbium", "Yb",
-            false);
-    public static final Element Lu = createAndRegister(GTCEu.id("Lutetium"), 71, 103, -1, null, "Lutetium", "Lu",
-            false);
-    public static final Element Hf = createAndRegister(GTCEu.id("Hafnium"), 72, 106, -1, null, "Hafnium", "Hf", false);
-    public static final Element Ta = createAndRegister(GTCEu.id("Tantalum"), 73, 107, -1, null, "Tantalum", "Ta",
-            false);
-    public static final Element W = createAndRegister(GTCEu.id("Tungsten"), 74, 109, -1, null, "Tungsten", "W", false);
-    public static final Element Re = createAndRegister(GTCEu.id("Rhenium"), 75, 111, -1, null, "Rhenium", "Re", false);
-    public static final Element Os = createAndRegister(GTCEu.id("Osmium"), 76, 114, -1, null, "Osmium", "Os", false);
-    public static final Element Ir = createAndRegister(GTCEu.id("Iridium"), 77, 115, -1, null, "Iridium", "Ir", false);
-    public static final Element Pt = createAndRegister(GTCEu.id("Platinum"), 78, 117, -1, null, "Platinum", "Pt",
-            false);
-    public static final Element Au = createAndRegister(GTCEu.id("Gold"), 79, 117, -1, null, "Gold", "Au", false);
-    public static final Element Hg = createAndRegister(GTCEu.id("Mercury"), 80, 120, -1, null, "Mercury", "Hg", false);
-    public static final Element Tl = createAndRegister(GTCEu.id("Thallium"), 81, 123, -1, null, "Thallium", "Tl",
-            false);
-    public static final Element Pb = createAndRegister(GTCEu.id("Lead"), 82, 125, -1, null, "Lead", "Pb", false);
-    public static final Element Bi = createAndRegister(GTCEu.id("Bismuth"), 83, 125, -1, null, "Bismuth", "Bi", false);
-    public static final Element Po = createAndRegister(GTCEu.id("Polonium"), 84, 124, -1, null, "Polonium", "Po",
-            false);
-    public static final Element At = createAndRegister(GTCEu.id("Astatine"), 85, 124, -1, null, "Astatine", "At",
-            false);
-    public static final Element Rn = createAndRegister(GTCEu.id("Radon"), 86, 134, -1, null, "Radon", "Rn", false);
-    public static final Element Fr = createAndRegister(GTCEu.id("Francium"), 87, 134, -1, null, "Francium", "Fr",
-            false);
-    public static final Element Ra = createAndRegister(GTCEu.id("Radium"), 88, 136, -1, null, "Radium", "Ra", false);
-    public static final Element Ac = createAndRegister(GTCEu.id("Actinium"), 89, 136, -1, null, "Actinium", "Ac",
-            false);
-    public static final Element Th = createAndRegister(GTCEu.id("Thorium"), 90, 140, -1, null, "Thorium", "Th", false);
-    public static final Element Pa = createAndRegister(GTCEu.id("Protactinium"), 91, 138, -1, null, "Protactinium",
-            "Pa", false);
-    public static final Element U = createAndRegister(GTCEu.id("Uranium"), 92, 146, -1, null, "Uranium", "U", false);
-    public static final Element U238 = createAndRegister(GTCEu.id("Uranium-238"), 92, 146, -1, null, "Uranium-238",
-            "U-238", false);
-    public static final Element U235 = createAndRegister(GTCEu.id("Uranium-235"), 92, 143, -1, null, "Uranium-235",
-            "U-235", true);
-    public static final Element Np = createAndRegister(GTCEu.id("Neptunium"), 93, 144, -1, null, "Neptunium", "Np",
-            false);
-    public static final Element Pu = createAndRegister(GTCEu.id("Plutonium"), 94, 152, -1, null, "Plutonium", "Pu",
-            false);
-    public static final Element Pu239 = createAndRegister(GTCEu.id("Plutonium-239"), 94, 145, -1, null, "Plutonium-239",
-            "Pu-239", false);
-    public static final Element Pu241 = createAndRegister(GTCEu.id("Plutonium-241"), 94, 149, -1, null, "Plutonium-241",
-            "Pu-241", true);
-    public static final Element Am = createAndRegister(GTCEu.id("Americium"), 95, 150, -1, null, "Americium", "Am",
-            false);
-    public static final Element Cm = createAndRegister(GTCEu.id("Curium"), 96, 153, -1, null, "Curium", "Cm", false);
-    public static final Element Bk = createAndRegister(GTCEu.id("Berkelium"), 97, 152, -1, null, "Berkelium", "Bk",
-            false);
-    public static final Element Cf = createAndRegister(GTCEu.id("Californium"), 98, 153, -1, null, "Californium", "Cf",
-            false);
-    public static final Element Es = createAndRegister(GTCEu.id("Einsteinium"), 99, 153, -1, null, "Einsteinium", "Es",
-            false);
-    public static final Element Fm = createAndRegister(GTCEu.id("Fermium"), 100, 157, -1, null, "Fermium", "Fm", false);
-    public static final Element Md = createAndRegister(GTCEu.id("Mendelevium"), 101, 157, -1, null, "Mendelevium", "Md",
-            false);
-    public static final Element No = createAndRegister(GTCEu.id("Nobelium"), 102, 157, -1, null, "Nobelium", "No",
-            false);
-    public static final Element Lr = createAndRegister(GTCEu.id("Lawrencium"), 103, 159, -1, null, "Lawrencium", "Lr",
-            false);
-    public static final Element Rf = createAndRegister(GTCEu.id("Rutherfordium"), 104, 161, -1, null, "Rutherfordium",
-            "Rf", false);
-    public static final Element Db = createAndRegister(GTCEu.id("Dubnium"), 105, 163, -1, null, "Dubnium", "Db", false);
-    public static final Element Sg = createAndRegister(GTCEu.id("Seaborgium"), 106, 165, -1, null, "Seaborgium", "Sg",
-            false);
-    public static final Element Bh = createAndRegister(GTCEu.id("Bohrium"), 107, 163, -1, null, "Bohrium", "Bh", false);
-    public static final Element Hs = createAndRegister(GTCEu.id("Hassium"), 108, 169, -1, null, "Hassium", "Hs", false);
-    public static final Element Mt = createAndRegister(GTCEu.id("Meitnerium"), 109, 167, -1, null, "Meitnerium", "Mt",
-            false);
-    public static final Element Ds = createAndRegister(GTCEu.id("Darmstadtium"), 110, 171, -1, null, "Darmstadtium",
-            "Ds", false);
-    public static final Element Rg = createAndRegister(GTCEu.id("Roentgenium"), 111, 169, -1, null, "Roentgenium", "Rg",
-            false);
-    public static final Element Cn = createAndRegister(GTCEu.id("Copernicium"), 112, 173, -1, null, "Copernicium", "Cn",
-            false);
-    public static final Element Nh = createAndRegister(GTCEu.id("Nihonium"), 113, 171, -1, null, "Nihonium", "Nh",
-            false);
-    public static final Element Fl = createAndRegister(GTCEu.id("Flerovium"), 114, 175, -1, null, "Flerovium", "Fl",
-            false);
-    public static final Element Mc = createAndRegister(GTCEu.id("Moscovium"), 115, 173, -1, null, "Moscovium", "Mc",
-            false);
-    public static final Element Lv = createAndRegister(GTCEu.id("Livermorium"), 116, 177, -1, null, "Livermorium", "Lv",
-            false);
-    public static final Element Ts = createAndRegister(GTCEu.id("Tennessine"), 117, 177, -1, null, "Tennessine", "Ts",
-            false);
-    public static final Element Og = createAndRegister(GTCEu.id("Oganesson"), 118, 176, -1, null, "Oganesson", "Og",
-            false);
-    public static final Element Tr = createAndRegister(GTCEu.id("Tritanium"), 119, 178, -1, null, "Tritanium", "Tr",
-            false);
-    public static final Element Dr = createAndRegister(GTCEu.id("Duranium"), 120, 180, -1, null, "Duranium", "Dr",
-            false);
-    public static final Element Ke = createAndRegister(GTCEu.id("Trinium"), 125, 198, -1, null, "Trinium", "Ke", false);
-    public static final Element Nq = createAndRegister(GTCEu.id("Naquadah"), 174, 352, 140, null, "Naquadah", "Nq",
-            true);
-    public static final Element Nq1 = createAndRegister(GTCEu.id("NaquadahEnriched"), 174, 354, 140, null,
-            "NaquadahEnriched", "Nq+", true);
-    public static final Element Nq2 = createAndRegister(GTCEu.id("Naquadria"), 174, 348, 140, null, "Naquadria", "*Nq*",
-            true);
-    public static final Element Nt = createAndRegister(GTCEu.id("Neutronium"), 0, 1000, -1, null, "Neutronium", "Nt",
-            false);
-    public static final Element Sp = createAndRegister(GTCEu.id("Space"), 1, 0, -1, null, "Space", "Sp", false);
-    public static final Element Ma = createAndRegister(GTCEu.id("Magic"), 1, 0, -1, null, "Magic", "Ma", false);
-
+    // spotless:off
+    public static final Element H = createAndRegister(GTCEu.id("hydrogen"), 1, 0, -1, null, "Hydrogen", "H", false);
+    public static final Element D = createAndRegister(GTCEu.id("deuterium"), 1, 1, -1, "H", "Deuterium", "D", true);
+    public static final Element T = createAndRegister(GTCEu.id("tritium"), 1, 2, -1, "D", "Tritium", "T", true);
+    public static final Element He = createAndRegister(GTCEu.id("helium"), 2, 2, -1, null, "Helium", "He", false);
+    public static final Element He3 = createAndRegister(GTCEu.id("helium-3"), 2, 1, -1, "H&D", "Helium-3", "He-3", true);
+    public static final Element Li = createAndRegister(GTCEu.id("lithium"), 3, 4, -1, null, "Lithium", "Li", false);
+    public static final Element Be = createAndRegister(GTCEu.id("beryllium"), 4, 5, -1, null, "Beryllium", "Be", false);
+    public static final Element B = createAndRegister(GTCEu.id("boron"), 5, 5, -1, null, "Boron", "B", false);
+    public static final Element C = createAndRegister(GTCEu.id("carbon"), 6, 6, -1, null, "Carbon", "C", false);
+    public static final Element N = createAndRegister(GTCEu.id("nitrogen"), 7, 7, -1, null, "Nitrogen", "N", false);
+    public static final Element O = createAndRegister(GTCEu.id("oxygen"), 8, 8, -1, null, "Oxygen", "O", false);
+    public static final Element F = createAndRegister(GTCEu.id("fluorine"), 9, 9, -1, null, "Fluorine", "F", false);
+    public static final Element Ne = createAndRegister(GTCEu.id("neon"), 10, 10, -1, null, "Neon", "Ne", false);
+    public static final Element Na = createAndRegister(GTCEu.id("sodium"), 11, 11, -1, null, "Sodium", "Na", false);
+    public static final Element Mg = createAndRegister(GTCEu.id("magnesium"), 12, 12, -1, null, "Magnesium", "Mg", false);
+    public static final Element Al = createAndRegister(GTCEu.id("aluminium"), 13, 13, -1, null, "Aluminium", "Al", false);
+    public static final Element Si = createAndRegister(GTCEu.id("silicon"), 14, 14, -1, null, "Silicon", "Si", false);
+    public static final Element P = createAndRegister(GTCEu.id("phosphorus"), 15, 15, -1, null, "Phosphorus", "P", false);
+    public static final Element S = createAndRegister(GTCEu.id("sulfur"), 16, 16, -1, null, "Sulfur", "S", false);
+    public static final Element Cl = createAndRegister(GTCEu.id("chlorine"), 17, 18, -1, null, "Chlorine", "Cl", false);
+    public static final Element Ar = createAndRegister(GTCEu.id("argon"), 18, 22, -1, null, "Argon", "Ar", false);
+    public static final Element K = createAndRegister(GTCEu.id("potassium"), 19, 20, -1, null, "Potassium", "K", false);
+    public static final Element Ca = createAndRegister(GTCEu.id("calcium"), 20, 20, -1, null, "Calcium", "Ca", false);
+    public static final Element Sc = createAndRegister(GTCEu.id("scandium"), 21, 24, -1, null, "Scandium", "Sc", false);
+    public static final Element Ti = createAndRegister(GTCEu.id("titanium"), 22, 26, -1, null, "Titanium", "Ti", false);
+    public static final Element V = createAndRegister(GTCEu.id("vanadium"), 23, 28, -1, null, "Vanadium", "V", false);
+    public static final Element Cr = createAndRegister(GTCEu.id("chrome"), 24, 28, -1, null, "Chrome", "Cr", false);
+    public static final Element Mn = createAndRegister(GTCEu.id("manganese"), 25, 30, -1, null, "Manganese", "Mn", false);
+    public static final Element Fe = createAndRegister(GTCEu.id("iron"), 26, 30, -1, null, "Iron", "Fe", false);
+    public static final Element Co = createAndRegister(GTCEu.id("cobalt"), 27, 32, -1, null, "Cobalt", "Co", false);
+    public static final Element Ni = createAndRegister(GTCEu.id("nickel"), 28, 30, -1, null, "Nickel", "Ni", false);
+    public static final Element Cu = createAndRegister(GTCEu.id("copper"), 29, 34, -1, null, "Copper", "Cu", false);
+    public static final Element Zn = createAndRegister(GTCEu.id("zinc"), 30, 35, -1, null, "Zinc", "Zn", false);
+    public static final Element Ga = createAndRegister(GTCEu.id("gallium"), 31, 39, -1, null, "Gallium", "Ga", false);
+    public static final Element Ge = createAndRegister(GTCEu.id("germanium"), 32, 40, -1, null, "Germanium", "Ge", false);
+    public static final Element As = createAndRegister(GTCEu.id("arsenic"), 33, 42, -1, null, "Arsenic", "As", false);
+    public static final Element Se = createAndRegister(GTCEu.id("selenium"), 34, 45, -1, null, "Selenium", "Se", false);
+    public static final Element Br = createAndRegister(GTCEu.id("bromine"), 35, 45, -1, null, "Bromine", "Br", false);
+    public static final Element Kr = createAndRegister(GTCEu.id("krypton"), 36, 48, -1, null, "Krypton", "Kr", false);
+    public static final Element Rb = createAndRegister(GTCEu.id("rubidium"), 37, 48, -1, null, "Rubidium", "Rb", false);
+    public static final Element Sr = createAndRegister(GTCEu.id("strontium"), 38, 49, -1, null, "Strontium", "Sr", false);
+    public static final Element Y = createAndRegister(GTCEu.id("yttrium"), 39, 50, -1, null, "Yttrium", "Y", false);
+    public static final Element Zr = createAndRegister(GTCEu.id("zirconium"), 40, 51, -1, null, "Zirconium", "Zr", false);
+    public static final Element Nb = createAndRegister(GTCEu.id("niobium"), 41, 53, -1, null, "Niobium", "Nb", false);
+    public static final Element Mo = createAndRegister(GTCEu.id("molybdenum"), 42, 53, -1, null, "Molybdenum", "Mo", false);
+    public static final Element Tc = createAndRegister(GTCEu.id("technetium"), 43, 55, -1, null, "Technetium", "Tc", false);
+    public static final Element Ru = createAndRegister(GTCEu.id("ruthenium"), 44, 57, -1, null, "Ruthenium", "Ru", false);
+    public static final Element Rh = createAndRegister(GTCEu.id("rhodium"), 45, 58, -1, null, "Rhodium", "Rh", false);
+    public static final Element Pd = createAndRegister(GTCEu.id("palladium"), 46, 60, -1, null, "Palladium", "Pd", false);
+    public static final Element Ag = createAndRegister(GTCEu.id("silver"), 47, 60, -1, null, "Silver", "Ag", false);
+    public static final Element Cd = createAndRegister(GTCEu.id("cadmium"), 48, 64, -1, null, "Cadmium", "Cd", false);
+    public static final Element In = createAndRegister(GTCEu.id("indium"), 49, 65, -1, null, "Indium", "In", false);
+    public static final Element Sn = createAndRegister(GTCEu.id("tin"), 50, 68, -1, null, "Tin", "Sn", false);
+    public static final Element Sb = createAndRegister(GTCEu.id("antimony"), 51, 70, -1, null, "Antimony", "Sb", false);
+    public static final Element Te = createAndRegister(GTCEu.id("tellurium"), 52, 75, -1, null, "Tellurium", "Te", false);
+    public static final Element I = createAndRegister(GTCEu.id("iodine"), 53, 74, -1, null, "Iodine", "I", false);
+    public static final Element Xe = createAndRegister(GTCEu.id("xenon"), 54, 77, -1, null, "Xenon", "Xe", false);
+    public static final Element Cs = createAndRegister(GTCEu.id("caesium"), 55, 77, -1, null, "Caesium", "Cs", false);
+    public static final Element Ba = createAndRegister(GTCEu.id("barium"), 56, 81, -1, null, "Barium", "Ba", false);
+    public static final Element La = createAndRegister(GTCEu.id("lanthanum"), 57, 81, -1, null, "Lanthanum", "La", false);
+    public static final Element Ce = createAndRegister(GTCEu.id("cerium"), 58, 82, -1, null, "Cerium", "Ce", false);
+    public static final Element Pr = createAndRegister(GTCEu.id("praseodymium"), 59, 81, -1, null, "Praseodymium", "Pr", false);
+    public static final Element Nd = createAndRegister(GTCEu.id("neodymium"), 60, 84, -1, null, "Neodymium", "Nd", false);
+    public static final Element Pm = createAndRegister(GTCEu.id("promethium"), 61, 83, -1, null, "Promethium", "Pm", false);
+    public static final Element Sm = createAndRegister(GTCEu.id("samarium"), 62, 88, -1, null, "Samarium", "Sm", false);
+    public static final Element Eu = createAndRegister(GTCEu.id("europium"), 63, 88, -1, null, "Europium", "Eu", false);
+    public static final Element Gd = createAndRegister(GTCEu.id("gadolinium"), 64, 93, -1, null, "Gadolinium", "Gd", false);
+    public static final Element Tb = createAndRegister(GTCEu.id("terbium"), 65, 93, -1, null, "Terbium", "Tb", false);
+    public static final Element Dy = createAndRegister(GTCEu.id("dysprosium"), 66, 96, -1, null, "Dysprosium", "Dy", false);
+    public static final Element Ho = createAndRegister(GTCEu.id("holmium"), 67, 97, -1, null, "Holmium", "Ho", false);
+    public static final Element Er = createAndRegister(GTCEu.id("erbium"), 68, 99, -1, null, "Erbium", "Er", false);
+    public static final Element Tm = createAndRegister(GTCEu.id("thulium"), 69, 99, -1, null, "Thulium", "Tm", false);
+    public static final Element Yb = createAndRegister(GTCEu.id("ytterbium"), 70, 103, -1, null, "Ytterbium", "Yb", false);
+    public static final Element Lu = createAndRegister(GTCEu.id("lutetium"), 71, 103, -1, null, "Lutetium", "Lu", false);
+    public static final Element Hf = createAndRegister(GTCEu.id("hafnium"), 72, 106, -1, null, "Hafnium", "Hf", false);
+    public static final Element Ta = createAndRegister(GTCEu.id("tantalum"), 73, 107, -1, null, "Tantalum", "Ta", false);
+    public static final Element W = createAndRegister(GTCEu.id("tungsten"), 74, 109, -1, null, "Tungsten", "W", false);
+    public static final Element Re = createAndRegister(GTCEu.id("rhenium"), 75, 111, -1, null, "Rhenium", "Re", false);
+    public static final Element Os = createAndRegister(GTCEu.id("osmium"), 76, 114, -1, null, "Osmium", "Os", false);
+    public static final Element Ir = createAndRegister(GTCEu.id("iridium"), 77, 115, -1, null, "Iridium", "Ir", false);
+    public static final Element Pt = createAndRegister(GTCEu.id("platinum"), 78, 117, -1, null, "Platinum", "Pt", false);
+    public static final Element Au = createAndRegister(GTCEu.id("gold"), 79, 117, -1, null, "Gold", "Au", false);
+    public static final Element Hg = createAndRegister(GTCEu.id("mercury"), 80, 120, -1, null, "Mercury", "Hg", false);
+    public static final Element Tl = createAndRegister(GTCEu.id("thallium"), 81, 123, -1, null, "Thallium", "Tl", false);
+    public static final Element Pb = createAndRegister(GTCEu.id("lead"), 82, 125, -1, null, "Lead", "Pb", false);
+    public static final Element Bi = createAndRegister(GTCEu.id("bismuth"), 83, 125, -1, null, "Bismuth", "Bi", false);
+    public static final Element Po = createAndRegister(GTCEu.id("polonium"), 84, 124, -1, null, "Polonium", "Po", false);
+    public static final Element At = createAndRegister(GTCEu.id("astatine"), 85, 124, -1, null, "Astatine", "At", false);
+    public static final Element Rn = createAndRegister(GTCEu.id("radon"), 86, 134, -1, null, "Radon", "Rn", false);
+    public static final Element Fr = createAndRegister(GTCEu.id("francium"), 87, 134, -1, null, "Francium", "Fr", false);
+    public static final Element Ra = createAndRegister(GTCEu.id("radium"), 88, 136, -1, null, "Radium", "Ra", false);
+    public static final Element Ac = createAndRegister(GTCEu.id("actinium"), 89, 136, -1, null, "Actinium", "Ac", false);
+    public static final Element Th = createAndRegister(GTCEu.id("thorium"), 90, 140, -1, null, "Thorium", "Th", false);
+    public static final Element Pa = createAndRegister(GTCEu.id("protactinium"), 91, 138, -1, null, "Protactinium", "Pa", false);
+    public static final Element U = createAndRegister(GTCEu.id("uranium"), 92, 146, -1, null, "Uranium", "U", false);
+    public static final Element U238 = createAndRegister(GTCEu.id("uranium-238"), 92, 146, -1, null, "Uranium-238", "U-238", false);
+    public static final Element U235 = createAndRegister(GTCEu.id("uranium-235"), 92, 143, -1, null, "Uranium-235", "U-235", true);
+    public static final Element Np = createAndRegister(GTCEu.id("neptunium"), 93, 144, -1, null, "Neptunium", "Np", false);
+    public static final Element Pu = createAndRegister(GTCEu.id("plutonium"), 94, 152, -1, null, "Plutonium", "Pu", false);
+    public static final Element Pu239 = createAndRegister(GTCEu.id("plutonium-239"), 94, 145, -1, null, "Plutonium-239", "Pu-239", false);
+    public static final Element Pu241 = createAndRegister(GTCEu.id("plutonium-241"), 94, 149, -1, null, "Plutonium-241", "Pu-241", true);
+    public static final Element Am = createAndRegister(GTCEu.id("americium"), 95, 150, -1, null, "Americium", "Am", false);
+    public static final Element Cm = createAndRegister(GTCEu.id("curium"), 96, 153, -1, null, "Curium", "Cm", false);
+    public static final Element Bk = createAndRegister(GTCEu.id("berkelium"), 97, 152, -1, null, "Berkelium", "Bk", false);
+    public static final Element Cf = createAndRegister(GTCEu.id("californium"), 98, 153, -1, null, "Californium", "Cf", false);
+    public static final Element Es = createAndRegister(GTCEu.id("einsteinium"), 99, 153, -1, null, "Einsteinium", "Es", false);
+    public static final Element Fm = createAndRegister(GTCEu.id("fermium"), 100, 157, -1, null, "Fermium", "Fm", false);
+    public static final Element Md = createAndRegister(GTCEu.id("mendelevium"), 101, 157, -1, null, "Mendelevium", "Md", false);
+    public static final Element No = createAndRegister(GTCEu.id("nobelium"), 102, 157, -1, null, "Nobelium", "No", false);
+    public static final Element Lr = createAndRegister(GTCEu.id("lawrencium"), 103, 159, -1, null, "Lawrencium", "Lr", false);
+    public static final Element Rf = createAndRegister(GTCEu.id("rutherfordium"), 104, 161, -1, null, "Rutherfordium", "Rf", false);
+    public static final Element Db = createAndRegister(GTCEu.id("dubnium"), 105, 163, -1, null, "Dubnium", "Db", false);
+    public static final Element Sg = createAndRegister(GTCEu.id("seaborgium"), 106, 165, -1, null, "Seaborgium", "Sg", false);
+    public static final Element Bh = createAndRegister(GTCEu.id("bohrium"), 107, 163, -1, null, "Bohrium", "Bh", false);
+    public static final Element Hs = createAndRegister(GTCEu.id("hassium"), 108, 169, -1, null, "Hassium", "Hs", false);
+    public static final Element Mt = createAndRegister(GTCEu.id("meitnerium"), 109, 167, -1, null, "Meitnerium", "Mt", false);
+    public static final Element Ds = createAndRegister(GTCEu.id("darmstadtium"), 110, 171, -1, null, "Darmstadtium", "Ds", false);
+    public static final Element Rg = createAndRegister(GTCEu.id("roentgenium"), 111, 169, -1, null, "Roentgenium", "Rg", false);
+    public static final Element Cn = createAndRegister(GTCEu.id("copernicium"), 112, 173, -1, null, "Copernicium", "Cn", false);
+    public static final Element Nh = createAndRegister(GTCEu.id("nihonium"), 113, 171, -1, null, "Nihonium", "Nh", false);
+    public static final Element Fl = createAndRegister(GTCEu.id("flerovium"), 114, 175, -1, null, "Flerovium", "Fl", false);
+    public static final Element Mc = createAndRegister(GTCEu.id("moscovium"), 115, 173, -1, null, "Moscovium", "Mc", false);
+    public static final Element Lv = createAndRegister(GTCEu.id("livermorium"), 116, 177, -1, null, "Livermorium", "Lv", false);
+    public static final Element Ts = createAndRegister(GTCEu.id("tennessine"), 117, 177, -1, null, "Tennessine", "Ts", false);
+    public static final Element Og = createAndRegister(GTCEu.id("oganesson"), 118, 176, -1, null, "Oganesson", "Og", false);
+    public static final Element Tr = createAndRegister(GTCEu.id("tritanium"), 119, 178, -1, null, "Tritanium", "Tr", false);
+    public static final Element Dr = createAndRegister(GTCEu.id("duranium"), 120, 180, -1, null, "Duranium", "Dr", false);
+    public static final Element Ke = createAndRegister(GTCEu.id("trinium"), 125, 198, -1, null, "Trinium", "Ke", false);
+    public static final Element Nq = createAndRegister(GTCEu.id("naquadah"), 174, 352, 140, null, "Naquadah", "Nq", true);
+    public static final Element Nq1 = createAndRegister(GTCEu.id("enriched_naquadah"), 174, 354, 140, null, "EnrichedNaquadah", "Nq+", true);
+    public static final Element Nq2 = createAndRegister(GTCEu.id("naquadria"), 174, 348, 140, null, "Naquadria", "*Nq*", true);
+    public static final Element Nt = createAndRegister(GTCEu.id("neutronium"), 0, 1000, -1, null, "Neutronium", "Nt", false);
+    public static final Element Sp = createAndRegister(GTCEu.id("space"), 1, 0, -1, null, "Space", "Sp", false);
+    public static final Element Ma = createAndRegister(GTCEu.id("magic"), 1, 0, -1, null, "Magic", "Ma", false);
+    // spotless:on
     /**
      * @deprecated Use
      *             {@link GTElements#createAndRegister(ResourceLocation, long, long, long, String, String, String, boolean)}
@@ -217,7 +158,7 @@ public class GTElements {
                                             String decayTo,
                                             String name, String symbol, boolean isIsotope) {
         Element element = new Element(protons, neutrons, halfLifeSeconds, decayTo, name, symbol, isIsotope);
-        GTRegistries.register(GTRegistries.ELEMENTS, GTCEu.id(name), element);
+        GTRegistries.register(GTRegistries.ELEMENTS, id, element);
         return element;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialBlocks.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTMaterialBlocks.java
@@ -15,7 +15,6 @@ import com.gregtechceu.gtceu.common.block.*;
 import com.gregtechceu.gtceu.common.pipelike.cable.Insulation;
 import com.gregtechceu.gtceu.common.pipelike.fluidpipe.FluidPipeType;
 import com.gregtechceu.gtceu.common.pipelike.item.ItemPipeType;
-import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.world.level.block.Block;
@@ -110,7 +109,7 @@ public class GTMaterialBlocks {
             final TagPrefix.OreType oreType = ore.getValue();
             String typePrefix = "";
             if (oreTag != TagPrefix.ore) {
-                typePrefix = FormattingUtil.toLowerCaseUnderscore(oreTag.name) + "_";
+                typePrefix = oreTag.name + "_";
             }
             var entry = registrate.block("%s%s_ore".formatted(typePrefix, material.getName()),
                     properties -> oreTag.blockConstructor().create(properties, oreTag, material))

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/MaterialRecipeHandler.java
@@ -15,7 +15,6 @@ import com.gregtechceu.gtceu.common.data.GTRecipeCategories;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
 import com.gregtechceu.gtceu.data.recipe.builder.GTRecipeBuilder;
-import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.util.Mth;
@@ -442,7 +441,7 @@ public final class MaterialRecipeHandler {
         if (material.hasFlag(MORTAR_GRINDABLE)) {
             VanillaRecipeHelper.addShapedRecipe(provider,
                     String.format("gem_to_dust_%s_%s", material.getName(),
-                            FormattingUtil.toLowerCaseUnderscore(prefix.name)),
+                            prefix.name),
                     crushedStack,
                     "X", "m", 'X', new MaterialEntry(prefix, material));
         }
@@ -457,14 +456,14 @@ public final class MaterialRecipeHandler {
         }
 
         VanillaRecipeHelper.addShapelessRecipe(provider,
-                String.format("gem_to_gem_%s_%s", FormattingUtil.toLowerCaseUnderscore(lowerPrefix.name),
+                String.format("gem_to_gem_%s_%s", lowerPrefix.name,
                         material.getName()),
                 prevStack,
                 'h', new MaterialEntry(prefix, material));
 
         CUTTER_RECIPES
-                .recipeBuilder("cut_" + material.getName() + "_" + FormattingUtil.toLowerCaseUnderscore(prefix.name) +
-                        "_to_" + FormattingUtil.toLowerCaseUnderscore(lowerPrefix.name))
+                .recipeBuilder("cut_" + material.getName() + "_" + prefix.name +
+                        "_to_" + prefix.name)
                 .inputItems(prefix, material)
                 .outputItems(prevStack)
                 .duration(20)
@@ -473,8 +472,8 @@ public final class MaterialRecipeHandler {
 
         LASER_ENGRAVER_RECIPES
                 .recipeBuilder(
-                        "engrave_" + material.getName() + "_" + FormattingUtil.toLowerCaseUnderscore(prefix.name) +
-                                "_to_" + FormattingUtil.toLowerCaseUnderscore(lowerPrefix.name))
+                        "engrave_" + material.getName() + "_" + prefix.name +
+                                "_to_" + lowerPrefix.name)
                 .inputItems(prevStack)
                 .notConsumable(lens, MarkerMaterials.Color.White)
                 .outputItems(prefix, material)

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PipeRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/generated/PipeRecipeHandler.java
@@ -9,7 +9,6 @@ import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.pipelike.duct.DuctPipeType;
 import com.gregtechceu.gtceu.data.recipe.VanillaRecipeHelper;
-import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.data.recipes.RecipeOutput;
 import net.minecraft.world.item.ItemStack;
@@ -66,7 +65,7 @@ public final class PipeRecipeHandler {
                 .save(provider);
 
         VanillaRecipeHelper.addShapedRecipe(provider,
-                FormattingUtil.toLowerCaseUnderscore(prefix + "_" + material.getName()),
+                prefix + "_" + material.getName(),
                 ChemicalHelper.get(prefix, material), "PR", "Rh",
                 'P', new MaterialEntry(unrestrictive, material), 'R', ChemicalHelper.get(ring, Iron));
     }


### PR DESCRIPTION
## What
Fixes uppercase paths being used in reslocs, causing a bunch of log spam. No AI