### PR TITLE
Cache pipe shapes by connection mask

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/block/PipeBlock.java
@@ -12,6 +12,7 @@ import com.gregtechceu.gtceu.api.item.tool.ToolHelper;
 import com.gregtechceu.gtceu.api.pipenet.IPipeNode;
 import com.gregtechceu.gtceu.api.pipenet.IPipeType;
 import com.gregtechceu.gtceu.api.pipenet.LevelPipeNet;
+import com.gregtechceu.gtceu.api.pipenet.Node;
 import com.gregtechceu.gtceu.api.pipenet.PipeNet;
 import com.gregtechceu.gtceu.api.registry.registrate.provider.GTBlockstateProvider;
 import com.gregtechceu.gtceu.api.sync_system.managed.ManagedSyncEntityBlock;
@@ -65,6 +66,7 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -78,6 +80,7 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
     public final PipeType pipeType;
 
     protected final Map<Direction, VoxelShape> shapes = new IdentityHashMap<>();
+    private final AtomicReferenceArray<VoxelShape> shapeCache = new AtomicReferenceArray<>(Node.ALL_OPENED + 1);
 
     public PipeBlock(Properties properties, PipeType pipeType) {
         super(properties);
@@ -474,9 +477,15 @@ public abstract class PipeBlock<PipeType extends Enum<PipeType> & IPipeType<Node
     }
 
     public VoxelShape getShapes(int connections) {
-        return this.shapes.entrySet().stream()
-                .filter(entry -> entry.getKey() == null || PipeBlockEntity.isConnected(connections, entry.getKey()))
+        int connectionMask = connections & Node.ALL_OPENED;
+        VoxelShape cachedShape = shapeCache.get(connectionMask);
+        if (cachedShape != null) return cachedShape;
+
+        VoxelShape shape = this.shapes.entrySet().stream()
+                .filter(entry -> entry.getKey() == null || PipeBlockEntity.isConnected(connectionMask, entry.getKey()))
                 .map(Map.Entry::getValue)
                 .reduce(Shapes.empty(), Shapes::or);
+        if (shapeCache.compareAndSet(connectionMask, null, shape)) return shape;
+        return shapeCache.get(connectionMask);
     }
 }


### PR DESCRIPTION
## What
Caches the combined base `VoxelShape` returned by `PipeBlock#getShapes` for each possible connection mask.

## Implementation Details
Adds a lazily populated 64 entry `AtomicReferenceArray<VoxelShape>` to each `PipeBlock`. The six connection bits are used as the cache index and compare-and-set safely publishes shapes when client and server threads query the same block at the same time.

### AI Usage 
- [X] No AI driven tools were used for this pull request.
- [ ] Yes AI driven tools were used for this pull request.

## Outcome
Removes repeated construction of identical pipe shapes during collision queries.
- Aggregate time for the affected entities dropped from 12.9% to 3.2%.
- Average per-entity tick time dropped from approximately 344 μs to 64 μs.

Before: https://observable.tas.sh/p/kRjSS/aggregated
After: https://observable.tas.sh/p/SidOa/aggregated
<img width="653" height="447" alt="image" src="https://github.com/user-attachments/assets/06145919-5a9c-4f36-8ae5-d0ce81d47367" />
<img width="1280" height="893" alt="image" src="https://github.com/user-attachments/assets/49fb18ce-fa77-494a-ab35-f7bbfd79868e" />

## How Was This Tested

- Ran `./gradlew spotlessCheck build` against the current `1.20.1` branch.
- Loaded the same world with the patched GTCEu 7.5.3 jar and captured the profiles.

## Potential Compatibility Issues
Should be none