### PR TITLE
Reworked recipe group color to not be stored on recipe instance

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -436,7 +436,7 @@ public class ToolHelper {
                         r -> RecipeHelper.matchContents(capHolder, r).isSuccess());
                 GTRecipe hammerRecipe = !hammerRecipes.hasNext() ? null : hammerRecipes.next();
                 if (hammerRecipe != null &&
-                        RecipeHelper.handleRecipeIO(capHolder, hammerRecipe, IO.IN, capHolder.getCacheChances())
+                        RecipeHelper.handleRecipeIO(capHolder, hammerRecipe, IO.IN, capHolder.getCacheChances(), -1)
                                 .isSuccess()) {
                     drops.clear();
                     TagPrefix prefix = ChemicalHelper.getPrefix(silktouchDrop.getItem());

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -137,6 +137,9 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
     @Setter
     protected boolean suspendAfterFinish = false;
     @Getter
+    @SaveField
+    protected int runningRecipeGroupColor = -1; // Group color for the running recipe object
+    @Getter
     @SaveField(nbtKey = "chance_cache")
     protected final IdentityHashMap<RecipeCapability<?>, Object2IntMap<?>> chanceCaches = makeChanceCaches();
     protected @Nullable TickableSubscription subscription;
@@ -305,7 +308,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         if (modified != null) {
             var recipeMatch = checkRecipe(modified);
             if (recipeMatch.isSuccess()) {
-                setupRecipe(modified);
+                setupRecipe(modified, recipeMatch.assignedGroupColor());
             } else {
                 recordFailureReason(match, recipeMatch.reason(), recipeMatch.score());
             }
@@ -322,7 +325,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         assert lastRecipe != null;
         var conditionResult = RecipeHelper.checkConditions(lastRecipe, this);
         if (conditionResult.isSuccess()) {
-            var handleTick = handleTickRecipe(lastRecipe);
+            var handleTick = handleTickRecipe(lastRecipe, runningRecipeGroupColor);
             if (handleTick.isSuccess()) {
                 setStatus(Status.WORKING);
                 if (!getRLMachine().onWorking()) {
@@ -393,7 +396,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
                 lastRecipe = null;
                 lastUnrolledRecipe = null;
                 lastOriginRecipe = null;
-                setupRecipe(last);
+                setupRecipe(last, lastCheck.assignedGroupColor());
                 recipeDirty = false;
                 return;
             }
@@ -430,10 +433,10 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         }
     }
 
-    public ActionResult handleTickRecipe(GTRecipe recipe) {
-        if (!recipe.hasTick()) return ActionResult.SUCCESS;
+    public ActionResult handleTickRecipe(GTRecipe recipe, int recipeGroupColor) {
+        if (!recipe.hasTick()) return ActionResult.success(recipeGroupColor);
 
-        var result = RecipeHelper.matchTickRecipe(getRLMachine(), recipe);
+        var result = RecipeHelper.matchTickRecipe(getRLMachine(), recipe, recipeGroupColor);
         if (!result.isSuccess()) return result;
 
         if (lastUnrolledRecipe == null) {
@@ -444,14 +447,14 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         }
         GTRecipe runningRecipe = RecipeHelper.doTickPrerolls(recipe, chanceCaches, lastUnrolledRecipe);
 
-        result = handleTickRecipeIO(runningRecipe, IO.IN);
+        result = handleTickRecipeIO(runningRecipe, IO.IN, recipeGroupColor);
         if (!result.isSuccess()) return result;
 
-        result = handleTickRecipeIO(runningRecipe, IO.OUT);
+        result = handleTickRecipeIO(runningRecipe, IO.OUT, recipeGroupColor);
         return result;
     }
 
-    public void setupRecipe(GTRecipe recipe) {
+    public void setupRecipe(GTRecipe recipe, int recipeGroupColor) {
         if (!getRLMachine().beforeWorking(recipe)) {
             setStatus(Status.IDLE);
             consecutiveRecipes = 0;
@@ -467,13 +470,14 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         lastUnrolledRecipe = recipe.copy();
         syncDataHolder.markClientSyncFieldDirty("lastDisplayedRecipe");
         GTRecipe runningRecipe = RecipeHelper.doPrerolls(recipe, chanceCaches);
-        var handledIO = handleRecipeIO(runningRecipe, IO.IN);
+        var handledIO = handleRecipeIO(runningRecipe, IO.IN, recipeGroupColor);
         if (handledIO.isSuccess()) {
             if (lastRecipe != null && !runningRecipe.equals(lastRecipe)) {
                 chanceCaches.clear();
             }
             clearFailureReason();
             recipeDirty = false;
+            runningRecipeGroupColor = recipeGroupColor;
             lastRecipe = runningRecipe;
             setStatus(Status.WORKING);
             progress = 0;
@@ -481,6 +485,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
             isActive = true;
             syncDataHolder.resyncAllFields();
         } else {
+            runningRecipeGroupColor = -1;
             lastRecipe = null;
             lastUnrolledRecipe = null;
             syncDataHolder.markClientSyncFieldDirty("lastDisplayedRecipe");
@@ -591,7 +596,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
             runAttempt = 0;
             runDelay = 0;
             consecutiveRecipes++;
-            handleRecipeIO(lastRecipe, IO.OUT);
+            handleRecipeIO(lastRecipe, IO.OUT, runningRecipeGroupColor);
             // Don't ready the next recipe after finish if suspend is set
             // so that the modifiers won't be applied until re-starting.
             if (suspendAfterFinish) {
@@ -601,6 +606,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
                 duration = 0;
                 isActive = false;
                 // Force a recipe recheck.
+                runningRecipeGroupColor = -1;
                 lastRecipe = null;
                 lastUnrolledRecipe = null;
                 syncDataHolder.resyncAllFields();
@@ -621,7 +627,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
             // try it again
             var recipeCheck = checkRecipe(lastRecipe);
             if (!recipeDirty && recipeCheck.isSuccess()) {
-                setupRecipe(lastRecipe);
+                setupRecipe(lastRecipe, recipeCheck.assignedGroupColor());
             } else {
                 setStatus(Status.IDLE);
                 consecutiveRecipes = 0;
@@ -633,12 +639,12 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         }
     }
 
-    protected ActionResult handleRecipeIO(GTRecipe recipe, IO io) {
-        return RecipeHelper.handleRecipeIO(getRLMachine(), recipe, io, this.chanceCaches);
+    protected ActionResult handleRecipeIO(GTRecipe recipe, IO io, int assignedGroupColor) {
+        return RecipeHelper.handleRecipeIO(getRLMachine(), recipe, io, this.chanceCaches, assignedGroupColor);
     }
 
-    protected ActionResult handleTickRecipeIO(GTRecipe recipe, IO io) {
-        return RecipeHelper.handleTickRecipeIO(getRLMachine(), recipe, io, this.chanceCaches);
+    protected ActionResult handleTickRecipeIO(GTRecipe recipe, IO io, int recipeGroupColor) {
+        return RecipeHelper.handleTickRecipeIO(getRLMachine(), recipe, io, this.chanceCaches, recipeGroupColor);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ActionResult.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ActionResult.java
@@ -8,21 +8,31 @@ import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * @param isSuccess is action success
- * @param reason    if fail, fail reason
- * @param score     how close the recipe was to succeeding, in {@code [0, 1]}. {@code 1} means fully satisfied
- *                  (success), {@code 0} means nothing matched. Used to pick the most-relevant failure reason to
- *                  display. Failures that don't measure contents (conditions, missing capabilities) use {@code 0}.
+ * @param isSuccess          is action success
+ * @param reason             if fail, fail reason
+ * @param score              how close the recipe was to succeeding, in {@code [0, 1]}. {@code 1} means fully satisfied
+ *                           (success), {@code 0} means nothing matched. Used to pick the most-relevant failure reason
+ *                           to
+ *                           display. Failures that don't measure contents (conditions, missing capabilities) use
+ *                           {@code 0}.
+ * @param assignedGroupColor recipe group color assigned by the runner. Will match the original recipe group color if no
+ *                           color was assigned.
  */
 public record ActionResult(boolean isSuccess, @Nullable Component reason, @Nullable RecipeCapability<?> capability,
-                           @Nullable IO io, double score) {
+                           @Nullable IO io, double score, int assignedGroupColor) {
 
-    public final static ActionResult SUCCESS = new ActionResult(true, null, null, null, 1.0);
-    public final static ActionResult FAIL_NO_REASON = new ActionResult(false, null, null, null, 0.0);
-    public final static ActionResult PASS_NO_CONTENTS = new ActionResult(true,
-            Component.translatable("gtceu.recipe_logic.no_contents"), null, null, 1.0);
+    public final static ActionResult FAIL_NO_REASON = new ActionResult(false, null, null, null, 0.0, -1);
     public final static ActionResult FAIL_NO_CAPABILITIES = new ActionResult(false,
-            Component.translatable("gtceu.recipe_logic.no_capabilities"), null, null, 0.0);
+            Component.translatable("gtceu.recipe_logic.no_capabilities"), null, null, 0.0, -1);
+
+    public static ActionResult success(int assignedGroupColor) {
+        return new ActionResult(true, null, null, null, 1.0, assignedGroupColor);
+    }
+
+    public static ActionResult passNoContents(int assignedGroupColor) {
+        return new ActionResult(true, Component.translatable("gtceu.recipe_logic.no_contents"), null, null, 1.0,
+                assignedGroupColor);
+    }
 
     public static ActionResult fail(@Nullable Component component, @Nullable RecipeCapability<?> capability, IO io) {
         return fail(component, capability, io, 0.0);
@@ -30,7 +40,7 @@ public record ActionResult(boolean isSuccess, @Nullable Component reason, @Nulla
 
     public static ActionResult fail(@Nullable Component component, @Nullable RecipeCapability<?> capability, IO io,
                                     double score) {
-        return new ActionResult(false, component, capability, io, score);
+        return new ActionResult(false, component, capability, io, score, -1);
     }
 
     public Component reason() {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -61,7 +61,6 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     private final @NotNull EnergyStack inputEUt = calculateEUt(tickInputs);
     @Getter(lazy = true)
     private final @NotNull EnergyStack outputEUt = calculateEUt(tickOutputs);
-    public int groupColor;
 
     public GTRecipe(GTRecipeType recipeType,
                     Map<RecipeCapability<?>, List<Content>> inputs,
@@ -76,12 +75,11 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     List<?> ingredientActions,
                     @NotNull CompoundTag data,
                     int duration, int parallels, int subtickParallels, int batchParallels,
-                    @NotNull GTRecipeCategory recipeCategory,
-                    int groupColor) {
+                    @NotNull GTRecipeCategory recipeCategory) {
         this(recipeType, null, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
                 conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels,
-                recipeCategory, groupColor);
+                recipeCategory);
     }
 
     /**
@@ -96,14 +94,13 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     CompoundTag data,
                     int duration,
                     GTRecipeSerializer.RecipeParallels allParallels,
-                    GTRecipeCategory recipeCategory,
-                    int groupColor) {
+                    GTRecipeCategory recipeCategory) {
         this(recipeType, null, recipeIO.inputs(), recipeIO.outputs(), recipeIO.tickInputs(), recipeIO.tickOutputs(),
                 recipeIO.inputChanceLogics(), recipeIO.outputChanceLogics(), recipeIO.tickInputChanceLogics(),
                 recipeIO.tickOutputChanceLogics(),
                 conditions, ingredientActions, data, duration, allParallels.parallels(),
                 allParallels.subtickParallels(),
-                allParallels.batchParallels(), recipeCategory, groupColor);
+                allParallels.batchParallels(), recipeCategory);
     }
 
     /**
@@ -123,11 +120,10 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     List<?> ingredientActions,
                     @NotNull CompoundTag data,
                     int duration,
-                    @NotNull GTRecipeCategory recipeCategory,
-                    int groupColor) {
+                    @NotNull GTRecipeCategory recipeCategory) {
         this(recipeType, id, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, 1, 1, 1, recipeCategory, groupColor);
+                conditions, ingredientActions, data, duration, 1, 1, 1, recipeCategory);
     }
 
     public GTRecipe(GTRecipeType recipeType,
@@ -144,7 +140,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     List<?> ingredientActions,
                     @NotNull CompoundTag data,
                     int duration, int parallels, int subtickParallels, int batchParallels,
-                    @NotNull GTRecipeCategory recipeCategory, int groupColor) {
+                    @NotNull GTRecipeCategory recipeCategory) {
         this.recipeType = recipeType;
         this.id = id;
 
@@ -166,7 +162,6 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
         this.subtickParallels = subtickParallels;
         this.batchParallels = batchParallels;
         this.recipeCategory = (recipeCategory != GTRecipeCategory.DEFAULT) ? recipeCategory : recipeType.getCategory();
-        this.groupColor = groupColor;
     }
 
     public GTRecipe copy() {
@@ -185,7 +180,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 new HashMap<>(tickInputChanceLogics), new HashMap<>(tickOutputChanceLogics),
                 new ArrayList<>(conditions),
                 new ArrayList<>(ingredientActions), data, duration, parallels, subtickParallels, batchParallels,
-                recipeCategory, groupColor);
+                recipeCategory);
         if (modifyDuration) {
             copied.duration = modifier.apply(this.duration);
         }
@@ -200,7 +195,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 new HashMap<>(inputChanceLogics), new HashMap<>(outputChanceLogics),
                 new HashMap<>(tickInputChanceLogics), new HashMap<>(tickOutputChanceLogics),
                 new ArrayList<>(conditions),
-                new ArrayList<>(ingredientActions), data, duration, recipeCategory, groupColor);
+                new ArrayList<>(ingredientActions), data, duration, recipeCategory);
         copied.ocLevel = ocLevel;
         copied.parallels = parallels;
         copied.batchParallels = batchParallels;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -146,8 +146,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         GTRecipe recipe = new GTRecipe(type, id,
                 inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, category,
-                groupColor);
+                conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, category);
 
         recipe.recipeCategory.addRecipe(recipe);
 
@@ -193,7 +192,6 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         buf.writeVarInt(recipe.parallels);
         buf.writeVarInt(recipe.subtickParallels);
         buf.writeVarInt(recipe.batchParallels);
-        buf.writeInt(recipe.groupColor);
         buf.writeResourceLocation(recipe.recipeCategory.registryKey);
     }
 
@@ -211,13 +209,12 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             CompoundTag.CODEC.optionalFieldOf("data", new CompoundTag()).forGetter(val -> val.data),
                             ExtraCodecs.NON_NEGATIVE_INT.fieldOf("duration").forGetter(val -> val.duration),
                             RecipeParallels.CODEC.optionalFieldOf("all_parallels", new RecipeParallels(1, 1, 1)).forGetter(val -> new RecipeParallels(val.parallels, val.subtickParallels, val.batchParallels)),
-                            GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
-                            Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor))
+                            GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory))
                     .apply(instance, (type,
                                       recipeIO,
-                                      conditions, data, duration, allParallels, recipeCategory, groupColor) ->
+                                      conditions, data, duration, allParallels, recipeCategory) ->
                             new GTRecipe(type, recipeIO,
-                                    conditions, List.of(), data, duration, allParallels, recipeCategory, groupColor)));
+                                    conditions, List.of(), data, duration, allParallels, recipeCategory)));
         } else {
             return RecordCodecBuilder.create(instance -> instance.group(
                             GTRegistries.RECIPE_TYPES.codec().fieldOf("type").forGetter(val -> val.recipeType),
@@ -227,8 +224,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             CompoundTag.CODEC.optionalFieldOf("data", new CompoundTag()).forGetter(val -> val.data),
                             ExtraCodecs.NON_NEGATIVE_INT.fieldOf("duration").forGetter(val -> val.duration),
                             RecipeParallels.CODEC.optionalFieldOf("all_parallels", new RecipeParallels(1, 1, 1)).forGetter(val -> new RecipeParallels(val.parallels, val.subtickParallels, val.batchParallels)),
-                            GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
-                            Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor))
+                            GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory))
                     .apply(instance, GTRecipe::new));
         }
         // spotless:on

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeHelper.java
@@ -177,57 +177,63 @@ public class RecipeHelper {
     }
 
     public static ActionResult matchRecipe(IRecipeCapabilityHolder holder, GTRecipe recipe) {
-        return matchRecipe(holder, recipe, false);
+        return matchRecipe(holder, recipe, false, -1);
     }
 
-    public static ActionResult matchTickRecipe(IRecipeCapabilityHolder holder, GTRecipe recipe) {
-        return recipe.hasTick() ? matchRecipe(holder, recipe, true) : ActionResult.SUCCESS;
+    public static ActionResult matchTickRecipe(IRecipeCapabilityHolder holder, GTRecipe recipe, int recipeGroupColor) {
+        return recipe.hasTick() ? matchRecipe(holder, recipe, true, recipeGroupColor) :
+                ActionResult.success(recipeGroupColor);
     }
 
-    private static ActionResult matchRecipe(IRecipeCapabilityHolder holder, GTRecipe recipe, boolean tick) {
+    private static ActionResult matchRecipe(IRecipeCapabilityHolder holder, GTRecipe recipe, boolean tick,
+                                            int recipeGroupColorOverride) {
         if (!holder.hasCapabilityProxies()) return ActionResult.FAIL_NO_CAPABILITIES;
 
         var result = handleRecipe(holder, recipe, IO.IN, tick ? recipe.tickInputs : recipe.inputs,
-                Collections.emptyMap(), tick, true);
+                Collections.emptyMap(), tick, true, recipeGroupColorOverride);
         if (!result.isSuccess()) return result;
 
         result = handleRecipe(holder, recipe, IO.OUT, tick ? recipe.tickOutputs : recipe.outputs,
-                Collections.emptyMap(), tick, true);
+                Collections.emptyMap(), tick, true, result.assignedGroupColor());
         return result;
     }
 
     public static ActionResult handleRecipeIO(IRecipeCapabilityHolder holder, GTRecipe recipe, IO io,
-                                              Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches) {
+                                              Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches,
+                                              int recipeGroupColor) {
         if (!holder.hasCapabilityProxies() || io == IO.BOTH) return ActionResult.FAIL_NO_CAPABILITIES;
         return handleRecipe(holder, recipe, io, io == IO.IN ? recipe.inputs : recipe.outputs, chanceCaches, false,
-                false);
+                false, recipeGroupColor);
     }
 
     public static ActionResult handleTickRecipeIO(IRecipeCapabilityHolder holder, GTRecipe recipe, IO io,
-                                                  Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches) {
+                                                  Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches,
+                                                  int recipeGroupColor) {
         if (!holder.hasCapabilityProxies() || io == IO.BOTH) return ActionResult.FAIL_NO_CAPABILITIES;
         return handleRecipe(holder, recipe, io, io == IO.IN ? recipe.tickInputs : recipe.tickOutputs, chanceCaches,
-                true, false);
+                true, false, recipeGroupColor);
     }
 
     /**
      * Checks if all the contents of the recipe are located in the holder.
      *
-     * @param simulated checks that the recipe ingredients are in the holder if true,
-     *                  process the recipe contents if false
+     * @param simulated              checks that the recipe ingredients are in the holder if true,
+     *                               process the recipe contents if false
+     * @param sourceRecipeGroupColor color assigned when handling the recipe inputs and passed around afterward.
+     *                               -1 means the color will be assigned by this runner (only supported for io == IN)
      */
     public static ActionResult handleRecipe(IRecipeCapabilityHolder holder, GTRecipe recipe, IO io,
                                             Map<RecipeCapability<?>, List<Content>> contents,
                                             Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches,
-                                            boolean isTick, boolean simulated) {
+                                            boolean isTick, boolean simulated, int sourceRecipeGroupColor) {
         if (contents.isEmpty()) {
-            return ActionResult.PASS_NO_CONTENTS;
+            return ActionResult.passNoContents(sourceRecipeGroupColor);
         }
-        RecipeRunner runner = new RecipeRunner(recipe, io, isTick, holder, chanceCaches, simulated);
+        RecipeRunner runner = new RecipeRunner(recipe, io, isTick, holder, chanceCaches, simulated,
+                sourceRecipeGroupColor);
         var result = runner.handle(contents);
 
         if (result.isSuccess() || result.capability() == null) {
-            recipe.groupColor = runner.getGroupColor();
             return result;
         }
 
@@ -244,7 +250,7 @@ public class RecipeHelper {
         var match = matchRecipe(holder, recipe);
         if (!match.isSuccess()) return match;
 
-        return matchTickRecipe(holder, recipe);
+        return matchTickRecipe(holder, recipe, match.assignedGroupColor());
     }
 
     /**
@@ -255,7 +261,7 @@ public class RecipeHelper {
      * @return the list of failed conditions, or success if all conditions are satisfied
      */
     public static ActionResult checkConditions(GTRecipe recipe, @NotNull RecipeLogic recipeLogic) {
-        if (recipe.conditions.isEmpty()) return ActionResult.SUCCESS;
+        if (recipe.conditions.isEmpty()) return ActionResult.success(-1);
         Map<RecipeConditionType<?>, List<RecipeCondition>> or = new Reference2ObjectArrayMap<>();
         for (RecipeCondition condition : recipe.conditions) {
             if (condition.isOr()) {
@@ -281,7 +287,7 @@ public class RecipeHelper {
                 return ActionResult.fail(component, null, null);
             }
         }
-        return ActionResult.SUCCESS;
+        return ActionResult.success(-1);
     }
 
     /**
@@ -407,7 +413,8 @@ public class RecipeHelper {
 
     /**
      * Rolls the value of all Ranged Ingredients in a recipe and replaces them with appropriate Sized Ingredients.
-     * Called once after successful recipe search, immediately before {@link RecipeLogic#handleRecipeIO(GTRecipe, IO)}.
+     * Called once after successful recipe search, immediately before
+     * {@link RecipeLogic#handleRecipeIO(GTRecipe, IO, int)}.
      * If a ranged ingredient rolls 0, it is replaced by a Non-Consumed ingredient of max size.
      *
      * Takes the machine's current Chance Caches, but does not use them. Yet. This parameter will be used in
@@ -453,7 +460,7 @@ public class RecipeHelper {
      * Rolls the value of all per-tick Ranged Ingredients in a recipe and replaces them with appropriate Sized
      * Ingredients.
      * Called every tick while a recipe is running, immediately before
-     * {@link RecipeLogic#handleTickRecipeIO(GTRecipe, IO)}.
+     * {@link RecipeLogic#handleTickRecipeIO(GTRecipe, IO, int)}.
      *
      * If a ranged ingredient rolls 0, it is replaced by a Non-Consumed ingredient of max size.
      *

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -42,6 +42,7 @@ public class RecipeRunner {
     private final Predicate<RecipeCapability<?>> outputVoid;
     @Getter
     private int groupColor;
+    private final boolean canAssignGroupColor;
 
     /** Highest closeness score seen across handler-group attempts, and the leftover map that produced it. */
     private double bestScore = 0;
@@ -49,7 +50,7 @@ public class RecipeRunner {
 
     public RecipeRunner(GTRecipe recipe, IO io, boolean isTick,
                         IRecipeCapabilityHolder holder, Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches,
-                        boolean simulated) {
+                        boolean simulated, int assignedGroupColor) {
         this.recipe = recipe;
         this.io = io;
         this.isTick = isTick;
@@ -59,7 +60,8 @@ public class RecipeRunner {
         this.searchRecipeContents = simulated ? recipeContents : new Reference2ObjectOpenHashMap<>();
         this.simulated = simulated;
         this.outputVoid = cap -> holder instanceof IVoidable voidable && voidable.canVoidRecipeOutputs(cap);
-        this.groupColor = recipe.groupColor;
+        this.groupColor = assignedGroupColor;
+        this.canAssignGroupColor = io == IO.IN && assignedGroupColor == -1;
     }
 
     @NotNull
@@ -67,7 +69,7 @@ public class RecipeRunner {
         fillContentMatchList(entries);
 
         if (searchRecipeContents.isEmpty()) {
-            return ActionResult.PASS_NO_CONTENTS;
+            return ActionResult.passNoContents(groupColor);
         }
 
         return this.handleContents();
@@ -119,7 +121,7 @@ public class RecipeRunner {
     }
 
     private ActionResult handleContents() {
-        if (recipeContents.isEmpty()) return ActionResult.SUCCESS;
+        if (recipeContents.isEmpty()) return ActionResult.success(this.groupColor);
         if (!capabilityProxies.containsKey(io)) {
             return ActionResult.fail(
                     Component.translatable("gtceu.recipe_logic.no_capabilities")
@@ -172,7 +174,7 @@ public class RecipeRunner {
                 }
             }
             recipeContents.clear();
-            return ActionResult.SUCCESS;
+            return ActionResult.success(this.groupColor);
         }
 
         // Check the other groups. For every group, try consuming the ingredients,
@@ -181,7 +183,7 @@ public class RecipeRunner {
             if (handlerListEntry.getKey().equals(BUS_DISTINCT)) continue;
 
             if (handlerListEntry.getKey() instanceof RecipeHandlerGroupColor coloredGroup) {
-                if (io == IO.IN && simulated && !isTick) {
+                if (canAssignGroupColor) {
                     groupColor = coloredGroup.color();
                 } else if (coloredGroup.color() != -1 && coloredGroup.color() != groupColor) {
                     continue;
@@ -218,14 +220,14 @@ public class RecipeRunner {
                     continue;
                 }
             }
-            if (simulated) return ActionResult.SUCCESS;
+            if (simulated) return ActionResult.success(this.groupColor);
             // Start actually removing items.
             // Keep track of the remaining items for this RecipeHandlerGroup
             // First go through the handlers of the group
             for (RecipeHandlerList handler : handlerListEntry.getValue()) {
                 recipeContents = handler.handleRecipe(io, recipe, recipeContents, false);
                 if (recipeContents.isEmpty()) {
-                    return ActionResult.SUCCESS;
+                    return ActionResult.success(this.groupColor);
                 }
             }
             // Then go through the handlers that bypass the distinctness system and empty those
@@ -235,7 +237,7 @@ public class RecipeRunner {
                         Collections.emptyList())) {
                     recipeContents = bypassHandler.handleRecipe(io, recipe, recipeContents, false);
                     if (recipeContents.isEmpty()) {
-                        return ActionResult.SUCCESS;
+                        return ActionResult.success(this.groupColor);
                     }
                 }
             }
@@ -269,7 +271,7 @@ public class RecipeRunner {
             }
         }
         if (!containsStuff) {
-            return ActionResult.PASS_NO_CONTENTS;
+            return ActionResult.passNoContents(groupColor);
         }
 
         return ActionResult.fail(null, null, io, bestScore);

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
@@ -183,7 +183,7 @@ public interface ModifierFunction {
                         new HashMap<>(recipe.inputChanceLogics), new HashMap<>(recipe.outputChanceLogics),
                         new HashMap<>(recipe.tickInputChanceLogics), new HashMap<>(recipe.tickOutputChanceLogics),
                         newConditions, new ArrayList<>(recipe.ingredientActions),
-                        recipe.data, recipe.duration, recipe.recipeCategory, recipe.groupColor);
+                        recipe.data, recipe.duration, recipe.recipeCategory);
                 copied.parallels = recipe.parallels * parallels;
                 copied.subtickParallels = recipe.subtickParallels * subtickParallels;
                 copied.ocLevel = recipe.ocLevel + addOCs;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ParallelLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ParallelLogic.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.*;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
+import com.gregtechceu.gtceu.api.recipe.ActionResult;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
@@ -213,8 +214,9 @@ public class ParallelLogic {
 
         while (parallelLimit > 0) {
             var copied = recipe.copy(ContentModifier.multiplier(parallelLimit), false);
-            if (RecipeHelper.matchRecipe(holder, copied).isSuccess() &&
-                    RecipeHelper.matchTickRecipe(holder, copied).isSuccess()) {
+            ActionResult actionResult = RecipeHelper.matchRecipe(holder, copied);
+            if (actionResult.isSuccess() &&
+                    RecipeHelper.matchTickRecipe(holder, copied, actionResult.assignedGroupColor()).isSuccess()) {
                 return parallelLimit;
             }
             parallelLimit /= 2;

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/AssemblyLineMachine.java
@@ -91,10 +91,10 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
         return true;
     }
 
-    private ActionResult consumeItemContents(GTRecipe recipe, boolean isTick) {
+    private ActionResult consumeItemContents(GTRecipe recipe, boolean isTick, int recipeGroupColor) {
         var itemInputs = (isTick ? recipe.tickInputs : recipe.inputs).getOrDefault(ItemRecipeCapability.CAP,
                 Collections.emptyList());
-        if (itemInputs.isEmpty()) return ActionResult.SUCCESS;
+        if (itemInputs.isEmpty()) return ActionResult.success(recipeGroupColor);
         int inputsSize = itemInputs.size();
         var itemHandlers = getCapabilitiesFlat(IO.IN, ItemRecipeCapability.CAP);
         if (itemHandlers.size() < inputsSize) return ActionResult.FAIL_NO_REASON;
@@ -129,7 +129,7 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
             }
         }
 
-        return ActionResult.SUCCESS;
+        return ActionResult.success(recipeGroupColor);
     }
 
     private boolean checkFluidInputs(GTRecipe recipe, boolean isTick) {
@@ -165,10 +165,10 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
         return true;
     }
 
-    private ActionResult consumeFluidContents(GTRecipe recipe, boolean isTick) {
+    private ActionResult consumeFluidContents(GTRecipe recipe, boolean isTick, int recipeGroupColor) {
         var fluidInputs = (isTick ? recipe.tickInputs : recipe.inputs).getOrDefault(FluidRecipeCapability.CAP,
                 Collections.emptyList());
-        if (fluidInputs.isEmpty()) return ActionResult.SUCCESS;
+        if (fluidInputs.isEmpty()) return ActionResult.success(recipeGroupColor);
         int fluidsSize = fluidInputs.size();
         var fluidHandlers = getCapabilitiesFlat(IO.IN, FluidRecipeCapability.CAP);
         if (fluidHandlers.size() < fluidsSize) return ActionResult.FAIL_NO_REASON;
@@ -201,11 +201,11 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
             }
         }
 
-        return ActionResult.SUCCESS;
+        return ActionResult.success(recipeGroupColor);
     }
 
     private ActionResult consumeAll(GTRecipe recipe, boolean isTick,
-                                    Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches) {
+                                    Map<RecipeCapability<?>, Object2IntMap<?>> chanceCaches, int recipeGroupColor) {
         GTRecipe copyWithItems = recipe.copy();
         copyWithItems.inputs.clear();
         copyWithItems.tickInputs.clear();
@@ -239,26 +239,26 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
         var config = ConfigHolder.INSTANCE.machines;
         ActionResult result;
         if (config.orderedAssemblyLineItems) {
-            result = consumeItemContents(copyWithItems, isTick);
+            result = consumeItemContents(copyWithItems, isTick, recipeGroupColor);
         } else {
             result = isTick ?
-                    RecipeHelper.handleTickRecipeIO(this, copyWithItems, IO.IN, chanceCaches) :
-                    RecipeHelper.handleRecipeIO(this, copyWithItems, IO.IN, chanceCaches);
+                    RecipeHelper.handleTickRecipeIO(this, copyWithItems, IO.IN, chanceCaches, recipeGroupColor) :
+                    RecipeHelper.handleRecipeIO(this, copyWithItems, IO.IN, chanceCaches, recipeGroupColor);
         }
         if (!result.isSuccess()) return result;
 
         if (config.orderedAssemblyLineFluids) {
-            result = consumeFluidContents(copyWithFluids, isTick);
+            result = consumeFluidContents(copyWithFluids, isTick, recipeGroupColor);
         } else {
             result = isTick ?
-                    RecipeHelper.handleTickRecipeIO(this, copyWithFluids, IO.IN, chanceCaches) :
-                    RecipeHelper.handleRecipeIO(this, copyWithFluids, IO.IN, chanceCaches);
+                    RecipeHelper.handleTickRecipeIO(this, copyWithFluids, IO.IN, chanceCaches, recipeGroupColor) :
+                    RecipeHelper.handleRecipeIO(this, copyWithFluids, IO.IN, chanceCaches, recipeGroupColor);
         }
         if (!result.isSuccess()) return result;
 
         return isTick ?
-                RecipeHelper.handleTickRecipeIO(this, copyWithoutItemsFluids, IO.IN, chanceCaches) :
-                RecipeHelper.handleRecipeIO(this, copyWithoutItemsFluids, IO.IN, chanceCaches);
+                RecipeHelper.handleTickRecipeIO(this, copyWithoutItemsFluids, IO.IN, chanceCaches, recipeGroupColor) :
+                RecipeHelper.handleRecipeIO(this, copyWithoutItemsFluids, IO.IN, chanceCaches, recipeGroupColor);
     }
 
     private static class AsslineRecipeLogic extends RecipeLogic {
@@ -278,19 +278,19 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
         }
 
         @Override
-        protected ActionResult handleRecipeIO(GTRecipe recipe, IO io) {
+        protected ActionResult handleRecipeIO(GTRecipe recipe, IO io, int assignedGroupColor) {
             if (io.equals(IO.IN)) {
-                return getMachine().consumeAll(recipe, false, this.getChanceCaches());
+                return getMachine().consumeAll(recipe, false, this.getChanceCaches(), assignedGroupColor);
             }
-            return RecipeHelper.handleRecipeIO(getMachine(), recipe, io, this.chanceCaches);
+            return RecipeHelper.handleRecipeIO(getMachine(), recipe, io, this.chanceCaches, assignedGroupColor);
         }
 
         @Override
-        protected ActionResult handleTickRecipeIO(GTRecipe recipe, IO io) {
+        protected ActionResult handleTickRecipeIO(GTRecipe recipe, IO io, int recipeGroupColor) {
             if (io.equals(IO.IN)) {
-                return getMachine().consumeAll(recipe, true, this.getChanceCaches());
+                return getMachine().consumeAll(recipe, true, this.getChanceCaches(), recipeGroupColor);
             }
-            return RecipeHelper.handleTickRecipeIO(getMachine(), recipe, io, this.chanceCaches);
+            return RecipeHelper.handleTickRecipeIO(getMachine(), recipe, io, this.chanceCaches, recipeGroupColor);
         }
 
         @Override
@@ -301,14 +301,15 @@ public class AssemblyLineMachine extends WorkableElectricMultiblockMachine {
 
             var config = ConfigHolder.INSTANCE.machines;
 
-            if (!config.orderedAssemblyLineItems && !config.orderedAssemblyLineFluids) return ActionResult.SUCCESS;
+            if (!config.orderedAssemblyLineItems && !config.orderedAssemblyLineFluids)
+                return ActionResult.success(normalMatch.assignedGroupColor());
             if (!getMachine().checkItemInputs(recipe, false)) return ActionResult.FAIL_NO_REASON;
             if (!getMachine().checkItemInputs(recipe, true)) return ActionResult.FAIL_NO_REASON;
 
-            if (!config.orderedAssemblyLineFluids) return ActionResult.SUCCESS;
+            if (!config.orderedAssemblyLineFluids) return ActionResult.success(normalMatch.assignedGroupColor());
             if (!getMachine().checkFluidInputs(recipe, false)) return ActionResult.FAIL_NO_REASON;
             if (!getMachine().checkFluidInputs(recipe, true)) return ActionResult.FAIL_NO_REASON;
-            return ActionResult.SUCCESS;
+            return ActionResult.success(normalMatch.assignedGroupColor());
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
@@ -166,7 +166,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
                 recipe.outputChanceLogics,
                 recipe.tickInputChanceLogics, recipe.tickOutputChanceLogics, recipe.conditions,
                 recipe.ingredientActions,
-                recipe.data, recipe.duration, recipe.recipeCategory, recipe.groupColor);
+                recipe.data, recipe.duration, recipe.recipeCategory);
     }
 
     public static class DistillationTowerLogic extends RecipeLogic {
@@ -196,7 +196,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
             var match = matchDTRecipe(recipe);
             if (!match.isSuccess()) return match;
 
-            return RecipeHelper.matchTickRecipe(getMachine(), recipe);
+            return RecipeHelper.matchTickRecipe(getMachine(), recipe, match.assignedGroupColor());
         }
 
         @Override
@@ -207,14 +207,14 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
 
         private ActionResult matchDTRecipe(GTRecipe recipe) {
             var result = RecipeHelper.handleRecipe(getMachine(), recipe, IO.IN, recipe.inputs,
-                    Collections.emptyMap(), false, true);
+                    Collections.emptyMap(), false, true, -1);
             if (!result.isSuccess()) return result;
 
             var items = recipe.getOutputContents(ItemRecipeCapability.CAP);
             if (!items.isEmpty()) {
                 Map<RecipeCapability<?>, List<Content>> out = Map.of(ItemRecipeCapability.CAP, items);
                 result = RecipeHelper.handleRecipe(getMachine(), recipe, IO.OUT, out, Collections.emptyMap(), false,
-                        true);
+                        true, result.assignedGroupColor());
                 if (!result.isSuccess()) return result;
             }
 
@@ -224,7 +224,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
                         .append(FluidRecipeCapability.CAP.getName()), FluidRecipeCapability.CAP, IO.OUT);
             }
 
-            return ActionResult.SUCCESS;
+            return ActionResult.success(result.assignedGroupColor());
         }
 
         private void updateWorkingRecipe(GTRecipe recipe) {
@@ -246,9 +246,9 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
         }
 
         @Override
-        protected ActionResult handleRecipeIO(GTRecipe recipe, IO io) {
+        protected ActionResult handleRecipeIO(GTRecipe recipe, IO io, int assignedGroupColor) {
             if (io != IO.OUT) {
-                var handleIO = super.handleRecipeIO(recipe, io);
+                var handleIO = super.handleRecipeIO(recipe, io, assignedGroupColor);
                 if (handleIO.isSuccess()) {
                     updateWorkingRecipe(recipe);
                 } else {
@@ -260,12 +260,13 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
             var items = recipe.getOutputContents(ItemRecipeCapability.CAP);
             if (!items.isEmpty()) {
                 Map<RecipeCapability<?>, List<Content>> out = Map.of(ItemRecipeCapability.CAP, items);
-                RecipeHelper.handleRecipe(getMachine(), recipe, io, out, chanceCaches, false, false);
+                RecipeHelper.handleRecipe(getMachine(), recipe, io, out, chanceCaches, false, false,
+                        assignedGroupColor);
             }
 
             if (applyFluidOutputs(recipe, FluidAction.EXECUTE, getMachine().getVoidingMode())) {
                 workingRecipe = null;
-                return ActionResult.SUCCESS;
+                return ActionResult.success(assignedGroupColor);
             }
 
             return ActionResult.fail(Component.translatable("gtceu.recipe_logic.insufficient_out")

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
@@ -161,7 +161,7 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
             var match = matchRecipeNoOutput(recipe);
             if (!match.isSuccess()) return match;
 
-            return matchTickRecipeNoOutput(recipe);
+            return matchTickRecipeNoOutput(recipe, match.assignedGroupColor());
         }
 
         @Override
@@ -175,7 +175,7 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
                 }
                 var recipeMatch = checkRecipe(modified);
                 if (recipeMatch.isSuccess()) {
-                    setupRecipe(modified);
+                    setupRecipe(modified, recipeMatch.assignedGroupColor());
                 } else {
                     setWaiting(recipeMatch.reason());
                 }
@@ -191,26 +191,26 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
         protected ActionResult matchRecipeNoOutput(GTRecipe recipe) {
             if (!getMachine().hasCapabilityProxies()) return ActionResult.FAIL_NO_CAPABILITIES;
             return RecipeHelper.handleRecipe(getMachine(), recipe, IO.IN, recipe.inputs, Collections.emptyMap(), false,
-                    true);
+                    true, -1);
         }
 
-        protected ActionResult matchTickRecipeNoOutput(GTRecipe recipe) {
+        protected ActionResult matchTickRecipeNoOutput(GTRecipe recipe, int assignedGroupColor) {
             if (recipe.hasTick()) {
                 if (!getMachine().hasCapabilityProxies()) return ActionResult.FAIL_NO_CAPABILITIES;
                 return RecipeHelper.handleRecipe(getMachine(), recipe, IO.IN, recipe.tickInputs, Collections.emptyMap(),
-                        false, true);
+                        false, true, assignedGroupColor);
             }
-            return ActionResult.SUCCESS;
+            return ActionResult.success(assignedGroupColor);
         }
 
         // Handle RecipeIO manually
         @Override
-        protected ActionResult handleRecipeIO(GTRecipe recipe, IO io) {
+        protected ActionResult handleRecipeIO(GTRecipe recipe, IO io, int assignedGroupColor) {
             if (io == IO.IN) {
                 // lock the object holder on recipe start
                 ObjectHolderMachine holder = getMachine().getObjectHolder();
                 holder.setLocked(true);
-                return ActionResult.SUCCESS;
+                return ActionResult.success(assignedGroupColor);
             }
 
             // "replace" the items in the slots rather than outputting elsewhere
@@ -218,7 +218,7 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
             ObjectHolderMachine holder = getMachine().getObjectHolder();
             if (lastRecipe == null) {
                 holder.setLocked(false);
-                return ActionResult.SUCCESS;
+                return ActionResult.success(assignedGroupColor);
             }
 
             holder.setHeldItem(ItemStack.EMPTY);
@@ -231,15 +231,15 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine
                 holder.setDataItem(outputItem.copy());
             }
             holder.setLocked(false);
-            return ActionResult.SUCCESS;
+            return ActionResult.success(assignedGroupColor);
         }
 
         @Override
-        protected ActionResult handleTickRecipeIO(GTRecipe recipe, IO io) {
+        protected ActionResult handleTickRecipeIO(GTRecipe recipe, IO io, int recipeGroupColor) {
             if (io != IO.OUT) {
-                return super.handleTickRecipeIO(recipe, io);
+                return super.handleTickRecipeIO(recipe, io, recipeGroupColor);
             }
-            return ActionResult.SUCCESS;
+            return ActionResult.success(recipeGroupColor);
         }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeCombustionEngineMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/generator/LargeCombustionEngineMachine.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.multiblock.util.RelativeDirection;
+import com.gregtechceu.gtceu.api.recipe.ActionResult;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.recipe.content.ContentModifier;
@@ -171,7 +172,7 @@ public class LargeCombustionEngineMachine extends WorkableElectricMultiblockMach
 
         if (runningTimer % 72 == 0) {
             // insufficient lubricant
-            if (!RecipeHelper.handleRecipeIO(this, getLubricantRecipe(), IO.IN, this.recipeLogic.getChanceCaches())
+            if (!RecipeHelper.handleRecipeIO(this, getLubricantRecipe(), IO.IN, this.recipeLogic.getChanceCaches(), -1)
                     .isSuccess()) {
                 recipeLogic.interruptRecipe();
                 return false;
@@ -180,8 +181,11 @@ public class LargeCombustionEngineMachine extends WorkableElectricMultiblockMach
         // check boost fluid
         if (isBoostAllowed()) {
             var boosterRecipe = getBoostRecipe();
-            this.isOxygenBoosted = RecipeHelper.matchRecipe(this, boosterRecipe).isSuccess() &&
-                    RecipeHelper.handleRecipeIO(this, boosterRecipe, IO.IN, this.recipeLogic.getChanceCaches())
+            ActionResult actionResult = RecipeHelper.matchRecipe(this, boosterRecipe);
+            this.isOxygenBoosted = actionResult.isSuccess() &&
+                    RecipeHelper
+                            .handleRecipeIO(this, boosterRecipe, IO.IN, this.recipeLogic.getChanceCaches(),
+                                    actionResult.assignedGroupColor())
                             .isSuccess();
             syncDataHolder.markClientSyncFieldDirty("isOxygenBoosted");
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/steam/LargeBoilerMachine.java
@@ -379,8 +379,8 @@ public class LargeBoilerMachine extends WorkableMultiblockMachine implements IMu
         }
 
         @Override
-        public void setupRecipe(GTRecipe recipe) {
-            super.setupRecipe(recipe);
+        public void setupRecipe(GTRecipe recipe, int recipeGroupColor) {
+            super.setupRecipe(recipe, recipeGroupColor);
             if (lastRecipe != null) {
                 setCurrentThrottle(getMachine().getThrottle());
             }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/BedrockOreMinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/BedrockOreMinerLogic.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.BedrockOreVeinSavedDat
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.OreVeinWorldEntry;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockore.WeightedMaterial;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
+import com.gregtechceu.gtceu.api.recipe.ActionResult;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.BedrockOreMinerMachine;
@@ -64,8 +65,9 @@ public class BedrockOreMinerLogic extends RecipeLogic {
             }
             var match = getOreMinerRecipe();
             if (match != null) {
-                if (RecipeHelper.matchContents(getMachine(), match).isSuccess()) {
-                    setupRecipe(match);
+                ActionResult actionResult = RecipeHelper.matchContents(getMachine(), match);
+                if (actionResult.isSuccess()) {
+                    setupRecipe(match, actionResult.assignedGroupColor());
                 }
             }
         }
@@ -135,14 +137,16 @@ public class BedrockOreMinerLogic extends RecipeLogic {
     public void onRecipeFinish() {
         getMachine().afterWorking();
         if (lastRecipe != null) {
-            RecipeHelper.handleRecipeIO(getMachine(), lastRecipe, IO.OUT, this.chanceCaches);
+            RecipeHelper.handleRecipeIO(getMachine(), lastRecipe, IO.OUT, this.chanceCaches,
+                    this.runningRecipeGroupColor);
         }
         depleteVein();
         // try it again
         var match = getOreMinerRecipe();
         if (match != null) {
-            if (RecipeHelper.matchContents(getMachine(), match).isSuccess()) {
-                setupRecipe(match);
+            ActionResult actionResult = RecipeHelper.matchContents(getMachine(), match);
+            if (actionResult.isSuccess()) {
+                setupRecipe(match, actionResult.assignedGroupColor());
                 return;
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/FluidDrillLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/FluidDrillLogic.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.BedrockFluidVeinSavedData;
 import com.gregtechceu.gtceu.api.data.worldgen.bedrockfluid.FluidVeinWorldEntry;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
+import com.gregtechceu.gtceu.api.recipe.ActionResult;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.common.machine.multiblock.electric.FluidDrillMachine;
@@ -59,8 +60,9 @@ public class FluidDrillLogic extends RecipeLogic {
             }
             var match = getFluidDrillRecipe();
             if (match != null) {
-                if (RecipeHelper.matchContents(getMachine(), match).isSuccess()) {
-                    setupRecipe(match);
+                ActionResult actionResult = RecipeHelper.matchContents(getMachine(), match);
+                if (actionResult.isSuccess()) {
+                    setupRecipe(match, actionResult.assignedGroupColor());
                 }
             }
         }
@@ -115,14 +117,16 @@ public class FluidDrillLogic extends RecipeLogic {
     public void onRecipeFinish() {
         getMachine().afterWorking();
         if (lastRecipe != null) {
-            RecipeHelper.handleRecipeIO(getMachine(), lastRecipe, IO.OUT, this.chanceCaches);
+            RecipeHelper.handleRecipeIO(getMachine(), lastRecipe, IO.OUT, this.chanceCaches,
+                    this.runningRecipeGroupColor);
         }
         depleteVein();
         // try it again
         var match = getFluidDrillRecipe();
         if (match != null) {
-            if (RecipeHelper.matchContents(getMachine(), match).isSuccess()) {
-                setupRecipe(match);
+            ActionResult actionResult = RecipeHelper.matchContents(getMachine(), match);
+            if (actionResult.isSuccess()) {
+                setupRecipe(match, actionResult.assignedGroupColor());
                 return;
             }
         }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -399,7 +399,7 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         if (recipe != null) {
             long eut = recipe.getInputEUt().getTotalEU();
             if (GTUtil.getTierByVoltage(eut) <= getVoltageTier()) {
-                if (RecipeHelper.handleRecipeIO(this, recipe, IO.OUT, this.chanceCaches).isSuccess()) {
+                if (RecipeHelper.handleRecipeIO(this, recipe, IO.OUT, this.chanceCaches, -1).isSuccess()) {
                     blockDrops.clear();
                     var result = new ArrayList<ItemStack>();
                     for (int i = 0; i < outputItemHandler.storage.getSlots(); ++i) {

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1800,7 +1800,7 @@ public class GTRecipeBuilder {
         return new GTRecipe(recipeType, id.withPrefix(recipeType.registryName.getPath() + "/"),
                 input, output, tickInput, tickOutput,
                 inputChanceLogic, outputChanceLogic, tickInputChanceLogic, tickOutputChanceLogic,
-                conditions, List.of(), data, duration, recipeCategory, -1);
+                conditions, List.of(), data, duration, recipeCategory);
     }
 
     protected void warnTooManyIngredients(RecipeCapability<?> capability,


### PR DESCRIPTION
## What

Reworked recipe group color to not be stored on recipe instance. This makes recipe group coloring consistent across all possible recipe execution paths across all machines (e.g. distillation tower, research station, and other special cases of recipe matching) and all entry points to setupRecipe (some machines have custom logic there that may run with the original, uncopied recipe).

## Implementation Details

ActionResult returned from recipe runner now stores assignedGroupColor value assigned by the recipe runner if no predefined group color was specified in the recipe handler call. Recipe handling family of functions now explicitly accepts recipe group color rather than implicitly reading it from recipe object. Running recipe group color is now stored on the recipe logic and not implicitly in the copied recipe. setupRecipe now explicitly takes recipe group color alongside the recipe, rather than expecting it to be set on the recipe. Consistency edits across the codebase to make sure all machines correctly handle recipe group coloring (most notably distillation tower).

### AI Usage 

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

Claude Sonnet 5 was used to review the code. All of the code is hand-written.

## Outcome

All machines and recipe logic implementations now correctly handle recipe group coloring under all circumstances and entry points to setupRecipe. group coloring information is always consistent after being assigned first during recipe matching.

## How Was This Tested

Tested a few multiblocks without colored buses and with colored buses and made sure the coloring logic works as expected.

## Potential Compatibility Issues

API did change, most notably RecipeHelper family of functions, RecipeLogic overridable functions, and ActionResult SUCCESS and PASS constants were replaced with factory methods.