### PR TITLE
Fix duplicate recipe lookup paths

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeDB.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/lookup/RecipeDB.java
@@ -18,6 +18,7 @@ import com.gregtechceu.gtceu.config.ConfigHolder;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import com.mojang.datafixers.util.Either;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.jetbrains.annotations.*;
 
@@ -146,7 +147,23 @@ public final class RecipeDB {
         if (list.isEmpty()) {
             return null;
         }
-        return list;
+
+        List<AbstractMapIngredient> uniqueIngredients = new ArrayList<>();
+        var ingredientHashes = new IntOpenHashSet();
+        Set<AbstractMapIngredient> specialIngredients = new LinkedHashSet<>();
+        for (List<AbstractMapIngredient> ingredientGroup : list) {
+            for (AbstractMapIngredient ingredient : ingredientGroup) {
+                if (ingredient.isSpecialIngredient()) {
+                    if (specialIngredients.add(ingredient)) {
+                        uniqueIngredients.add(ingredient);
+                    }
+                } else if (ingredientHashes.add(ingredient.hashCode())) {
+                    uniqueIngredients.add(ingredient);
+                }
+            }
+        }
+
+        return List.of(uniqueIngredients);
     }
 
     /**

--- a/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/api/recipe/lookup/GTRecipeLookupTest.java
@@ -1,7 +1,9 @@
 package com.gregtechceu.gtceu.api.recipe.lookup;
 
 import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeHandlerList;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.ingredient.SizedIngredient;
@@ -10,6 +12,7 @@ import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.fluid.FluidStackMapIng
 import com.gregtechceu.gtceu.api.recipe.lookup.ingredient.item.ItemStackMapIngredient;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.gametest.util.TestUtils;
+import com.gregtechceu.gtceu.utils.DummyRecipeUtils;
 
 import net.minecraft.gametest.framework.BeforeBatch;
 import net.minecraft.gametest.framework.GameTest;
@@ -22,6 +25,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.gametest.GameTestHolder;
 import net.minecraftforge.gametest.PrefixGameTestTemplate;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -142,6 +146,21 @@ public class GTRecipeLookupTest {
         GTRecipe resultRecipe = DB.find(ingredients, ALWAYS_TRUE);
         helper.assertTrue(SMELT_STONE.equals(resultRecipe),
                 "GT Recipe should be smelt_stone, instead was " + resultRecipe);
+        helper.succeed();
+    }
+
+    @GameTest(template = "empty", batch = "GTRecipeLookup")
+    public static void recipeLookupDuplicatePathsTest(GameTestHelper helper) {
+        var itemHandler = new DummyRecipeUtils.DummyItemHandler(IO.IN, 1);
+        itemHandler.getStorage().setStackInSlot(0, new ItemStack(Items.COBBLESTONE));
+        var holder = new DummyRecipeUtils.DummyRecipeCapabilityHolder(
+                RecipeHandlerList.of(IO.IN, itemHandler, itemHandler));
+        var recipes = new ArrayList<GTRecipe>();
+        var iterator = DB.iterator(holder, ALWAYS_TRUE);
+        helper.assertTrue(iterator != null, "Recipe iterator should not be null");
+        iterator.forEachRemaining(recipes::add);
+        helper.assertTrue(recipes.equals(List.of(SMELT_STONE)),
+                "Duplicate handlers should return smelt_stone once, instead returned " + recipes);
         helper.succeed();
     }
 


### PR DESCRIPTION
## Summary

- deduplicate recipe lookup ingredients before building the iterator search space
- use `IntOpenHashSet` for non-special ingredient hashes to avoid boxing
- add a GameTest covering duplicate handlers returning the same recipe only once

## Why

`RecipeDB.fromHolder` retained duplicate ingredients while `RecipeIterator` explored every retained entry at each tree level. Repeated inputs could therefore multiply the number of lookup paths and stall a server.

This follows the small fix proposed in #5251, incorporates the `IntOpenHashSet` review improvement, and adds regression coverage.

## Validation

- `./gradlew spotlessApply`
- `./gradlew compileTestJava`
