### PR TITLE
bugfix: corrected a typo in the ru word tooltip_energy_cracking

### DIFF
--- a/src/main/resources/assets/gtceu/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceu/lang/ru_ru.json
@@ -1630,7 +1630,7 @@
     "block.gtceu.white_metal_sheet": "Белый лист металла",
     "block.gtceu.white_studs": "Белая перегородка",
     "block.gtceu.wire_coil.tooltip_cracking": "§8Крекинг:",
-    "block.gtceu.wire_coil.tooltip_energy_cracking": "  §§aЭнергопотребление: §f%s%%",
+    "block.gtceu.wire_coil.tooltip_energy_cracking": "  §aЭнергопотребление: §f%s%%",
     "block.gtceu.wire_coil.tooltip_energy_smelter": "  §aЭнергопотребление: §f%s EU/т",
     "block.gtceu.wire_coil.tooltip_extended_info": "§7Зажмите SHIFT для просмотра Бонуса Катушек",
     "block.gtceu.wire_coil.tooltip_heat": "§cТеплоемкость: §f%d K",


### PR DESCRIPTION
## What
Fixed the color display for the `tooltip_energy_cracking` string in `ru_ru.json`.
<img width="498" height="322" alt="image" src="https://github.com/user-attachments/assets/c7ee3b53-fc9a-44e4-a254-82389206c7e6" />
