### PR TITLE
Get rid of SpoilageRecipeData

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
@@ -4,6 +4,8 @@ import com.gregtechceu.gtceu.api.capability.recipe.FluidRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.IFilteredHandler;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
@@ -189,12 +191,22 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
                             visited[tank] = drained.copy();
                             visited[tank].setAmount(count - drained.getAmount());
                             changed = true;
-                            if (recipe != null) {
+                            if (!simulate) {
                                 FluidStack copied = drained.copy();
-                                getMachine().getTraitOptional(RecipeLogic.class)
-                                        .map(RecipeLogic::getConsumedInputs)
-                                        .ifPresent(inputs -> inputs.addConsumedInput(GTRecipeCapabilities.FLUID,
-                                                FluidIngredient.of(copied)));
+                                if (getMachine() instanceof MultiblockPartMachine partMachine) {
+                                    for (MultiblockControllerMachine controller : partMachine.getControllers()) {
+                                        RecipeLogic logic = controller.getTrait(RecipeLogic.class);
+                                        if (logic != null && logic.getStartingRecipe() == recipe) {
+                                            logic.getConsumedInputs().addConsumedInput(GTRecipeCapabilities.FLUID,
+                                                    FluidIngredient.of(copied));
+                                        }
+                                    }
+                                } else {
+                                    getMachine().getTraitOptional(RecipeLogic.class)
+                                            .map(RecipeLogic::getConsumedInputs)
+                                            .ifPresent(inputs -> inputs.addConsumedInput(GTRecipeCapabilities.FLUID,
+                                                    FluidIngredient.of(copied)));
+                                }
                             }
                         }
                         amount -= drained.getAmount();

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableFluidTank.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.IFilteredHandler;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.FluidIngredient;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderFluidIngredient;
@@ -190,8 +191,10 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
                             changed = true;
                             if (recipe != null) {
                                 FluidStack copied = drained.copy();
-                                recipe.spoilageData.addConsumedInput(GTRecipeCapabilities.FLUID,
-                                        FluidIngredient.of(copied));
+                                getMachine().getTraitOptional(RecipeLogic.class)
+                                        .map(RecipeLogic::getConsumedInputs)
+                                        .ifPresent(inputs -> inputs.addConsumedInput(GTRecipeCapabilities.FLUID,
+                                                FluidIngredient.of(copied)));
                             }
                         }
                         amount -= drained.getAmount();

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
@@ -8,6 +8,8 @@ import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.item.component.ISpoilableItem;
 import com.gregtechceu.gtceu.api.item.component.SpoilUtils;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
 import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.DummyCraftingContainer;
@@ -148,7 +150,15 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                                 ItemStack copied = extracted.copy();
                                 ISpoilableItem spoilable = GTCapabilityHelper.getSpoilable(copied);
                                 if (spoilable != null) spoilable.freezeSpoiling();
-                                if (machine != null) machine.getTraitOptional(RecipeLogic.class)
+                                if (machine instanceof MultiblockPartMachine partMachine) {
+                                    for (MultiblockControllerMachine controller : partMachine.getControllers()) {
+                                        RecipeLogic logic = controller.getTrait(RecipeLogic.class);
+                                        if (logic != null && logic.getStartingRecipe() == recipe) {
+                                            logic.getConsumedInputs().addConsumedInput(GTRecipeCapabilities.ITEM,
+                                                    Ingredient.of(copied));
+                                        }
+                                    }
+                                } else if (machine != null) machine.getTraitOptional(RecipeLogic.class)
                                         .map(RecipeLogic::getConsumedInputs)
                                         .ifPresent(inputs -> inputs.addConsumedInput(GTRecipeCapabilities.ITEM,
                                                 Ingredient.of(copied)));

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
@@ -7,7 +7,9 @@ import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 import com.gregtechceu.gtceu.api.item.component.ISpoilableItem;
 import com.gregtechceu.gtceu.api.item.component.SpoilUtils;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.trait.ICapabilityTrait;
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
 import com.gregtechceu.gtceu.api.recipe.DummyCraftingContainer;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.ingredient.IntProviderIngredient;
@@ -87,14 +89,15 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
     @Override
     public List<Ingredient> handleRecipeInner(IO io, @Nullable GTRecipe recipe, List<Ingredient> left,
                                               boolean simulate) {
-        return handleRecipe(io, recipe, left, simulate, handlerIO, storage);
+        return handleRecipe(io, recipe, left, simulate, handlerIO, storage, getMachine());
     }
 
     // TODO: See if implementable in outside callers and unstatic; or move to different common class if not
     // Notable caller is ItemRecipeHandler, used for MinerLogic
     public static List<Ingredient> handleRecipe(IO io, @Nullable GTRecipe recipe, List<Ingredient> left,
                                                 boolean simulate,
-                                                IO handlerIO, CustomItemStackHandler storage) {
+                                                IO handlerIO, CustomItemStackHandler storage,
+                                                @Nullable MetaMachine machine) {
         if (io != handlerIO) return left;
         if (io != IO.IN && io != IO.OUT) return left;
 
@@ -145,7 +148,10 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                                 ItemStack copied = extracted.copy();
                                 ISpoilableItem spoilable = GTCapabilityHelper.getSpoilable(copied);
                                 if (spoilable != null) spoilable.freezeSpoiling();
-                                recipe.spoilageData.addConsumedInput(GTRecipeCapabilities.ITEM, Ingredient.of(copied));
+                                if (machine != null) machine.getTraitOptional(RecipeLogic.class)
+                                        .map(RecipeLogic::getConsumedInputs)
+                                        .ifPresent(inputs -> inputs.addConsumedInput(GTRecipeCapabilities.ITEM,
+                                                Ingredient.of(copied)));
                             }
                         }
                         amount -= extracted.getCount();

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/notifiable/NotifiableItemStackHandler.java
@@ -146,7 +146,7 @@ public class NotifiableItemStackHandler extends NotifiableRecipeHandlerTrait<Ing
                         if (!extracted.isEmpty()) {
                             changed = true;
                             visited[slot] = extracted.copyWithCount(count - extracted.getCount());
-                            if (recipe != null) {
+                            if (!simulate) {
                                 ItemStack copied = extracted.copy();
                                 ISpoilableItem spoilable = GTCapabilityHelper.getSpoilable(copied);
                                 if (spoilable != null) spoilable.freezeSpoiling();

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
 import com.gregtechceu.gtceu.api.machine.property.GTMachineModelProperties;
 import com.gregtechceu.gtceu.api.machine.trait.MachineTrait;
 import com.gregtechceu.gtceu.api.recipe.ActionResult;
+import com.gregtechceu.gtceu.api.recipe.ConsumedInputsData;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
@@ -164,6 +165,9 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
      * Defaults to true, so that recipes will always attempt to update OC, parallels, etc.
      */
     protected boolean alwaysTryModifyRecipe = true;
+
+    @Getter
+    protected ConsumedInputsData consumedInputs = new ConsumedInputsData();
 
     public RecipeLogic() {
         super();
@@ -464,6 +468,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         }
         lastUnrolledRecipe = recipe.copy();
         syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
+        consumedInputs.clear();
         GTRecipe runningRecipe = RecipeHelper.doPrerolls(recipe, chanceCaches);
         var handledIO = handleRecipeIO(runningRecipe, IO.IN);
         if (handledIO.isSuccess()) {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -112,6 +112,10 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
     @SaveField
     protected GTRecipe lastOriginRecipe;
 
+    @Nullable
+    @Getter
+    protected GTRecipe startingRecipe;
+
     @Getter
     @SaveField
     @SyncToClient
@@ -468,8 +472,8 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         }
         lastUnrolledRecipe = recipe.copy();
         syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
-        consumedInputs.clear();
         GTRecipe runningRecipe = RecipeHelper.doPrerolls(recipe, chanceCaches);
+        startingRecipe = runningRecipe;
         var handledIO = handleRecipeIO(runningRecipe, IO.IN);
         if (handledIO.isSuccess()) {
             if (lastRecipe != null && !runningRecipe.equals(lastRecipe)) {
@@ -633,6 +637,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
                 isActive = false;
                 syncDataHolder.resyncAllFields();
             }
+            consumedInputs.clear();
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -171,6 +171,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
     protected boolean alwaysTryModifyRecipe = true;
 
     @Getter
+    @SaveField
     protected ConsumedInputsData consumedInputs = new ConsumedInputsData();
 
     public RecipeLogic() {

--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/recipe/RecipeLogic.java
@@ -475,6 +475,7 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
         syncDataHolder.markClientSyncFieldDirty("lastUnrolledRecipe");
         GTRecipe runningRecipe = RecipeHelper.doPrerolls(recipe, chanceCaches);
         startingRecipe = runningRecipe;
+        consumedInputs.clear();
         var handledIO = handleRecipeIO(runningRecipe, IO.IN);
         if (handledIO.isSuccess()) {
             if (lastRecipe != null && !runningRecipe.equals(lastRecipe)) {
@@ -638,7 +639,6 @@ public class RecipeLogic extends MachineTrait implements IWorkable {
                 isActive = false;
                 syncDataHolder.resyncAllFields();
             }
-            consumedInputs.clear();
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/misc/ItemRecipeHandler.java
@@ -4,6 +4,7 @@ import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.capability.recipe.IRecipeHandler;
 import com.gregtechceu.gtceu.api.capability.recipe.ItemRecipeCapability;
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.trait.notifiable.NotifiableItemStackHandler;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
@@ -22,16 +23,18 @@ public class ItemRecipeHandler implements IRecipeHandler<Ingredient> {
     @Getter
     public final IO handlerIO;
     public final CustomItemStackHandler storage;
+    private final MetaMachine machine;
 
-    public ItemRecipeHandler(IO handlerIO, int slots) {
+    public ItemRecipeHandler(IO handlerIO, int slots, MetaMachine machine) {
         this.handlerIO = handlerIO;
         this.storage = new CustomItemStackHandler(slots);
+        this.machine = machine;
     }
 
     @Override
     public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
                                                        boolean simulate) {
-        return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, this.handlerIO, storage);
+        return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, this.handlerIO, storage, machine);
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ConsumedInputsData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ConsumedInputsData.java
@@ -2,14 +2,11 @@ package com.gregtechceu.gtceu.api.recipe;
 
 import com.gregtechceu.gtceu.api.capability.recipe.RecipeCapability;
 
-import net.minecraft.network.FriendlyByteBuf;
-
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.experimental.Accessors;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
@@ -19,14 +16,13 @@ import java.util.Map;
 import java.util.function.Function;
 
 @AllArgsConstructor
-public class RecipeSpoilageData {
+public class ConsumedInputsData {
 
-    public static final Codec<RecipeSpoilageData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final Codec<ConsumedInputsData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             RecipeCapability.INGREDIENT_CODEC.optionalFieldOf("consumedInputs", new HashMap<>())
                     .xmap((map -> (Map<RecipeCapability<?>, List<?>>) new HashMap(map)), Function.identity())
-                    .forGetter(RecipeSpoilageData::getConsumedInputs),
-            Codec.BOOL.fieldOf("keepSpoilingProgress").forGetter(RecipeSpoilageData::keepSpoilingProgress))
-            .apply(instance, RecipeSpoilageData::new));
+                    .forGetter(ConsumedInputsData::getConsumedInputs))
+            .apply(instance, ConsumedInputsData::new));
 
     /**
      * Populated after the inputs are already consumed, but the recipe didn't start yet.
@@ -34,21 +30,18 @@ public class RecipeSpoilageData {
      */
     @Getter(AccessLevel.PRIVATE)
     private Map<RecipeCapability<?>, List<?>> consumedInputs;
-    @Accessors(fluent = true)
-    @Getter
-    private boolean keepSpoilingProgress;
 
-    public RecipeSpoilageData(boolean keepSpoilingProgress) {
-        this(new HashMap<>(), keepSpoilingProgress);
+    public ConsumedInputsData() {
+        this(new HashMap<>());
     }
 
-    public RecipeSpoilageData copy() {
+    public ConsumedInputsData copy() {
         HashMap<RecipeCapability<?>, List<?>> copied = new HashMap<>();
         for (Map.Entry<RecipeCapability<?>, List<?>> entry : consumedInputs.entrySet()) {
             copied.put(entry.getKey(),
                     new ArrayList<>(entry.getValue().stream().map(entry.getKey()::copyContent).toList()));
         }
-        return new RecipeSpoilageData(copied, keepSpoilingProgress);
+        return new ConsumedInputsData(copied);
     }
 
     public void clear() {
@@ -64,13 +57,5 @@ public class RecipeSpoilageData {
     public <T> List<T> getConsumedInputs(RecipeCapability<T> recipeCapability) {
         // noinspection unchecked
         return (List<T>) consumedInputs.getOrDefault(recipeCapability, List.of());
-    }
-
-    public static RecipeSpoilageData readFromNetwork(FriendlyByteBuf buf) {
-        return new RecipeSpoilageData(new HashMap<>(), buf.readBoolean());
-    }
-
-    public void writeToNetwork(FriendlyByteBuf buf) {
-        buf.writeBoolean(keepSpoilingProgress);
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipe.java
@@ -69,7 +69,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
     @Getter(lazy = true)
     private final @NotNull EnergyStack outputEUt = calculateEUt(tickOutputs);
     public int groupColor;
-    public RecipeSpoilageData spoilageData;
+    public boolean keepSpoilingProgress;
 
     public GTRecipe(GTRecipeType recipeType,
                     Map<RecipeCapability<?>, List<Content>> inputs,
@@ -86,11 +86,11 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     int duration, int parallels, int subtickParallels, int batchParallels,
                     @NotNull GTRecipeCategory recipeCategory,
                     int groupColor,
-                    RecipeSpoilageData spoilageData) {
+                    boolean keepSpoilingProgress) {
         this(recipeType, null, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
                 conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels,
-                recipeCategory, groupColor, spoilageData);
+                recipeCategory, groupColor, keepSpoilingProgress);
     }
 
     /**
@@ -107,13 +107,13 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     GTRecipeSerializer.RecipeParallels allParallels,
                     GTRecipeCategory recipeCategory,
                     int groupColor,
-                    RecipeSpoilageData spoilageData) {
+                    boolean keepSpoilingProgress) {
         this(recipeType, null, recipeIO.inputs(), recipeIO.outputs(), recipeIO.tickInputs(), recipeIO.tickOutputs(),
                 recipeIO.inputChanceLogics(), recipeIO.outputChanceLogics(), recipeIO.tickInputChanceLogics(),
                 recipeIO.tickOutputChanceLogics(),
                 conditions, ingredientActions, data, duration, allParallels.parallels(),
                 allParallels.subtickParallels(),
-                allParallels.batchParallels(), recipeCategory, groupColor, spoilageData);
+                allParallels.batchParallels(), recipeCategory, groupColor, keepSpoilingProgress);
     }
 
     /**
@@ -135,10 +135,11 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     int duration,
                     @NotNull GTRecipeCategory recipeCategory,
                     int groupColor,
-                    RecipeSpoilageData spoilageData) {
+                    boolean keepSpoilingProgress) {
         this(recipeType, id, inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
-                conditions, ingredientActions, data, duration, 1, 1, 1, recipeCategory, groupColor, spoilageData);
+                conditions, ingredientActions, data, duration, 1, 1, 1, recipeCategory, groupColor,
+                keepSpoilingProgress);
     }
 
     public GTRecipe(GTRecipeType recipeType,
@@ -156,7 +157,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                     @NotNull CompoundTag data,
                     int duration, int parallels, int subtickParallels, int batchParallels,
                     @NotNull GTRecipeCategory recipeCategory, int groupColor,
-                    RecipeSpoilageData spoilageData) {
+                    boolean keepSpoilingProgress) {
         this.recipeType = recipeType;
         this.id = id;
 
@@ -179,7 +180,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
         this.batchParallels = batchParallels;
         this.recipeCategory = (recipeCategory != GTRecipeCategory.DEFAULT) ? recipeCategory : recipeType.getCategory();
         this.groupColor = groupColor;
-        this.spoilageData = spoilageData;
+        this.keepSpoilingProgress = keepSpoilingProgress;
     }
 
     public GTRecipe copy() {
@@ -198,7 +199,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 new HashMap<>(tickInputChanceLogics), new HashMap<>(tickOutputChanceLogics),
                 new ArrayList<>(conditions),
                 new ArrayList<>(ingredientActions), data, duration, parallels, subtickParallels, batchParallels,
-                recipeCategory, groupColor, spoilageData.copy());
+                recipeCategory, groupColor, keepSpoilingProgress);
         if (modifyDuration) {
             copied.duration = modifier.apply(this.duration);
         }
@@ -214,7 +215,7 @@ public class GTRecipe implements net.minecraft.world.item.crafting.Recipe<Contai
                 new HashMap<>(inputChanceLogics), new HashMap<>(outputChanceLogics),
                 new HashMap<>(tickInputChanceLogics), new HashMap<>(tickOutputChanceLogics),
                 new ArrayList<>(conditions),
-                new ArrayList<>(ingredientActions), data, duration, recipeCategory, groupColor, spoilageData);
+                new ArrayList<>(ingredientActions), data, duration, recipeCategory, groupColor, keepSpoilingProgress);
         copied.ocLevel = ocLevel;
         copied.parallels = parallels;
         copied.batchParallels = batchParallels;

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -216,7 +216,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             RecipeParallels.CODEC.optionalFieldOf("all_parallels", new RecipeParallels(1, 1, 1)).forGetter(val -> new RecipeParallels(val.parallels, val.subtickParallels, val.batchParallels)),
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
                             Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor),
-                            Codec.BOOL.optionalFieldOf("spoilageData", true).forGetter(val -> val.keepSpoilingProgress))
+                            Codec.BOOL.optionalFieldOf("keepSpoilingProgress", true).forGetter(val -> val.keepSpoilingProgress))
                     .apply(instance, (type,
                                       recipeIO,
                                       conditions, data, duration, allParallels, recipeCategory, groupColor, keepSpoilingProgress) ->

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/GTRecipeSerializer.java
@@ -143,13 +143,13 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         GTRecipeType type = (GTRecipeType) BuiltInRegistries.RECIPE_TYPE.get(recipeType);
         GTRecipeCategory category = GTRegistries.RECIPE_CATEGORIES.get(categoryLoc);
 
-        RecipeSpoilageData spoilageData = RecipeSpoilageData.readFromNetwork(buf);
+        boolean keepSpoilingProgress = buf.readBoolean();
 
         GTRecipe recipe = new GTRecipe(type, id,
                 inputs, outputs, tickInputs, tickOutputs,
                 inputChanceLogics, outputChanceLogics, tickInputChanceLogics, tickOutputChanceLogics,
                 conditions, ingredientActions, data, duration, parallels, subtickParallels, batchParallels, category,
-                groupColor, spoilageData);
+                groupColor, keepSpoilingProgress);
 
         recipe.recipeCategory.addRecipe(recipe);
 
@@ -197,7 +197,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
         buf.writeVarInt(recipe.batchParallels);
         buf.writeInt(recipe.groupColor);
         buf.writeResourceLocation(recipe.recipeCategory.registryKey);
-        recipe.spoilageData.writeToNetwork(buf);
+        buf.writeBoolean(recipe.keepSpoilingProgress);
     }
 
     /**
@@ -216,12 +216,12 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             RecipeParallels.CODEC.optionalFieldOf("all_parallels", new RecipeParallels(1, 1, 1)).forGetter(val -> new RecipeParallels(val.parallels, val.subtickParallels, val.batchParallels)),
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
                             Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor),
-                            RecipeSpoilageData.CODEC.optionalFieldOf("spoilageData", new RecipeSpoilageData(true)).forGetter(val -> val.spoilageData))
+                            Codec.BOOL.optionalFieldOf("spoilageData", true).forGetter(val -> val.keepSpoilingProgress))
                     .apply(instance, (type,
                                       recipeIO,
-                                      conditions, data, duration, allParallels, recipeCategory, groupColor, spoilageData) ->
+                                      conditions, data, duration, allParallels, recipeCategory, groupColor, keepSpoilingProgress) ->
                             new GTRecipe(type, recipeIO,
-                                    conditions, List.of(), data, duration, allParallels, recipeCategory, groupColor, spoilageData)));
+                                    conditions, List.of(), data, duration, allParallels, recipeCategory, groupColor, keepSpoilingProgress)));
         } else {
             return RecordCodecBuilder.create(instance -> instance.group(
                             GTRegistries.RECIPE_TYPES.codec().fieldOf("type").forGetter(val -> val.recipeType),
@@ -233,7 +233,7 @@ public class GTRecipeSerializer implements RecipeSerializer<GTRecipe> {
                             RecipeParallels.CODEC.optionalFieldOf("all_parallels", new RecipeParallels(1, 1, 1)).forGetter(val -> new RecipeParallels(val.parallels, val.subtickParallels, val.batchParallels)),
                             GTRegistries.RECIPE_CATEGORIES.codec().optionalFieldOf("category", GTRecipeCategory.DEFAULT).forGetter(val -> val.recipeCategory),
                             Codec.INT.optionalFieldOf("groupColor", -1).forGetter(val -> val.groupColor),
-                            RecipeSpoilageData.CODEC.optionalFieldOf("spoilageData", new RecipeSpoilageData(true)).forGetter(val -> val.spoilageData))
+                            Codec.BOOL.optionalFieldOf("keepSpoilingProgress", true).forGetter(val -> val.keepSpoilingProgress))
                     .apply(instance, GTRecipe::new));
         }
         // spotless:on

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/RecipeRunner.java
@@ -127,8 +127,6 @@ public class RecipeRunner {
                             .append(Component.translatable(io.getTooltip())),
                     null, io);
         }
-        if (!simulated && io.support(IO.IN) && !isTick)
-            recipe.spoilageData.clear();
 
         List<RecipeHandlerList> handlers = capabilityProxies.getOrDefault(io, Collections.emptyList());
         // Only sort for non-tick outputs

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/modifier/ModifierFunction.java
@@ -190,7 +190,8 @@ public interface ModifierFunction {
                         new HashMap<>(recipe.inputChanceLogics), new HashMap<>(recipe.outputChanceLogics),
                         new HashMap<>(recipe.tickInputChanceLogics), new HashMap<>(recipe.tickOutputChanceLogics),
                         newConditions, new ArrayList<>(recipe.ingredientActions),
-                        recipe.data, recipe.duration, recipe.recipeCategory, recipe.groupColor, recipe.spoilageData);
+                        recipe.data, recipe.duration, recipe.recipeCategory, recipe.groupColor,
+                        recipe.keepSpoilingProgress);
                 copied.parallels = recipe.parallels * parallels;
                 copied.subtickParallels = recipe.subtickParallels * subtickParallels;
                 copied.ocLevel = recipe.ocLevel + addOCs;

--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/ValueTransformers.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/ValueTransformers.java
@@ -2,6 +2,7 @@ package com.gregtechceu.gtceu.api.sync_system.data_transformers;
 
 import com.gregtechceu.gtceu.api.cover.CoverBehavior;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
+import com.gregtechceu.gtceu.api.recipe.ConsumedInputsData;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.registry.GTRegistries;
@@ -193,6 +194,6 @@ public final class ValueTransformers {
         registerTransformer(MonitorGroup.class, new MonitorGroupTransformer());
 
         registerTransformer(CoverBehavior.class, new CoverBehaviorTransformer());
-        registerTransformer(ConsumedInputsDataTransformer.class, new ConsumedInputsDataTransformer());
+        registerTransformer(ConsumedInputsData.class, new ConsumedInputsDataTransformer());
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/ValueTransformers.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/ValueTransformers.java
@@ -193,5 +193,6 @@ public final class ValueTransformers {
         registerTransformer(MonitorGroup.class, new MonitorGroupTransformer());
 
         registerTransformer(CoverBehavior.class, new CoverBehaviorTransformer());
+        registerTransformer(ConsumedInputsDataTransformer.class, new ConsumedInputsDataTransformer());
     }
 }

--- a/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/gtceu/ConsumedInputsDataTransformer.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/sync_system/data_transformers/gtceu/ConsumedInputsDataTransformer.java
@@ -1,0 +1,23 @@
+package com.gregtechceu.gtceu.api.sync_system.data_transformers.gtceu;
+
+import com.gregtechceu.gtceu.GTCEu;
+import com.gregtechceu.gtceu.api.recipe.ConsumedInputsData;
+import com.gregtechceu.gtceu.api.sync_system.data_transformers.ValueTransformer;
+
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
+
+import org.jetbrains.annotations.Nullable;
+
+public class ConsumedInputsDataTransformer implements ValueTransformer<ConsumedInputsData> {
+
+    @Override
+    public Tag serializeNBT(ConsumedInputsData value, TransformerContext<ConsumedInputsData> context) {
+        return ConsumedInputsData.CODEC.encodeStart(NbtOps.INSTANCE, value).getOrThrow(false, GTCEu.LOGGER::error);
+    }
+
+    @Override
+    public @Nullable ConsumedInputsData deserializeNBT(Tag tag, TransformerContext<ConsumedInputsData> context) {
+        return ConsumedInputsData.CODEC.decode(NbtOps.INSTANCE, tag).getOrThrow(false, GTCEu.LOGGER::error).getFirst();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/data/GTRecipeModifiers.java
@@ -11,6 +11,8 @@ import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.CoilWorkableElectricMultiblockMachine;
 import com.gregtechceu.gtceu.api.machine.multiblock.MultiblockControllerMachine;
+import com.gregtechceu.gtceu.api.machine.trait.recipe.RecipeLogic;
+import com.gregtechceu.gtceu.api.recipe.ConsumedInputsData;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.OverclockingLogic;
 import com.gregtechceu.gtceu.api.recipe.RecipeHelper;
@@ -62,10 +64,13 @@ public class GTRecipeModifiers {
                 ISpoilableItem outputSpoilable = GTCapabilityHelper.getSpoilable(stack);
                 if (outputSpoilable == null) return;
                 SpoilUtils.update(stack, new SpoilContext(machine));
-                if (!r.spoilageData.keepSpoilingProgress()) return;
+                if (!r.keepSpoilingProgress) return;
                 double spoilProgress = 0;
                 int spoilableCount = 0;
-                for (Object inObject : r.spoilageData.getConsumedInputs(GTRecipeCapabilities.ITEM)) {
+                ConsumedInputsData inputs = machine.getTraitOptional(RecipeLogic.class)
+                        .map(RecipeLogic::getConsumedInputs).orElse(null);
+                if (inputs == null) return;
+                for (Object inObject : inputs.getConsumedInputs(GTRecipeCapabilities.ITEM)) {
                     if (!(inObject instanceof Ingredient ingredient)) continue;
                     if (ingredient.getItems().length == 0) continue;
                     ItemStack in = ingredient.getItems()[0];

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/DistillationTowerMachine.java
@@ -166,7 +166,7 @@ public class DistillationTowerMachine extends WorkableElectricMultiblockMachine
                 recipe.outputChanceLogics,
                 recipe.tickInputChanceLogics, recipe.tickOutputChanceLogics, recipe.conditions,
                 recipe.ingredientActions,
-                recipe.data, recipe.duration, recipe.recipeCategory, recipe.groupColor, recipe.spoilageData);
+                recipe.data, recipe.duration, recipe.recipeCategory, recipe.groupColor, recipe.keepSpoilingProgress);
     }
 
     public static class DistillationTowerLogic extends RecipeLogic {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/ProgrammableCircuitSlotTrait.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/ProgrammableCircuitSlotTrait.java
@@ -96,7 +96,8 @@ public class ProgrammableCircuitSlotTrait extends NotifiableRecipeHandlerTrait<I
     public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
                                               boolean simulate) {
         if (!controllerAllowsCircuits || !enabled || !ConfigHolder.INSTANCE.machines.ghostCircuit) return left;
-        return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, getHandlerIO(), storage);
+        return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, getHandlerIO(), storage,
+                getMachine());
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/miner/MinerLogic.java
@@ -162,9 +162,9 @@ public class MinerLogic extends RecipeLogic implements IRecipeCapabilityHolder {
         super.onMachineLoad();
 
         this.inputItemHandler = new ItemRecipeHandler(IO.IN,
-                getRLMachine().getRecipeType().getMaxInputs(ItemRecipeCapability.CAP));
+                getRLMachine().getRecipeType().getMaxInputs(ItemRecipeCapability.CAP), getMachine());
         this.outputItemHandler = new ItemRecipeHandler(IO.OUT,
-                getRLMachine().getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP));
+                getRLMachine().getRecipeType().getMaxOutputs(ItemRecipeCapability.CAP), getMachine());
 
         RecipeHandlerList inHandlers = RecipeHandlerList.of(IO.IN, inputItemHandler, new IgnoreEnergyRecipeHandler());
         RecipeHandlerList outHandlers = RecipeHandlerList.of(IO.OUT, outputItemHandler);

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -141,6 +141,7 @@ public class GTRecipeBuilder {
         this.data = toCopy.data.copy();
         this.duration = toCopy.duration;
         this.recipeCategory = toCopy.recipeCategory;
+        this.keepSpoilingProgress = toCopy.keepSpoilingProgress;
     }
 
     public static GTRecipeBuilder of(ResourceLocation id, GTRecipeType recipeType) {
@@ -172,6 +173,7 @@ public class GTRecipeBuilder {
         copy.perTick = this.perTick;
         copy.recipeCategory = this.recipeCategory;
         copy.onSave = this.onSave;
+        copy.keepSpoilingProgress = this.keepSpoilingProgress;
         return copy;
     }
 
@@ -1646,7 +1648,7 @@ public class GTRecipeBuilder {
                 input, output, tickInput, tickOutput,
                 inputChanceLogic, outputChanceLogic, tickInputChanceLogic, tickOutputChanceLogic,
                 conditions, List.of(), data, duration, recipeCategory, -1,
-                true);
+                keepSpoilingProgress);
     }
 
     protected void warnTooManyIngredients(RecipeCapability<?> capability,

--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/builder/GTRecipeBuilder.java
@@ -1646,7 +1646,7 @@ public class GTRecipeBuilder {
                 input, output, tickInput, tickOutput,
                 inputChanceLogic, outputChanceLogic, tickInputChanceLogic, tickOutputChanceLogic,
                 conditions, List.of(), data, duration, recipeCategory, -1,
-                new RecipeSpoilageData(keepSpoilingProgress));
+                true);
     }
 
     protected void warnTooManyIngredients(RecipeCapability<?> capability,

--- a/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/ExportOnlyAEItemList.java
+++ b/src/main/java/com/gregtechceu/gtceu/integration/ae2/slot/ExportOnlyAEItemList.java
@@ -84,7 +84,8 @@ public class ExportOnlyAEItemList extends NotifiableItemStackHandler implements 
     @Override
     public List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
                                               boolean simulate) {
-        return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, this.handlerIO, getHandler());
+        return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, this.handlerIO, getHandler(),
+                getMachine());
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/utils/DummyRecipeUtils.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/DummyRecipeUtils.java
@@ -101,7 +101,7 @@ public class DummyRecipeUtils {
         @Override
         public @NotNull List<Ingredient> handleRecipeInner(IO io, GTRecipe recipe, List<Ingredient> left,
                                                            boolean simulate) {
-            return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, handlerIO, storage);
+            return NotifiableItemStackHandler.handleRecipe(io, recipe, left, simulate, handlerIO, storage, null);
         }
 
         @Override


### PR DESCRIPTION
## What
Get rid of `SpoilageRecipeData`, put the old `keepSpoilingProgress` boolean in its place in `GTRecipe`.
Move info about consumed inputs to `RecipeLogic`.

no ai
tested by running tests