### PR TITLE
Fix remap on mixin spoilage

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/InvWrapperMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/InvWrapperMixin.java
@@ -41,7 +41,8 @@ public abstract class InvWrapperMixin {
 
     @WrapOperation(method = { "setStackInSlot", "insertItem" },
                    at = @At(value = "INVOKE",
-                            target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V"))
+                            target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V",
+                            remap = true))
     private void gtceu$spoilInsertedItem(Container instance, int slot, ItemStack itemStack, Operation<Void> original) {
         SpoilUtils.update(itemStack, gtceu$getSpoilContext().withSlot(slot));
         original.call(instance, slot, itemStack);


### PR DESCRIPTION
opus 5 was used to find and fix the issue 

fixes
Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Callback method gtceu$spoilInsertedItem(Lnet/minecraft/world/Container;ILnet/minecraft/world/item/ItemStack;Lcom/llamalad7/mixinextras/injector/wrapoperation/Operation;)V in gtceu.mixins.json:InvWrapperMixin failed injection check, (0/1) succeeded. Scanned 2 target(s). Using refmap gtceu.refmap.json
