### PR TITLE
Fix mutability issue in deserialized spoilage data

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/capability/recipe/RecipeCapability.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
+import java.util.function.Function;
 
 /**
  * Used to detect whether a machine has a certain capability.
@@ -65,11 +66,11 @@ public abstract class RecipeCapability<T> {
     }
 
     public static Codec<List<Content>> contentCodec(RecipeCapability<?> capability) {
-        return Content.codec(capability).listOf();
+        return Content.codec(capability).listOf().xmap(ArrayList::new, Function.identity());
     }
 
     public static <T> Codec<List<T>> ingredientCodec(RecipeCapability<T> capability) {
-        return Content.ingredientCodec(capability).listOf();
+        return Content.ingredientCodec(capability).listOf().xmap(ArrayList::new, Function.identity());
     }
 
     public Tag contentToNbt(Object value) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -95,7 +95,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
     @Nullable
     @Getter
     @SaveField
-    @SyncToClient
     protected GTRecipe lastRecipe;
     @Nullable
     @Getter
@@ -405,8 +404,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         lastUnrolledRecipe = null;
         lastOriginRecipe = null;
         handleSearchingRecipes(searchRecipe());
-        syncDataHolder.markClientSyncFieldDirty("lastRecipe");
-        syncDataHolder.markClientSyncFieldDirty("lastDisplayedRecipe");
+        syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
         recipeDirty = false;
     }
 
@@ -439,7 +437,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         if (lastUnrolledRecipe == null) {
             GTCEu.LOGGER.warn("Last Displayed Recipe is null! Ingredients may roll incorrectly.");
             this.lastUnrolledRecipe = lastRecipe.copy();
-            syncDataHolder.markClientSyncFieldDirty("lastDisplayedRecipe");
+            syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
             markLastRecipeDirty();
         }
         GTRecipe runningRecipe = RecipeHelper.doTickPrerolls(recipe, chanceCaches, lastUnrolledRecipe);
@@ -465,7 +463,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
             chanceCaches.clear();
         }
         lastUnrolledRecipe = recipe.copy();
-        syncDataHolder.markClientSyncFieldDirty("lastDisplayedRecipe");
+        syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
         GTRecipe runningRecipe = RecipeHelper.doPrerolls(recipe, chanceCaches);
         var handledIO = handleRecipeIO(runningRecipe, IO.IN);
         if (handledIO.isSuccess()) {
@@ -483,7 +481,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         } else {
             lastRecipe = null;
             lastUnrolledRecipe = null;
-            syncDataHolder.markClientSyncFieldDirty("lastDisplayedRecipe");
+            syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
@@ -23,7 +23,7 @@ public class RecipeSpoilageData {
 
     public static final Codec<RecipeSpoilageData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             RecipeCapability.INGREDIENT_CODEC.optionalFieldOf("consumedInputs", new HashMap<>())
-                    .xmap(RecipeSpoilageData::mutableCopy, Function.identity())
+                    .xmap(HashMap::new, Function.identity())
                     .forGetter(RecipeSpoilageData::getConsumedInputs),
             Codec.BOOL.fieldOf("keepSpoilingProgress").forGetter(RecipeSpoilageData::keepSpoilingProgress))
             .apply(instance, RecipeSpoilageData::new));
@@ -40,12 +40,6 @@ public class RecipeSpoilageData {
 
     public RecipeSpoilageData(boolean keepSpoilingProgress) {
         this(new HashMap<>(), keepSpoilingProgress);
-    }
-
-    private static Map<RecipeCapability<?>, List<?>> mutableCopy(Map<RecipeCapability<?>, List<?>> consumedInputs) {
-        Map<RecipeCapability<?>, List<?>> copied = new HashMap<>();
-        consumedInputs.forEach((capability, inputs) -> copied.put(capability, new ArrayList<>(inputs)));
-        return copied;
     }
 
     public RecipeSpoilageData copy() {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
@@ -16,12 +16,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 @AllArgsConstructor
 public class RecipeSpoilageData {
 
     public static final Codec<RecipeSpoilageData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             RecipeCapability.INGREDIENT_CODEC.optionalFieldOf("consumedInputs", new HashMap<>())
+                    .xmap(RecipeSpoilageData::mutableCopy, Function.identity())
                     .forGetter(RecipeSpoilageData::getConsumedInputs),
             Codec.BOOL.fieldOf("keepSpoilingProgress").forGetter(RecipeSpoilageData::keepSpoilingProgress))
             .apply(instance, RecipeSpoilageData::new));
@@ -38,6 +40,12 @@ public class RecipeSpoilageData {
 
     public RecipeSpoilageData(boolean keepSpoilingProgress) {
         this(new HashMap<>(), keepSpoilingProgress);
+    }
+
+    private static Map<RecipeCapability<?>, List<?>> mutableCopy(Map<RecipeCapability<?>, List<?>> consumedInputs) {
+        Map<RecipeCapability<?>, List<?>> copied = new HashMap<>();
+        consumedInputs.forEach((capability, inputs) -> copied.put(capability, new ArrayList<>(inputs)));
+        return copied;
     }
 
     public RecipeSpoilageData copy() {

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeSpoilageData.java
@@ -23,7 +23,7 @@ public class RecipeSpoilageData {
 
     public static final Codec<RecipeSpoilageData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             RecipeCapability.INGREDIENT_CODEC.optionalFieldOf("consumedInputs", new HashMap<>())
-                    .xmap(HashMap::new, Function.identity())
+                    .xmap((map -> (Map<RecipeCapability<?>, List<?>>) new HashMap(map)), Function.identity())
                     .forGetter(RecipeSpoilageData::getConsumedInputs),
             Codec.BOOL.fieldOf("keepSpoilingProgress").forGetter(RecipeSpoilageData::keepSpoilingProgress))
             .apply(instance, RecipeSpoilageData::new));

--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/AssemblyLineRender.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/impl/AssemblyLineRender.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.client.renderer.machine.impl;
 import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.multiblock.util.RelativeDirection;
+import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.client.renderer.GTRenderTypes;
 import com.gregtechceu.gtceu.client.renderer.machine.DynamicRender;
 import com.gregtechceu.gtceu.client.renderer.machine.DynamicRenderType;
@@ -48,12 +49,13 @@ public class AssemblyLineRender extends DynamicRender<AssemblyLineMachine, Assem
 
     @OnlyIn(Dist.CLIENT)
     private void renderLines(AssemblyLineMachine machine, float partialTick, PoseStack stack, VertexConsumer buffer) {
-        if (machine.getRecipeLogic().getLastRecipe() == null) return;
+        GTRecipe recipe = machine.getRecipeLogic().getLastUnrolledRecipe();
+        if (recipe == null) return;
         int asslineColor = Long.decode(ConfigHolder.INSTANCE.client.renderer.assemblyLineLaser).intValue();
         float progress = machine.getProgress() / (float) machine.getMaxProgress();
         int recipeInputs = Math.max(
-                machine.getRecipeLogic().getLastRecipe().getInputContents(ItemRecipeCapability.CAP).size(),
-                machine.getRecipeLogic().getLastRecipe().getInputContents(FluidRecipeCapability.CAP).size());
+                recipe.getInputContents(ItemRecipeCapability.CAP).size(),
+                recipe.getInputContents(FluidRecipeCapability.CAP).size());
         progress *= recipeInputs;
         Direction down = RelativeDirection.DOWN.getRelativeFacing(machine.getFrontFacing(), machine.getUpwardsFacing(),
                 machine.isFlipped());

--- a/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/mui/GTMultiblockTextUtil.java
@@ -479,6 +479,10 @@ public class GTMultiblockTextUtil {
                         .copy(GTRecipe::copy)
                         .build());
 
+        BooleanSyncValue hasRunningRecipe = syncManager.getOrCreateSyncHandler("hasRunningRecipe",
+                BooleanSyncValue.class,
+                () -> new BooleanSyncValue(() -> rlmachine.getRecipeLogic().getLastRecipe() != null));
+
         DynamicLinkedSyncHandler<GenericSyncValue<GTRecipe>> dynamicLinkedSyncHandler = new DynamicLinkedSyncHandler<>(
                 recipeSyncValue)
                 .widgetProvider((syncManager1, recipeSyncHandler) -> {
@@ -508,7 +512,7 @@ public class GTMultiblockTextUtil {
                 .widthRel(1)
                 .coverChildrenHeight()
                 .syncHandler(dynamicLinkedSyncHandler)
-                .setEnabledIf(w -> rlmachine.getRecipeLogic().getLastRecipe() != null);
+                .setEnabledIf(w -> hasRunningRecipe.getBoolValue());
     }
 
     public static Optional<Widget<?>> createItemLineForOutput(Content itemOutput, GTRecipe recipe) {


### PR DESCRIPTION
Make content and ingredient data immutable by default. also, the optionalFieldOf default value is only created once so all values would share the one instance, so we xmap with HashMap::new

made with opus 5

Currently compiling for testing in my moni run