### PR TITLE
Add default panel to kjs simple machine builer

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/kjs/builders/machine/KJSTieredMachineBuilder.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.registry.registrate.BuilderBase;
 import com.gregtechceu.gtceu.api.registry.registrate.GTRegistrate;
 import com.gregtechceu.gtceu.api.registry.registrate.MachineBuilder;
 import com.gregtechceu.gtceu.common.data.machines.GTMachineUtils;
+import com.gregtechceu.gtceu.common.mui.GTSingleblockMachinePanels;
 
 import net.minecraft.resources.ResourceLocation;
 
@@ -110,6 +111,9 @@ public class KJSTieredMachineBuilder extends BuilderBase<MachineDefinition[]> {
                             GTMachineUtils.workableTiered(tier, GTValues.V[tier], GTValues.V[tier] * 64, recipeType,
                                     tankScalingFunction.applyAsInt(tier), !isGenerator));
                 }
+            }
+            if (builder.ui() == null) {
+                builder.ui(GTSingleblockMachinePanels.GENERAL_MACHINE);
             }
 
             this.builders[tier] = builder;


### PR DESCRIPTION
This used to not have a UI, now it does:
```
GTCEuStartupEvents.registry("gtceu:machine", event => {
    event.create("atomic_reconstructor", "simple")
        .tiers(GTValues.LV, GTValues.MV, GTValues.HV, GTValues.EV, GTValues.IV, GTValues.LuV, GTValues.ZPM, GTValues.UV, GTValues.UHV, GTValues.UEV)
        .definition((tier, builder) =>
            builder
                .langValue(`${GTValues.VLVH[tier]} Atomic Reconstructor`)
                .recipeType("atomic_reconstruction")
                .workableTieredHullModel("gtceu:block/machines/reconstructor")
        )
})
```


this is because we assign the default UI (if none exist) inside SImpleMachineBuilder.register() in GTMachineUtils and the kjs builder doesn't go through that

no AI