### PR TITLE
Documentation for a big part of 8.0.0

### DIFF
--- a/docs/content/Development/Glossary.md
+++ b/docs/content/Development/Glossary.md
@@ -38,7 +38,7 @@ connects to a dedicated server instead.
 The remote side is the part of the game that is **connected to** the game's server side.  
 It always runs on the [client](#client-side).
 
-This side may not have the same amount of data available to it as the server does (see [SyncData](../Development/SyncData/index.md) if you
+This side may not have the same amount of data available to it as the server does (see [SyncData](Data-Sync-System/index.md) if you
 need to automatically synchronize certain data to the remote side).
 It also does not perform any tick update logic.
 

--- a/docs/content/Development/MUI2/.pages
+++ b/docs/content/Development/MUI2/.pages
@@ -1,0 +1,8 @@
+nav:
+  - index.md
+  - Test-Machine.md
+  - Widget-Layout.md
+  - Syncing
+  - Machine-UI.md
+  - Recipe-Type-UI.md
+  - ...

--- a/docs/content/Development/MUI2/Machine-UI.md
+++ b/docs/content/Development/MUI2/Machine-UI.md
@@ -120,7 +120,7 @@ public MachineUIPanelBuilder getPanelBuilder(PosGuiData data, PanelSyncManager s
 what `SteamBoilerMachine` uses.
 
 !!! note
-    The configurator columns are *panels of their own*, drawn to the left and right of the machine
+    The configurator columns are drawn to the left and right of the machine
     panel. They hide themselves when they have no children, so a machine that adds no configurators
     shows neither column.
 

--- a/docs/content/Development/MUI2/Machine-UI.md
+++ b/docs/content/Development/MUI2/Machine-UI.md
@@ -1,0 +1,286 @@
+---
+title: Machine UIs
+---
+
+# Machine UIs
+
+Any machine that should open a UI when right-clicked implements `IMuiMachine`. The interface extends
+MUI2's `IUIHolder<PosGuiData>` and GTM's `IMachineFeature`, so implementing it on a `MetaMachine`
+subclass is all that is needed to get a working panel:
+
+```java
+public class MyMachine extends MetaMachine implements IMuiMachine {
+
+    public MyMachine(BlockEntityCreationInfo info) {
+        super(info);
+    }
+}
+```
+
+Right-clicking the machine now opens a panel with a title bar and the player inventory attached.
+See [Making a MUI2 Test Machine](Test-Machine.md) for a machine definition you can register to try
+this out.
+
+## How a machine panel is built
+
+`IMuiMachine` splits UI creation into a few overridable steps. The order they run in determines
+which one you want to override:
+
+```java
+default ModularPanel<?> buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings settings) {
+    var panelBuilder = getPanelBuilder(data, syncManager, settings);       // (1)
+    panelBuilder.mainContents(parent -> buildMainUI(parent, data, syncManager, settings)); // (2)
+    return panelBuilder.build(syncManager, settings);                      // (3)
+}
+```
+
+1. `getPanelBuilder` returns a `MachineUIPanelBuilder`, which decides what the *frame* of the panel
+   looks like: title bar, player inventory, configurator buttons.
+2. `buildMainUI` fills the content area in the middle of that frame. This is the method to override
+   in almost every case.
+3. `build` assembles everything into a `MachineUIPanel`.
+
+!!! note
+    `buildUI`, `buildMainUI` and `getPanelBuilder` all run on both the client and the server. Any
+    value read from the machine has to be wrapped in a sync handler before a widget can display it.
+    See [Sync Basics](Syncing/Sync-Basics.md).
+
+## `buildMainUI`
+
+`buildMainUI` receives the panel's main content area as a `ParentWidget<?>`, and adds children to it.
+The content area defaults to `MachineUIPanel.DEFAULT_CONTENT_WIDTH` × `DEFAULT_CONTENT_HEIGHT`
+(169 × 77) but will cover larger children.
+
+```java
+@Override
+public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
+                        UISettings settings) {
+    IntSyncValue bucketSyncer = new IntSyncValue(() -> cache.getFluidInTank(0).getAmount(), v -> {});
+    syncManager.syncValue("bucket_amount", bucketSyncer);
+
+    mainWidget.child(new ParentWidget<>()
+            .background(GTGuiTextures.DISPLAY)
+            .size(90, 63)
+            .center()
+            .child(Text.lang("gtceu.gui.fluid_amount").asWidget()
+                    .color(0xffffff)
+                    .margin(8, 0, 8, 0))
+            .child(Text.dynamic(() -> Component.literal(
+                            FormattingUtil.formatBuckets(bucketSyncer.getIntValue())))
+                    .asWidget()
+                    .margin(8, 0, 20, 0)));
+}
+```
+
+`PumpMachine`, `FisherMachine` and `MinerMachine` are good references for progressively more
+complicated content areas.
+
+## `getPanelBuilder`
+
+Override `getPanelBuilder` when you need to change the panel frame itself. `MachineUIPanelBuilder`
+is a fluent builder with the following options:
+
+| Method                            | Default                    | Effect                                                                                            |
+|-----------------------------------|----------------------------|---------------------------------------------------------------------------------------------------|
+| `attachInventory(boolean)`        | `true`                     | Attaches the player inventory below the content area.                                              |
+| `addTitleBar(boolean)`            | `true`                     | Draws the machine name title bar.                                                                  |
+| `drawGTLogo(boolean)`             | `false`                    | Draws a logo in the bottom right corner.                                                           |
+| `gtLogoTexture(UITexture)`        | `GTGuiTextures.GREGTECH_LOGO` | The logo texture to use when `drawGTLogo` is enabled.                                           |
+| `addDefaultConfigurators(boolean)`| `true`                     | Adds the power button, voiding button, distinct-buses button, batch mode button and recipe type button, when the machine supports them. |
+| `addTraitConfigurators(boolean)`  | `true`                     | Lets attached traits implementing `IAttachConfiguratorsTrait` add their own configurators.          |
+| `leftConfigurators(Consumer<Flow>)` | no-op                    | Adds your own buttons to the left configurator column.                                             |
+| `rightConfigurators(Consumer<Flow>)` | no-op                   | Adds your own buttons to the right configurator column.                                            |
+
+A machine that wants an extra toggle button next to the stock ones:
+
+```java
+@Override
+public MachineUIPanelBuilder getPanelBuilder(PosGuiData data, PanelSyncManager syncManager,
+                                             UISettings settings) {
+    return MachineUIPanelBuilder.panelBuilder(this)
+            .rightConfigurators(configurators -> configurators
+                    .child(new ToggleButton()
+                            .value(new BoolValue.Dynamic(this::isJunkEnabled, this::setJunkEnabled))
+                            .overlay(new ItemDrawable(Items.NAME_TAG))));
+}
+```
+
+A machine that wants a bare panel with none of the stock buttons, as the primitive multiblocks do:
+
+```java
+@Override
+public MachineUIPanelBuilder getPanelBuilder(PosGuiData data, PanelSyncManager syncManager,
+                                             UISettings settings) {
+    return MachineUIPanelBuilder.panelBuilder(this)
+            .addDefaultConfigurators(false)
+            .addTraitConfigurators(false);
+}
+```
+
+`MachineUIPanelBuilder.defaultSteamMachinePanelBuilder(machine)` is a shorthand for the above, and is
+what `SteamBoilerMachine` uses.
+
+!!! note
+    The configurator columns are *panels of their own*, drawn to the left and right of the machine
+    panel. They hide themselves when they have no children, so a machine that adds no configurators
+    shows neither column.
+
+## `shouldOpenUI`
+
+Return `false` to suppress opening the UI for a particular interaction. The default implementation
+always returns `true`. The block's `onUse` handling runs before this, so this hook only decides
+whether the panel opens, not whether the click is consumed.
+
+```java
+@Override
+public boolean shouldOpenUI(Player player, InteractionHand hand, BlockHitResult hit) {
+    return isFormed();
+}
+```
+
+## Overriding `buildUI` directly
+
+Override `buildUI` when you need to attach something to the panel that is not part of the main
+content area, such as an extra popup panel. Reproduce the default three steps, then keep working
+with the returned panel. `LargeMinerMachine` does this:
+
+```java
+@Override
+public ModularPanel<?> buildUI(PosGuiData data, PanelSyncManager syncManager, UISettings settings) {
+    var panelBuilder = getPanelBuilder(data, syncManager, settings);
+    panelBuilder.mainContents(parent -> buildMainUI(parent, data, syncManager, settings));
+    var machinePanel = panelBuilder.build(syncManager, settings);
+
+    // ... attach extra widgets and panels to machinePanel here
+
+    return machinePanel;
+}
+```
+
+If you skip `getPanelBuilder`/`build` entirely and construct a plain `ModularPanel` yourself, you
+lose the title bar, player inventory and configurators. Only do that for a machine whose UI has
+nothing in common with the standard machine layout.
+
+## Definition-level panels
+
+A UI can also be attached to the machine *definition* rather than the machine class, with
+`MachineBuilder::ui`. It takes a `PanelFactory`, which is the same thing as `IMuiMachine` except the
+machine is handed to it as an argument instead of being `this`:
+
+```java
+ModularPanel<?> buildUIFunction(PosGuiData data, PanelSyncManager syncManager, UISettings settings,
+                                MetaMachine machine);
+```
+
+```java
+REGISTRATE.machine("my_machine", MyMachine::new)
+        .ui((data, syncManager, settings, machine) -> MachineUIPanelBuilder.panelBuilder(machine)
+                .mainContents(parent -> parent.child(Text.str("Hello").asWidget()))
+                .build(syncManager, settings))
+        .register();
+```
+
+This is how the shared singleblock recipe machine UI works: every simple machine gets
+`GTSingleblockMachinePanels.GENERAL_MACHINE`, a `PanelFactory` that reads the machine's recipe type
+UI layout and builds the slots from it. See [Recipe Type UIs](Recipe-Type-UI.md).
+
+!!! warning
+    A definition-level UI takes precedence over `IMuiMachine`. If a machine has both, only the
+    definition's `PanelFactory` runs, and `buildUI`/`buildMainUI` on the machine are never called.
+
+## Related methods
+
+- `tryToOpenUI(Player, InteractionHand, BlockHitResult)` is called by `MetaMachineBlock`. It calls
+  `shouldOpenUI` and then opens the panel through `MachineUIFactory`. You normally do not override
+  this.
+- `createScreen(PosGuiData, ModularPanel)` is client-only, and returns the `ModularScreen` wrapper.
+  It defaults to `GTGuiScreen`. Override it only if you need a custom screen implementation.
+
+## Multiblock display text
+
+Multiblock controllers do not build their status readout in `buildMainUI`. `WorkableElectricMultiblockMachine`
+already overrides `buildMainUI` to draw the black display box in the middle of the panel, and fills it
+from `getWidgetsForDisplay(PanelSyncManager)`, a flat `List<IWidget>` rendered one entry per line.
+
+The column that holds them is set to `collapseDisabledChildren`, so a disabled line takes up no space.
+Give a widget a `setEnabledIf` to hide it without leaving a gap.
+
+### Adding lines from the definition
+
+The usual way to add a line is `additionalDisplay` on the machine builder, which does not require a
+custom machine class. It is a `BiFunction<MultiblockControllerMachine, PanelSyncManager, List<IWidget>>`:
+
+```java
+public static final MultiblockMachineDefinition MY_MULTIBLOCK = REGISTRATE
+        .multiblock("my_multiblock", WorkableElectricMultiblockMachine::new)
+        // ... rotation, recipe types, pattern, model ...
+        .additionalDisplay((controller, syncManager) -> {
+            if (!(controller instanceof WorkableElectricMultiblockMachine machine))
+                return Collections.emptyList();
+
+            BooleanSyncValue isFormed = syncManager.getOrCreateSyncHandler("isFormed",
+                    BooleanSyncValue.class,
+                    () -> new BooleanSyncValue(controller::isFormed));
+            IntSyncValue tier = syncManager.getOrCreateSyncHandler("machineTier", IntSyncValue.class,
+                    () -> new IntSyncValue(machine::getTier));
+
+            return List.of(Text
+                    .dynamic(() -> Component.translatable("my_addon.multiblock.my_multiblock.tier",
+                            GTValues.VNF[tier.getIntValue()]))
+                    .asWidget()
+                    .setEnabledIf(w -> isFormed.getBoolValue()));
+        })
+        .register();
+```
+
+Most real uses need the same things this example does:
+
+- The function is handed a `MultiblockControllerMachine`, which has no tier, no recipe logic and no
+  coils. Anything more specific needs an `instanceof` check and an `emptyList()` bail-out. `getTier()`
+  above comes from `ITieredMachine`, not from the base class.
+- `getWidgetsForDisplay` runs on both the client and the server, and the controller's fields are only
+  meaningful on the server, so anything the text depends on goes through a sync handler. Use
+  `getOrCreateSyncHandler` to reuse a handler if another line already made one under that name.
+- `Text.lang` and `Text.str` are evaluated once when the panel is built, while `Text.dynamic`
+  re-evaluates while it is open. Use `Text.dynamic` for text that changes.
+- Most status text is meaningless for an unformed structure, so guard it with `setEnabledIf`.
+
+### Adding the same line from the machine class
+
+If the multiblock already has its own class, override `getWidgetsForDisplay` instead. The same line as
+above becomes:
+
+```java
+public class MyMultiblockMachine extends WorkableElectricMultiblockMachine {
+
+    @Override
+    public List<IWidget> getWidgetsForDisplay(PanelSyncManager syncManager) {
+        List<IWidget> widgets = super.getWidgetsForDisplay(syncManager);
+
+        BooleanSyncValue isFormed = syncManager.getOrCreateSyncHandler("isFormed",
+                BooleanSyncValue.class,
+                () -> new BooleanSyncValue(this::isFormed));
+        IntSyncValue tier = syncManager.getOrCreateSyncHandler("machineTier", IntSyncValue.class,
+                () -> new IntSyncValue(this::getTier));
+
+        widgets.add(Text
+                .dynamic(() -> Component.translatable("my_addon.multiblock.my_multiblock.tier",
+                        GTValues.VNF[tier.getIntValue()]))
+                .asWidget()
+                .setEnabledIf(w -> isFormed.getBoolValue()));
+
+        return widgets;
+    }
+}
+```
+
+The syncing, `Text.dynamic` and `setEnabledIf` points above apply here too. The main difference is
+that you call `super.getWidgetsForDisplay` first and add to what it returns. Dropping the `super`
+call replaces the entire readout instead of adding to it. Because you own the list here, you can also
+insert a line at a specific position or remove a default one.
+
+### Where the lines end up
+
+Lines added through `additionalDisplay` are inserted part-way down the standard list rather than
+appended to the end of it, below the machine's core status lines and above the parallel and output
+ones. The exact position is decided by `WorkableMultiblockMachine.getWidgetsForDisplay`.

--- a/docs/content/Development/MUI2/Machine-UI.md
+++ b/docs/content/Development/MUI2/Machine-UI.md
@@ -139,9 +139,8 @@ public boolean shouldOpenUI(Player player, InteractionHand hand, BlockHitResult 
 
 ## Overriding `buildUI` directly
 
-Override `buildUI` when you need to attach something to the panel that is not part of the main
-content area, such as an extra popup panel. Reproduce the default three steps, then keep working
-with the returned panel. `LargeMinerMachine` does this:
+Override `buildUI` when you need more granular control outside what getPanelBuilder would allow you. 
+One way to do this is to reproduce the default three steps, then keep working with the returned panel like so:
 
 ```java
 @Override
@@ -150,7 +149,7 @@ public ModularPanel<?> buildUI(PosGuiData data, PanelSyncManager syncManager, UI
     panelBuilder.mainContents(parent -> buildMainUI(parent, data, syncManager, settings));
     var machinePanel = panelBuilder.build(syncManager, settings);
 
-    // ... attach extra widgets and panels to machinePanel here
+    // ... attach extra widgets and panels to or make further changes to machinePanel here
 
     return machinePanel;
 }

--- a/docs/content/Development/MUI2/Machine-UI.md
+++ b/docs/content/Development/MUI2/Machine-UI.md
@@ -4,9 +4,8 @@ title: Machine UIs
 
 # Machine UIs
 
-Any machine that should open a UI when right-clicked implements `IMuiMachine`. The interface extends
-MUI2's `IUIHolder<PosGuiData>` and GTM's `IMachineFeature`, so implementing it on a `MetaMachine`
-subclass is all that is needed to get a working panel:
+When any machine that extends `IMuiMachine` or has a machine panel in its definition is right-clicked, it will attempt to open a UI. 
+Implementing `IMuiMachine` on a `MetaMachine` subclass is all that is needed to get a working panel:
 
 ```java
 public class MyMachine extends MetaMachine implements IMuiMachine {

--- a/docs/content/Development/MUI2/Recipe-Type-UI.md
+++ b/docs/content/Development/MUI2/Recipe-Type-UI.md
@@ -238,7 +238,7 @@ handle a capability that is not slot-shaped: instead of slots they attach an emp
 
 ### 3. Recipe contents, `setCapabilityContentBuilder`
 
-A `CapabilityContentBuilder` maps one `Content` of a recipe onto the widget that step 2 created:
+A `CapabilityContentBuilder` takes in one `Content` and the widget that step 2 created and then builds the content into it:
 
 ```java
 void buildWidgetContent(IWidget widget, Content content, IO io, boolean perTick,

--- a/docs/content/Development/MUI2/Recipe-Type-UI.md
+++ b/docs/content/Development/MUI2/Recipe-Type-UI.md
@@ -293,7 +293,7 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
         .setMaxIOSize(3, 3, 3, 3)
         .setProgressBar(GTGuiTextures.PROGRESS_ARROW)
         .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.SOLIDIFIER_OVERLAY)
-        .addRecipeInfo(recipe => `Temperature: ${recipe.data.getInt('RequiredTemp')}K`)
+        .addRecipeInfo(recipe => Text.literal(`Temperature: ${recipe.data.getInt('RequiredTemp')}K`))
         .setSound(GTSoundEntries.COOLING)
 })
 ```
@@ -307,16 +307,19 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
 | `setFluidSlotsOverlay(io, startIndex, endIndex, overlay)`       | `setFluidSlotsOverlay`                             |
 | `setSlotOverlay(io, index, cap, overlay)`                       | `setSlotOverlay`                                   |
 | `setSlotsOverlay(io, startIndex, endIndex, cap, overlay)`       | `setSlotsOverlay`                                  |
-| `addRecipeInfo(recipe => text)`                                 | `addRecipeUIModifier`, adding one text line        |
+| `addRecipeInfo(recipe => component)`                            | `addRecipeUIModifier`, adding one text line        |
 
 `addRecipeInfo` is the KubeJS-facing form of a recipe UI modifier. It is given the recipe and returns
-the text to show for it. Returning an empty string draws no line, which is how a line is limited to
-some recipes. Call it more than once for more than one line.
+the component to show for it. Returning `Text.empty()` draws no line, which is how a line is limited
+to some recipes. Call it more than once for more than one line.
 
 ```js
 .addRecipeInfo(recipe => recipe.data.contains('RequiredTemp') ?
-    `Temperature: ${recipe.data.getInt('RequiredTemp')}K` : '')
+    Text.literal(`Temperature: ${recipe.data.getInt('RequiredTemp')}K`) : Text.empty())
 ```
+
+Build the return value with KubeJS's `Text` bindings, such as `Text.literal(string)` and
+`Text.translate(langKey, args...)`.
 
 `GTGuiTextures`, `IO` and `RecipeCapability` are bound as globals. Capabilities also accept their id
 as a string, so `setSlotsOverlay(IO.IN, 0, 2, 'item', overlay)` works.

--- a/docs/content/Development/MUI2/Recipe-Type-UI.md
+++ b/docs/content/Development/MUI2/Recipe-Type-UI.md
@@ -154,7 +154,7 @@ Most modifiers want `textComponents`.
 
 ### Conditional lines
 
-To show a line only for some recipes, add the widget unconditionally and disable it.
+To show a line only for some recipes, add the widget unconditionally and add a condition to only show it with `.setEnabledIf`.
 `textComponents` is set to `collapseDisabledChildren`, so a disabled line takes up no space:
 
 ```java

--- a/docs/content/Development/MUI2/Recipe-Type-UI.md
+++ b/docs/content/Development/MUI2/Recipe-Type-UI.md
@@ -1,0 +1,324 @@
+---
+title: Recipe Type UIs
+---
+
+# Recipe Type UIs
+
+A `GTRecipeType` carries a `GTRecipeTypeUILayout` that describes how recipes of that type are drawn.
+The same layout drives two different UIs:
+
+- the machine UI of singleblock machines using that recipe type, and
+- the recipe viewer UI shown in recipe viewers.
+
+
+## From Java
+In machine UIs, the layout is declared with `GTRecipeType::UI`, which takes a `Consumer<GTRecipeTypeUILayout.Builder>`:
+
+```java
+public final static GTRecipeType CANNER_RECIPES = register("canner", ELECTRIC)
+        .setMaxIOSize(2, 2, 1, 1)
+        .setEUIO(IO.IN)
+        .UI(builder -> builder.setProgressBar(GTGuiTextures.PROGRESS_CANNER)
+                .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.CANNER_OVERLAY)
+                .setItemSlotOverlay(IO.IN, 1, GTGuiTextures.CANISTER_OVERLAY)
+                .setItemSlotOverlay(IO.OUT, 0, GTGuiTextures.CANISTER_OVERLAY)
+                .setFluidSlotOverlay(IO.IN, 0, GTGuiTextures.DARK_CANISTER_OVERLAY)
+                .setFluidSlotOverlay(IO.OUT, 0, GTGuiTextures.DARK_CANISTER_OVERLAY))
+        .setSound(GTSoundEntries.BATH);
+```
+
+Every recipe type starts with a default layout, so `UI` is only needed when you want to change
+something. Left alone, a type draws with the `PROGRESS_ARROW` progress bar, no slot overlays, and item
+and fluid grids sized from `setMaxIOSize` at up to three slots per row. If the type declares EU or
+computation, the recipe viewer picks those lines up too.
+
+The defaults cannot cover a custom `RecipeCapability`, which is described in
+[Capability UIs](#capability-uis) below.
+
+## Slot overlays
+
+Overlays are set per capability, per slot index:
+
+```java
+.UI(builder -> builder.setItemSlotsOverlay(IO.IN, 0, 8, GTGuiTextures.ARROW_INPUT_OVERLAY))
+```
+
+| Method                                                            | Applies to                                     |
+|-------------------------------------------------------------------|------------------------------------------------|
+| `setItemSlotOverlay(IO, int slotIndex, IDrawable)`                 | one item slot                                  |
+| `setFluidSlotOverlay(IO, int slotIndex, IDrawable)`                | one fluid slot                                 |
+| `setItemSlotsOverlay(IO, int startIndex, int endIndex, IDrawable)` | a range of item slots, both ends inclusive     |
+| `setFluidSlotsOverlay(IO, int startIndex, int endIndex, IDrawable)`| a range of fluid slots, both ends inclusive    |
+| `setSlotOverlay(IO, int slotIndex, RecipeCapability<?>, IDrawable)`| one slot of any capability                     |
+| `setSlotsOverlay(IO, int startIndex, int endIndex, RecipeCapability<?>, IDrawable)` | a range of slots of any capability |
+
+The item and fluid methods are shorthands for the two generic ones.
+
+Overlay textures come from [GTGuiTextures](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/common/mui/GTGuiTextures.java)
+and are `UITexture`s.
+
+## Progress bars
+
+`setProgressBar` takes a `ProgressBarTextureSet`, which bundles the texture, its size and its fill
+direction (and optionally bronze/steel variants used by steam machines):
+
+```java
+.UI(builder -> builder.setProgressBar(GTGuiTextures.PROGRESS_ARROW))
+```
+
+The fill direction is part of the texture set rather than a separate argument. If you need a set that
+does not exist yet, construct your own:
+
+```java
+public static final ProgressBarTextureSet ALWAYS_FULL_ARROW =
+        new ProgressBarTextureSet(20, ProgressDrawable.Direction.RIGHT, MY_ARROW_TEXTURE);
+```
+
+For anything that is not a simple filling texture, use `setProgressBarSupplier` and return a widget.
+The supplier gets the layout, an `IDoubleValue<Double>` holding the 0–1 progress, and the machine
+(`null` when the bar is being drawn in a recipe viewer):
+
+```java
+.UI(builder -> builder.setProgressBarSupplier((layout, value, machine) ->
+        new CircularProgressDrawable()
+                .emptyTexture(GTGuiTextures.PROGRESS_BATH[0])
+                .filledTexture(GTGuiTextures.PROGRESS_BATH[1])
+                .clockwise()
+                .asWidget()
+                .value(value)))
+```
+
+## Slot grids
+
+Slots are laid out from a `String[]` matrix, where `'s'` marks a slot and a space marks a gap. This
+is the same format MUI2's `SlotGroupWidget.builder().matrix(...)` takes. By default a grid is generated from
+the recipe type's max slot count with a row size of at most 3, via `GTMuiWidgets.createGrid(amount,
+rowSize, output, key)`.
+
+Override it when the slot count depends on something. The macerator, for instance, shows a different
+number of output slots per machine tier:
+
+```java
+.UI(builder -> builder.setProgressBar(GTGuiTextures.PROGRESS_MACERATE)
+        .setMachineLayoutGridBuilder(ItemRecipeCapability.CAP, IO.OUT, (machine, layout) -> {
+            int slots = layout.getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP);
+            int width = 3;
+            if (machine instanceof ITieredMachine tieredMachine) {
+                if (tieredMachine.getTier() < GTValues.HV) {
+                    slots = 1;
+                    width = 1;
+                } else if (tieredMachine.getTier() == GTValues.HV) {
+                    slots = 3;
+                } else {
+                    slots = 4;
+                    width = 2;
+                }
+            }
+            return GTMuiWidgets.createGrid(slots, width, true, 's');
+        }))
+```
+
+| Method                                                | Affects                                                          |
+|--------------------------------------------------------|------------------------------------------------------------------|
+| `setMachineLayoutGridBuilder(cap, io, gridBuilder)`    | machine UI only; the builder receives the `MetaMachine`           |
+| `setRecipeViewerLayoutGridBuilder(cap, io, gridBuilder)` | recipe viewer UI only                                           |
+| `setLayoutGridBuilder(cap, io, gridBuilder)`           | both, from a single `Function<GTRecipeTypeUILayout, String[]>`    |
+
+## Recipe UI modifiers
+
+A `RecipeUIModifier` is a `(GTRecipe recipe, GTRecipeViewerWidget widget) -> void` callback that runs
+once per recipe when the recipe viewer entry is built. It is handed the widget tree, so it can attach
+text, slots, rows, tooltips or anything else. This is how per-recipe extra information gets into the
+recipe viewer.
+
+```java
+.UI(builder -> builder.addRecipeUIModifier((recipe, widget) ->
+        widget.textComponents.child(
+                Text.lang("emi_info.example.projector_info", recipe.data.getByte("projector_tier"))
+                        .asWidget())))
+```
+
+### Where to attach
+
+`GTRecipeViewerWidget` exposes a few public attachment points:
+
+| Field                     | What it is                                                                                  |
+|---------------------------|---------------------------------------------------------------------------------------------|
+| `textComponents`          | The column of text lines under the recipe. Disabled children collapse, so empty lines vanish. |
+| `additionalRecipeContent` | The full-width area below the recipe row that `textComponents` lives in.                     |
+| `inputColumn`             | The column of input slots.                                                                   |
+| `outputColumn`            | The column of output slots.                                                                  |
+| `recipeContentRow`        | The row holding inputs, progress bar and outputs.                                             |
+
+Most modifiers want `textComponents`.
+
+### Conditional lines
+
+To show a line only for some recipes, add the widget unconditionally and disable it.
+`textComponents` is set to `collapseDisabledChildren`, so a disabled line takes up no space:
+
+```java
+.addRecipeUIModifier((recipe, widget) -> widget.textComponents
+        .child(Text.dynamic(() -> {
+                    if (!recipe.data.contains("updated_microverse")) return Component.empty();
+                    return Component.translatable("emi_info.monilabs.new_microverse",
+                            Component.translatable(
+                                    Microverse.values()[recipe.data.getInt("updated_microverse")].langKey));
+                })
+                .asWidget()
+                .setEnabledIf(w -> recipe.data.contains("updated_microverse"))))
+```
+
+Use `Text.lang(...)`/`Text.str(...)` for text that never changes, and `Text.dynamic(...)` for text
+that is recomputed while the panel is open (for example when the viewer's overclock tier button is
+used).
+
+!!! note
+    There is no need to reserve vertical space for lines you might add later. The text column sizes
+    itself to its enabled children.
+
+### Reusable modifiers
+
+`RecipeUIModifier` has helpers for the common cases:
+
+```java
+RecipeUIModifier.textLine(Text.lang("gtceu.recipe.byproduct_tier", GTValues.VNF[GTValues.HV]))
+RecipeUIModifier.all(modifierA, modifierB)   // run several
+modifierA.then(modifierB, modifierC)         // run this one, then the others
+```
+
+GTM ships a few in `GTRecipeUIModifiers`:
+
+- `TEMP_COIL_INFO` adds the EBF temperature line plus the coils that satisfy it. Used by
+  `BLAST_RECIPES` and the GCYM alloy blast smelter.
+- `RESEARCH_INFO` adds the data item catalyst slots for research-gated recipes.
+
+### From recipe conditions
+
+`RecipeCondition::modifyUI` returns a `RecipeUIModifier`, so a condition can render itself. The base
+implementation writes the condition's tooltip as a text line:
+
+```java
+public RecipeUIModifier modifyUI() {
+    return RecipeUIModifier.textLine(Text.of(getTooltips()));
+}
+```
+
+Override it on your own condition when a text line is not enough. `AdjacentBlockCondition`,
+`AdjacentFluidCondition`, `DimensionCondition` and `ResearchCondition` all do. Condition modifiers
+run before the layout's own modifiers.
+
+## Capability UIs
+
+Everything above is per-slot styling of the *default* item and fluid layouts. When you add a custom
+`RecipeCapability`, the layout does not know how to draw it, so you have to supply that yourself.
+Three separate hooks are involved, because the machine UI, the recipe viewer layout and the recipe
+*contents* are built at different times.
+
+### 1. Machine UI layout, `setMachineCapabilityLayoutBuilder`
+
+A `MachineCapabilityLayoutBuilder` creates the widgets for one capability inside a singleblock
+machine UI. It receives the machine, the layout, the `GTRecipeTypeMachineWidget` and the IO mode, and
+is expected to attach its widgets to `widget.inputColumn` or `widget.outputColumn`.
+
+The defaults are `MachineCapabilityLayoutBuilder.ITEM` and `.FLUID`, which read the machine's
+`NotifiableItemStackHandler`/`NotifiableFluidTank` and build a `SlotGroupWidget` from the capability's
+machine grid.
+
+### 2. Recipe viewer layout, `setRecipeViewerLayoutCapabilityLayoutBuilder`
+
+A `RecipeViewerCapabilityLayoutBuilder` does the same job for the recipe viewer. There is no machine
+to read from here, so it creates empty widgets that get filled in step 3. Each widget must be named
+`GTRecipeViewerWidget.capabilityWidgetName(cap, io, index)`, which is how the content builder finds
+it later.
+
+Defaults exist for `ITEM`, `FLUID`, `EU` and `COMPUTATION`. The EU and computation ones show how to
+handle a capability that is not slot-shaped: instead of slots they attach an empty `Flow` column to
+`widget.textComponents`.
+
+### 3. Recipe contents, `setCapabilityContentBuilder`
+
+A `CapabilityContentBuilder` maps one `Content` of a recipe onto the widget that step 2 created:
+
+```java
+void buildWidgetContent(IWidget widget, Content content, IO io, boolean perTick,
+                        GTRecipeType recipeType, GTRecipe recipe, int chanceTier, int recipeTier);
+```
+
+`GTRecipeViewerWidget` walks the recipe's contents per capability, looks up the widget with the
+matching name, and hands both to this builder. The builder is responsible for checking the widget
+type it got. `CapabilityContentBuilder.ITEM` and `.FLUID` start with
+`if (!(widget instanceof RecipeViewerSlotWidget<?> slot)) return;`, while `.COMPUTATION` and `.EU`
+expect a `Flow` and add text children to it.
+
+`perTick` distinguishes per-tick contents from per-recipe ones, and `chanceTier` and `recipeTier` are
+the tier the recipe is currently being previewed at, which the recipe viewer's tier button changes.
+
+A minimal custom capability therefore looks like:
+
+```java
+.UI(builder -> builder
+        .setRecipeViewerLayoutCapabilityLayoutBuilder(MyCapabilities.CHROMA, (layout, widget, io) -> {
+            if (layout.getRecipeType().getMaxSlots(MyCapabilities.CHROMA, io) == 0) return;
+            widget.textComponents.child(Flow.col()
+                    .coverChildrenHeight()
+                    .widthRel(1f)
+                    .name(GTRecipeViewerWidget.capabilityWidgetName(MyCapabilities.CHROMA, io, 0)));
+        })
+        .setCapabilityContentBuilder(MyCapabilities.CHROMA,
+                (widget, content, io, perTick, recipeType, recipe, chanceTier, recipeTier) -> {
+                    if (!(widget instanceof Flow flow)) return;
+                    flow.child(Text.lang("my.recipe.chroma",
+                            MyCapabilities.CHROMA.of(content.content())).asWidget());
+                }))
+```
+
+## Replacing the whole layout
+
+`customRecipeTypeUI(Function<GTRecipe, Flow>)` replaces the generated input/progress/output row
+outright and returns your own `Flow`. This overrides the grid builders, the recipe viewer capability
+layout builders and the progress bar for that recipe type, so only use it when the standard
+three-column shape does not fit.
+
+## In KubeJS
+
+KubeJS scripts do not build or touch widgets directly. `GTRecipeTypeBuilder`
+exposes the common options as plain builder methods instead:
+
+```js
+GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
+    event.create('test_recipe_type')
+        .category('test')
+        .setEUIO('in')
+        .setMaxIOSize(3, 3, 3, 3)
+        .setProgressBar(GTGuiTextures.PROGRESS_ARROW)
+        .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.SOLIDIFIER_OVERLAY)
+        .addRecipeInfo(recipe => `Temperature: ${recipe.data.getInt('RequiredTemp')}K`)
+        .setSound(GTSoundEntries.COOLING)
+})
+```
+
+| Method                                                        | Wraps                                              |
+|----------------------------------------------------------------|----------------------------------------------------|
+| `setProgressBar(textureSet)`                                    | `setProgressBar`                                   |
+| `setItemSlotOverlay(io, index, overlay)`                        | `setItemSlotOverlay`                               |
+| `setItemSlotsOverlay(io, startIndex, endIndex, overlay)`        | `setItemSlotsOverlay`                              |
+| `setFluidSlotOverlay(io, index, overlay)`                       | `setFluidSlotOverlay`                              |
+| `setFluidSlotsOverlay(io, startIndex, endIndex, overlay)`       | `setFluidSlotsOverlay`                             |
+| `setSlotOverlay(io, index, cap, overlay)`                       | `setSlotOverlay`                                   |
+| `setSlotsOverlay(io, startIndex, endIndex, cap, overlay)`       | `setSlotsOverlay`                                  |
+| `addRecipeInfo(recipe => text)`                                 | `addRecipeUIModifier`, adding one text line        |
+
+`addRecipeInfo` is the KubeJS-facing form of a recipe UI modifier. It is given the recipe and returns
+the text to show for it. Returning an empty string draws no line, which is how a line is limited to
+some recipes. Call it more than once for more than one line.
+
+```js
+.addRecipeInfo(recipe => recipe.data.contains('RequiredTemp') ?
+    `Temperature: ${recipe.data.getInt('RequiredTemp')}K` : '')
+```
+
+`GTGuiTextures`, `IO` and `RecipeCapability` are bound as globals. Capabilities also accept their id
+as a string, so `setSlotsOverlay(IO.IN, 0, 2, 'item', overlay)` works.
+
+As in Java, calling none of these is fine, and the type keeps its default layout.

--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -113,6 +113,32 @@ A large number of machine feature interfaces have been removed, and have had the
 - `IFluidRendererMulti` - Use `MultiblockFluidRendererTrait`
 - `IMaintenanceMachine` Use `MaintenanceHatchPartMachine`
 
+# Multiblock pattern changes
+
+- `FactoryBlockPattern` has been renamed to `MultiblockPatternBuilder`
+- `.aisle(...)` has been renamed to `.slice(...)`, and `.aisleRepeatable(...)` to `.sliceRepeatable(...)`.
+- The three `RelativeDirection` arguments of `start` are taken in the opposite order. It used to be `start(charDir, stringDir, aisleDir)` and is now `start(sliceDir, stringDir, charDir)`, so an existing call has its arguments reversed:
+```java
+/////// OLD
+FactoryBlockPattern.start(RelativeDirection.LEFT, RelativeDirection.UP, RelativeDirection.FRONT)
+////// NEW
+MultiblockPatternBuilder.start(RelativeDirection.FRONT, RelativeDirection.UP, RelativeDirection.LEFT)
+```
+- The no-argument `start()` does not use the same directions anymore. In `7.5.3` it was `(charDir = LEFT, stringDir = UP, aisleDir = FRONT)`, and in `8.0.0` it is `(sliceDir = BACK, stringDir = UP, charDir = RIGHT)`.
+
+There are two ways to fix a pattern that broke this way. Either reverse the order of the slices, so that
+```java
+/////// OLD
+.aisle(A).aisle(B).aisle(C)
+////// NEW
+.slice(C).slice(B).slice(A)
+```
+or leave the slices in their original order and pass the old directions to `start` instead:
+```java
+MultiblockPatternBuilder.start(RelativeDirection.FRONT, RelativeDirection.UP, RelativeDirection.LEFT)
+        .slice(A).slice(B).slice(C)
+```
+
 # ModularUI changes
 
 All your machines need to be migrated from LDLib's UI system to ModularUI's system. See [this category](../../Development/MUI2/index.md).
@@ -125,6 +151,95 @@ is now
 !!! note
     Do not forget that just like in your machine UI builders, you need to sync your data to the client. See [this page on syncing](../../Development/MUI2/Syncing/Sync-Basics.md).
 
+Machines that opened a UI implemented `IUIMachine` (or a definition-level UI creator) before; they now implement `IMuiMachine`. See [Machine UIs](../../Development/MUI2/Machine-UI.md) for the methods to override.
+
+## Recipe type UIs
+
+Recipe type UI options have moved off `GTRecipeType` onto a `GTRecipeTypeUILayout`, declared with `.UI(builder -> ...)`. See [this page](../../Development/MUI2/Recipe-Type-UI.md).
+
+The following changes can be made in java:
+
+- `.setProgressBar(texture, fillDirection)` -> `.UI(builder -> builder.setProgressBar(textureSet))`. Size and fill direction are part of the `ProgressBarTextureSet`.
+- `.setSlotOverlay(isOutput, isFluid, overlay)` is now per-capability and per-slot:
+  ```java
+  /////// OLD
+  .setSlotOverlay(false, false, GuiTextures.ARROW_INPUT_OVERLAY)
+  ////// NEW (for a recipe type that has 4 input item slots that we wanna set:)
+  .UI(builder -> builder.setSlotsOverlay(IO.IN, 0, 3, ItemRecipeCapability.CAP, GTGuiTextures.ARROW_INPUT_OVERLAY))
+  ```
+  `setItemSlotsOverlay`/`setFluidSlotsOverlay` and the single-slot `setItemSlotOverlay`/`setFluidSlotOverlay` are shorthands for the item and fluid capabilities.
+- `.addDataInfo(data -> string)` -> `.UI(builder -> builder.addRecipeUIModifier((recipe, widget) -> ...))`, which gives you the recipe viewer's widget tree instead of a string:
+  ```java
+  /////// OLD
+  .addDataInfo(data -> I18n.get("emi_info.example.info", data.getByte("tier")))
+  ////// NEW
+  .UI(builder -> builder.addRecipeUIModifier((recipe, widget) -> widget.textComponents.child(
+          Text.lang("emi_info.example.info", recipe.data.getByte("tier")).asWidget())))
+  ```
+  Filler calls such as `.addDataInfo(data -> " ")` can be deleted.
+- Custom `RecipeCapability`s no longer draw themselves. Supply a `MachineCapabilityLayoutBuilder`, a `RecipeViewerCapabilityLayoutBuilder` and a `CapabilityContentBuilder`.
+
+KubeJS scripts do not use `.UI()`; the recipe type builder exposes `setProgressBar`, the `setSlotOverlay`/`setSlotsOverlay` family and `addRecipeInfo` directly instead:
+```js
+/////// OLD
+.setSlotOverlay(false, false, GuiTextures.ARROW_INPUT_OVERLAY)
+.setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT)
+.addDataInfo(data => `Temperature: ${data.getInt("RequiredTemp")}K`)
+////// NEW
+.setItemSlotsOverlay(IO.IN, 0, 3, GTGuiTextures.ARROW_INPUT_OVERLAY)
+.setProgressBar(GTGuiTextures.PROGRESS_ARROW)
+.addRecipeInfo(recipe => `Temperature: ${recipe.data.getInt("RequiredTemp")}K`)
+```
+`addRecipeInfo` is given the recipe and returns the text for it; return an empty string to show no line.
+
+# Registration changes
+
+- `GTRegistrate#registerRegistrate` has been removed. `GTRegistrate.create(modId)` now registers the event listeners itself, so the call can simply be deleted.
+- `MaterialRegistryEvent` has been removed, along with the per-addon material registries. Delete the listener that called `GTCEuAPI.materialManager.createRegistry(MOD_ID)`. `MaterialEvent` and `PostMaterialEvent` are unchanged.
+- `GTElements.createAndRegister` takes a `ResourceLocation` id first, so addon elements register into your own namespace:
+  ```java
+  /////// OLD
+  GTElements.createAndRegister(6, 6, -1, null, "Crystal Matrix", "C☆", false);
+  ////// NEW
+  GTElements.createAndRegister(MyAddon.id("crystal_matrix"), 6, 6, -1, null, "Crystal Matrix", "C☆", false);
+  ```
+- The deprecated `IGTAddon.registerX()` callbacks are replaced by generic `GTCEuAPI.RegisterEvent<ResourceLocation, T>` events on your mod event bus:
+  ```java
+  modEventBus.addGenericListener(Element.class, this::registerElements);
+
+  private void registerElements(GTCEuAPI.RegisterEvent<ResourceLocation, Element> event) {
+      MyElements.init();
+  }
+  ```
+  Events exist for elements, material icon sets, tag prefixes, covers, recipe capabilities, recipe types, recipe categories, machines, sounds, placeholders, dimension markers, chance logics, medical conditions, pattern errors and worldgen layers.
+
+# Client model and rendering changes
+
+- `ModelUtils` has been split up:
+    - `ModelUtils.register*EventListener` -> `ModelEventHelper.register*EventListener`
+    - `ModelUtils.getModelForState` -> `RenderUtil.getModelForState`
+    - `ModelUtils.getPropertyValueString` -> `GTStringUtils.getPropertyValueString`
+    - `ModelUtils.getBakedModelQuads` has been removed, call `BakedModel::getQuads` directly.
+- Extra models must be registered through `ModelEventHelper` rather than your own `ModelEvent.RegisterAdditional` listener, and the bake listener no longer exposes the baked models, so look them up at render time instead of caching them from the event:
+  ```java
+  /////// OLD
+  // in your mod class
+  public void registerAdditionalModels(ModelEvent.RegisterAdditional event) {
+      event.register(SPHERE);
+  }
+  // in your renderer
+  ModelUtils.registerBakeEventListener(true, event -> sphereModel = event.getModels().get(SPHERE));
+
+  ////// NEW
+  // at class init time
+  ModelEventHelper.registerAddModelsEventListener(false, event -> event.register(SPHERE));
+  // at render time
+  if (sphereModel == null) sphereModel = Minecraft.getInstance().getModelManager().getModel(SPHERE);
+  ```
+  Models are rebaked on every resource reload, so the lookup must stay refreshable.
+- `registerBakeEventListener` is now a replacement function `(modelLocation, baked, rootModel, modelBakery) -> BakedModel` instead of an event consumer.
+- `RenderUtil.vertex` and others take a `PoseStack.Pose` instead of a `Matrix4f`. Pass `poseStack.last()` rather than `poseStack.last().pose()`.
+
 ## Connected texture reimplementation
 The mod's connected texture logic has been reimplemented in GTM proper.
 Texture packs, addons, and modpacks will have to change their texture metadata files for connected texures slightly.  
@@ -136,6 +251,8 @@ A few regexes for fixing all the MCMeta files is follows, run them in order:
    Replace with: `,$1` 
 3. Match: `(\{\s*)"shimmer":(\s*\{\s*"bloom":.*)`  
    Replace with: `$1"gtceu":$2` 
+
+# Other API changes
 
 ## IRecipeHandler nullability
 Previously, `handleRecipeInner` should return `null` when there's nothing left to process. This has been changed to requiring an empty list (e.g. the list of remaining ingredients). Returning `null` is now wrong and will crash (NPE).

--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -220,21 +220,14 @@ KubeJS scripts do not use `.UI()`; the recipe type builder exposes `setProgressB
     - `ModelUtils.getModelForState` -> `RenderUtil.getModelForState`
     - `ModelUtils.getPropertyValueString` -> `GTStringUtils.getPropertyValueString`
     - `ModelUtils.getBakedModelQuads` has been removed, call `BakedModel::getQuads` directly.
-- Extra models must be registered through `ModelEventHelper` rather than your own `ModelEvent.RegisterAdditional` listener, and the bake listener no longer exposes the baked models, so look them up at render time instead of caching them from the event:
+- The bake listener no longer exposes the baked models, so look them up at render time instead of caching them from the event:
   ```java
   /////// OLD
-  // in your mod class
-  public void registerAdditionalModels(ModelEvent.RegisterAdditional event) {
-      event.register(SPHERE);
-  }
-  // in your renderer
   ModelUtils.registerBakeEventListener(true, event -> sphereModel = event.getModels().get(SPHERE));
 
   ////// NEW
-  // at class init time
-  ModelEventHelper.registerAddModelsEventListener(false, event -> event.register(SPHERE));
-  // at render time
-  if (sphereModel == null) sphereModel = Minecraft.getInstance().getModelManager().getModel(SPHERE);
+  // at render time:
+  Minecraft.getInstance().getModelManager().getModel(SPHERE); // do something with this
   ```
   Models are rebaked on every resource reload, so the lookup must stay refreshable.
 - `registerBakeEventListener` is now a replacement function `(modelLocation, baked, rootModel, modelBakery) -> BakedModel` instead of an event consumer.

--- a/docs/content/Modpacks/Changes/v8.0.0.md
+++ b/docs/content/Modpacks/Changes/v8.0.0.md
@@ -188,9 +188,9 @@ KubeJS scripts do not use `.UI()`; the recipe type builder exposes `setProgressB
 ////// NEW
 .setItemSlotsOverlay(IO.IN, 0, 3, GTGuiTextures.ARROW_INPUT_OVERLAY)
 .setProgressBar(GTGuiTextures.PROGRESS_ARROW)
-.addRecipeInfo(recipe => `Temperature: ${recipe.data.getInt("RequiredTemp")}K`)
+.addRecipeInfo(recipe => Text.literal(`Temperature: ${recipe.data.getInt("RequiredTemp")}K`))
 ```
-`addRecipeInfo` is given the recipe and returns the text for it; return an empty string to show no line.
+`addRecipeInfo` is given the recipe and returns the component for it, built with KubeJS's `Text.literal` or `Text.translate`. Return `Text.empty()` to show no line.
 
 # Registration changes
 

--- a/docs/content/Modpacks/Other-Topics/Custom-Recipe-Types.md
+++ b/docs/content/Modpacks/Other-Topics/Custom-Recipe-Types.md
@@ -25,14 +25,14 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
 
 ## Recipe info lines
 
-`addRecipeInfo` adds a line of text below recipes of this type in the recipe viewer. It is given the recipe being displayed and returns the text to show for it. Return an empty string to show nothing for that recipe. Call it several times for several lines.
+`addRecipeInfo` adds a line of text below recipes of this type in the recipe viewer. It is given the recipe being displayed and returns the component to show for it, built with `Text.literal` or `Text.translate`. Return `Text.empty()` to show nothing for that recipe. Call it several times for several lines.
 
 ```js title="test_recipe_type.js"
 GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
     event.create('test_recipe_type')
         .addRecipeInfo(recipe => Text.translate('test_recipe_type.info'))
         .addRecipeInfo(recipe => recipe.data.contains('RequiredTemp') ?
-            `Temperature: ${recipe.data.getInt('RequiredTemp')}K` : '')
+            Text.literal(`Temperature: ${recipe.data.getInt('RequiredTemp')}K`) : Text.empty())
 })
 ```
    

--- a/docs/content/Modpacks/Other-Topics/Custom-Recipe-Types.md
+++ b/docs/content/Modpacks/Other-Topics/Custom-Recipe-Types.md
@@ -13,12 +13,26 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
         .category('test')
         .setEUIO('in')
         .setMaxIOSize(3, 3, 3, 3) // (1)
-        .setSlotOverlay(false, false, GuiTextures.SOLIDIFIER_OVERLAY)
-        .setProgressBar(GuiTextures.PROGRESS_BAR_ARROW, FillDirection.LEFT_TO_RIGHT) // (2)
+        .setItemSlotOverlay(IO.IN, 0, GTGuiTextures.SOLIDIFIER_OVERLAY) // (2)
+        .setProgressBar(GTGuiTextures.PROGRESS_ARROW) // (3)
         .setSound(GTSoundEntries.COOLING)
 })
 ```
 
 1. Max Item Inputs, Max Item Outputs, Max Fluid Inputs, Max Fluid Outputs
-2. A list of available ```GuiTextures``` and ```FillDirection```s can be found in the GTCEu Modern Github, or in the .jar file.
+2. Slot overlays are set per slot. `setItemSlotOverlay(io, index, overlay)` and `setFluidSlotOverlay(io, index, overlay)` set one slot; `setItemSlotsOverlay(io, startIndex, endIndex, overlay)` and `setFluidSlotsOverlay(io, startIndex, endIndex, overlay)` set an inclusive range, both ends included.
+3. A list of available textures can be found in [GTGuiTextures.java](https://github.com/GregTechCEu/GregTech-Modern/blob/1.20.1/src/main/java/com/gregtechceu/gtceu/common/mui/GTGuiTextures.java). Progress bar textures already carry their size and fill direction.
+
+## Recipe info lines
+
+`addRecipeInfo` adds a line of text below recipes of this type in the recipe viewer. It is given the recipe being displayed and returns the text to show for it. Return an empty string to show nothing for that recipe. Call it several times for several lines.
+
+```js title="test_recipe_type.js"
+GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
+    event.create('test_recipe_type')
+        .addRecipeInfo(recipe => Text.translate('test_recipe_type.info'))
+        .addRecipeInfo(recipe => recipe.data.contains('RequiredTemp') ?
+            `Temperature: ${recipe.data.getInt('RequiredTemp')}K` : '')
+})
+```
    

--- a/docs/content/Modpacks/Other-Topics/Dynamic-Renders.md
+++ b/docs/content/Modpacks/Other-Topics/Dynamic-Renders.md
@@ -112,10 +112,10 @@ public static final MultiblockMachineDefinition MY_MACHINE = REGISTRATE
 
 ### Optional overrides
 
-- `shouldRender(machine, cameraPos)` controls whether the renderer runs at all for a given frame. By default it returns `true` as long as the camera is within the view distance returned by `getViewDistance()`. Override it to add further conditions, such as skipping the render when the machine is not working.
+- **`shouldRender(machine, cameraPos)`** — Controls whether the renderer runs at all for a given frame. By default it returns `true` as long as the camera is within the view distance returned by `getViewDistance()`. You can override this to add additional conditions, such as skipping the render when the machine is not working.
 
-- `shouldRenderOffScreen(machine)` determines whether the renderer continues to run when the controller block is outside the camera frustum. Defaults to `false`, meaning the renderer is culled along with the block when the block moves out of view.
+- **`shouldRenderOffScreen(machine)`** — Determines whether the renderer continues to run when the controller block is outside the camera frustum. Defaults to `false`, meaning the renderer is culled along with the block when the block moves out of view.
 
-- `getRenderBoundingBox(machine)` defines the bounding box used for off-screen culling when `shouldRenderOffScreen` is `true`. Defaults to a 3×2×3 box centered on the controller. Override it to return a box that tightly wraps your rendered content. A box that is too small will cause the render to disappear while still partially visible, and a box that is too large will prevent culling and waste resources.
+- **`getRenderBoundingBox(machine)`** — Defines the bounding box used for off-screen culling when `shouldRenderOffScreen` is `true`. Defaults to a 3×2×3 box centered on the controller. Override this to return a box that tightly wraps your actual rendered content; a box that is too small will cause the render to disappear while still partially visible, and a box that is too large will prevent culling and waste resources.
 
-- `getViewDistance()` sets the maximum distance in blocks at which the renderer will run, used by the default `shouldRender` implementation. Defaults to `64`. Lower it for expensive renders that do not need to be visible far away, or raise it if the render needs to be legible from a long distance.
+- **`getViewDistance()`** — Sets the maximum distance in blocks at which the renderer will run, used by the default `shouldRender` implementation. Defaults to `64`. Lower this for expensive renders that do not need to be visible far away, or raise it if the render needs to be legible from a long distance.

--- a/docs/content/Modpacks/Other-Topics/Dynamic-Renders.md
+++ b/docs/content/Modpacks/Other-Topics/Dynamic-Renders.md
@@ -112,10 +112,10 @@ public static final MultiblockMachineDefinition MY_MACHINE = REGISTRATE
 
 ### Optional overrides
 
-- **`shouldRender(machine, cameraPos)`** — Controls whether the renderer runs at all for a given frame. By default it returns `true` as long as the camera is within the view distance returned by `getViewDistance()`. You can override this to add additional conditions, such as skipping the render when the machine is not working.
+- `shouldRender(machine, cameraPos)` controls whether the renderer runs at all for a given frame. By default it returns `true` as long as the camera is within the view distance returned by `getViewDistance()`. Override it to add further conditions, such as skipping the render when the machine is not working.
 
-- **`shouldRenderOffScreen(machine)`** — Determines whether the renderer continues to run when the controller block is outside the camera frustum. Defaults to `false`, meaning the renderer is culled along with the block when the block moves out of view.
+- `shouldRenderOffScreen(machine)` determines whether the renderer continues to run when the controller block is outside the camera frustum. Defaults to `false`, meaning the renderer is culled along with the block when the block moves out of view.
 
-- **`getRenderBoundingBox(machine)`** — Defines the bounding box used for off-screen culling when `shouldRenderOffScreen` is `true`. Defaults to a 3×2×3 box centered on the controller. Override this to return a box that tightly wraps your actual rendered content; a box that is too small will cause the render to disappear while still partially visible, and a box that is too large will prevent culling and waste resources.
+- `getRenderBoundingBox(machine)` defines the bounding box used for off-screen culling when `shouldRenderOffScreen` is `true`. Defaults to a 3×2×3 box centered on the controller. Override it to return a box that tightly wraps your rendered content. A box that is too small will cause the render to disappear while still partially visible, and a box that is too large will prevent culling and waste resources.
 
-- **`getViewDistance()`** — Sets the maximum distance in blocks at which the renderer will run, used by the default `shouldRender` implementation. Defaults to `64`. Lower this for expensive renders that do not need to be visible far away, or raise it if the render needs to be legible from a long distance.
+- `getViewDistance()` sets the maximum distance in blocks at which the renderer will run, used by the default `shouldRender` implementation. Defaults to `64`. Lower it for expensive renders that do not need to be visible far away, or raise it if the render needs to be legible from a long distance.

--- a/docs/content/Modpacks/Recipes/Custom-Recipe-Modifiers.md
+++ b/docs/content/Modpacks/Recipes/Custom-Recipe-Modifiers.md
@@ -42,15 +42,12 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
 	event.create('example_smelting')
 		.category('multiblock')
 		.setMaxIOSize(1, 1, 0, 0)
-		.setProgressBar(GuiTextures.PROGRESS_BAR_FUSION, FillDirection.LEFT_TO_RIGHT)
+		.setProgressBar(GTGuiTextures.PROGRESS_FUSION)
+		.addRecipeInfo(recipe => `Temperature: ${recipe.data.getInt("RequiredTemp")}K`) // (3) (4)
 		.setSound(GTSoundEntries.BATH);
 });
 
 GTCEuStartupEvents.registry('gtceu:machine', event => {
-
-	GTRecipeTypes.get("example_smelting").addDataInfo((data) => (
-		`Temperature: ${data.getInt("RequiredTemp")}K` // (4)
-	)) // (3)
 
 	event.create('example_smelter', 'multiblock')
 		.rotationState(RotationState.NON_Y_AXIS)

--- a/docs/content/Modpacks/Recipes/Custom-Recipe-Modifiers.md
+++ b/docs/content/Modpacks/Recipes/Custom-Recipe-Modifiers.md
@@ -43,7 +43,7 @@ GTCEuStartupEvents.registry('gtceu:recipe_type', event => {
 		.category('multiblock')
 		.setMaxIOSize(1, 1, 0, 0)
 		.setProgressBar(GTGuiTextures.PROGRESS_FUSION)
-		.addRecipeInfo(recipe => `Temperature: ${recipe.data.getInt("RequiredTemp")}K`) // (3) (4)
+		.addRecipeInfo(recipe => Text.literal(`Temperature: ${recipe.data.getInt("RequiredTemp")}K`)) // (3) (4)
 		.setSound(GTSoundEntries.BATH);
 });
 

--- a/docs/content/Modpacks/Recipes/TagPrefixRecipeGeneration.md
+++ b/docs/content/Modpacks/Recipes/TagPrefixRecipeGeneration.md
@@ -12,7 +12,7 @@ Gregtech will iterate through all materials and all tag prefixes possible for th
 
 public static void recipeAddition(Consumer<FinishedRecipe> consumer) {
 
-    for (Material material : GTRegistries.MATERIALS.values()) {
+    for (Material material : GTRegistries.MATERIALS) {
             if (material.hasFlag(MaterialFlags.NO_UNIFICATION)) {
                 continue;
             }

--- a/docs/content/Modpacks/Recipes/TagPrefixRecipeGeneration.md
+++ b/docs/content/Modpacks/Recipes/TagPrefixRecipeGeneration.md
@@ -12,7 +12,7 @@ Gregtech will iterate through all materials and all tag prefixes possible for th
 
 public static void recipeAddition(Consumer<FinishedRecipe> consumer) {
 
-    for (Material material : GTCEuAPI.materialManager.getRegisteredMaterials()) {
+    for (Material material : GTRegistries.MATERIALS.values()) {
             if (material.hasFlag(MaterialFlags.NO_UNIFICATION)) {
                 continue;
             }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeType.java
@@ -100,6 +100,7 @@ public class GTRecipeType implements RecipeType<GTRecipe> {
             map.put(proxyRecipe, new ArrayList<>());
         }
         this.proxyRecipes = map;
+        this.uiLayout = new GTRecipeTypeUILayout.Builder(this).build();
     }
 
     public GTRecipeType setMaxIOSize(int maxItemInputs, int maxItemOutputs, int maxFluidInputs, int maxFluidOutputs) {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/GTRecipeTypeUILayout.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/gui/GTRecipeTypeUILayout.java
@@ -191,6 +191,23 @@ public class GTRecipeTypeUILayout {
         }
 
         /**
+         * Adds a slot overlay for multiple slots.
+         *
+         * @param ioMode         The IO of the slot
+         * @param slotIndexStart The first slot to add the overlay to.
+         * @param slotIndexEnd   The last slot to add the overlay to.
+         * @param cap            The slot capability
+         * @param overlay        The slot overlay.
+         */
+        public Builder setSlotsOverlay(IO ioMode, int slotIndexStart, int slotIndexEnd, RecipeCapability<?> cap,
+                                       IDrawable overlay) {
+            for (int i = slotIndexStart; i <= slotIndexEnd; i++) {
+                setSlotOverlay(ioMode, i, cap, overlay);
+            }
+            return this;
+        }
+
+        /**
          * Adds a slot overlay for multiple item slots.
          *
          * @param ioMode         The IO of the slot
@@ -199,10 +216,7 @@ public class GTRecipeTypeUILayout {
          * @param overlay        The slot overlay.
          */
         public Builder setItemSlotsOverlay(IO ioMode, int slotIndexStart, int slotIndexEnd, IDrawable overlay) {
-            for (int i = slotIndexStart; i <= slotIndexEnd; i++) {
-                setSlotOverlay(ioMode, i, ItemRecipeCapability.CAP, overlay);
-            }
-            return this;
+            return setSlotsOverlay(ioMode, slotIndexStart, slotIndexEnd, ItemRecipeCapability.CAP, overlay);
         }
 
         /**
@@ -214,10 +228,7 @@ public class GTRecipeTypeUILayout {
          * @param overlay        The slot overlay.
          */
         public Builder setFluidSlotsOverlay(IO ioMode, int slotIndexStart, int slotIndexEnd, IDrawable overlay) {
-            for (int i = slotIndexStart; i <= slotIndexEnd; i++) {
-                setSlotOverlay(ioMode, i, FluidRecipeCapability.CAP, overlay);
-            }
-            return this;
+            return setSlotsOverlay(ioMode, slotIndexStart, slotIndexEnd, FluidRecipeCapability.CAP, overlay);
         }
 
         /**

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
@@ -1,20 +1,27 @@
 package com.gregtechceu.gtceu.integration.kjs.builders;
 
 import com.gregtechceu.gtceu.api.capability.recipe.*;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.gui.GTRecipeTypeUILayout;
+import com.gregtechceu.gtceu.api.recipe.gui.ProgressBarTextureSet;
 import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
 import com.gregtechceu.gtceu.api.sound.SoundEntry;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 
+import brachy.modularui.api.drawable.IDrawable;
+import brachy.modularui.api.drawable.Text;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 @SuppressWarnings("unused")
@@ -49,9 +56,89 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         return this;
     }
 
+    @HideFromJS
     public GTRecipeTypeBuilder ui(Consumer<GTRecipeTypeUILayout.Builder> builder) {
-        this.layout = builder;
+        this.layout = this.layout == null ? builder : this.layout.andThen(builder);
         return this;
+    }
+
+    /**
+     * Sets the progress bar texture, e.g. {@code GTGuiTextures.PROGRESS_ARROW}.
+     */
+    public GTRecipeTypeBuilder setProgressBar(ProgressBarTextureSet progressBar) {
+        return ui(builder -> builder.setProgressBar(progressBar));
+    }
+
+    /**
+     * Adds an overlay to a single slot.
+     *
+     * @param ioMode    The IO of the slot.
+     * @param slotIndex The index of the slot.
+     * @param cap       The slot capability.
+     * @param overlay   The slot overlay.
+     */
+    public GTRecipeTypeBuilder setSlotOverlay(IO ioMode, int slotIndex, RecipeCapability<?> cap, IDrawable overlay) {
+        return ui(builder -> builder.setSlotOverlay(ioMode, slotIndex, cap, overlay));
+    }
+
+    /**
+     * Adds an overlay to a range of slots, both ends inclusive.
+     *
+     * @param ioMode         The IO of the slots.
+     * @param slotIndexStart The first slot to add the overlay to.
+     * @param slotIndexEnd   The last slot to add the overlay to.
+     * @param cap            The slot capability.
+     * @param overlay        The slot overlay.
+     */
+    public GTRecipeTypeBuilder setSlotsOverlay(IO ioMode, int slotIndexStart, int slotIndexEnd,
+                                               RecipeCapability<?> cap, IDrawable overlay) {
+        return ui(builder -> builder.setSlotsOverlay(ioMode, slotIndexStart, slotIndexEnd, cap, overlay));
+    }
+
+    /**
+     * Adds an overlay to a single item slot.
+     */
+    public GTRecipeTypeBuilder setItemSlotOverlay(IO ioMode, int slotIndex, IDrawable overlay) {
+        return setSlotOverlay(ioMode, slotIndex, ItemRecipeCapability.CAP, overlay);
+    }
+
+    /**
+     * Adds an overlay to a range of item slots, both ends inclusive.
+     */
+    public GTRecipeTypeBuilder setItemSlotsOverlay(IO ioMode, int slotIndexStart, int slotIndexEnd,
+                                                   IDrawable overlay) {
+        return setSlotsOverlay(ioMode, slotIndexStart, slotIndexEnd, ItemRecipeCapability.CAP, overlay);
+    }
+
+    /**
+     * Adds an overlay to a single fluid slot.
+     */
+    public GTRecipeTypeBuilder setFluidSlotOverlay(IO ioMode, int slotIndex, IDrawable overlay) {
+        return setSlotOverlay(ioMode, slotIndex, FluidRecipeCapability.CAP, overlay);
+    }
+
+    /**
+     * Adds an overlay to a range of fluid slots, both ends inclusive.
+     */
+    public GTRecipeTypeBuilder setFluidSlotsOverlay(IO ioMode, int slotIndexStart, int slotIndexEnd,
+                                                    IDrawable overlay) {
+        return setSlotsOverlay(ioMode, slotIndexStart, slotIndexEnd, FluidRecipeCapability.CAP, overlay);
+    }
+
+    /**
+     * Adds a line of text below recipes of this type in the recipe viewer.
+     * <p>
+     * The function is given the recipe being displayed and returns the text to show for it. Return an
+     * empty component to show no line for a given recipe. Call this multiple times to add several lines.
+     *
+     * @param info Returns the text to show for a recipe.
+     */
+    public GTRecipeTypeBuilder addRecipeInfo(Function<GTRecipe, Component> info) {
+        return ui(builder -> builder.addRecipeUIModifier((recipe, widget) -> {
+            Component text = info.apply(recipe);
+            if (text == null || text.getString().isEmpty()) return;
+            widget.textComponents.child(Text.of(text).asWidget());
+        }));
     }
 
     public GTRecipeTypeBuilder setMaxIOSize(int maxInputs, int maxOutputs, int maxFluidInputs, int maxFluidOutputs) {
@@ -111,11 +198,11 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         var type = GTRecipeTypes.register(name, category);
         type.maxInputs.putAll(maxInputs);
         type.maxOutputs.putAll(maxOutputs);
+        var uiBuilder = new GTRecipeTypeUILayout.Builder(type);
         if (this.layout != null) {
-            var builder = new GTRecipeTypeUILayout.Builder(type);
-            this.layout.accept(builder);
-            type.setUiLayout(builder.build());
+            this.layout.accept(uiBuilder);
         }
+        type.setUiLayout(uiBuilder.build());
         type.setSound(sound);
         type.setHasResearchSlot(hasResearchSlot);
         type.setMaxTooltips(maxTooltips);

--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/GTRecipeTypeBuilder.java
@@ -198,11 +198,11 @@ public class GTRecipeTypeBuilder extends BuilderBase<GTRecipeType> {
         var type = GTRecipeTypes.register(name, category);
         type.maxInputs.putAll(maxInputs);
         type.maxOutputs.putAll(maxOutputs);
-        var uiBuilder = new GTRecipeTypeUILayout.Builder(type);
         if (this.layout != null) {
-            this.layout.accept(uiBuilder);
+            var builder = new GTRecipeTypeUILayout.Builder(type);
+            this.layout.accept(builder);
+            type.setUiLayout(builder.build());
         }
-        type.setUiLayout(uiBuilder.build());
         type.setSound(sound);
         type.setHasResearchSlot(hasResearchSlot);
         type.setMaxTooltips(maxTooltips);


### PR DESCRIPTION
## What
Does what it says on the tin. Documents all problems we found in https://github.com/PortingMoni/MoniLabs/issues/3 and some extras.

## Implementation Details
I had to make some changes to make it work properly, like adding a default gtrecipetypelayout builder, adding KJS overrides to GTRecipeTypeBuilder so KJS doesn't / can't touch UI widgets directly, and making adding .UI optional (so that not calling it gives a default UI)

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Opus 4.8 High
#### Agent Usage Description
This PR is basically 50/50 me and claude. Claude wrote the initial setup and I refined and checked it into the form it is now.
  
## Outcome
We have documentation on the many many new features (and pitfalls) of porting to 8.0.0

## How Was This Tested
Opened in MKDocs, visually looked fine, content-wise not tested.