### PR TITLE
Prevent server stalls from duplicate recipe lookup paths

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeDB.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeDB.java
@@ -146,7 +146,23 @@ public final class RecipeDB {
         if (list.isEmpty()) {
             return null;
         }
-        return list;
+
+        List<AbstractMapIngredient> uniqueIngredients = new ArrayList<>();
+        Set<Integer> ingredientHashes = new HashSet<>();
+        Set<AbstractMapIngredient> specialIngredients = new LinkedHashSet<>();
+        for (List<AbstractMapIngredient> ingredientGroup : list) {
+            for (AbstractMapIngredient ingredient : ingredientGroup) {
+                if (ingredient.isSpecialIngredient()) {
+                    if (specialIngredients.add(ingredient)) {
+                        uniqueIngredients.add(ingredient);
+                    }
+                } else if (ingredientHashes.add(ingredient.hashCode())) {
+                    uniqueIngredients.add(ingredient);
+                }
+            }
+        }
+
+        return List.of(uniqueIngredients);
     }
 
     /**


### PR DESCRIPTION
## What

This PR fixes severe server lag caused by duplicate recipe lookup paths in affected GTCEu processing machines.

`RecipeDB` currently retains repeated equivalent search entries produced by repeated machine inputs or recipe handlers. `RecipeIterator` traverses each entry independently at every level of the recipe tree. When a usable recipe is not found quickly, the lookup may explore all of these duplicate paths, generating enough work on the server thread for TPS to reach zero and the server to become effectively unresponsive.

This change deduplicates holder-derived search entries before constructing the iterator. The iterator still checks entries in first-encounter order and uses the existing recipe-matching logic; it simply no longer traverses repeated entries.


### Duplicate Path Growth and Reproduction

Take a recipe with `n` input ingredients and place all of them into an input hatch. Copy that hatch together with its NBT and attach `m` identical copies to the same machine. Keep the machine ticking without allowing the recipe to start, for example by continuously supplying too little power (energy-hatch updates retrigger `RecipeLogic`) or by omitting a required cleanroom.

The machine then repeatedly searches for a usable recipe. Each required ingredient can be reached through any of the `m` identical hatches. Across a recipe-tree path of `n` ingredients, this produces `m^n` equivalent ways to reach the same recipe. Because the candidate cannot start, the lookup continues and can visit all of those equivalent paths again on each search attempt.

The previously observed Pattern Buffer lag followed the same principle. If `m` requested patterns expose the same `n` shared ingredients, each shared ingredient is repeated at least `m` times in the lookup input, producing at least `m^n` equivalent paths to the same recipe candidates.


## Implementation Details

The holder-derived ingredient groups are flattened in encounter order and deduplicated before lookup:

- Non-special ingredients intentionally use their raw `hashCode()` as lookup identity.
- Special ingredients continue to use an insertion-ordered `LinkedHashSet`.
- Equality-based deduplication is intentionally not used for non-special ingredients because the concrete ingredient implementations have representation-specific `equals()` behavior that is unsuitable as the identity for this lookup path.
- The duplicate-driven path is reduced to one corresponding branch.


### Why Hash-Based Deduplication Works

This follows the contract documented on `Branch.nodes`: `Keys on this have *(should)* have unique hashcodes.` Keys whose hashes may collide are expected to be special ingredients and are stored separately in `Branch.specialNodes`, where equality is used to distinguish them.


### Full Explanation

Hash-only deduplication can change lookup behavior only if two non-special machine-side ingredients `a` and `b` have the same hash, but for a branch key `c` with that hash one matches and the other does not, for example `a.equals(c) && !b.equals(c)`. Because deduplication retains the first entry, behavior can differ only when the non-matching `b` is retained instead of the matching `a`.

For such a `b`, one of the following must be true:

1. `!b.equals(x)` for every practically constructible branch key `x`.
2. Every practically constructible branch key `x` for which `b.equals(x)` is true has `b.hashCode() != x.hashCode()`.
3. A practically constructible branch key `x` exists for which `b.equals(x) && b.hashCode() == x.hashCode()`.

In the first two cases, `nodes.get(b)` cannot succeed regardless of the map contents: `b` is present in the machine but can never select a real recipe-tree key. In the third case, `b.equals(x)` but `!b.equals(c)`, so `x` and `c` have the same hash while behaving as different keys. This leaves two possibilities:

- If `c.equals(x) || x.equals(c)`, two behaviorally different keys can collapse into one map entry depending on recipe insertion order. That is already unstable key behavior and indicates that the ingredient should have been treated as special.
- If `!c.equals(x) && !x.equals(c)`, two distinct keys with the same hash can coexist in one non-special branch, directly violating the `Branch.nodes` unique-hash contract.

Therefore, under normal lookup conditions, a hash uniquely identifies a non-special branch key and hash-only deduplication is valid. The exceptional cases require either an unusable machine-side ingredient, behaviorally inconsistent map keys, or a violation of the GTCEu branch-key contract.

The implementation is intentionally limited to `RecipeDB.fromHolder()` and keeps the surrounding recipe lookup architecture unchanged. The fix was originally implemented and validated as a Mixin at this method boundary, so this PR ports that proven scope directly instead of expanding it into a broader refactor that could introduce unrelated regressions. Other lookup entry points are unaffected.

Closed PR #4905 proposed deduplicating Pattern Buffer handlers, while merged PR #4910 reworked the Pattern Buffer to reduce redundant handler scans. This patch instead protects the general holder-based `RecipeDB` lookup path from duplicate entries regardless of their source.


### AI Usage

- [ ] No AI driven tools were used for this pull request.
- [x] Yes AI driven tools were used for this pull request.


#### Agent Used

OpenAI Codex


#### Agent Usage Description

OpenAI Codex was used to port code from a Mixin into `RecipeDB` and prepare the pull request description.


## Outcome

Eliminates duplicate-driven branch growth in the affected holder-based `RecipeDB` lookup path while preserving first-encounter ordering.

Related to #4726


## How Was This Tested

The same functional implementation as this PR was used as a Mixin on a Minecraft server over an extended period. Configurations that had previously reduced the server to zero TPS no longer caused observable lag after the Mixin was installed. No new issues attributable to the change were observed during that extended production usage.


## Potential Compatibility Issues

Compatibility can differ only if one of the exceptional cases described above is practically reachable: the GTCEu unique-hash contract is violated, a machine contains an ingredient that can never select a real recipe-tree key but shares a hash with a valid ingredient, or two behaviorally different keys collapse into one map entry. In each case, the underlying problem is in the ingredient or key implementation rather than the deduplication logic.