### PR TITLE
Allow Setting Fluid/Item Counts in Filters

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleFluidFilter.java
@@ -31,6 +31,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public class SimpleFluidFilter extends Filter<FluidStack> {
 
+    private static final int MAX_STACK_SIZE = 2_048_000_000; // Capacity of quantum tank IX
+
     @Getter
     protected boolean isBlackList;
     @Getter
@@ -49,7 +51,7 @@ public class SimpleFluidFilter extends Filter<FluidStack> {
 
         for (int i = 0; i < 9; i++) {
             int finalI = i;
-            fluidStorageSlots[i] = new CustomFluidTank(64000);
+            fluidStorageSlots[i] = new CustomFluidTank(MAX_STACK_SIZE);
             fluidStorageSlots[i].setOnContentsChanged(() -> {
                 matches[finalI] = fluidStorageSlots[finalI].getFluid();
                 updateAndSaveFilter();

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/SimpleItemFilter.java
@@ -3,6 +3,7 @@ package com.gregtechceu.gtceu.api.cover.filter;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.item.component.ISpoilableItem;
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler;
+import com.gregtechceu.gtceu.common.cover.data.TransferMode;
 import com.gregtechceu.gtceu.common.data.GTItems;
 import com.gregtechceu.gtceu.common.mui.GTGuiTextures;
 
@@ -42,7 +43,7 @@ public class SimpleItemFilter extends Filter<ItemStack> {
     protected ItemStack[] matches = new ItemStack[9];
 
     @Getter
-    protected int maxStackSize;
+    protected int maxStackSize = TransferMode.MAX_SIZE_STACK;
 
     public SimpleItemFilter(ItemStack stack) {
         super(stack);
@@ -50,7 +51,6 @@ public class SimpleItemFilter extends Filter<ItemStack> {
         var tag = stack.getOrCreateTag();
 
         Arrays.fill(matches, ItemStack.EMPTY);
-        maxStackSize = 1;
 
         if (tag.isEmpty()) return;
 
@@ -155,7 +155,7 @@ public class SimpleItemFilter extends Filter<ItemStack> {
 
         @Override
         protected int getStackLimit(int slot, ItemStack stack) {
-            return 1;
+            return TransferMode.MAX_SIZE_STACK;
         }
 
         @Override
@@ -174,7 +174,7 @@ public class SimpleItemFilter extends Filter<ItemStack> {
         @Override
         public void setStackInSlot(int slot, ItemStack stack) {
             super.setStackInSlot(slot, stack);
-            matches[slot] = stack.copyWithCount(1);
+            matches[slot] = stack.copy();
             filter.updateAndSaveFilter();
         }
     }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.common.cover;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.filter.Filter;
-import com.gregtechceu.gtceu.api.cover.filter.SimpleFluidFilter;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;
@@ -27,6 +26,7 @@ import brachy.modularui.value.sync.EnumSyncValue;
 import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -35,8 +35,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public class FluidRegulatorCover extends PumpCover {
-
-    private static final int MAX_STACK_SIZE = 2_048_000_000; // Capacity of quantum tank IX
 
     @SaveField
     @Getter
@@ -182,11 +180,9 @@ public class FluidRegulatorCover extends PumpCover {
 
         GTMuiCoverUtil.addTransferModeRow(column, transferMode);
 
-        column.child(GTMuiWidgets.createIntInputWithBucketMode(transferSize, transferBucketMode,
-                () -> maxFluidTransferRate));
-
-        column.child(GTMuiWidgets.createIntInputWithButtons(transferSize, () -> 1, () -> MAX_STACK_SIZE)
-                .setEnabledIf($ -> shouldShowTransferSize()));
+        column.child(
+                GTMuiWidgets.createIntInputWithBucketMode(transferSize, transferBucketMode, () -> maxFluidTransferRate)
+                        .setEnabledIf($ -> shouldShowTransferSize()));
     }
 
     private boolean shouldShowTransferSize() {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
@@ -25,7 +25,6 @@ import brachy.modularui.value.sync.EnumSyncValue;
 import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -37,7 +36,7 @@ public class FluidRegulatorCover extends PumpCover {
 
     @SaveField
     @Getter
-    @Setter(AccessLevel.PRIVATE)
+    @Setter
     private TransferMode transferMode = TransferMode.TRANSFER_ANY;
 
     @Setter

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
@@ -11,7 +11,6 @@ import com.gregtechceu.gtceu.common.cover.data.TransferMode;
 import com.gregtechceu.gtceu.common.mui.GTMuiCoverUtil;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 
-import lombok.AccessLevel;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/FluidRegulatorCover.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.common.cover.data.TransferMode;
 import com.gregtechceu.gtceu.common.mui.GTMuiCoverUtil;
 import com.gregtechceu.gtceu.common.mui.GTMuiWidgets;
 
+import lombok.AccessLevel;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -39,6 +40,7 @@ public class FluidRegulatorCover extends PumpCover {
 
     @SaveField
     @Getter
+    @Setter(AccessLevel.PRIVATE)
     private TransferMode transferMode = TransferMode.TRANSFER_ANY;
 
     @Setter
@@ -151,21 +153,6 @@ public class FluidRegulatorCover extends PumpCover {
         }
 
         return platformTransferLimit - fluidLeftToTransfer;
-    }
-
-    private void setTransferMode(TransferMode transferMode) {
-        this.transferMode = transferMode;
-
-        if (!this.isRemote()) {
-            configureFilter();
-        }
-    }
-
-    @Override
-    protected void configureFilter() {
-        if (filterHandler.getFilter() instanceof SimpleFluidFilter filter) {
-            filter.setMaxStackSize(transferMode == TransferMode.TRANSFER_ANY ? 1 : MAX_STACK_SIZE);
-        }
     }
 
     private int getFilteredFluidAmount(FluidStack fluidStack) {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/RobotArmCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/RobotArmCover.java
@@ -4,7 +4,6 @@ import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.capability.recipe.IO;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.filter.Filter;
-import com.gregtechceu.gtceu.api.cover.filter.SimpleItemFilter;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.common.cover.data.TransferMode;
 import com.gregtechceu.gtceu.common.mui.GTMuiCoverUtil;
@@ -24,6 +23,7 @@ import brachy.modularui.value.sync.EnumSyncValue;
 import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -36,6 +36,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public class RobotArmCover extends ConveyorCover {
 
+    @Setter(AccessLevel.PRIVATE)
     @SaveField
     @Getter
     protected TransferMode transferMode;
@@ -172,21 +173,6 @@ public class RobotArmCover extends ConveyorCover {
 
         column.child(GTMuiWidgets.createIntInputWithButtons(transferSize, () -> 1, () -> getTransferMode().maxStackSize)
                 .setEnabledIf($ -> shouldShowStackSize()));
-    }
-
-    public void setTransferMode(TransferMode transferMode) {
-        this.transferMode = transferMode;
-
-        if (!this.isRemote()) {
-            configureFilter();
-        }
-    }
-
-    @Override
-    protected void configureFilter() {
-        if (filterHandler.getFilter() instanceof SimpleItemFilter filter) {
-            filter.setMaxStackSize(filter.supportsAmounts() ? transferMode.maxStackSize : 1);
-        }
     }
 
     private boolean shouldShowStackSize() {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/RobotArmCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/RobotArmCover.java
@@ -23,7 +23,6 @@ import brachy.modularui.value.sync.EnumSyncValue;
 import brachy.modularui.value.sync.IntSyncValue;
 import brachy.modularui.value.sync.PanelSyncManager;
 import brachy.modularui.widgets.layout.Flow;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -36,7 +35,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @MethodsReturnNonnullByDefault
 public class RobotArmCover extends ConveyorCover {
 
-    @Setter(AccessLevel.PRIVATE)
+    @Setter
     @SaveField
     @Getter
     protected TransferMode transferMode;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/data/TransferMode.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/data/TransferMode.java
@@ -26,4 +26,6 @@ public enum TransferMode {
     public String getTooltip() {
         return "cover.robotic_arm.transfer_mode." + localeName;
     }
+
+    public static final int MAX_SIZE_STACK = 1024;
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/data/VoidingMode.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/data/VoidingMode.java
@@ -15,4 +15,6 @@ public enum VoidingMode {
         this.tooltip = tooltip;
         this.maxStackSize = maxStackSize;
     }
+
+    public static final int MAX_SIZE_STACK = 1024;
 }

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.common.cover.voiding;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.filter.Filter;
-import com.gregtechceu.gtceu.api.cover.filter.SimpleFluidFilter;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.api.transfer.fluid.IFluidHandlerModifiable;

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedFluidVoidingCover.java
@@ -102,10 +102,6 @@ public class AdvancedFluidVoidingCover extends FluidVoidingCover {
     public void setVoidingMode(VoidingMode voidingMode) {
         this.voidingMode = voidingMode;
         syncDataHolder.markClientSyncFieldDirty("voidingMode");
-
-        if (!this.isRemote()) {
-            configureFilter();
-        }
     }
 
     private void setTransferBucketMode(BucketMode transferBucketMode) {
@@ -152,13 +148,6 @@ public class AdvancedFluidVoidingCover extends FluidVoidingCover {
     private void setCurrentBucketModeTransferSize(int transferSize) {
         this.globalTransferSizeMillibuckets = Math.max(transferSize * this.transferBucketMode.multiplier, 0);
         syncDataHolder.markClientSyncFieldDirty("globalTransferSizeMillibuckets");
-    }
-
-    @Override
-    protected void configureFilter() {
-        if (filterHandler.getFilter() instanceof SimpleFluidFilter filter) {
-            filter.setMaxStackSize(voidingMode == VoidingMode.VOID_ANY ? 1 : Integer.MAX_VALUE);
-        }
     }
 
     private boolean shouldShowStackSize() {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedItemVoidingCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/voiding/AdvancedItemVoidingCover.java
@@ -3,7 +3,6 @@ package com.gregtechceu.gtceu.common.cover.voiding;
 import com.gregtechceu.gtceu.api.capability.ICoverable;
 import com.gregtechceu.gtceu.api.cover.CoverDefinition;
 import com.gregtechceu.gtceu.api.cover.filter.Filter;
-import com.gregtechceu.gtceu.api.cover.filter.SimpleItemFilter;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SaveField;
 import com.gregtechceu.gtceu.api.sync_system.annotations.SyncToClient;
 import com.gregtechceu.gtceu.common.cover.data.VoidingMode;
@@ -104,11 +103,7 @@ public class AdvancedItemVoidingCover extends ItemVoidingCover {
 
     public void setVoidingMode(VoidingMode voidingMode) {
         this.voidingMode = voidingMode;
-
-        if (!this.isRemote()) {
-            syncDataHolder.markClientSyncFieldDirty("voidingMode");
-            configureFilter();
-        }
+        syncDataHolder.markClientSyncFieldDirty("voidingMode");
     }
 
     //////////////////////////////////////
@@ -137,13 +132,6 @@ public class AdvancedItemVoidingCover extends ItemVoidingCover {
 
         column.child(GTMuiWidgets.createIntInputWithButtons(voidingLimit, () -> 1, () -> getVoidingMode().maxStackSize)
                 .setEnabledIf($ -> shouldShowStackSize()));
-    }
-
-    @Override
-    protected void configureFilter() {
-        if (filterHandler.getFilter() instanceof SimpleItemFilter filter) {
-            filter.setMaxStackSize(this.voidingMode.maxStackSize);
-        }
     }
 
     private boolean shouldShowStackSize() {


### PR DESCRIPTION
## What
Three things:
(1) Simple Item and Fluid Filters cannot have stack sizes set other than 1. This means that the Supply Exact and Keep Exact modes on Robot Arms, Fluid Regulators, and Advanced Voiding Covers cannot function correctly.
(2) Robot Arms and Fluid Regulators would, upon being toggled onto Transfer-Any mode, wipe the stack sizes of any filters they were configured with.
(3) Fluid Regulator Covers had a duplicate Transfer Size UI element, one of which was always shown even when it shouldn't and the other of which didn't have a Bucket Mode toggle for it.

## Implementation Details
MUI2's PhantomItemSlotHandler can handle changing stack sizes via scroll wheel. However, the setStackInSlot() of filters was always setting with only a size of 1 and thus ignoring the changes.
The Item Filter is still limited to a stack size of only 64. However, this is actually an MUI2 bug and not a GTM bug; `PhantomItemSlotSyncHandler.incrementStackCount()` does not actually ignore the maximum stack size of a slot when trying to increment. https://github.com/brachy84/ModularUI-Modern/issues/101 
The Fluid Filter is not limited in this way.

The extra Transfer Size UI element is not related to the filter issues but it got in the way while testing and cleaning up from the other bugs.

### AI Usage 
- [ X ] No AI driven tools were used for this pull request.

## Outcome
Stacks placed in a filter will now set size based on the stack they were placed with; and stacks can now be modified with the scroll wheel. (Hold Ctrl/Shift/Alt to multiply the amount scrolled.)

