### PR TITLE
Fix simulated recipe matching causing visible side effects

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.capability.recipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
@@ -25,6 +26,8 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
 
     /**
      * matching or handling the given recipe.
+     * The implementations must not produce any visible side effects when simulate == true.
+     * Multiple handleRecipeInner invocations with simulate == true can happen in parallel during recipe lookup.
      *
      * @param io       the IO type of this recipe. always be one of the {@link IO#IN} or {@link IO#OUT}
      * @param recipe   recipe.
@@ -41,18 +44,36 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
     /**
      * container size, if it has one. otherwise -1.
      */
+    @Contract(pure = true)
     default int getSize() {
         return -1;
     }
 
+    /**
+     * Returns a list of contents for of this handler for the purposes of recipe searching.
+     * The implementations must be pure, e.g. should not introduce no visible side effects.
+     * Multiple getContents invocations can happen in parallel during recipe lookup.
+     * 
+     * @return a list of ingredients for recipe lookup.
+     */
     @NotNull
+    @Contract(pure = true)
     List<Object> getContents();
 
+    /**
+     * Returns a list of contents for of this handler for the purposes of recipe searching.
+     * The implementations must be pure, e.g. should not introduce no visible side effects.
+     * Multiple getContents invocations can happen in parallel during recipe lookup.
+     *
+     * @return a total amount of content within this handler
+     */
+    @Contract(pure = true)
     double getTotalContentAmount();
 
     /**
      * Whether the content of same capability can only be handled distinct.
      */
+    @Contract(pure = true)
     default boolean isDistinct() {
         return false;
     }
@@ -63,6 +84,7 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
      * 
      * @return {@code true} if this {@code IRecipeHandler} has content to be searched
      */
+    @Contract(pure = true)
     default boolean shouldSearchContent() {
         return true;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/IRecipeHandler.java
@@ -50,7 +50,7 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
     }
 
     /**
-     * Returns a list of contents for of this handler for the purposes of recipe searching.
+     * Returns a list of contents of this handler for the purposes of recipe searching.
      * The implementations must be pure, e.g. should not introduce no visible side effects.
      * Multiple getContents invocations can happen in parallel during recipe lookup.
      * 
@@ -61,7 +61,8 @@ public interface IRecipeHandler<K> extends IFilteredHandler<K> {
     List<Object> getContents();
 
     /**
-     * Returns a list of contents for of this handler for the purposes of recipe searching.
+     * Returns a total amount of contents (meaning of that is content type-specific)
+     * in this handler for purposes of recipe searching.
      * The implementations must be pure, e.g. should not introduce no visible side effects.
      * Multiple getContents invocations can happen in parallel during recipe lookup.
      *

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
@@ -113,10 +113,13 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         if (io != IO.IN && io != IO.OUT) return left;
 
         // Temporarily remove listeners so that we can broadcast the entire set of transactions once
-        Runnable[] listeners = new Runnable[storages.length];
-        for (int i = 0; i < storages.length; i++) {
-            listeners[i] = storages[i].getOnContentsChanged();
-            storages[i].setOnContentsChanged(() -> {});
+        Runnable[] listeners = null;
+        if (!simulate) {
+            listeners = new Runnable[storages.length];
+            for (int i = 0; i < storages.length; i++) {
+                listeners[i] = storages[i].getOnContentsChanged();
+                storages[i].setOnContentsChanged(() -> {});
+            }
         }
         boolean changed = false;
 
@@ -222,9 +225,11 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
             }
         }
 
-        for (int i = 0; i < storages.length; i++) {
-            storages[i].setOnContentsChanged(listeners[i]);
-            if (changed && action.execute()) listeners[i].run();
+        if (listeners != null && !simulate) {
+            for (int i = 0; i < storages.length; i++) {
+                storages[i].setOnContentsChanged(listeners[i]);
+                if (changed && action.execute()) listeners[i].run();
+            }
         }
 
         return left;

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
@@ -94,8 +94,11 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
         if (io != IO.IN && io != IO.OUT) return left;
 
         // Temporarily remove listener so that we can broadcast the entire set of transactions once
-        Runnable listener = storage.getOnContentsChanged();
-        storage.setOnContentsChanged(() -> {});
+        Runnable listener = null;
+        if (!simulate) {
+            listener = storage.getOnContentsChanged();
+            storage.setOnContentsChanged(() -> {});
+        }
         boolean changed = false;
 
         // Store the ItemStack in each slot after an operation
@@ -170,8 +173,10 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
             }
         }
 
-        storage.setOnContentsChanged(listener);
-        if (changed && !simulate) listener.run();
+        if (!simulate) {
+            storage.setOnContentsChanged(listener);
+            if (changed) listener.run();
+        }
 
         return left;
     }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -130,7 +130,9 @@ public class RecipeRunner {
 
         List<RecipeHandlerList> handlers = capabilityProxies.getOrDefault(io, Collections.emptyList());
         // Only sort for non-tick outputs
-        if (!isTick && io.support(IO.OUT)) {
+        if (!isTick && io.support(IO.OUT) && !handlers.isEmpty()) {
+            // Copy before we sort, capabilityProxies is a live map which we should not modify during recipe search
+            handlers = new ArrayList<>(handlers);
             handlers.sort(RecipeHandlerList.COMPARATOR.reversed());
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/machine/MEPatternBufferPartMachine.java
@@ -85,6 +85,7 @@ import com.mojang.blaze3d.platform.InputConstants;
 import it.unimi.dsi.fastutil.objects.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -963,22 +964,24 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
             }
         }
 
+        // This function is not technically pure, but it has no visible side effects, and is safe to execute in parallel
+        @Contract(pure = true)
         public List<ItemStack> getItems() {
             if (itemStacks == null) {
-                itemStacks = new ArrayList<>();
-                itemInventory.object2LongEntrySet().stream()
-                        .map(e -> GTMath.splitStacks(e.getKey(), e.getLongValue()))
-                        .forEach(itemStacks::addAll);
+                itemStacks = itemInventory.object2LongEntrySet().stream()
+                        .flatMap(e -> GTMath.splitStacks(e.getKey(), e.getLongValue()).stream())
+                        .toList();
             }
             return itemStacks;
         }
 
+        // This function is not technically pure, but it has no visible side effects, and is safe to execute in parallel
+        @Contract(pure = true)
         public List<FluidStack> getFluids() {
             if (fluidStacks == null) {
-                fluidStacks = new ArrayList<>();
-                fluidInventory.object2LongEntrySet().stream()
-                        .map(e -> GTMath.splitFluidStacks(e.getKey(), e.getLongValue()))
-                        .forEach(fluidStacks::addAll);
+                fluidStacks = fluidInventory.object2LongEntrySet().stream()
+                        .flatMap(e -> GTMath.splitFluidStacks(e.getKey(), e.getLongValue()).stream())
+                        .toList();
             }
             return fluidStacks;
         }
@@ -1058,7 +1061,9 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
                     var stack = entry.getKey();
                     var count = entry.getLongValue();
                     if (stack.isEmpty() || count == 0) {
-                        it2.remove();
+                        if (!simulate) {
+                            it2.remove();
+                        }
                         continue;
                     }
                     if (!ingredient.test(stack)) continue;
@@ -1110,7 +1115,9 @@ public class MEPatternBufferPartMachine extends MEBusPartMachine
                     var stack = entry.getKey();
                     var count = entry.getLongValue();
                     if (stack.isEmpty() || count == 0) {
-                        it2.remove();
+                        if (!simulate) {
+                            it2.remove();
+                        }
                         continue;
                     }
                     if (!ingredient.test(stack)) continue;


### PR DESCRIPTION
## What

Fixes simulated recipe matching causing visible side effects, making it unsafe to run in parallel and violating semantics of simulated == true family of functions.

## Implementation Details

Just gating of some functionality behind !simulated, clarifying contracts in IRecipeHandler interface in regards to purity and side effects, and changing ME hatch item/fluid list caching to avoid assigning the list before it is finished being built.

### AI Usage 

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

Claude Sonnet 5 was used to review the code.
  
## Outcome

A certain subset of recipe search APIs is now safe to run in parallel.

## How Was This Tested

Checked that recipe matching still works as expected.

## Potential Compatibility Issues

None expected.
