### PR TITLE
fix pipenet not always refreshing when it needs to

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/pipenet/LevelPipeNet.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pipenet/LevelPipeNet.java
@@ -67,6 +67,8 @@ public abstract class LevelPipeNet<NodeDataType, T extends PipeNet<NodeDataType>
             myPipeNet.addNode(nodePos, node);
             addPipeNet(myPipeNet);
             setDirty();
+        } else {
+            myPipeNet.onPipeConnectionsUpdate();
         }
     }
 


### PR DESCRIPTION
## What
Fix pipenet not always refreshing when it needs to


## Implementation Details
Fixes the issue when if you place a cable clicking on a energy hatch, and it auto connects to other cables that you did not click on, it not refreshes the pipenet so the hatch wont get energy untill you manually click with wirecutters or sth. 

### AI Usage 

- [x] No AI driven tools were used for this pull request.

## Outcome
you can click on a hatch with a cable, and it will get power after the cable autoconnects with other cables
