### PR TITLE
Fix ranged test rolling

### DIFF
--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredientTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderFluidIngredientTest.java
@@ -225,7 +225,11 @@ public class IntProviderFluidIngredientTest {
         helper.assertTrue(stacks[0].isFluidStackIdentical(ingredient.getStacks()[0]),
                 "IntProviderFluidIngredient.getStacks shouldn't change between getStacks calls");
         ingredient.reset();
-        helper.assertFalse(stacks[0].isFluidStackIdentical(ingredient.getStacks()[0]),
+        helper.assertFalse(ingredient.isRolled(),
+                "IntProviderFluidIngredient shouldn't be rolled after being reset");
+        int forcedAmount = stacks[0].getAmount() == 1 ? 2 : 1;
+        ingredient.setSampledCount(forcedAmount);
+        helper.assertTrue(ingredient.getStacks()[0].getAmount() == forcedAmount,
                 "IntProviderFluidIngredient.getStacks should have changed after rerolling");
         helper.succeed();
     }
@@ -238,6 +242,8 @@ public class IntProviderFluidIngredientTest {
         // serialize/deserialize before rolling count
         var jsonPreRoll = ingredient.toJson();
         var ingredientDeserializedPreRoll = IntProviderFluidIngredient.fromJson(jsonPreRoll);
+        helper.assertFalse(ingredientDeserializedPreRoll.isRolled(),
+                "IntProviderFluidIngredient shouldn't be rolled if it wasn't rolled before serializing");
 
         var stacks = ingredient.getStacks();
         var stacksDeserializedPreRoll = ingredientDeserializedPreRoll.getStacks();
@@ -245,6 +251,10 @@ public class IntProviderFluidIngredientTest {
         // serialize/deserialize after rolling count
         var jsonPostRoll = ingredient.toJson();
         var ingredientDeserializedPostRoll = IntProviderFluidIngredient.fromJson(jsonPostRoll);
+        helper.assertTrue(ingredientDeserializedPostRoll.getSampledCount() == ingredient.getSampledCount(),
+                "IntProviderFluidIngredient should keep its roll if it was rolled before serializing, got [" +
+                        ingredientDeserializedPostRoll.getSampledCount() + "] not [" + ingredient.getSampledCount() +
+                        "]");
         var stacksDeserializedPostRoll = ingredientDeserializedPostRoll.getStacks();
 
         helper.assertTrue(
@@ -254,8 +264,9 @@ public class IntProviderFluidIngredientTest {
                 "IntProviderFluidIngredient should have fluid equal to what it was made with after serializing");
         helper.assertTrue(stacksDeserializedPostRoll[0].isFluidEqual(GTMaterials.Water.getFluid(1)),
                 "IntProviderFluidIngredient should have fluid equal to what it was made with after serializing");
-        helper.assertFalse(TestUtils.areFluidStacksEqual(stacksDeserializedPreRoll, ingredient.getStacks()),
-                "IntProviderFluidIngredient.getStacks should be different if it wasn't rolled before serializing");
+        helper.assertTrue(TestUtils.isFluidWithinRange(stacksDeserializedPreRoll[0], 1, 500000),
+                "IntProviderFluidIngredient.getStacks should roll within its own range if it wasn't rolled before " +
+                        "serializing, rolled [" + stacksDeserializedPreRoll[0].getAmount() + "] not [1-500000]");
         helper.assertTrue(TestUtils.areFluidStacksEqual(stacksDeserializedPostRoll, ingredient.getStacks()),
                 "IntProviderFluidIngredient.getStacks shouldn't change between getStacks calls if it was rolled before serializing");
         helper.succeed();

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredientTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/ingredient/IntProviderIngredientTest.java
@@ -24,6 +24,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
@@ -219,7 +220,11 @@ public class IntProviderIngredientTest {
         helper.assertTrue(TestUtils.areItemStacksEqual(stacks, ingredient.getItems()),
                 "IntProviderIngredient.getItems shouldn't change between getStacks calls");
         ingredient.reset();
-        helper.assertFalse(TestUtils.areItemStacksEqual(stacks, ingredient.getItems()),
+        helper.assertFalse(ingredient.isRolled(),
+                "IntProviderIngredient shouldn't be rolled after being reset");
+        int forcedCount = stacks[0].getCount() == 1 ? 2 : 1;
+        ingredient.setSampledCount(forcedCount);
+        helper.assertTrue(ingredient.getItems()[0].getCount() == forcedCount,
                 "IntProviderIngredient.getItems should have changed after rerolling");
         helper.succeed();
     }
@@ -231,14 +236,20 @@ public class IntProviderIngredientTest {
 
         // serialize/deserialize before rolling count
         var jsonPreRoll = ingredient.toJson();
-        var ingredientDeserializedPreRoll = IntProviderIngredient.fromJson(jsonPreRoll);
+        var ingredientDeserializedPreRoll = (IntProviderIngredient) Ingredient.fromJson(jsonPreRoll);
+        helper.assertFalse(ingredientDeserializedPreRoll.isRolled(),
+                "IntProviderIngredient shouldn't be rolled if it wasn't rolled before serializing");
 
         var stacks = ingredient.getItems();
         var stacksDeserializedPreRoll = ingredientDeserializedPreRoll.getItems();
 
         // serialize/deserialize after rolling count
         var jsonPostRoll = ingredient.toJson();
-        var ingredientDeserializedPostRoll = IntProviderIngredient.fromJson(jsonPostRoll);
+        var ingredientDeserializedPostRoll = (IntProviderIngredient) Ingredient.fromJson(jsonPostRoll);
+        helper.assertTrue(ingredientDeserializedPostRoll.getSampledCount() == ingredient.getSampledCount(),
+                "IntProviderIngredient should keep its roll if it was rolled before serializing, got [" +
+                        ingredientDeserializedPostRoll.getSampledCount() + "] not [" + ingredient.getSampledCount() +
+                        "]");
         var stacksDeserializedPostRoll = ingredientDeserializedPostRoll.getItems();
 
         helper.assertTrue(
@@ -248,8 +259,9 @@ public class IntProviderIngredientTest {
                 "IntProviderIngredient should have item equal to what it was made with after serializing");
         helper.assertTrue(stacksDeserializedPostRoll[0].is(new ItemStack(Items.BRICK, 1).getItem()),
                 "IntProviderIngredient should have item equal to what it was made with after serializing");
-        helper.assertFalse(TestUtils.areItemStacksEqual(stacksDeserializedPreRoll, ingredient.getItems()),
-                "IntProviderIngredient.getItems should be different if it wasn't rolled before serializing");
+        helper.assertTrue(TestUtils.isItemWithinRange(stacksDeserializedPreRoll[0], 1, 5000),
+                "IntProviderIngredient.getItems should roll within its own range if it wasn't rolled before " +
+                        "serializing, rolled [" + stacksDeserializedPreRoll[0].getCount() + "] not [1-5000]");
         helper.assertTrue(TestUtils.areItemStacksEqual(stacksDeserializedPostRoll, ingredient.getItems()),
                 "IntProviderIngredient.getItems shouldn't change between getItems calls if it was rolled before serializing");
         helper.succeed();


### PR DESCRIPTION
## What
Fix the test failure on #5262

### AI Usage 
Yes AI, opus 4.8 triaged and wrote the fix. I looked over it but would like review from lilith because she wrote the tests and better understands them

AI sloppa notes:
```
 The CI log (gh api .../jobs/93130039092/logs) shows the exact assertion:

  ranged_ingredient_json_test failed! IntProviderIngredient.getItems should be different if it wasn't rolled before serializing


  var ingredient = IntProviderIngredient.of(new ItemStack(Items.BRICK, 1), UniformInt.of(1, 5000));
  var pre = IntProviderIngredient.fromJson(ingredient.toJson());   // sampledCount == -1, unrolled                                                                                                                                                                                                                  
  ... ingredient.getItems();   // rolls R1                                                                                                                                                                                                                                                                          
  ... pre.getItems();          // rolls R2, fully independent                                                                                                                                                                                                                                                       
  assertFalse(R1 == R2);       // fails whenever the two rolls collide                                                                                                                                                                                                                                              

  The intent was "the roll wasn't carried over through serialization", but it was written as "the two numbers differ" — which luck is allowed to violate, at 1/5000 per run.

  I measured it rather than assuming: a temporary stress gametest doing 200,000 round-trips reported

  STRESSTEST collisions=40 / trials=200000 (expected ~40.0), bucket min=20 max=65 empty=0

  Exactly 1/5000, uniform distribution, no empty buckets — the RNG is fine, the test is not.

  Fix

  Rewrote the luck-based assertions as deterministic state checks, in both the item and fluid tests (the fluid one had the identical flaw at 1/500000, plus both *GetStacksTests had it at 1/5000 via reset()):

  - pre-roll: assertFalse(deserialized.isRolled()) — the precise, deterministic statement of "nothing was carried over".
  - post-roll: assertTrue(deserialized.getSampledCount() == ingredient.getSampledCount()) — new coverage; the old test only checked this indirectly.
  - after reset(): assertFalse(isRolled()), then setSampledCount(x) with an x that can't match the previous roll, so a stale cached itemStacks/fluidStacks array is still caught — that was the real behavior the old assertion protected.
  - Replaced the "must differ" checks with in-range checks on the fresh roll.

  One thing found along the way: IntProviderIngredient.fromJson takes a JsonObject, so passing the JsonElement from toJson() was silently resolving to the inherited Ingredient.fromJson and typing the variable as plain Ingredient. Behavior is unchanged (it dispatches back through the registered serializer), 
  but it now needs an explicit cast, which I added with a comment.

```


## Outcome
ranged ingredient tests no longer have a 1/5k to fail

