### PR TITLE
Disambiguate Predicate.blocks(Block) and fix spoilage network issue

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/multiblock/Predicates.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/multiblock/Predicates.java
@@ -34,6 +34,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.tags.ITagManager;
 
 import com.tterrag.registrate.util.entry.RegistryEntry;
+import dev.latvian.mods.rhino.util.HideFromJS;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.Nullable;
@@ -85,6 +86,7 @@ public class Predicates {
                 .toMultiPredicate();
     }
 
+    @HideFromJS
     public static MultiPredicate blocks(Block block) {
         return builder("Block")
                 .predicate(ctx -> ctx.state().is(block))

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -197,6 +197,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         buf.writeVarInt(recipe.batchParallels);
         buf.writeInt(recipe.groupColor);
         buf.writeResourceLocation(recipe.recipeCategory.registryKey);
+        recipe.spoilageData.writeToNetwork(buf);
     }
 
     /**

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
@@ -58,4 +58,8 @@ public class RecipeSpoilageData {
     public static RecipeSpoilageData readFromNetwork(FriendlyByteBuf buf) {
         return new RecipeSpoilageData(new HashMap<>(), buf.readBoolean());
     }
+
+    public void writeToNetwork(FriendlyByteBuf buf) {
+        buf.writeBoolean(keepSpoilingProgress);
+    }
 }

--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/InvWrapperMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/InvWrapperMixin.java
@@ -41,7 +41,8 @@ public abstract class InvWrapperMixin {
 
     @WrapOperation(method = { "setStackInSlot", "insertItem" },
                    at = @At(value = "INVOKE",
-                            target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V"))
+                            target = "Lnet/minecraft/world/Container;setItem(ILnet/minecraft/world/item/ItemStack;)V",
+                            remap = true))
     private void gtceu$spoilInsertedItem(Container instance, int slot, ItemStack itemStack, Operation<Void> original) {
         SpoilUtils.update(itemStack, gtceu$getSpoilContext().withSlot(slot));
         original.call(instance, slot, itemStack);


### PR DESCRIPTION
Dis-ambiguate Predicate.blocks(one block) to use the (Blocks...) form
also fixes a network desync in spoilage because my game wouldn't launch otherwise to test

Opus 5 used to find and fix the network issue