### PR TITLE
Tweaked steam boilers to have lower fuel consumption when fully heated.

### DIFF
--- a/src/generated/resources/assets/gtceu/lang/en_us.json
+++ b/src/generated/resources/assets/gtceu/lang/en_us.json
@@ -2723,6 +2723,8 @@
   "gtceu.machine.block_breaker.tooltip": "§7Mines block on front face and collects its drops",
   "gtceu.machine.boiler.info.cooling.down": "§9Cooling§r",
   "gtceu.machine.boiler.info.heating.up": "§cHeating§r",
+  "gtceu.machine.boiler.info.heated_up": "§cHeated Up§r",
+  "gtceu.machine.boiler.info.fuel_consumption_discount": "§eFuel Consumption Discount: §f%s%%",
   "gtceu.machine.boiler.info.production.data": "§aProducing %s§a mB/t",
   "gtceu.machine.buffer.tooltip": "A Small Buffer to store Items and Fluids",
   "gtceu.machine.canner.jei_description": "You can fill and empty any fluid containers with the Fluid Canner (e.g. Buckets or Fluid Cells)",

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/steam/SteamBoilerMachine.java
@@ -9,6 +9,7 @@ import com.gregtechceu.gtceu.api.machine.feature.*;
 import com.gregtechceu.gtceu.api.machine.mui.MachineUIPanelBuilder;
 import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableFluidTank;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
+import com.gregtechceu.gtceu.api.recipe.ActionResult;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.modifier.ModifierFunction;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
@@ -74,12 +75,16 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
     protected TickableSubscription temperatureSubs, autoOutputSubs;
     @Nullable
     protected ISubscription steamTankSubs;
+    @SaveField
+    @Getter
+    private int heatingTimeDebt; // amount of time the fuel should be burned for to account for the boiler cooling down
 
     public SteamBoilerMachine(BlockEntityCreationInfo info, boolean isHighPressure) {
-        super(info, isHighPressure, new RecipeLogic(),
+        super(info, isHighPressure, new SteamBoilerRecipeLogic(),
                 new NotifiableFluidTank(1, 16 * FluidType.BUCKET_VOLUME, IO.OUT));
         this.waterTank = attachTrait(createWaterTank());
         this.waterTank.setFilter(fluid -> fluid.getFluid().is(GTMaterials.Water.getFluidTag()));
+        recipeLogic.setRegressWhenWaiting(false);
     }
 
     //////////////////////////////////////
@@ -157,18 +162,31 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
     }
 
     protected void updateCurrentTemperature() {
-        if (recipeLogic.isWorking()) {
-            if (getOffsetTimer() % 12 == 0) {
-                if (currentTemperature < getMaxTemperature())
-                    if (isHighPressure) {
-                        currentTemperature++;
-                    } else if (getOffsetTimer() % 24 == 0) {
-                        currentTemperature++;
-                    }
+        if (shouldDiscountFuelConsumptionAtMaxTemperature() &&
+                currentTemperature >= getMaxTemperature() &&
+                (recipeLogic.isWorking() || recipeLogic.isWaiting())) {
+            // We are fully heated up and are running a recipe. We want to simulate the cooling logic here,
+            // but instead of actually lowering the temperature, we instead manipulate the heating time debt
+            // to simulate the fuel burn cycle without actually affecting the temperature.
+            if (timeBeforeCoolingDown == 0) {
+                // Heating interval times cool down rate is the same amount of fuel recipe progress it would take
+                // to get the lowered temperature back up to the maximum temperature.
+                heatingTimeDebt += getHeatingTimeDebtAtMaxTemperature();
+                timeBeforeCoolingDown = getCooldownInterval();
+            } else {
+                --timeBeforeCoolingDown;
+            }
+        } else if (recipeLogic.isWorking()) {
+            this.timeBeforeCoolingDown = getCooldownInterval();
+            if (getOffsetTimer() % getHeatingInterval() == 0) {
+                if (currentTemperature < getMaxTemperature()) {
+                    currentTemperature++;
+                }
             }
         } else if (timeBeforeCoolingDown == 0) {
             if (currentTemperature > 0) {
                 currentTemperature -= getCoolDownRate();
+                heatingTimeDebt = 0;
                 timeBeforeCoolingDown = getCooldownInterval();
             }
         } else {
@@ -229,6 +247,10 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
         return 1;
     }
 
+    protected int getHeatingInterval() {
+        return isHighPressure ? 12 : 24;
+    }
+
     public int getMaxTemperature() {
         return isHighPressure ? 1000 : 500;
     }
@@ -267,6 +289,9 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
 
     @Override
     public boolean onWorking() {
+        if (heatingTimeDebt > 0) {
+            --this.heatingTimeDebt;
+        }
         boolean value = super.onWorking();
         if (currentTemperature < getMaxTemperature()) {
             currentTemperature = Math.max(1, currentTemperature);
@@ -275,10 +300,28 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
         return value;
     }
 
-    @Override
-    public void afterWorking() {
-        super.afterWorking();
-        this.timeBeforeCoolingDown = getCooldownInterval();
+    /** Returns true if fuel consumption should be discounted at max temperature */
+    protected boolean shouldDiscountFuelConsumptionAtMaxTemperature() {
+        return true;
+    }
+
+    /** Returns true if we should suspend the currently running burning recipe due to the boiler being fully heated */
+    protected boolean shouldSuspendRecipeDueToBeingFullyHeated() {
+        return shouldDiscountFuelConsumptionAtMaxTemperature() &&
+                currentTemperature >= getMaxTemperature() &&
+                heatingTimeDebt <= 0;
+    }
+
+    protected int getHeatingTimeDebtAtMaxTemperature() {
+        return Math.min(getHeatingInterval() * getCoolDownRate(), getCooldownInterval());
+    }
+
+    /** Returns the effective fuel consumption rate, normalized */
+    public float getEffectiveFuelConsumptionRate() {
+        if (shouldDiscountFuelConsumptionAtMaxTemperature() && currentTemperature >= getMaxTemperature()) {
+            return getHeatingTimeDebtAtMaxTemperature() * 1.0f / getCooldownInterval();
+        }
+        return 1.0f;
     }
 
     //////////////////////////////////////
@@ -390,5 +433,17 @@ public abstract class SteamBoilerMachine extends SteamWorkableMachine
                     FormattingUtil.formatNumbers((int) (getTemperaturePercent() * 100))));
         }
         return new ArrayList<>();
+    }
+
+    private static class SteamBoilerRecipeLogic extends RecipeLogic {
+
+        @Override
+        public ActionResult handleTickRecipe(GTRecipe recipe) {
+            SteamBoilerMachine boilerMachine = (SteamBoilerMachine) getMachine();
+            if (boilerMachine.shouldSuspendRecipeDueToBeingFullyHeated()) {
+                return ActionResult.FAIL_NO_REASON;
+            }
+            return super.handleTickRecipe(recipe);
+        }
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamSolarBoiler.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/steam/SteamSolarBoiler.java
@@ -71,6 +71,11 @@ public class SteamSolarBoiler extends SteamBoilerMachine {
     }
 
     @Override
+    protected boolean shouldDiscountFuelConsumptionAtMaxTemperature() {
+        return false; // does not really make sense for solar boiler
+    }
+
+    @Override
     public void buildMainUI(ParentWidget<?> mainWidget, PosGuiData guiData, PanelSyncManager syncManager,
                             UISettings settings) {
         super.buildMainUI(mainWidget, guiData, syncManager, settings);

--- a/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/SteamBoilerBlockProvider.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/jade/provider/SteamBoilerBlockProvider.java
@@ -9,6 +9,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
@@ -25,11 +26,14 @@ public class SteamBoilerBlockProvider extends MachineInfoProvider<SteamBoilerMac
     @Override
     protected CompoundTag write(SteamBoilerMachine machine) {
         CompoundTag data = new CompoundTag();
-        data.putBoolean("isBurning", machine.getTraitOptional(RecipeLogic.class).orElseThrow().isWorking());
+        RecipeLogic recipeLogic = machine.getTraitOptional(RecipeLogic.class).orElseThrow();
+        data.putBoolean("isBurning", recipeLogic.isWorking() || recipeLogic.isWaiting());
         data.putBoolean("hasWater", !machine.isHasNoWater());
         data.putLong("steamProduction", machine.getTotalSteamOutput());
         data.putInt("currentTemperature", machine.getCurrentTemperature());
         data.putInt("maxTemperature", machine.getMaxTemperature());
+        int fuelConsumptionRate = Mth.ceil(machine.getEffectiveFuelConsumptionRate() * 100.0f);
+        data.putInt("fuelConsumptionRate", fuelConsumptionRate);
         return data;
     }
 
@@ -41,12 +45,24 @@ public class SteamBoilerBlockProvider extends MachineInfoProvider<SteamBoilerMac
         long production = capData.getLong("steamProduction");
         int temperature = capData.getInt("currentTemperature");
         int maxTemperature = capData.getInt("maxTemperature");
+        int fuelConsumptionRate = capData.getInt("fuelConsumptionRate");
 
         boolean makingSteam = hasWater && temperature >= 100;
 
+        // Append fuel consumption discount first
+        if (fuelConsumptionRate < 100) {
+            // Round up to a nicer number. precision less than 5% is irrelevant here
+            int fuelConsumptionDiscount = Math.round((100.0f - fuelConsumptionRate) / 5.0f) * 5;
+            tooltip.add(Component.translatable("gtceu.machine.boiler.info.fuel_consumption_discount",
+                    fuelConsumptionDiscount));
+        }
+
         // Determine the first section
         MutableComponent root;
-        if (isBurning && temperature < maxTemperature) {
+        if (isBurning && temperature >= maxTemperature) {
+            // Fully heated
+            root = Component.translatable("gtceu.machine.boiler.info.heated_up");
+        } else if (isBurning) {
             // Heating up
             root = Component.translatable("gtceu.machine.boiler.info.heating.up");
         } else if (!isBurning && temperature > 0) {


### PR DESCRIPTION
## What

Tweaked steam boilers to have lower fuel consumption when fully heated.
The new fuel consumption when fully heated matches the optimal fuel consumption that presently can be reached if the player lets the boiler heat up to maximum temperature and then removes fuel, and adds one fuel item at a time once boiler temperature drops back down enough for the entirety of the burned fuel item to be spent on heating the boiler up. This can be automated with redstone as well to remove the manual player interaction from the picture.

To simulate this scenario, the boilers now have a fuel consumption discount when at maximum temperature. The consumption discount matches the optimal fuel efficiency that can already be reached via the scenario described above:
Fuel Consumption Discount = 1.0 - (Heating Interval * Cool Down Rate / Cool Down Interval)

The math above produces 45% fuel consumption discount for low pressure solid and liquid boilers and 70% fuel consumption discount for their high pressure versions. Solar boilers are unaffected due to not burning conventional fuel.

This reduces the early game grind significantly by removing the boilerplate of having to manually interact with small boilers to achieve reasonable fuel efficiency for them (given their horrible fuel efficiency compared to large boilers), without the need of building a setup specifically to reach satisfactory fuel consumption rate.

## Implementation Details

Boilers now throttle their fuel consumption by stopping the recipe working by failing the handleTickRecipe in a controlled fashion to achieve the desired fuel consumption rate. When at max temperature, the boiler simulates the cooling off mechanic without actually modifying the externally observed temperature, preventing it from continuously jumping between maximum temperature and maximum temperature - 1. Heating time needed to counteract the cooling is added to the heating time debt, where the time debt is calculated as `getHeatingInterval() * getCoolDownRate()`, from which the formula presented above is derived. The boiler pauses its fuel consumption at max temperature if it has no heating time debt, and resumes it once the debt is accumulated. Additionally, fuel consumption discount is now shown in JADE when it is applicable.

### AI Usage 

- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

Claude Sonnet 5 was used to review the code.
  
## Outcome

Boilers consume less fuel now when at max temperature, with the discounted consumption ratio matching the optimal consumption ratio that could previously be achieved by the players by manually controlling the boiler fuel consumption.

## How Was This Tested

By placing the boilers down and timing their fuel consumption under various circumstances.

## Additional Information

Screenshot of fuel consumption discount in JADE.
<img width="396" height="203" alt="image" src="https://github.com/user-attachments/assets/299894af-79a2-4775-b07d-8cf072bc36a6" />

