### PR TITLE
4x the rare earth separation recipe

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/recipe/serialized/chemistry/SeparationRecipes.java
@@ -214,14 +214,14 @@ public class SeparationRecipes {
                 .chancedOutput(dust, Tantalite, 125)
                 .save(provider);
 
-        CENTRIFUGE_RECIPES.recipeBuilder("rare_earth_separation").duration(64).EUt(20)
-                .inputItems(dust, RareEarth)
-                .chancedOutput(dustSmall, Cadmium, 3500)
-                .chancedOutput(dustSmall, Neodymium, 4500)
-                .chancedOutput(dustSmall, Samarium, 3500)
-                .chancedOutput(dustSmall, Cerium, 5500)
-                .chancedOutput(dustSmall, Yttrium, 3500)
-                .chancedOutput(dustSmall, Lanthanum, 2500)
+        CENTRIFUGE_RECIPES.recipeBuilder("rare_earth_separation").duration(256).EUt(20)
+                .inputItems(dust, RareEarth, 4)
+                .chancedOutput(dust, Cadmium, 3500)
+                .chancedOutput(dust, Neodymium, 4500)
+                .chancedOutput(dust, Samarium, 3500)
+                .chancedOutput(dust, Cerium, 5500)
+                .chancedOutput(dust, Yttrium, 3500)
+                .chancedOutput(dust, Lanthanum, 2500)
                 .save(provider);
 
         CENTRIFUGE_RECIPES.recipeBuilder("red_sand_separation").duration(50).EUt(VA[LV])


### PR DESCRIPTION
## What
Removes the small piles from rare earth

No AI

Pros: allows me to remove the packer in oreproc that's used for one(1) recipe, gets rid of small piles in a place bcs I think they're dumb
Cons: devalues the packer

## How Was This Tested
before:
<img width="1000" height="956" alt="image" src="https://github.com/user-attachments/assets/1a66d745-69af-4753-9862-fed1f07a9e73" />

after:
<img width="437" height="349" alt="image" src="https://github.com/user-attachments/assets/2e5d84e1-07cd-4cb1-8685-c6ed7187e7c6" />

Needs content discussion with ghosti
