### PR TITLE
Fix typo in GTConfigValueCondition

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/loot/condition/GTConfigValueCondition.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/loot/condition/GTConfigValueCondition.java
@@ -34,7 +34,7 @@ public class GTConfigValueCondition implements LootItemCondition {
         this.configField = configField;
 
         Optional<IConfigValue<Boolean>> configEntry = ConfigHolder.INTERNAL_INSTANCE
-                .getConfigValue(configField, boolean.class);
+                .getConfigValue(configField, Boolean.class);
         this.configValueGetter = () -> configEntry.map(IConfigValue::get).orElse(false);
     }
 


### PR DESCRIPTION
## What
Fix typo in GTConfigValueCondition that added some warnings to the log and made the actual value always `false`

## Implementation Details
`b` -> `B`

### AI Usage 
- [x] No AI driven tools were used for this pull request.

## Outcome
the condition actually works as expected

## How Was This Tested
opened world, checked log, no more warnings
