### PR TITLE
Improve Pattern Errors

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/MultiPredicate.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/MultiPredicate.java
@@ -90,7 +90,7 @@ public abstract class MultiPredicate {
         ctx.setStage(PredicateContext.PredicateStage.GLOBAL_MIN);
         if (testGlobalMin(ctx)) return true;
         for (Component content : getDescriptiveContents()) {
-            ctx.appendError(PatternStringError.component(content));
+            ctx.appendError(PatternStringError.of(content));
         }
         return false;
     }
@@ -103,7 +103,7 @@ public abstract class MultiPredicate {
         ctx.setStage(PredicateContext.PredicateStage.SLICE_MIN);
         if (testSliceMin(ctx)) return true;
         for (Component content : getDescriptiveContents()) {
-            ctx.appendError(PatternStringError.component(content));
+            ctx.appendError(PatternStringError.of(content));
         }
         return false;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/Predicates.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/Predicates.java
@@ -22,7 +22,6 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.common.data.GTMaterialBlocks;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
@@ -48,7 +47,7 @@ public class Predicates {
      * Return this for your pattern errors if you want them to be a default error with the pos of the BlockWorldState
      * and candidates of the simple predicate's error.
      */
-    public static final PlaceholderError PLACEHOLDER = new PlaceholderError(BlockPos.ZERO, Collections.emptyList());
+    public static final PlaceholderError PLACEHOLDER = PlaceholderError.instance();
 
     public static MultiPredicate controller(MultiblockMachineDefinition def) {
         return blocks(def.getBlock()).setController(true);

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/BlockMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/BlockMatchingError.java
@@ -13,15 +13,13 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 public class BlockMatchingError extends PatternError {
 
     public static final Codec<BlockMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            Codec.list(BuiltInRegistries.BLOCK.byNameCodec()).fieldOf("blocks")
+            BuiltInRegistries.BLOCK.byNameCodec().listOf().fieldOf("blocks")
                     .forGetter(BlockMatchingError::getBlocks))
             .apply(instance, BlockMatchingError::new));
 
@@ -31,7 +29,7 @@ public class BlockMatchingError extends PatternError {
     private final List<Block> blocks;
 
     public BlockMatchingError(BlockPos pos, List<Block> blocks) {
-        super(pos, Collections.emptyList());
+        super(pos);
         this.blocks = blocks;
     }
 
@@ -42,7 +40,6 @@ public class BlockMatchingError extends PatternError {
             for (Block block : blocks) {
                 comps.add(block.getName());
             }
-            Objects.requireNonNull(pos);
             comps.add(Component.translatable("gtceu.pattern_predicate.blocks", pos.getX(), pos.getY(), pos.getZ()));
             comps.forEach(comp -> parent.child(Text.of(comp).asWidget()));
         };

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
@@ -9,32 +9,26 @@ import net.minecraft.network.chat.Component;
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import lombok.Getter;
 
-public class CoilMatchingError extends PatternError {
+public class CoilMatchingError extends MismatchError<ICoilType> {
 
     public static Codec<CoilMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            ICoilType.CODEC.fieldOf("coil_type_1").forGetter(CoilMatchingError::getCoilType1),
-            ICoilType.CODEC.fieldOf("coil_type_2").forGetter(CoilMatchingError::getCoilType2))
+            ICoilType.CODEC.fieldOf("coil_type_1").forGetter(CoilMatchingError::getActual),
+            ICoilType.CODEC.fieldOf("coil_type_2").forGetter(CoilMatchingError::getExpected))
             .apply(instance, CoilMatchingError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("coil_matching_error"), CODEC);
 
-    @Getter
-    ICoilType coilType1, coilType2;
-
-    public CoilMatchingError(BlockPos pos, ICoilType type1, ICoilType type2) {
-        super(pos);
-        coilType1 = type1;
-        coilType2 = type2;
+    public CoilMatchingError(BlockPos pos, ICoilType expected, ICoilType actual) {
+        super(pos, expected, actual);
     }
 
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {
         return (parent) -> {
             Component comp = Component.translatable("gtceu.pattern_error.mismatch_coils",
-                    coilType1.getMaterial().getName(), coilType2.getMaterial().getName(),
+                    getExpected().getMaterial().getName(), getActual().getMaterial().getName(),
                     pos.getX(), pos.getY(), pos.getZ());
             parent.child(Text.of(comp).asWidget());
         };

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
@@ -11,15 +11,12 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
-import java.util.Collections;
-import java.util.Objects;
-
 public class CoilMatchingError extends PatternError {
 
     public static Codec<CoilMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            ICoilType.CODEC.fieldOf("coilType1").forGetter(CoilMatchingError::getCoilType1),
-            ICoilType.CODEC.fieldOf("coilType2").forGetter(CoilMatchingError::getCoilType2))
+            ICoilType.CODEC.fieldOf("coil_type_1").forGetter(CoilMatchingError::getCoilType1),
+            ICoilType.CODEC.fieldOf("coil_type_2").forGetter(CoilMatchingError::getCoilType2))
             .apply(instance, CoilMatchingError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("coil_matching_error"), CODEC);
@@ -28,7 +25,7 @@ public class CoilMatchingError extends PatternError {
     ICoilType coilType1, coilType2;
 
     public CoilMatchingError(BlockPos pos, ICoilType type1, ICoilType type2) {
-        super(pos, Collections.emptyList());
+        super(pos);
         coilType1 = type1;
         coilType2 = type2;
     }
@@ -36,7 +33,6 @@ public class CoilMatchingError extends PatternError {
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {
         return (parent) -> {
-            Objects.requireNonNull(pos);
             Component comp = Component.translatable("gtceu.pattern_error.mismatch_coils",
                     coilType1.getMaterial().getName(), coilType2.getMaterial().getName(),
                     pos.getX(), pos.getY(), pos.getZ());

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
@@ -8,15 +8,10 @@ import net.minecraft.network.chat.Component;
 
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 public class CoilMatchingError extends MismatchError<ICoilType> {
 
-    public static Codec<CoilMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            ICoilType.CODEC.fieldOf("coil_type_1").forGetter(CoilMatchingError::getActual),
-            ICoilType.CODEC.fieldOf("coil_type_2").forGetter(CoilMatchingError::getExpected))
-            .apply(instance, CoilMatchingError::new));
+    public static Codec<CoilMatchingError> CODEC = makeCodec(ICoilType.CODEC, CoilMatchingError::new);
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("coil_matching_error"), CODEC);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
@@ -15,15 +15,11 @@ public class CoilMatchingError extends MismatchError<ICoilType> {
 
     public CoilMatchingError(BlockPos pos, ICoilType expected, ICoilType actual) {
         super(pos, expected, actual);
+        valueToString(coil -> coil.getMaterial().getName());
     }
 
     @Override
-    protected String stringify(ICoilType value) {
-        return value.getMaterial().getName();
-    }
-
-    @Override
-    protected String lang() {
+    protected String langKey() {
         return "gtceu.pattern_error.mismatch_coils";
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
@@ -11,7 +11,7 @@ import com.mojang.serialization.Codec;
 
 public class CoilMatchingError extends MismatchError<ICoilType> {
 
-    public static Codec<CoilMatchingError> CODEC = makeCodec(ICoilType.CODEC, CoilMatchingError::new);
+    public static final Codec<CoilMatchingError> CODEC = makeCodec(ICoilType.CODEC, CoilMatchingError::new);
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("coil_matching_error"), CODEC);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/CoilMatchingError.java
@@ -4,9 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.block.ICoilType;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
 
-import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 
 public class CoilMatchingError extends MismatchError<ICoilType> {
@@ -20,13 +18,13 @@ public class CoilMatchingError extends MismatchError<ICoilType> {
     }
 
     @Override
-    public PatternErrorUI getPatternErrorUIModifier() {
-        return (parent) -> {
-            Component comp = Component.translatable("gtceu.pattern_error.mismatch_coils",
-                    getExpected().getMaterial().getName(), getActual().getMaterial().getName(),
-                    pos.getX(), pos.getY(), pos.getZ());
-            parent.child(Text.of(comp).asWidget());
-        };
+    protected String stringify(ICoilType value) {
+        return value.getMaterial().getName();
+    }
+
+    @Override
+    protected String lang() {
+        return "gtceu.pattern_error.mismatch_coils";
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
@@ -9,32 +9,26 @@ import net.minecraft.network.chat.Component;
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import lombok.Getter;
 
-public class FilterMatchingError extends PatternError {
+public class FilterMatchingError extends MismatchError<CleanroomType> {
 
     public static Codec<FilterMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            CleanroomType.CODEC.fieldOf("filter_type_1").forGetter(FilterMatchingError::getFilterType1),
-            CleanroomType.CODEC.fieldOf("filter_type_2").forGetter(FilterMatchingError::getFilterType2))
+            CleanroomType.CODEC.fieldOf("filter_type_1").forGetter(FilterMatchingError::getExpected),
+            CleanroomType.CODEC.fieldOf("filter_type_2").forGetter(FilterMatchingError::getActual))
             .apply(instance, FilterMatchingError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("filter_matching_error"), CODEC);
 
-    @Getter
-    CleanroomType filterType1, filterType2;
-
-    public FilterMatchingError(BlockPos pos, CleanroomType type1, CleanroomType type2) {
-        super(pos);
-        this.filterType1 = type1;
-        this.filterType2 = type2;
+    public FilterMatchingError(BlockPos pos, CleanroomType expected, CleanroomType actual) {
+        super(pos, expected, actual);
     }
 
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {
         return (parent) -> {
             Component comp = Component.translatable("gtceu.pattern_error.mismatch_filters",
-                    filterType1.getName(), filterType2.getName(),
+                    getExpected().getName(), getActual().getName(),
                     pos.getX(), pos.getY(), pos.getZ());
             parent.child(Text.of(comp).asWidget());
         };

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
@@ -8,15 +8,10 @@ import net.minecraft.network.chat.Component;
 
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 public class FilterMatchingError extends MismatchError<CleanroomType> {
 
-    public static Codec<FilterMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            CleanroomType.CODEC.fieldOf("filter_type_1").forGetter(FilterMatchingError::getExpected),
-            CleanroomType.CODEC.fieldOf("filter_type_2").forGetter(FilterMatchingError::getActual))
-            .apply(instance, FilterMatchingError::new));
+    public static Codec<FilterMatchingError> CODEC = makeCodec(CleanroomType.CODEC, FilterMatchingError::new);
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("filter_matching_error"), CODEC);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
@@ -15,15 +15,11 @@ public class FilterMatchingError extends MismatchError<CleanroomType> {
 
     public FilterMatchingError(BlockPos pos, CleanroomType expected, CleanroomType actual) {
         super(pos, expected, actual);
+        valueToString(CleanroomType::getName);
     }
 
     @Override
-    protected String stringify(CleanroomType value) {
-        return value.getName();
-    }
-
-    @Override
-    protected String lang() {
+    protected String langKey() {
         return "gtceu.pattern_error.mismatch_filters";
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
@@ -4,9 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.machine.multiblock.CleanroomType;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
 
-import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 
 public class FilterMatchingError extends MismatchError<CleanroomType> {
@@ -20,13 +18,13 @@ public class FilterMatchingError extends MismatchError<CleanroomType> {
     }
 
     @Override
-    public PatternErrorUI getPatternErrorUIModifier() {
-        return (parent) -> {
-            Component comp = Component.translatable("gtceu.pattern_error.mismatch_filters",
-                    getExpected().getName(), getActual().getName(),
-                    pos.getX(), pos.getY(), pos.getZ());
-            parent.child(Text.of(comp).asWidget());
-        };
+    protected String stringify(CleanroomType value) {
+        return value.getName();
+    }
+
+    @Override
+    protected String lang() {
+        return "gtceu.pattern_error.mismatch_filters";
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
@@ -11,15 +11,12 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
-import java.util.Collections;
-import java.util.Objects;
-
 public class FilterMatchingError extends PatternError {
 
     public static Codec<FilterMatchingError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            CleanroomType.CODEC.fieldOf("coilType1").forGetter(FilterMatchingError::getFilterType1),
-            CleanroomType.CODEC.fieldOf("coilType2").forGetter(FilterMatchingError::getFilterType2))
+            CleanroomType.CODEC.fieldOf("filter_type_1").forGetter(FilterMatchingError::getFilterType1),
+            CleanroomType.CODEC.fieldOf("filter_type_2").forGetter(FilterMatchingError::getFilterType2))
             .apply(instance, FilterMatchingError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("filter_matching_error"), CODEC);
@@ -28,7 +25,7 @@ public class FilterMatchingError extends PatternError {
     CleanroomType filterType1, filterType2;
 
     public FilterMatchingError(BlockPos pos, CleanroomType type1, CleanroomType type2) {
-        super(pos, Collections.emptyList());
+        super(pos);
         this.filterType1 = type1;
         this.filterType2 = type2;
     }
@@ -36,7 +33,6 @@ public class FilterMatchingError extends PatternError {
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {
         return (parent) -> {
-            Objects.requireNonNull(pos);
             Component comp = Component.translatable("gtceu.pattern_error.mismatch_filters",
                     filterType1.getName(), filterType2.getName(),
                     pos.getX(), pos.getY(), pos.getZ());

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/FilterMatchingError.java
@@ -11,7 +11,7 @@ import com.mojang.serialization.Codec;
 
 public class FilterMatchingError extends MismatchError<CleanroomType> {
 
-    public static Codec<FilterMatchingError> CODEC = makeCodec(CleanroomType.CODEC, FilterMatchingError::new);
+    public static final Codec<FilterMatchingError> CODEC = makeCodec(CleanroomType.CODEC, FilterMatchingError::new);
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("filter_matching_error"), CODEC);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
@@ -1,0 +1,19 @@
+package com.gregtechceu.gtceu.api.multiblock.error;
+
+import net.minecraft.core.BlockPos;
+
+import lombok.Getter;
+
+public abstract class MismatchError<T> extends PatternError {
+
+    @Getter
+    private final T expected;
+    @Getter
+    private final T actual;
+
+    public MismatchError(BlockPos pos, T expected, T actual) {
+        super(pos);
+        this.expected = expected;
+        this.actual = actual;
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
@@ -1,7 +1,9 @@
 package com.gregtechceu.gtceu.api.multiblock.error;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 
+import brachy.modularui.api.drawable.Text;
 import com.mojang.datafixers.util.Function3;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -18,6 +20,20 @@ public abstract class MismatchError<T> extends PatternError {
         super(pos);
         this.expected = expected;
         this.actual = actual;
+    }
+
+    protected abstract String stringify(T value);
+
+    protected abstract String lang();
+
+    @Override
+    public PatternErrorUI getPatternErrorUIModifier() {
+        return parent -> {
+            Component comp = Component.translatable(lang(),
+                    stringify(getExpected()), stringify(getActual()),
+                    pos.getX(), pos.getY(), pos.getZ());
+            parent.child(Text.of(comp).asWidget());
+        };
     }
 
     protected static <T, R extends MismatchError<T>> Codec<R> makeCodec(Codec<T> typeCodec,

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
@@ -2,6 +2,9 @@ package com.gregtechceu.gtceu.api.multiblock.error;
 
 import net.minecraft.core.BlockPos;
 
+import com.mojang.datafixers.util.Function3;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
 public abstract class MismatchError<T> extends PatternError {
@@ -15,5 +18,13 @@ public abstract class MismatchError<T> extends PatternError {
         super(pos);
         this.expected = expected;
         this.actual = actual;
+    }
+
+    protected static <T, R extends MismatchError<T>> Codec<R> makeCodec(Codec<T> typeCodec,
+                                                                        Function3<BlockPos, T, T, R> function3) {
+        return RecordCodecBuilder.create(instance -> instance.group(
+                BlockPos.CODEC.fieldOf("pos").forGetter(MismatchError::getPos),
+                typeCodec.fieldOf("expected").forGetter(MismatchError::getExpected),
+                typeCodec.fieldOf("actual").forGetter(MismatchError::getActual)).apply(instance, function3));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
@@ -21,10 +21,10 @@ public abstract class MismatchError<T> extends PatternError {
     }
 
     protected static <T, R extends MismatchError<T>> Codec<R> makeCodec(Codec<T> typeCodec,
-                                                                        Function3<BlockPos, T, T, R> function3) {
+                                                                        Function3<BlockPos, T, T, R> constructor) {
         return RecordCodecBuilder.create(instance -> instance.group(
                 BlockPos.CODEC.fieldOf("pos").forGetter(MismatchError::getPos),
                 typeCodec.fieldOf("expected").forGetter(MismatchError::getExpected),
-                typeCodec.fieldOf("actual").forGetter(MismatchError::getActual)).apply(instance, function3));
+                typeCodec.fieldOf("actual").forGetter(MismatchError::getActual)).apply(instance, constructor));
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/MismatchError.java
@@ -9,12 +9,15 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
+import java.util.function.Function;
+
 public abstract class MismatchError<T> extends PatternError {
 
     @Getter
     private final T expected;
     @Getter
     private final T actual;
+    private Function<T, String> stringify = Object::toString;
 
     public MismatchError(BlockPos pos, T expected, T actual) {
         super(pos);
@@ -22,18 +25,26 @@ public abstract class MismatchError<T> extends PatternError {
         this.actual = actual;
     }
 
-    protected abstract String stringify(T value);
+    protected void valueToString(Function<T, String> stringify) {
+        this.stringify = stringify;
+    }
 
-    protected abstract String lang();
+    /// @return the lang key string used in {@link #lang()}
+    protected abstract String langKey();
+
+    /// See {@link #valueToString(Function)} to customize how the values are stringified
+    /// @return a translatable component with
+    /// stringified expected and actual values at a given BlockPos
+    public Component lang() {
+        return Component.translatable(langKey(),
+                stringify.apply(expected),
+                stringify.apply(actual),
+                pos.getX(), pos.getY(), pos.getZ());
+    }
 
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {
-        return parent -> {
-            Component comp = Component.translatable(lang(),
-                    stringify(getExpected()), stringify(getActual()),
-                    pos.getX(), pos.getY(), pos.getZ());
-            parent.child(Text.of(comp).asWidget());
-        };
+        return parent -> parent.child(Text.of(lang()).asWidget());
     }
 
     protected static <T, R extends MismatchError<T>> Codec<R> makeCodec(Codec<T> typeCodec,

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PartAbilityError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PartAbilityError.java
@@ -16,14 +16,13 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
 import java.util.Collection;
-import java.util.Collections;
 
 public class PartAbilityError extends PatternError {
 
     public static Codec<PartAbilityError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
             Codec.STRING.fieldOf("name").forGetter(PartAbilityError::getPartAbilityName))
-            .apply(instance, (a, b) -> new PartAbilityError(a, PartAbility.VALUES.get(b))));
+            .apply(instance, PartAbilityError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("part_ability_error"), CODEC);
 
@@ -31,8 +30,12 @@ public class PartAbilityError extends PatternError {
     private final String partAbilityName;
 
     public PartAbilityError(BlockPos pos, PartAbility partAbility) {
-        super(pos, Collections.emptyList());
-        partAbilityName = partAbility.getName();
+        this(pos, partAbility.getName());
+    }
+
+    private PartAbilityError(BlockPos pos, String partAbilityName) {
+        super(pos);
+        this.partAbilityName = partAbilityName;
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PartAbilityError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PartAbilityError.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class PartAbilityError extends PatternError {
 
-    public static Codec<PartAbilityError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<PartAbilityError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
             Codec.STRING.fieldOf("name").forGetter(PartAbilityError::getPartAbilityName))
             .apply(instance, PartAbilityError::new));

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternError.java
@@ -1,8 +1,5 @@
 package com.gregtechceu.gtceu.api.multiblock.error;
 
-import com.gregtechceu.gtceu.api.multiblock.MultiPredicate;
-import com.gregtechceu.gtceu.api.multiblock.predicates.BasePredicate;
-import com.gregtechceu.gtceu.api.multiblock.util.BlockInfo;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
 
 import net.minecraft.core.BlockPos;
@@ -10,10 +7,6 @@ import net.minecraft.resources.ResourceLocation;
 
 import com.mojang.serialization.Codec;
 import lombok.Getter;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.Collections;
-import java.util.List;
 
 public abstract class PatternError {
 
@@ -21,21 +14,10 @@ public abstract class PatternError {
             .dispatch(PatternError::type, PatternErrorType::codec);
 
     @Getter
-    protected @Nullable BlockPos pos;
-    @Getter
-    protected List<List<BlockInfo>> candidates;
+    protected BlockPos pos;
 
-    public PatternError(@Nullable BlockPos pos, List<List<BlockInfo>> candidates) {
+    public PatternError(BlockPos pos) {
         this.pos = pos;
-        this.candidates = candidates;
-    }
-
-    public PatternError(@Nullable BlockPos pos, MultiPredicate predicate) {
-        this(pos, predicate.getCandidates());
-    }
-
-    public PatternError(@Nullable BlockPos pos, BasePredicate failingPredicate) {
-        this(pos, Collections.singletonList(failingPredicate.getCandidates()));
     }
 
     public abstract PatternErrorType type();

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternError.java
@@ -20,6 +20,10 @@ public abstract class PatternError {
         this.pos = pos;
     }
 
+    protected PatternError() {
+        this.pos = BlockPos.ZERO;
+    }
+
     public abstract PatternErrorType type();
 
     public abstract PatternErrorUI getPatternErrorUIModifier();

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 
 public class PatternStringError extends PatternError {
 
-    public static Codec<PatternStringError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<PatternStringError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             ExtraCodecs.COMPONENT.fieldOf("component").forGetter(PatternStringError::getComponent))
             .apply(instance, PatternStringError::new));
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.multiblock.error;
 
 import com.gregtechceu.gtceu.GTCEu;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.ExtraCodecs;
 
@@ -9,8 +10,6 @@ import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
-
-import java.util.Collections;
 
 public class PatternStringError extends PatternError {
 
@@ -24,11 +23,11 @@ public class PatternStringError extends PatternError {
     public final Component component;
 
     public PatternStringError(Component component) {
-        super(null, Collections.emptyList());
+        super(BlockPos.ZERO);
         this.component = component;
     }
 
-    public static PatternStringError component(Component component) {
+    public static PatternStringError of(Component component) {
         return new PatternStringError(component);
     }
 
@@ -50,9 +49,7 @@ public class PatternStringError extends PatternError {
 
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {
-        return (parent) -> {
-            parent.child(Text.of(component).asWidget());
-        };
+        return (parent) -> parent.child(Text.of(component).asWidget());
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
@@ -37,12 +37,12 @@ public class PatternStringError extends PatternError {
         return new PatternStringError(Component.literal(String.format(s, args)));
     }
 
-    public static PatternStringError translatable(String s) {
-        return new PatternStringError(Component.translatable(s));
+    public static PatternStringError translatable(String langKey) {
+        return new PatternStringError(Component.translatable(langKey));
     }
 
-    public static PatternStringError translatable(String s, Object... args) {
-        return new PatternStringError(Component.translatable(s, args));
+    public static PatternStringError translatable(String langKey, Object... args) {
+        return new PatternStringError(Component.translatable(langKey, args));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PatternStringError.java
@@ -2,7 +2,6 @@ package com.gregtechceu.gtceu.api.multiblock.error;
 
 import com.gregtechceu.gtceu.GTCEu;
 
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.ExtraCodecs;
 
@@ -23,7 +22,6 @@ public class PatternStringError extends PatternError {
     public final Component component;
 
     public PatternStringError(Component component) {
-        super(BlockPos.ZERO);
         this.component = component;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PlaceholderError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PlaceholderError.java
@@ -2,8 +2,6 @@ package com.gregtechceu.gtceu.api.multiblock.error;
 
 import com.gregtechceu.gtceu.GTCEu;
 
-import net.minecraft.core.BlockPos;
-
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 
@@ -19,9 +17,7 @@ public class PlaceholderError extends PatternError {
         return INSTANCE;
     }
 
-    private PlaceholderError() {
-        super(BlockPos.ZERO);
-    }
+    private PlaceholderError() {}
 
     @Override
     public PatternErrorUI getPatternErrorUIModifier() {

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PlaceholderError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PlaceholderError.java
@@ -7,7 +7,7 @@ import com.mojang.serialization.Codec;
 
 public class PlaceholderError extends PatternError {
 
-    public static Codec<PlaceholderError> CODEC = Codec.unit(PlaceholderError::instance);
+    public static final Codec<PlaceholderError> CODEC = Codec.unit(PlaceholderError::instance);
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("placeholder_error"), CODEC);
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PlaceholderError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/PlaceholderError.java
@@ -1,28 +1,26 @@
 package com.gregtechceu.gtceu.api.multiblock.error;
 
 import com.gregtechceu.gtceu.GTCEu;
-import com.gregtechceu.gtceu.api.multiblock.util.BlockInfo;
 
 import net.minecraft.core.BlockPos;
 
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 public class PlaceholderError extends PatternError {
 
-    public static Codec<PlaceholderError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            Codec.list(Codec.list(BlockInfo.CODEC)).fieldOf("candidates").forGetter(PatternError::getCandidates))
-            .apply(instance, PlaceholderError::new));
+    public static Codec<PlaceholderError> CODEC = Codec.unit(PlaceholderError::instance);
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("placeholder_error"), CODEC);
 
-    public PlaceholderError(@Nullable BlockPos pos, List<List<BlockInfo>> candidates) {
-        super(pos, candidates);
+    private static final PlaceholderError INSTANCE = new PlaceholderError();
+
+    public static PlaceholderError instance() {
+        return INSTANCE;
+    }
+
+    private PlaceholderError() {
+        super(BlockPos.ZERO);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SimplePatternError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SimplePatternError.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class SimplePatternError extends PatternError {
 
-    public static Codec<SimplePatternError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<SimplePatternError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
             BlockInfo.CODEC.listOf().listOf().fieldOf("candidates").forGetter(SimplePatternError::getCandidates))
             .apply(instance, SimplePatternError::new));

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SimplePatternError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SimplePatternError.java
@@ -9,6 +9,7 @@ import net.minecraft.network.chat.Component;
 import brachy.modularui.api.drawable.Text;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,13 +18,16 @@ public class SimplePatternError extends PatternError {
 
     public static Codec<SimplePatternError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             BlockPos.CODEC.fieldOf("pos").forGetter(PatternError::getPos),
-            Codec.list(Codec.list(BlockInfo.CODEC)).fieldOf("candidates").forGetter(PatternError::getCandidates))
+            BlockInfo.CODEC.listOf().listOf().fieldOf("candidates").forGetter(SimplePatternError::getCandidates))
             .apply(instance, SimplePatternError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("simple_pattern_error"), CODEC);
+    @Getter
+    private final List<List<BlockInfo>> candidates;
 
     public SimplePatternError(BlockPos pos, List<List<BlockInfo>> candidates) {
-        super(pos, candidates);
+        super(pos);
+        this.candidates = candidates;
     }
 
     @Override
@@ -31,11 +35,9 @@ public class SimplePatternError extends PatternError {
         return (parent) -> {
             List<Component> lines = new ArrayList<>();
 
-            if (pos != null) {
-                lines.add(Component.translatable("gtceu.multiblock.pattern.error.0"));
-                lines.add(Component.translatable("gtceu.multiblock.pattern.error.1", pos.getX(), pos.getY(),
-                        pos.getZ()));
-            }
+            lines.add(Component.translatable("gtceu.multiblock.pattern.error.0"));
+            lines.add(Component.translatable("gtceu.multiblock.pattern.error.1", pos.getX(), pos.getY(),
+                    pos.getZ()));
             for (List<BlockInfo> candidate : candidates) {
                 if (!candidate.isEmpty()) {
                     Component c = candidate.get(0).getItemStackForm().getHoverName();

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SinglePredicateError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SinglePredicateError.java
@@ -4,12 +4,12 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.multiblock.predicates.BasePredicate;
 import com.gregtechceu.gtceu.api.multiblock.util.BlockInfo;
 
-import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.StringRepresentable;
 
 import brachy.modularui.api.drawable.Text;
 import brachy.modularui.drawable.ItemDrawable;
+import brachy.modularui.widget.ParentWidget;
 import brachy.modularui.widgets.menu.ContextMenuButton;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -20,7 +20,7 @@ import java.util.List;
 public class SinglePredicateError extends PatternError {
 
     public static final Codec<SinglePredicateError> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-            SinglePredicateError.ErrorType.CODEC.fieldOf("error_type").forGetter(e -> e.type),
+            ErrorType.CODEC.fieldOf("error_type").forGetter(e -> e.type),
             Codec.INT.fieldOf("actual_count").forGetter(e -> e.actualCount),
             Codec.INT.fieldOf("pred_min_count").forGetter(e -> e.predMinCount),
             Codec.INT.fieldOf("pred_max_count").forGetter(e -> e.predMaxCount),
@@ -55,7 +55,6 @@ public class SinglePredicateError extends PatternError {
 
     public SinglePredicateError(ErrorType type, int actualCount, int minCount, int maxCount, int minLayerCount,
                                 int maxLayerCount, String name, List<BlockInfo> candidates) {
-        super(BlockPos.ZERO);
         this.type = type;
         this.actualCount = actualCount;
         this.candidates = candidates;
@@ -70,26 +69,7 @@ public class SinglePredicateError extends PatternError {
     public PatternErrorUI getPatternErrorUIModifier() {
         return (parent) -> {
             parent.child(Text.of(Component.translatable(debugName)).asWidget());
-            switch (type) {
-                case MAX_COUNT -> {
-                    parent.child(Text.of(Component.translatable("gtceu.multiblock.pattern.error.limited.max_count",
-                            predMaxCount, actualCount)).asWidget());
-                }
-                case MIN_COUNT -> {
-                    parent.child(Text.of(Component.translatable("gtceu.multiblock.pattern.error.limited.min_count",
-                            predMinCount, actualCount)).asWidget());
-                }
-                case MAX_LAYER_COUNT -> {
-                    parent.child(
-                            Text.of(Component.translatable("gtceu.multiblock.pattern.error.limited.max_layer_count",
-                                    predMaxLayerCount, actualCount)).asWidget());
-                }
-                case MIN_LAYER_COUNT -> {
-                    parent.child(
-                            Text.of(Component.translatable("gtceu.multiblock.pattern.error.limited.min_layer_count",
-                                    predMinLayerCount, actualCount)).asWidget());
-                }
-            }
+            this.type.appendComponent(parent, this);
             parent.child(new ContextMenuButton<>("predicate")
                     .menuList(l -> l
                             .maxSize(40)
@@ -135,6 +115,23 @@ public class SinglePredicateError extends PatternError {
         @Override
         public String getSerializedName() {
             return getName();
+        }
+
+        private void appendComponent(ParentWidget<?> parent, SinglePredicateError error) {
+            parent.child(Text.of(getComponent(error)).asWidget());
+        }
+
+        private Component getComponent(SinglePredicateError error) {
+            return switch (this) {
+                case MAX_COUNT -> Component.translatable("gtceu.multiblock.pattern.error.limited.max_count",
+                        error.predMaxCount, error.actualCount);
+                case MIN_COUNT -> Component.translatable("gtceu.multiblock.pattern.error.limited.min_count",
+                        error.predMinCount, error.actualCount);
+                case MAX_LAYER_COUNT -> Component.translatable("gtceu.multiblock.pattern.error.limited.max_layer_count",
+                        error.predMaxLayerCount, error.actualCount);
+                case MIN_LAYER_COUNT -> Component.translatable("gtceu.multiblock.pattern.error.limited.min_layer_count",
+                        error.predMinLayerCount, error.actualCount);
+            };
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SinglePredicateError.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/error/SinglePredicateError.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.multiblock.predicates.BasePredicate;
 import com.gregtechceu.gtceu.api.multiblock.util.BlockInfo;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.StringRepresentable;
 
@@ -14,7 +15,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.Getter;
 
-import java.util.Collections;
 import java.util.List;
 
 public class SinglePredicateError extends PatternError {
@@ -27,7 +27,7 @@ public class SinglePredicateError extends PatternError {
             Codec.INT.fieldOf("pred_min_layer_count").forGetter(e -> e.predMinLayerCount),
             Codec.INT.fieldOf("pred_max_layer_count").forGetter(e -> e.predMaxLayerCount),
             Codec.STRING.fieldOf("name").forGetter(e -> e.debugName),
-            Codec.list(BlockInfo.CODEC).fieldOf("candidates").forGetter(e -> e.candidates))
+            BlockInfo.CODEC.listOf().fieldOf("candidates").forGetter(e -> e.candidates))
             .apply(instance, SinglePredicateError::new));
 
     public static final PatternErrorType TYPE = new PatternErrorType(GTCEu.id("single_predicate_error"), CODEC);
@@ -55,7 +55,7 @@ public class SinglePredicateError extends PatternError {
 
     public SinglePredicateError(ErrorType type, int actualCount, int minCount, int maxCount, int minLayerCount,
                                 int maxLayerCount, String name, List<BlockInfo> candidates) {
-        super(null, Collections.singletonList(candidates));
+        super(BlockPos.ZERO);
         this.type = type;
         this.actualCount = actualCount;
         this.candidates = candidates;


### PR DESCRIPTION
## What
As I was working on #5131, I had some gripes with how PatternError was handled
Improves PatternError along with the extending classes.

## Implementation Details
PatternError constructors have been simplified to only a BlockPos or no-args. block pos is also nonnull
CoilMatchingError and FilterMatchingError extened a new class MismatchError along with codec helper method
renamed `component()` to `of()` in PatternStringError
PlaceholderError is now just a singleton
add constructor to PartAbilityError to simplify codec
make all codecs final

### AI Usage 
- [x] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.
  
## Outcome
better DX when extending PatternError

## How Was This Tested
ran client and looked at some errors, seems fine