### PR TITLE
UI fixes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/TagFilter.java
@@ -1,6 +1,8 @@
 package com.gregtechceu.gtceu.api.cover.filter;
 
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
+import com.gregtechceu.gtceu.common.mui.widgets.textfield.TextEditorWidget;
+import com.gregtechceu.gtceu.data.lang.LangHandler;
 import com.gregtechceu.gtceu.utils.TagExprFilter;
 
 import net.minecraft.nbt.CompoundTag;
@@ -11,7 +13,6 @@ import brachy.modularui.screen.UISettings;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.value.sync.StringSyncValue;
 import brachy.modularui.widgets.layout.Flow;
-import brachy.modularui.widgets.textfield.TextFieldWidget;
 import lombok.Getter;
 
 import java.util.function.Consumer;
@@ -51,11 +52,12 @@ public abstract class TagFilter<T, S extends Filter<T, S>> implements Filter<T, 
     @Override
     public Flow getFilterUI(GuiData data, PanelSyncManager syncManager, UISettings settings) {
         StringSyncValue filterString = new StringSyncValue(this::getFilterString, this::setFilterString).allowC2S();
-        RichTooltip infoTooltip = new RichTooltip().add("cover.tag_filter.info");
+        RichTooltip infoTooltip = new RichTooltip();
+        LangHandler.getMultiLang("cover.tag_filter.info").forEach(infoTooltip::addLine);
 
         return Flow.row()
                 .coverChildren()
-                .child(new TextFieldWidget().width(140).value(filterString))
+                .child(new TextEditorWidget<>().width(140).height(50).padding(4).value(filterString))
                 .child(GTGuiTextures.INFO.asWidget().tooltip(infoTooltip));
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/SyncDataHolder.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/SyncDataHolder.java
@@ -57,13 +57,15 @@ public class SyncDataHolder {
 
         CompoundTag tag = new CompoundTag();
         for (var field : fieldsToSerialize) {
-            if (shouldSerializeField(field, writeClientFields, fullSync)) {
-                Tag nbtValue = serializeField(holder, field, writeClientFields, fullSync);
+            if (shouldSerializeField(field, writeClientFields, fullSync || resyncAll)) {
+                Tag nbtValue = serializeField(holder, field, writeClientFields, fullSync || resyncAll);
                 tag.put(field.nbtSaveKey, nbtValue);
             }
         }
-        resyncAll = false;
-        dirtySyncFields.clear();
+        if (writeClientFields) {
+            resyncAll = false;
+            dirtySyncFields.clear();
+        }
         return tag;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/MachineControllerCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/MachineControllerCover.java
@@ -209,8 +209,8 @@ public class MachineControllerCover extends CoverBehavior implements IMuiCover {
                         .child(coverUIRow()
                                 .child(new ToggleButton()
                                         .size(16).left(0)
-                                        .value(new BooleanSyncValue(this::isInverted, ($) -> this.setInverted(true))
-                                                .allowC2S())
+                                        .value(new BooleanSyncValue(this::isInverted,
+                                                this::setInverted).allowC2S())
                                         .overlay(GTGuiTextures.OVERLAY_REDSTONE_ON))
                                 .child(Text.comp(Component.translatable("cover.enable_with_redstone")).asWidget()
                                         .heightRel(1.0f).left(20)))
@@ -218,7 +218,7 @@ public class MachineControllerCover extends CoverBehavior implements IMuiCover {
                                 .child(new ToggleButton()
                                         .size(16).left(0)
                                         .value(new BooleanSyncValue(() -> !this.isInverted(),
-                                                ($) -> this.setInverted(false)).allowC2S())
+                                                ($) -> this.setInverted(!$)).allowC2S())
                                         .overlay(GTGuiTextures.OVERLAY_REDSTONE_OFF))
                                 .child(Text.lang("cover.disable_with_redstone").asWidget()
                                         .heightRel(1.0f).left(20)))
@@ -227,7 +227,10 @@ public class MachineControllerCover extends CoverBehavior implements IMuiCover {
                                         .size(16).left(0)
                                         .value(new BooleanSyncValue(() -> preventPowerFail,
                                                 bool -> preventPowerFail = bool).allowC2S())
-                                        .overlay(GTGuiTextures.CIRCUIT_OVERLAY))
+                                        .background(true,
+                                                GTGuiTextures.BUTTON_POWER[0])
+                                        .background(
+                                                GTGuiTextures.BUTTON_POWER[1]))
                                 .child(Text.lang("cover.machine_controller.suspend_powerfail").asWidget()
                                         .heightRel(1.0f).left(20)))
                         .child(coverUIRow()

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/detector/AdvancedItemDetectorCover.java
@@ -130,7 +130,7 @@ public class AdvancedItemDetectorCover extends ItemDetectorCover implements IMui
                         .overlay(false, GTGuiTextures.OVERLAY_REDSTONE_OFF)
                         .overlay(true, GTGuiTextures.OVERLAY_REDSTONE_ON)
                         .tooltip(false, t -> t.add("cover.advanced_item_detector.invert.disabled"))
-                        .tooltip(true, t -> t.add("cover.advanced_item_detector.invert.disabled")))
+                        .tooltip(true, t -> t.add("cover.advanced_item_detector.invert.enabled")))
                 .child(new ToggleButton().value(new BooleanSyncValue(this::isLatched, this::setLatched))
                         .overlay(false, GTGuiTextures.BUTTON_LOCK)
                         .overlay(true, GTGuiTextures.BUTTON_LOCK)

--- a/src/main/java/com/gregtechceu/gtceu/common/item/behavior/ItemMagnetBehavior.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/behavior/ItemMagnetBehavior.java
@@ -15,6 +15,7 @@ import com.gregtechceu.gtceu.api.item.component.IItemLifeCycle;
 import com.gregtechceu.gtceu.api.mui.IItemUIHolder;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
+import com.gregtechceu.gtceu.common.mui.widgets.textfield.TextEditorWidget;
 import com.gregtechceu.gtceu.data.lang.LangHandler;
 
 import net.minecraft.nbt.CompoundTag;
@@ -55,7 +56,6 @@ import brachy.modularui.widgets.layout.Flow;
 import brachy.modularui.widgets.layout.Grid;
 import brachy.modularui.widgets.slot.ModularSlot;
 import brachy.modularui.widgets.slot.PhantomItemSlot;
-import brachy.modularui.widgets.textfield.TextFieldWidget;
 import com.tterrag.registrate.util.entry.ItemEntry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -176,10 +176,11 @@ public class ItemMagnetBehavior implements IInteractionItem, IItemLifeCycle, IAd
                         .coverChildren()
                         .childPadding(2)
                         .left(7)
-                        .top(19)
-                        .child(new TextFieldWidget()
+                        .top(2)
+                        .child(new TextEditorWidget<>()
                                 .width(117)
-                                .height(18)
+                                .height(50)
+                                .padding(4)
                                 .value(filterString))
                         .child(GTGuiTextures.INFO.asWidget()
                                 .size(16)

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -245,6 +245,7 @@ public class GTMuiWidgets {
                         .value(new BoolValue.Dynamic(() -> (i + 1) == circuitSyncValue.getIntValue(),
                                 (v) -> {
                                     if (v) circuitSyncValue.setValue(i + 1);
+                                    else circuitSyncValue.setValue(-1);
                                 })));
 
         return new Dialog<>("circuit_panel")

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMuiWidgets.java
@@ -158,7 +158,7 @@ public class GTMuiWidgets {
 
     public static ItemSlot createBatterySlot(BatterySlotTrait batterySlot, PanelSyncManager syncManager) {
         ItemSlotSyncHandler battery = new ItemSlotSyncHandler(
-                new ModularSlot(batterySlot.getStorage(), 0).singletonSlotGroup(-10));
+                new ModularSlot(batterySlot.getStorage(), 0).singletonSlotGroup(10));
         syncManager.syncValue("battery", battery);
         return new ItemSlot().syncHandler("battery").background(GTGuiTextures.SLOT, GTGuiTextures.CHARGER_OVERLAY);
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/widgets/textfield/TextEditorWidget.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/widgets/textfield/TextEditorWidget.java
@@ -1,6 +1,8 @@
 package com.gregtechceu.gtceu.common.mui.widgets.textfield;
 
 import brachy.modularui.api.value.IStringValue;
+import brachy.modularui.api.value.ISyncOrValue;
+import brachy.modularui.api.widget.Interactable;
 import brachy.modularui.screen.viewport.ModularGuiContext;
 import brachy.modularui.utils.Alignment;
 import brachy.modularui.value.StringValue;
@@ -19,6 +21,19 @@ public class TextEditorWidget<W extends TextEditorWidget<W>> extends BaseTextFie
     public TextEditorWidget() {
         this.handler.setMaxLines(10000);
         this.setTextAlignment(Alignment.TopLeft);
+    }
+
+    @Override
+    public boolean isValidSyncOrValue(@NotNull ISyncOrValue syncOrValue) {
+        return syncOrValue.isTypeOrEmpty(IStringValue.class);
+    }
+
+    @Override
+    public Interactable.@NotNull Result onMousePressed(int button) {
+        if (button == 1) {
+            return Result.IGNORE;
+        }
+        return super.onMousePressed(button);
     }
 
     @Override


### PR DESCRIPTION
## What
Fix some UI bugs that I found when play testing v8
- prevent power failing button had circuit overlay, i changed it to an on/off button.
- double clicking on redstone mode in machine controller gui was flickering the button on the second click, now it disables it and enables the other one instead.
- ender covers had their title set to "air" often because nested sync items were not always synced, resyncAll flag was ignored.
- the only way of selecting circuit 0 after selecting any other was to scroll your mouse on the circuit slot. I made it so clicking on a selected circuit deselects it now.
- TextEditorWidget was clearing its contents on right click, so one missclick while editing a longer text would delete it all, i changed it so it no longer does that. CodeEditorWidget that extends this class inherits that behavior. Also added strings as a valid value for the text editor.
- Fixed tooltip in TagFilter
- Changed TextFieldWidget to TextEditorWidget in Tag Filter and in the Magnet item to allow multiline expresions.
- Changed the priority of the machines battery slot to 10 from -10, so players inventory (0) now has priority over the battery slot when taking items from the machine, inserting items works the same, batteries go to the battery slot first, then to machine input (prio 100)
- fixed a typo in advanced item detector cover, it had the .disabled lang key when it was enabled

### AI Usage 

- [x] No AI driven tools were used for this pull request.
  
## How Was This Tested
I tested all those changes both on single player and on multiplayer, especially the sync change and ender covers as they were behaving differently on sp and mp
