### PR TITLE
add constructors with custom `RecipeLogic`s to multiblock classes

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/CoilWorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/CoilWorkableElectricMultiblockMachine.java
@@ -32,6 +32,10 @@ public class CoilWorkableElectricMultiblockMachine extends WorkableElectricMulti
     @Getter
     private int coilTier = 1;
 
+    public CoilWorkableElectricMultiblockMachine(BlockEntityCreationInfo info, RecipeLogic recipeLogic) {
+        super(info, recipeLogic);
+    }
+
     public CoilWorkableElectricMultiblockMachine(BlockEntityCreationInfo info) {
         super(info);
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/CoilWorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/CoilWorkableElectricMultiblockMachine.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.machine.multiblock;
 import com.gregtechceu.gtceu.api.GTCEuAPI;
 import com.gregtechceu.gtceu.api.block.ICoilType;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.multiblock.error.CoilMatchingError;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.common.block.CoilBlock;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/TieredWorkableElectricMultiblockMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/TieredWorkableElectricMultiblockMachine.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.blockentity.BlockEntityCreationInfo;
 import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -21,6 +22,11 @@ public class TieredWorkableElectricMultiblockMachine extends WorkableElectricMul
     @SaveField
     @Getter
     protected int overclockTier;
+
+    public TieredWorkableElectricMultiblockMachine(BlockEntityCreationInfo info, RecipeLogic recipeLogic, int tier) {
+        super(info, recipeLogic);
+        this.tier = tier;
+    }
 
     public TieredWorkableElectricMultiblockMachine(BlockEntityCreationInfo info, int tier) {
         super(info);


### PR DESCRIPTION
## What
Currently, `CoilWorkableElectricMultiblockMachine` and `TieredWorkableElectricMultiblockMachine` don't have a convenient way to set `recipeLogic` to anything besides the default one. This appears to be unintended, since the other classes add such constructors.

## Implementation Details
This PR adds an extra constructor to both `CoilWorkableElectricMultiblockMachine` and `TieredWorkableElectricMultiblockMachine`. That's it.

### AI Usage

- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
This will allow multiblocks inheriting from `CoilWorkableElectricMultiblockMachine` or `TieredWorkableElectricMultiblockMachine` to use their own recipe logic.

## How Was This Tested
I ran a spotless check (it passed) and a gametest to ensure the code was functional. It also matches the rest of the API, and frankly, I only added, like, nine lines total. It's not a substantial change.

## Potential Compatibility Issues
As far as I can see, this shouldn't affect existing code.