### PR TITLE
Fix substation not charging all the way

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/PowerSubstationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/PowerSubstationMachine.java
@@ -459,6 +459,7 @@ public class PowerSubstationMachine extends WorkableMultiblockMachine
                 maximums[i] = batteries.get(i).getCapacity();
             }
             capacity = summarize(maximums);
+            index = 0;
         }
 
         public void deserializeNBT(CompoundTag storageTag) {
@@ -473,6 +474,10 @@ public class PowerSubstationMachine extends WorkableMultiblockMachine
                 maximums[i] = subtag.getLong(NBT_MAX);
             }
             capacity = summarize(maximums);
+            index = 0;
+            for (int i = 0; i < size; i++) {
+                if (storage[i] > 0) index = i;
+            }
         }
 
         public CompoundTag serializeNBT() {


### PR DESCRIPTION
## What
Sometimes substations would not charge all the way and instead be capped at a non-max capacity like this:
<img width="1062" height="884" alt="image" src="https://github.com/user-attachments/assets/0be1d66b-3a8b-4eaa-8b81-b36987e49b8a" />


## Implementation Details
there's an index variable that points at the currently charging/draining battery
When the multi reforms, everything but that index is reset
This properly resets and also re-sets the index

### AI Usage 
- [ ] No AI driven tools were used for this pull request.
- [X] Yes AI driven tools were used for this pull request.

#### Agent Used
Opus 5
#### Agent Usage Description
It found the problem and proposed a solution and I reviewed it
  
## Outcome
it's fixed

## How Was This Tested
I couldn't get the bug to reproduce again in singleplayer after fixing it despite my best efforts and numerous reloading etc


I ran into it during the moni playthrough 🫡 