### PR TITLE
Reworked optical computation transfer logic to correctly handle simulated case.

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/IOpticalComputationProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/IOpticalComputationProvider.java
@@ -2,8 +2,8 @@ package com.gregtechceu.gtceu.api.capability;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * MUST be implemented on any multiblock which uses
@@ -19,52 +19,50 @@ public interface IOpticalComputationProvider {
      * @return The amount of CWU/t that could be supplied.
      */
     default int requestCWUt(int cwut, boolean simulate) {
-        Collection<IOpticalComputationProvider> list = new ArrayList<>();
-        list.add(this);
-        return requestCWUt(cwut, simulate, list);
+        Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
+        return requestCWUt(cwut, simulate, seenWithContext);
     }
 
     /**
      * Request some amount of CWU/t (Compute Work Units per tick) from this Machine.
      * Implementors should expect these requests to occur each tick that computation is required.
      *
-     * @param cwut Maximum amount of CWU/t requested.
-     * @param seen The Optical Computation Providers already checked
+     * @param cwut            Maximum amount of CWU/t requested.
+     * @param seenWithContext The Optical Computation Providers already checked, with provider-specific context for
+     *                        simulation case
      * @return The amount of CWU/t that could be supplied.
      */
-    int requestCWUt(int cwut, boolean simulate, @NotNull Collection<IOpticalComputationProvider> seen);
+    int requestCWUt(int cwut, boolean simulate, @NotNull Map<IOpticalComputationProvider, Object> seenWithContext);
 
     /**
      * The maximum of CWU/t that this computation provider can provide.
      */
     default int getMaxCWUt() {
-        Collection<IOpticalComputationProvider> list = new ArrayList<>();
-        list.add(this);
-        return getMaxCWUt(list);
+        Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
+        return getMaxCWUt(seenWithContext);
     }
 
     /**
      * The maximum of CWU/t that this computation provider can provide.
      *
-     * @param seen The Optical Computation Providers already checked
+     * @param seenWithContext The Optical Computation Providers already checked
      */
-    int getMaxCWUt(@NotNull Collection<IOpticalComputationProvider> seen);
+    int getMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext);
 
     /**
      * Whether this Computation Provider can "Bridge" with other Computation Providers.
      * Checked by machines like the Network Switch.
      */
     default boolean canBridge() {
-        Collection<IOpticalComputationProvider> list = new ArrayList<>();
-        list.add(this);
-        return canBridge(list);
+        Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
+        return canBridge(seenWithContext);
     }
 
     /**
      * Whether this Computation Provider can "Bridge" with other Computation Providers.
      * Checked by machines like the Network Switch.
      *
-     * @param seen The Optical Computation Providers already checked
+     * @param seenWithContext The Optical Computation Providers already checked
      */
-    boolean canBridge(@NotNull Collection<IOpticalComputationProvider> seen);
+    boolean canBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/IOpticalComputationProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/IOpticalComputationProvider.java
@@ -3,7 +3,9 @@ package com.gregtechceu.gtceu.api.capability;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * MUST be implemented on any multiblock which uses
@@ -19,8 +21,22 @@ public interface IOpticalComputationProvider {
      * @return The amount of CWU/t that could be supplied.
      */
     default int requestCWUt(int cwut, boolean simulate) {
-        Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
-        return requestCWUt(cwut, simulate, seenWithContext);
+        Set<IOpticalComputationProvider> seen = new HashSet<>();
+        Map<IOpticalComputationProvider, Object> simulationState = new HashMap<>();
+        return requestCWUt(cwut, simulate, seen, simulationState);
+    }
+
+    /**
+     * Simulates a request of some amount of CWU/t (Compute Work Units per tick) from this Machine.
+     * Simulation state allows sharing the simulation across multiple requests.
+     *
+     * @param cwut            Maximum amount of CWU/t requested.
+     * @param simulationState simulation state to allow sharing simulation across multiple requests
+     * @return The amount of CWU/t that could be supplied.
+     */
+    default int requestCWUtSimulated(int cwut, Map<IOpticalComputationProvider, Object> simulationState) {
+        Set<IOpticalComputationProvider> seen = new HashSet<>();
+        return requestCWUt(cwut, true, seen, simulationState);
     }
 
     /**
@@ -28,41 +44,65 @@ public interface IOpticalComputationProvider {
      * Implementors should expect these requests to occur each tick that computation is required.
      *
      * @param cwut            Maximum amount of CWU/t requested.
-     * @param seenWithContext The Optical Computation Providers already checked, with provider-specific context for
-     *                        simulation case
+     * @param seen            The Optical Computation Providers already checked
+     * @param simulationState state of simulation for each provider
+     *
      * @return The amount of CWU/t that could be supplied.
      */
-    int requestCWUt(int cwut, boolean simulate, @NotNull Map<IOpticalComputationProvider, Object> seenWithContext);
+    int requestCWUt(int cwut, boolean simulate,
+                    @NotNull Set<IOpticalComputationProvider> seen,
+                    @NotNull Map<IOpticalComputationProvider, Object> simulationState);
 
     /**
      * The maximum of CWU/t that this computation provider can provide.
      */
     default int getMaxCWUt() {
-        Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
-        return getMaxCWUt(seenWithContext);
+        Set<IOpticalComputationProvider> seen = new HashSet<>();
+        Map<IOpticalComputationProvider, Object> simulationState = new HashMap<>();
+        return getMaxCWUt(seen, simulationState);
+    }
+
+    /**
+     * The maximum of CWU/t that this computation provider can provide.
+     */
+    default int getMaxCWUtInSimulation(Map<IOpticalComputationProvider, Object> simulationState) {
+        Set<IOpticalComputationProvider> seen = new HashSet<>();
+        return getMaxCWUt(seen, simulationState);
     }
 
     /**
      * The maximum of CWU/t that this computation provider can provide.
      *
-     * @param seenWithContext The Optical Computation Providers already checked
+     * @param seen The Optical Computation Providers already checked
      */
-    int getMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext);
+    int getMaxCWUt(@NotNull Set<IOpticalComputationProvider> seen,
+                   @NotNull Map<IOpticalComputationProvider, Object> simulationState);
 
     /**
      * Whether this Computation Provider can "Bridge" with other Computation Providers.
      * Checked by machines like the Network Switch.
      */
     default boolean canBridge() {
-        Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
-        return canBridge(seenWithContext);
+        Set<IOpticalComputationProvider> seen = new HashSet<>();
+        Map<IOpticalComputationProvider, Object> simulationState = new HashMap<>();
+        return canBridge(seen, simulationState);
+    }
+
+    /**
+     * Whether this Computation Provider can "Bridge" with other Computation Providers.
+     * Checked by machines like the Network Switch.
+     */
+    default boolean canBridgeInSimulation(Map<IOpticalComputationProvider, Object> simulationState) {
+        Set<IOpticalComputationProvider> seen = new HashSet<>();
+        return canBridge(seen, simulationState);
     }
 
     /**
      * Whether this Computation Provider can "Bridge" with other Computation Providers.
      * Checked by machines like the Network Switch.
      *
-     * @param seenWithContext The Optical Computation Providers already checked
+     * @param seen The Optical Computation Providers already checked
      */
-    boolean canBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext);
+    boolean canBridge(@NotNull Set<IOpticalComputationProvider> seen,
+                      @NotNull Map<IOpticalComputationProvider, Object> simulationState);
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableComputationContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableComputationContainer.java
@@ -18,13 +18,10 @@ import com.gregtechceu.gtceu.utils.GTUtil;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
-import com.google.common.base.Preconditions;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait<Integer>
                                             implements IOpticalComputationHatch, IOpticalComputationReceiver {
@@ -66,30 +63,35 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
     }
 
     @Override
-    public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
-        ComputationTransferContext localTransferContext = this.transferContext.conditionalTimedUpdate(getMachine());
+    public int requestCWUt(int cwut, boolean simulate, Set<IOpticalComputationProvider> seen,
+                           Map<IOpticalComputationProvider, Object> simulationState) {
+        ComputationTransferContext localTransferContext = (ComputationTransferContext) simulationState
+                .getOrDefault(this, this.transferContext);
+        localTransferContext = localTransferContext.conditionalTimedUpdate(getMachine());
         if (!simulate) {
             this.transferContext = localTransferContext;
+        } else {
+            simulationState.put(this, localTransferContext);
         }
 
-        seenWithContext.put(this, localTransferContext);
+        seen.add(this);
         if (handlerIO == IO.IN) {
             if (isTransmitter()) {
                 var machine = getMachine();
                 // Ask the Multiblock controller, which *should* be an IOpticalComputationProvider
                 if (machine instanceof IOpticalComputationProvider provider) {
-                    return provider.requestCWUt(cwut, simulate, seenWithContext);
+                    return provider.requestCWUt(cwut, simulate, seen, simulationState);
                 } else if (machine instanceof MultiblockPartMachine part) {
                     if (!part.isFormed()) {
                         return 0;
                     }
                     for (MultiblockControllerMachine controller : part.getControllers()) {
                         if (controller instanceof IOpticalComputationProvider provider) {
-                            return provider.requestCWUt(cwut, simulate, seenWithContext);
+                            return provider.requestCWUt(cwut, simulate, seen, simulationState);
                         }
                         for (MachineTrait trait : controller.getAllTraits()) {
                             if (trait instanceof IOpticalComputationProvider provider) {
-                                return provider.requestCWUt(cwut, simulate, seenWithContext);
+                                return provider.requestCWUt(cwut, simulate, seen, simulationState);
                             }
                         }
                     }
@@ -104,26 +106,30 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 // Ask the attached Transmitter hatch, if it exists
                 IOpticalComputationProvider provider = getOpticalNetProvider();
                 if (provider == null) return 0;
-                return provider.requestCWUt(cwut, simulate, seenWithContext);
+                return provider.requestCWUt(cwut, simulate, seen, simulationState);
             }
         } else {
             localTransferContext = localTransferContext.subtractLastOutput(cwut);
+            localTransferContext = localTransferContext.conditionalTimedUpdate(getMachine());
             if (!simulate) {
                 this.transferContext = localTransferContext;
+            } else {
+                simulationState.put(this, localTransferContext);
             }
             return Math.min(localTransferContext.lastOutputCwu(), cwut);
         }
     }
 
     @Override
-    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, this.transferContext);
+    public int getMaxCWUt(Set<IOpticalComputationProvider> seen,
+                          Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         if (handlerIO == IO.IN) {
             if (isTransmitter()) {
                 var machine = getMachine();
                 // Ask the Multiblock controller, which *should* be an IOpticalComputationProvider
                 if (machine instanceof IOpticalComputationProvider provider) {
-                    return provider.getMaxCWUt(seenWithContext);
+                    return provider.getMaxCWUt(seen, simulationState);
                 } else if (machine instanceof MultiblockPartMachine part) {
                     if (!part.isFormed()) {
                         return 0;
@@ -133,11 +139,11 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                             continue;
                         }
                         if (controller instanceof IOpticalComputationProvider provider) {
-                            return provider.getMaxCWUt(seenWithContext);
+                            return provider.getMaxCWUt(seen, simulationState);
                         }
                         for (MachineTrait trait : controller.getAllTraits()) {
                             if (trait instanceof IOpticalComputationProvider provider) {
-                                return provider.getMaxCWUt(seenWithContext);
+                                return provider.getMaxCWUt(seen, simulationState);
                             }
                         }
                     }
@@ -152,22 +158,25 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 // Ask the attached Transmitter hatch, if it exists
                 IOpticalComputationProvider provider = getOpticalNetProvider();
                 if (provider == null) return 0;
-                return provider.getMaxCWUt(seenWithContext);
+                return provider.getMaxCWUt(seen, simulationState);
             }
         } else {
-            return Preconditions.checkNotNull((ComputationTransferContext) seenWithContext.get(this)).lastOutputCwu();
+            ComputationTransferContext localTransferContext = (ComputationTransferContext) simulationState
+                    .getOrDefault(this, this.transferContext);
+            return localTransferContext.lastOutputCwu();
         }
     }
 
     @Override
-    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, this.transferContext);
+    public boolean canBridge(Set<IOpticalComputationProvider> seen,
+                             Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         if (handlerIO == IO.IN) {
             if (isTransmitter()) {
                 var machine = getMachine();
                 // Ask the Multiblock controller, which *should* be an IOpticalComputationProvider
                 if (machine instanceof IOpticalComputationProvider provider) {
-                    return provider.canBridge(seenWithContext);
+                    return provider.canBridge(seen, simulationState);
                 } else if (machine instanceof MultiblockPartMachine part) {
                     if (!part.isFormed()) {
                         return false;
@@ -177,11 +186,11 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                             continue;
                         }
                         if (controller instanceof IOpticalComputationProvider provider) {
-                            return provider.canBridge(seenWithContext);
+                            return provider.canBridge(seen, simulationState);
                         }
                         for (MachineTrait trait : controller.getAllTraits()) {
                             if (trait instanceof IOpticalComputationProvider provider) {
-                                return provider.canBridge(seenWithContext);
+                                return provider.canBridge(seen, simulationState);
                             }
                         }
                     }
@@ -196,7 +205,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 // Ask the attached Transmitter hatch, if it exists
                 IOpticalComputationProvider provider = getOpticalNetProvider();
                 if (provider == null) return true; // nothing found, so don't report a problem, just pass quietly
-                return provider.canBridge(seenWithContext);
+                return provider.canBridge(seen, simulationState);
             }
         } else {
             return false;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableComputationContainer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableComputationContainer.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.capability.IOpticalComputationHatch;
 import com.gregtechceu.gtceu.api.capability.IOpticalComputationProvider;
 import com.gregtechceu.gtceu.api.capability.IOpticalComputationReceiver;
 import com.gregtechceu.gtceu.api.capability.recipe.*;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
@@ -17,12 +18,13 @@ import com.gregtechceu.gtceu.utils.GTUtil;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
+import com.google.common.base.Preconditions;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait<Integer>
                                             implements IOpticalComputationHatch, IOpticalComputationReceiver {
@@ -32,44 +34,62 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
     @Getter
     protected boolean transmitter;
 
-    protected long lastTimeStamp;
-    private int currentOutputCwu = 0, lastOutputCwu = 0;
+    private ComputationTransferContext transferContext = ComputationTransferContext.create();
+
+    private record ComputationTransferContext(long lastTimeStamp, int currentOutputCwu, int lastOutputCwu) {
+
+        public static ComputationTransferContext create() {
+            return new ComputationTransferContext(Long.MIN_VALUE, 0, 0);
+        }
+
+        public ComputationTransferContext conditionalTimedUpdate(MetaMachine machine) {
+            var latestTimeStamp = machine.getOffsetTimer();
+            if (lastTimeStamp < latestTimeStamp) {
+                return new ComputationTransferContext(latestTimeStamp, 0, currentOutputCwu());
+            }
+            return this;
+        }
+
+        public ComputationTransferContext subtractLastOutput(int transferred) {
+            return new ComputationTransferContext(lastTimeStamp(), currentOutputCwu(), lastOutputCwu() - transferred);
+        }
+
+        public ComputationTransferContext setOutput(int newOutputCwu) {
+            return new ComputationTransferContext(lastTimeStamp(), newOutputCwu, lastOutputCwu());
+        }
+    }
 
     public NotifiableComputationContainer(IO handlerIO, boolean transmitter) {
         super();
         this.handlerIO = handlerIO;
         this.transmitter = transmitter;
-
-        this.lastTimeStamp = Long.MIN_VALUE;
     }
 
     @Override
-    public int requestCWUt(int cwut, boolean simulate, Collection<IOpticalComputationProvider> seen) {
-        var latestTimeStamp = getMachine().getOffsetTimer();
-        if (lastTimeStamp < latestTimeStamp) {
-            lastOutputCwu = currentOutputCwu;
-            currentOutputCwu = 0;
-            lastTimeStamp = latestTimeStamp;
+    public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
+        ComputationTransferContext localTransferContext = this.transferContext.conditionalTimedUpdate(getMachine());
+        if (!simulate) {
+            this.transferContext = localTransferContext;
         }
 
-        seen.add(this);
+        seenWithContext.put(this, localTransferContext);
         if (handlerIO == IO.IN) {
             if (isTransmitter()) {
                 var machine = getMachine();
                 // Ask the Multiblock controller, which *should* be an IOpticalComputationProvider
                 if (machine instanceof IOpticalComputationProvider provider) {
-                    return provider.requestCWUt(cwut, simulate, seen);
+                    return provider.requestCWUt(cwut, simulate, seenWithContext);
                 } else if (machine instanceof MultiblockPartMachine part) {
                     if (!part.isFormed()) {
                         return 0;
                     }
                     for (MultiblockControllerMachine controller : part.getControllers()) {
                         if (controller instanceof IOpticalComputationProvider provider) {
-                            return provider.requestCWUt(cwut, simulate, seen);
+                            return provider.requestCWUt(cwut, simulate, seenWithContext);
                         }
                         for (MachineTrait trait : controller.getAllTraits()) {
                             if (trait instanceof IOpticalComputationProvider provider) {
-                                return provider.requestCWUt(cwut, simulate, seen);
+                                return provider.requestCWUt(cwut, simulate, seenWithContext);
                             }
                         }
                     }
@@ -84,23 +104,26 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 // Ask the attached Transmitter hatch, if it exists
                 IOpticalComputationProvider provider = getOpticalNetProvider();
                 if (provider == null) return 0;
-                return provider.requestCWUt(cwut, simulate, seen);
+                return provider.requestCWUt(cwut, simulate, seenWithContext);
             }
         } else {
-            lastOutputCwu = lastOutputCwu - cwut;
-            return Math.min(lastOutputCwu, cwut);
+            localTransferContext = localTransferContext.subtractLastOutput(cwut);
+            if (!simulate) {
+                this.transferContext = localTransferContext;
+            }
+            return Math.min(localTransferContext.lastOutputCwu(), cwut);
         }
     }
 
     @Override
-    public int getMaxCWUt(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, this.transferContext);
         if (handlerIO == IO.IN) {
             if (isTransmitter()) {
                 var machine = getMachine();
                 // Ask the Multiblock controller, which *should* be an IOpticalComputationProvider
                 if (machine instanceof IOpticalComputationProvider provider) {
-                    return provider.getMaxCWUt(seen);
+                    return provider.getMaxCWUt(seenWithContext);
                 } else if (machine instanceof MultiblockPartMachine part) {
                     if (!part.isFormed()) {
                         return 0;
@@ -110,11 +133,11 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                             continue;
                         }
                         if (controller instanceof IOpticalComputationProvider provider) {
-                            return provider.getMaxCWUt(seen);
+                            return provider.getMaxCWUt(seenWithContext);
                         }
                         for (MachineTrait trait : controller.getAllTraits()) {
                             if (trait instanceof IOpticalComputationProvider provider) {
-                                return provider.getMaxCWUt(seen);
+                                return provider.getMaxCWUt(seenWithContext);
                             }
                         }
                     }
@@ -129,22 +152,22 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 // Ask the attached Transmitter hatch, if it exists
                 IOpticalComputationProvider provider = getOpticalNetProvider();
                 if (provider == null) return 0;
-                return provider.getMaxCWUt(seen);
+                return provider.getMaxCWUt(seenWithContext);
             }
         } else {
-            return lastOutputCwu;
+            return Preconditions.checkNotNull((ComputationTransferContext) seenWithContext.get(this)).lastOutputCwu();
         }
     }
 
     @Override
-    public boolean canBridge(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, this.transferContext);
         if (handlerIO == IO.IN) {
             if (isTransmitter()) {
                 var machine = getMachine();
                 // Ask the Multiblock controller, which *should* be an IOpticalComputationProvider
                 if (machine instanceof IOpticalComputationProvider provider) {
-                    return provider.canBridge(seen);
+                    return provider.canBridge(seenWithContext);
                 } else if (machine instanceof MultiblockPartMachine part) {
                     if (!part.isFormed()) {
                         return false;
@@ -154,11 +177,11 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                             continue;
                         }
                         if (controller instanceof IOpticalComputationProvider provider) {
-                            return provider.canBridge(seen);
+                            return provider.canBridge(seenWithContext);
                         }
                         for (MachineTrait trait : controller.getAllTraits()) {
                             if (trait instanceof IOpticalComputationProvider provider) {
-                                return provider.canBridge(seen);
+                                return provider.canBridge(seenWithContext);
                             }
                         }
                     }
@@ -173,7 +196,7 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 // Ask the attached Transmitter hatch, if it exists
                 IOpticalComputationProvider provider = getOpticalNetProvider();
                 if (provider == null) return true; // nothing found, so don't report a problem, just pass quietly
-                return provider.canBridge(seen);
+                return provider.canBridge(seenWithContext);
             }
         } else {
             return false;
@@ -211,9 +234,10 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
                 }
             }
         } else if (io == IO.OUT) {
-            int canInput = this.getMaxCWUt() - this.lastOutputCwu;
+            int canInput = this.getMaxCWUt() - this.transferContext.lastOutputCwu();
             if (!simulate) {
-                this.currentOutputCwu = Math.min(canInput, sum);
+                int newOutputCwu = Math.min(canInput, sum);
+                this.transferContext = this.transferContext.setOutput(newOutputCwu);
             }
             sum = sum - canInput;
         }
@@ -222,12 +246,12 @@ public class NotifiableComputationContainer extends NotifiableRecipeHandlerTrait
 
     @Override
     public List<Object> getContents() {
-        return List.of(lastOutputCwu);
+        return List.of(this.transferContext.lastOutputCwu());
     }
 
     @Override
     public double getTotalContentAmount() {
-        return lastOutputCwu;
+        return this.transferContext.lastOutputCwu();
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/OpticalPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/OpticalPipeBlockEntity.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.EnumMap;
+import java.util.Map;
 
 public class OpticalPipeBlockEntity extends PipeBlockEntity<OpticalPipeType, OpticalPipeProperties> {
 
@@ -178,17 +179,18 @@ public class OpticalPipeBlockEntity extends PipeBlockEntity<OpticalPipeType, Opt
     private static class DefaultComputationHandler implements IOpticalComputationProvider {
 
         @Override
-        public int requestCWUt(int cwut, boolean simulate, @NotNull Collection<IOpticalComputationProvider> seen) {
+        public int requestCWUt(int cwut, boolean simulate,
+                               @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
             return 0;
         }
 
         @Override
-        public int getMaxCWUt(@NotNull Collection<IOpticalComputationProvider> seen) {
+        public int getMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
             return 0;
         }
 
         @Override
-        public boolean canBridge(@NotNull Collection<IOpticalComputationProvider> seen) {
+        public boolean canBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
             return false;
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/blockentity/OpticalPipeBlockEntity.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/blockentity/OpticalPipeBlockEntity.java
@@ -27,6 +27,7 @@ import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.Set;
 
 public class OpticalPipeBlockEntity extends PipeBlockEntity<OpticalPipeType, OpticalPipeProperties> {
 
@@ -180,17 +181,20 @@ public class OpticalPipeBlockEntity extends PipeBlockEntity<OpticalPipeType, Opt
 
         @Override
         public int requestCWUt(int cwut, boolean simulate,
-                               @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+                               @NotNull Set<IOpticalComputationProvider> seen,
+                               @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
             return 0;
         }
 
         @Override
-        public int getMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        public int getMaxCWUt(@NotNull Set<IOpticalComputationProvider> seen,
+                              @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
             return 0;
         }
 
         @Override
-        public boolean canBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        public boolean canBridge(@NotNull Set<IOpticalComputationProvider> seen,
+                                 @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
             return false;
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -161,21 +161,23 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
         this.hpcaHandler.onStructureInvalidate();
     }
 
+    private static final Object PLACEHOLDER_TRANSFER_CONTEXT = new Object();
+
     @Override
-    public int requestCWUt(int cwut, boolean simulate, Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         return isActive() && isWorkingEnabled() && !hasNotEnoughEnergy ? hpcaHandler.allocateCWUt(cwut, simulate) : 0;
     }
 
     @Override
-    public int getMaxCWUt(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         return isActive() && isWorkingEnabled() ? hpcaHandler.getMaxCWUt() : 0;
     }
 
     @Override
-    public boolean canBridge(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         // don't show a problem if the structure is not yet formed
         return !isFormed() || hpcaHandler.hasHPCABridge();
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -161,23 +161,25 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
         this.hpcaHandler.onStructureInvalidate();
     }
 
-    private static final Object PLACEHOLDER_TRANSFER_CONTEXT = new Object();
-
     @Override
-    public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
-        return isActive() && isWorkingEnabled() && !hasNotEnoughEnergy ? hpcaHandler.allocateCWUt(cwut, simulate) : 0;
+    public int requestCWUt(int cwut, boolean simulate, Set<IOpticalComputationProvider> seen,
+                           Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
+        return isActive() && isWorkingEnabled() && !hasNotEnoughEnergy ?
+                hpcaHandler.allocateCWUt(cwut, simulate, this, simulationState) : 0;
     }
 
     @Override
-    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+    public int getMaxCWUt(Set<IOpticalComputationProvider> seen,
+                          Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         return isActive() && isWorkingEnabled() ? hpcaHandler.getMaxCWUt() : 0;
     }
 
     @Override
-    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+    public boolean canBridge(Set<IOpticalComputationProvider> seen,
+                             Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         // don't show a problem if the structure is not yet formed
         return !isFormed() || hpcaHandler.hasHPCABridge();
     }
@@ -580,13 +582,20 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine
         }
 
         /** Allocate computation on a given request. Allocates for one tick. */
-        public int allocateCWUt(int cwut, boolean simulate) {
+        public int allocateCWUt(int cwut, boolean simulate, IOpticalComputationProvider selfProvider,
+                                Map<IOpticalComputationProvider, Object> simulationState) {
             if (cwut == 0) return 0;
             int maxCWUt = getMaxCWUt();
-            int availableCWUt = maxCWUt - this.allocatedCWUt;
+
+            int localAllocatedCWUt = (Integer) simulationState.getOrDefault(selfProvider, this.allocatedCWUt);
+            int availableCWUt = maxCWUt - localAllocatedCWUt;
             int toAllocate = Math.min(cwut, availableCWUt);
+
+            localAllocatedCWUt += toAllocate;
             if (!simulate) {
-                this.allocatedCWUt += toAllocate;
+                this.allocatedCWUt = localAllocatedCWUt;
+            } else {
+                simulationState.put(selfProvider, localAllocatedCWUt);
             }
             return toAllocate;
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
@@ -6,6 +6,7 @@ import com.gregtechceu.gtceu.api.capability.IOpticalComputationHatch;
 import com.gregtechceu.gtceu.api.capability.IOpticalComputationProvider;
 import com.gregtechceu.gtceu.api.capability.recipe.CWURecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableComputationContainer;
 
@@ -26,8 +27,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class NetworkSwitchMachine extends DataBankMachine implements IOpticalComputationProvider {
 
     public static final int EUT_PER_HATCH = GTValues.VA[GTValues.IV];
-
-    private static final Object PLACEHOLDER_TRANSFER_CONTEXT = new Object();
 
     private final MultipleComputationHandler computationHandler;
 
@@ -95,22 +94,25 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
     }
 
     @Override
-    public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+    public int requestCWUt(int cwut, boolean simulate, Set<IOpticalComputationProvider> seen,
+                           Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         return isActive() && !getRecipeLogic().isWaiting() ?
-                computationHandler.requestCWUt(cwut, simulate, seenWithContext) : 0;
+                computationHandler.requestCWUt(cwut, simulate, seen, simulationState) : 0;
     }
 
     @Override
-    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
-        return isFormed() ? computationHandler.getMaxCWUt(seenWithContext) : 0;
+    public int getMaxCWUt(Set<IOpticalComputationProvider> seen,
+                          Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
+        return isFormed() ? computationHandler.getMaxCWUt(seen, simulationState) : 0;
     }
 
     // allows chaining Network Switches together
     @Override
-    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+    public boolean canBridge(Set<IOpticalComputationProvider> seen,
+                             Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         return true;
     }
 
@@ -158,7 +160,8 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
                 return new SwitchTransferContext(-1, false);
             }
 
-            public SwitchTransferContext conditionalTimedUpdate(long timer) {
+            public SwitchTransferContext conditionalTimedUpdate(MetaMachine machine) {
+                long timer = machine.getOffsetTimer();
                 if (timerCWUt != timer) {
                     return new SwitchTransferContext(timer, false);
                 }
@@ -189,27 +192,36 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
         }
 
         @Override
-        public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
-            if (seenWithContext.containsKey(this)) return 0;
+        public int requestCWUt(int cwut, boolean simulate, Set<IOpticalComputationProvider> seen,
+                               Map<IOpticalComputationProvider, Object> simulationState) {
+            if (seen.contains(this)) return 0;
+            seen.add(this);
 
             // The max CWU/t that this Network Switch can provide, combining all its inputs.
-            SwitchTransferContext localContext = this.transferContext
-                    .conditionalTimedUpdate(NetworkSwitchMachine.this.getOffsetTimer());
-            seenWithContext.put(this, localContext);
+            SwitchTransferContext localTransferContext = (SwitchTransferContext) simulationState.getOrDefault(this,
+                    this.transferContext);
+            localTransferContext = localTransferContext.conditionalTimedUpdate(getMachine());
+            if (!simulate) {
+                this.transferContext = localTransferContext;
+            } else {
+                simulationState.put(this, localTransferContext);
+            }
 
             // Exit early if this Network Switch has already provided all available CWUt on its subnetwork for this tick
-            if (cwut == 0 || localContext.tickSaturated()) {
+            if (cwut == 0 || localTransferContext.tickSaturated()) {
                 if (!simulate) {
-                    this.transferContext = localContext;
+                    this.transferContext = localTransferContext;
+                } else {
+                    simulationState.put(this, localTransferContext);
                 }
                 return 0;
             }
 
-            Map<IOpticalComputationProvider, Object> bridgeSeen = new HashMap<>(seenWithContext);
+            Set<IOpticalComputationProvider> bridgeSeen = new HashSet<>(seen);
             int allocatedCWUt = 0;
             for (var provider : providers) {
-                if (!provider.canBridge(bridgeSeen)) continue;
-                int allocated = provider.requestCWUt(cwut, simulate, seenWithContext);
+                if (!provider.canBridge(bridgeSeen, simulationState)) continue;
+                int allocated = provider.requestCWUt(cwut, simulate, seen, simulationState);
                 allocatedCWUt += allocated;
                 cwut -= allocated;
                 if (cwut == 0) break;
@@ -217,49 +229,52 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
 
             if (allocatedCWUt == 0) {
                 // No computation left to give, remember this for subsequent calls this tick
-                localContext = localContext.markSaturated();
-                seenWithContext.put(this, localContext);
-            }
-
-            if (!simulate) {
-                this.transferContext = localContext;
+                localTransferContext = localTransferContext.markSaturated();
+                if (!simulate) {
+                    this.transferContext = localTransferContext;
+                } else {
+                    simulationState.put(this, localTransferContext);
+                }
             }
 
             return allocatedCWUt;
         }
 
         public int getMaxCWUtForDisplay() {
-            Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
+            Set<IOpticalComputationProvider> seen = new HashSet<>();
+            Map<IOpticalComputationProvider, Object> simulationState = new HashMap<>();
             // The max CWU/t that this Network Switch can provide, combining all its inputs.
-            seenWithContext.put(this, this.transferContext);
-            Map<IOpticalComputationProvider, Object> bridgeSeen = new HashMap<>(seenWithContext);
+            seen.add(this);
+            Set<IOpticalComputationProvider> bridgeSeen = new HashSet<>(seen);
             int maximumCWUt = 0;
             for (var provider : providers) {
-                if (!provider.canBridge(bridgeSeen)) continue;
-                maximumCWUt += provider.getMaxCWUt(seenWithContext);
+                if (!provider.canBridge(bridgeSeen, simulationState)) continue;
+                maximumCWUt += provider.getMaxCWUt(seen, simulationState);
             }
             return maximumCWUt;
         }
 
-        public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
-            if (seenWithContext.containsKey(this)) return 0;
+        public int getMaxCWUt(Set<IOpticalComputationProvider> seen,
+                              Map<IOpticalComputationProvider, Object> simulationState) {
+            if (seen.contains(this)) return 0;
             // The max CWU/t that this Network Switch can provide, combining all its inputs.
-            seenWithContext.put(this, this.transferContext);
-            Map<IOpticalComputationProvider, Object> bridgeSeen = new HashMap<>(seenWithContext);
+            seen.add(this);
+            Set<IOpticalComputationProvider> bridgeSeen = new HashSet<>(seen);
             int maximumCWUt = 0;
             for (var provider : providers) {
-                if (!provider.canBridge(bridgeSeen)) continue;
-                maximumCWUt += provider.getMaxCWUt(seenWithContext);
+                if (!provider.canBridge(bridgeSeen, simulationState)) continue;
+                maximumCWUt += provider.getMaxCWUt(seen, simulationState);
             }
             return maximumCWUt;
         }
 
         @Override
-        public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
-            if (seenWithContext.containsKey(this)) return false;
-            seenWithContext.put(this, this.transferContext);
+        public boolean canBridge(Set<IOpticalComputationProvider> seen,
+                                 Map<IOpticalComputationProvider, Object> simulationState) {
+            if (seen.contains(this)) return false;
+            seen.add(this);
             for (var provider : providers) {
-                if (provider.canBridge(seenWithContext)) {
+                if (provider.canBridge(seen, simulationState)) {
                     return true;
                 }
             }
@@ -268,9 +283,10 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
 
         /** Test if any of the provider hatches do not allow bridging */
         private boolean hasNonBridgingConnections() {
-            Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
+            Set<IOpticalComputationProvider> seen = new HashSet<>();
+            Map<IOpticalComputationProvider, Object> simulationState = new HashMap<>();
             for (var provider : providers) {
-                if (!provider.canBridge(seenWithContext)) {
+                if (!provider.canBridge(seen, simulationState)) {
                     return true;
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/NetworkSwitchMachine.java
@@ -17,10 +17,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -29,6 +26,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class NetworkSwitchMachine extends DataBankMachine implements IOpticalComputationProvider {
 
     public static final int EUT_PER_HATCH = GTValues.VA[GTValues.IV];
+
+    private static final Object PLACEHOLDER_TRANSFER_CONTEXT = new Object();
 
     private final MultipleComputationHandler computationHandler;
 
@@ -96,21 +95,22 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
     }
 
     @Override
-    public int requestCWUt(int cwut, boolean simulate, Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
-        return isActive() && !getRecipeLogic().isWaiting() ? computationHandler.requestCWUt(cwut, simulate, seen) : 0;
+    public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+        return isActive() && !getRecipeLogic().isWaiting() ?
+                computationHandler.requestCWUt(cwut, simulate, seenWithContext) : 0;
     }
 
     @Override
-    public int getMaxCWUt(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
-        return isFormed() ? computationHandler.getMaxCWUt(seen) : 0;
+    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+        return isFormed() ? computationHandler.getMaxCWUt(seenWithContext) : 0;
     }
 
     // allows chaining Network Switches together
     @Override
-    public boolean canBridge(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         return true;
     }
 
@@ -150,8 +150,25 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
         @Getter(value = AccessLevel.PRIVATE)
         private int EUt;
 
-        private boolean tickSaturated;
-        private long timerCWUt = -1;
+        private SwitchTransferContext transferContext = SwitchTransferContext.create();
+
+        private record SwitchTransferContext(long timerCWUt, boolean tickSaturated) {
+
+            public static SwitchTransferContext create() {
+                return new SwitchTransferContext(-1, false);
+            }
+
+            public SwitchTransferContext conditionalTimedUpdate(long timer) {
+                if (timerCWUt != timer) {
+                    return new SwitchTransferContext(timer, false);
+                }
+                return this;
+            }
+
+            public SwitchTransferContext markSaturated() {
+                return new SwitchTransferContext(timerCWUt, true);
+            }
+        }
 
         public MultipleComputationHandler() {
             super(IO.IN, false);
@@ -172,75 +189,77 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
         }
 
         @Override
-        public int requestCWUt(int cwut, boolean simulate, Collection<IOpticalComputationProvider> seen) {
-            if (seen.contains(this)) return 0;
-            // The max CWU/t that this Network Switch can provide, combining all its inputs.
-            seen.add(this);
+        public int requestCWUt(int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
+            if (seenWithContext.containsKey(this)) return 0;
 
-            if (cwut == 0) return 0;
+            // The max CWU/t that this Network Switch can provide, combining all its inputs.
+            SwitchTransferContext localContext = this.transferContext
+                    .conditionalTimedUpdate(NetworkSwitchMachine.this.getOffsetTimer());
+            seenWithContext.put(this, localContext);
 
             // Exit early if this Network Switch has already provided all available CWUt on its subnetwork for this tick
-            long timer = NetworkSwitchMachine.this.getOffsetTimer();
-            if (timerCWUt == timer) {
-                if (tickSaturated) {
-                    return 0;
+            if (cwut == 0 || localContext.tickSaturated()) {
+                if (!simulate) {
+                    this.transferContext = localContext;
                 }
-            } else {
-                // First call this tick, reset saturation
-                timerCWUt = timer;
-                tickSaturated = false;
+                return 0;
             }
 
-            Collection<IOpticalComputationProvider> bridgeSeen = new ArrayList<>(seen);
+            Map<IOpticalComputationProvider, Object> bridgeSeen = new HashMap<>(seenWithContext);
             int allocatedCWUt = 0;
             for (var provider : providers) {
                 if (!provider.canBridge(bridgeSeen)) continue;
-                int allocated = provider.requestCWUt(cwut, simulate, seen);
+                int allocated = provider.requestCWUt(cwut, simulate, seenWithContext);
                 allocatedCWUt += allocated;
                 cwut -= allocated;
                 if (cwut == 0) break;
             }
 
-            if (!simulate && allocatedCWUt == 0) {
+            if (allocatedCWUt == 0) {
                 // No computation left to give, remember this for subsequent calls this tick
-                tickSaturated = true;
+                localContext = localContext.markSaturated();
+                seenWithContext.put(this, localContext);
+            }
+
+            if (!simulate) {
+                this.transferContext = localContext;
             }
 
             return allocatedCWUt;
         }
 
         public int getMaxCWUtForDisplay() {
-            Collection<IOpticalComputationProvider> seen = new ArrayList<>();
+            Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
             // The max CWU/t that this Network Switch can provide, combining all its inputs.
-            seen.add(this);
-            Collection<IOpticalComputationProvider> bridgeSeen = new ArrayList<>(seen);
+            seenWithContext.put(this, this.transferContext);
+            Map<IOpticalComputationProvider, Object> bridgeSeen = new HashMap<>(seenWithContext);
             int maximumCWUt = 0;
             for (var provider : providers) {
                 if (!provider.canBridge(bridgeSeen)) continue;
-                maximumCWUt += provider.getMaxCWUt(seen);
+                maximumCWUt += provider.getMaxCWUt(seenWithContext);
             }
             return maximumCWUt;
         }
 
-        public int getMaxCWUt(Collection<IOpticalComputationProvider> seen) {
-            if (seen.contains(this)) return 0;
+        public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
+            if (seenWithContext.containsKey(this)) return 0;
             // The max CWU/t that this Network Switch can provide, combining all its inputs.
-            seen.add(this);
-            Collection<IOpticalComputationProvider> bridgeSeen = new ArrayList<>(seen);
+            seenWithContext.put(this, this.transferContext);
+            Map<IOpticalComputationProvider, Object> bridgeSeen = new HashMap<>(seenWithContext);
             int maximumCWUt = 0;
             for (var provider : providers) {
                 if (!provider.canBridge(bridgeSeen)) continue;
-                maximumCWUt += provider.getMaxCWUt(seen);
+                maximumCWUt += provider.getMaxCWUt(seenWithContext);
             }
             return maximumCWUt;
         }
 
         @Override
-        public boolean canBridge(Collection<IOpticalComputationProvider> seen) {
-            if (seen.contains(this)) return false;
-            seen.add(this);
+        public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
+            if (seenWithContext.containsKey(this)) return false;
+            seenWithContext.put(this, this.transferContext);
             for (var provider : providers) {
-                if (provider.canBridge(seen)) {
+                if (provider.canBridge(seenWithContext)) {
                     return true;
                 }
             }
@@ -249,9 +268,9 @@ public class NetworkSwitchMachine extends DataBankMachine implements IOpticalCom
 
         /** Test if any of the provider hatches do not allow bridging */
         private boolean hasNonBridgingConnections() {
-            Collection<IOpticalComputationProvider> seen = new ArrayList<>();
+            Map<IOpticalComputationProvider, Object> seenWithContext = new HashMap<>();
             for (var provider : providers) {
-                if (!provider.canBridge(seen)) {
+                if (!provider.canBridge(seenWithContext)) {
                     return true;
                 }
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeComputationProviderMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeComputationProviderMachine.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -71,12 +72,11 @@ public class CreativeComputationProviderMachine extends MetaMachine
         }
     }
 
-    private static final Object PLACEHOLDER_TRANSFER_CONTEXT = new Object();
-
     @Override
     public int requestCWUt(
-                           int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+                           int cwut, boolean simulate, Set<IOpticalComputationProvider> seen,
+                           Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         int requestedCWUt = workingEnabled ? Math.min(cwut, maxCWUt) : 0;
         if (!simulate) {
             this.requestedCWUPerSec += requestedCWUt;
@@ -85,14 +85,16 @@ public class CreativeComputationProviderMachine extends MetaMachine
     }
 
     @Override
-    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+    public int getMaxCWUt(Set<IOpticalComputationProvider> seen,
+                          Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         return workingEnabled ? maxCWUt : 0;
     }
 
     @Override
-    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
-        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
+    public boolean canBridge(Set<IOpticalComputationProvider> seen,
+                             Map<IOpticalComputationProvider, Object> simulationState) {
+        seen.add(this);
         return true;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeComputationProviderMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/storage/CreativeComputationProviderMachine.java
@@ -24,7 +24,7 @@ import brachy.modularui.widgets.textfield.TextFieldWidget;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
+import java.util.Map;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -71,10 +71,12 @@ public class CreativeComputationProviderMachine extends MetaMachine
         }
     }
 
+    private static final Object PLACEHOLDER_TRANSFER_CONTEXT = new Object();
+
     @Override
     public int requestCWUt(
-                           int cwut, boolean simulate, Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+                           int cwut, boolean simulate, Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         int requestedCWUt = workingEnabled ? Math.min(cwut, maxCWUt) : 0;
         if (!simulate) {
             this.requestedCWUPerSec += requestedCWUt;
@@ -83,14 +85,14 @@ public class CreativeComputationProviderMachine extends MetaMachine
     }
 
     @Override
-    public int getMaxCWUt(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public int getMaxCWUt(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         return workingEnabled ? maxCWUt : 0;
     }
 
     @Override
-    public boolean canBridge(Collection<IOpticalComputationProvider> seen) {
-        seen.add(this);
+    public boolean canBridge(Map<IOpticalComputationProvider, Object> seenWithContext) {
+        seenWithContext.put(this, PLACEHOLDER_TRANSFER_CONTEXT);
         return true;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/optical/OpticalNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/optical/OpticalNetHandler.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Map;
 
 public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationProvider {
 
@@ -49,21 +50,22 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
     }
 
     @Override
-    public int requestCWUt(int cwut, boolean simulate, @NotNull Collection<IOpticalComputationProvider> seen) {
+    public int requestCWUt(int cwut, boolean simulate,
+                           @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
         if (cwut == 0) return 0;
-        int provided = traverseRequestCWUt(cwut, simulate, seen);
-        if (provided > 0) setPipesActive();
+        int provided = traverseRequestCWUt(cwut, simulate, seenWithContext);
+        if (provided > 0 && !simulate) setPipesActive();
         return provided;
     }
 
     @Override
-    public int getMaxCWUt(@NotNull Collection<IOpticalComputationProvider> seen) {
-        return traverseMaxCWUt(seen);
+    public int getMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        return traverseMaxCWUt(seenWithContext);
     }
 
     @Override
-    public boolean canBridge(@NotNull Collection<IOpticalComputationProvider> seen) {
-        return traverseCanBridge(seen);
+    public boolean canBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        return traverseCanBridge(seenWithContext);
     }
 
     private void setPipesActive() {
@@ -93,33 +95,35 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
         return false;
     }
 
-    private int traverseRequestCWUt(int cwut, boolean simulate, @NotNull Collection<IOpticalComputationProvider> seen) {
-        IOpticalComputationProvider provider = getComputationProvider(seen);
+    private int traverseRequestCWUt(int cwut, boolean simulate,
+                                    @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        IOpticalComputationProvider provider = getComputationProvider(seenWithContext);
         if (provider == null) return 0;
-        return provider.requestCWUt(cwut, simulate, seen);
+        return provider.requestCWUt(cwut, simulate, seenWithContext);
     }
 
-    private int traverseMaxCWUt(@NotNull Collection<IOpticalComputationProvider> seen) {
-        IOpticalComputationProvider provider = getComputationProvider(seen);
+    private int traverseMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        IOpticalComputationProvider provider = getComputationProvider(seenWithContext);
         if (provider == null) return 0;
-        return provider.getMaxCWUt(seen);
+        return provider.getMaxCWUt(seenWithContext);
     }
 
-    private boolean traverseCanBridge(@NotNull Collection<IOpticalComputationProvider> seen) {
-        IOpticalComputationProvider provider = getComputationProvider(seen);
+    private boolean traverseCanBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+        IOpticalComputationProvider provider = getComputationProvider(seenWithContext);
         if (provider == null) return true; // nothing found, so don't report a problem, just pass quietly
-        return provider.canBridge(seen);
+        return provider.canBridge(seenWithContext);
     }
 
     @Nullable
-    private IOpticalComputationProvider getComputationProvider(@NotNull Collection<IOpticalComputationProvider> seen) {
+    private IOpticalComputationProvider getComputationProvider(
+                                                               @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
         if (isNetInvalidForTraversal()) return null;
 
         OpticalRoutePath inv = net.getNetData(pipe.getBlockPos(), facing);
         if (inv == null) return null;
 
         IOpticalComputationProvider hatch = inv.getComputationHatch();
-        if (hatch == null || seen.contains(hatch)) return null;
+        if (hatch == null || seenWithContext.containsKey(hatch)) return null;
         return hatch;
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/optical/OpticalNetHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/optical/OpticalNetHandler.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationProvider {
 
@@ -51,21 +52,24 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
 
     @Override
     public int requestCWUt(int cwut, boolean simulate,
-                           @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+                           @NotNull Set<IOpticalComputationProvider> seen,
+                           @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
         if (cwut == 0) return 0;
-        int provided = traverseRequestCWUt(cwut, simulate, seenWithContext);
+        int provided = traverseRequestCWUt(cwut, simulate, seen, simulationState);
         if (provided > 0 && !simulate) setPipesActive();
         return provided;
     }
 
     @Override
-    public int getMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
-        return traverseMaxCWUt(seenWithContext);
+    public int getMaxCWUt(@NotNull Set<IOpticalComputationProvider> seen,
+                          @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
+        return traverseMaxCWUt(seen, simulationState);
     }
 
     @Override
-    public boolean canBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
-        return traverseCanBridge(seenWithContext);
+    public boolean canBridge(@NotNull Set<IOpticalComputationProvider> seen,
+                             @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
+        return traverseCanBridge(seen, simulationState);
     }
 
     private void setPipesActive() {
@@ -96,34 +100,36 @@ public class OpticalNetHandler implements IDataAccessHatch, IOpticalComputationP
     }
 
     private int traverseRequestCWUt(int cwut, boolean simulate,
-                                    @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
-        IOpticalComputationProvider provider = getComputationProvider(seenWithContext);
+                                    @NotNull Set<IOpticalComputationProvider> seen,
+                                    @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
+        IOpticalComputationProvider provider = getComputationProvider(seen);
         if (provider == null) return 0;
-        return provider.requestCWUt(cwut, simulate, seenWithContext);
+        return provider.requestCWUt(cwut, simulate, seen, simulationState);
     }
 
-    private int traverseMaxCWUt(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
-        IOpticalComputationProvider provider = getComputationProvider(seenWithContext);
+    private int traverseMaxCWUt(@NotNull Set<IOpticalComputationProvider> seen,
+                                @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
+        IOpticalComputationProvider provider = getComputationProvider(seen);
         if (provider == null) return 0;
-        return provider.getMaxCWUt(seenWithContext);
+        return provider.getMaxCWUt(seen, simulationState);
     }
 
-    private boolean traverseCanBridge(@NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
-        IOpticalComputationProvider provider = getComputationProvider(seenWithContext);
+    private boolean traverseCanBridge(@NotNull Set<IOpticalComputationProvider> seen,
+                                      @NotNull Map<IOpticalComputationProvider, Object> simulationState) {
+        IOpticalComputationProvider provider = getComputationProvider(seen);
         if (provider == null) return true; // nothing found, so don't report a problem, just pass quietly
-        return provider.canBridge(seenWithContext);
+        return provider.canBridge(seen, simulationState);
     }
 
     @Nullable
-    private IOpticalComputationProvider getComputationProvider(
-                                                               @NotNull Map<IOpticalComputationProvider, Object> seenWithContext) {
+    private IOpticalComputationProvider getComputationProvider(@NotNull Set<IOpticalComputationProvider> seen) {
         if (isNetInvalidForTraversal()) return null;
 
         OpticalRoutePath inv = net.getNetData(pipe.getBlockPos(), facing);
         if (inv == null) return null;
 
         IOpticalComputationProvider hatch = inv.getComputationHatch();
-        if (hatch == null || seenWithContext.containsKey(hatch)) return null;
+        if (hatch == null || seen.contains(hatch)) return null;
         return hatch;
     }
 }


### PR DESCRIPTION

## What

Reworked optical computation transfer logic to correctly handle simulated case. Simulated case is important for recipe matching logic since it is not supposed to mutate the state or consume any optical power.

## Implementation Details

Replaced seen element set with a map that maps element to an opaque context object used by the element to store its modified state without touching the live data on the instance.

### AI Usage 

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

Claude Sonnet 5 was used to review the code. All of the code was written by hand.
  
## Outcome

Recipe search logic no longer mutates the state of the computation power transfer related machines.

## How Was This Tested

Built research station and other computation-related multiblocks and made sure computation transfer still works.

## Potential Compatibility Issues

`IOpticalComputationProvider` API has changed in a breaking way, so any mods dependant on that part of the GTM API will need to be updated and recompiled against the new version.
