### PR TITLE
Remove level requirement for SmartItemFilter.onFilterLoaded

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SmartItemFilter.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.machine.MachineCoverContainer;
-import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
@@ -71,10 +70,7 @@ public class SmartItemFilter extends Filter<ItemStack> {
     public void onFilterLoaded(FilterHandler<ItemStack> handler) {
         if (handler.getParentSyncObject() instanceof CoverBehavior cover &&
                 cover.coverHolder instanceof MachineCoverContainer mcc) {
-            var machine = MetaMachine.getMachine(mcc.getLevel(), mcc.getBlockPos());
-            if (machine != null) {
-                setModeFromMachine(machine.getDefinition().getName());
-            }
+            setModeFromMachine(mcc.getMachine().getDefinition().getName());
         }
     }
 


### PR DESCRIPTION
In my previous PR I made the filter load happen during NBT serialization, which means the level isn't available yet. Luckily we already store a reference to the machine that the cover is applied to so no need to go through the level

Tested in game by saving and loading it in all configurations (on crate, on relevant machine, in robot arm, without robot artm etc)

Made with opus 5 